### PR TITLE
resolve tickets

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -4,6 +4,8 @@ var moment = require('moment');
 var sendMessage = require('./utils/config').sendMessage;
 var Queue = require('./utils/queue');
 var workerQueue = new Queue;
+var statContainer = require('./utils/analytics').statContainer;
+var addStats = require('./utils/analytics').addStats;
 
 
 module.exports = function(context) {
@@ -15,11 +17,15 @@ module.exports = function(context) {
 
     var reader = code.reader;
     var nextSlice = reader.newSlicer(context, code.readerConfig, code.jobConfig);
+    var analyticsData = statContainer(code.jobs);
 
-    var scheduler = code.scheduler(nextSlice, start, workerQueue);
+    var scheduler = code.scheduler(nextSlice, start, workerQueue, code.jobConfig, analyticsData);
 
     function enqueue(msg) {
         if (msg.message === 'ready') {
+            if(msg.analytics){
+                addStats(analyticsData, msg.analytics);
+            }
             workerQueue.enqueue(msg);
         }
     }

--- a/lib/readers/elasticsearch_reader.js
+++ b/lib/readers/elasticsearch_reader.js
@@ -2,10 +2,11 @@
 var Promise = require('bluebird');
 var moment = require('moment');
 var processInterval = require('./elastic_utils').processInterval;
+var getClient = require('../utils/config').getClient;
 
 
 function newReader(context, opConfig, jobConfig) {
-    var client = context.foundation.getConnection({type: 'elasticsearch', cached: true}).client;
+    var client = getClient(context, opConfig, 'elasticsearch');
 
     if (opConfig.full_response) {
         return function(msg) {
@@ -223,7 +224,7 @@ function awaitChunk(opConfig, client, jobConfig) {
 
 function newSlicer(context, opConfig, jobConfig) {
     var opConfig = opConfig;
-    var client = context.foundation.getConnection({type: 'elasticsearch', cached: true}).client;
+    var client = getClient(context, opConfig, 'elasticsearch');
     var isPersistent = jobConfig.lifecycle === 'persistent';
 
     if (isPersistent) {

--- a/lib/senders/elasticsearch_bulk_insert.js
+++ b/lib/senders/elasticsearch_bulk_insert.js
@@ -1,5 +1,6 @@
 'use strict';
 var Promise = require('bluebird');
+var getClient = require('../utils/config').getClient;
 
 function newSender(context, opConfig, jobConfig) {
     var context = context;
@@ -7,7 +8,7 @@ function newSender(context, opConfig, jobConfig) {
     var limit = opConfig.size;
     //TODO make this based off dynamic config
     //var client = context.elasticsearch.default;
-    var client = context.foundation.getConnection({type: 'elasticsearch', cached: true}).client;
+    var client = getClient(context, opConfig, 'elasticsearch');
 
     return function(data) {
         //bulk throws an error if you send an empty array

--- a/lib/senders/hdfs_file_append.js
+++ b/lib/senders/hdfs_file_append.js
@@ -52,7 +52,7 @@ function newSender(context, opConfig, jobConfig) {
         var stores = [];
         _.forOwn(map, function(chunks, key) {
             stores.push(prepare_file(key, chunks));
-        })
+        });
 
         return Promise.all(stores);
     }

--- a/lib/senders/kafka_simple_sender.js
+++ b/lib/senders/kafka_simple_sender.js
@@ -44,7 +44,7 @@ function newSender(context, opConfig, jobConfig) {
                         else resolve(response);
                     });
                 })
-            }
+            };
 
             // Divide the data up into partitions
             var buckets = initializeBuckets();

--- a/lib/utils/analytics.js
+++ b/lib/utils/analytics.js
@@ -19,6 +19,10 @@ function analyze(fn) {
                     else if (result.length) {
                         obj.size.push(result.length);
                     }
+                    else {
+                        //need to account for senders
+                        obj.size.push(0);
+                    }
                 }
                 return result;
             });
@@ -31,7 +35,72 @@ function insertAnalyzers(array) {
     })
 }
 
+function statContainer(ops) {
+    var obj = {time: [], size: []};
+
+    for (var i = 0; i < ops.length; i++) {
+        obj.time.push([]);
+        obj.size.push([]);
+    }
+
+    return obj;
+}
+
+function addStats(obj, data) {
+
+    data.time.forEach(function(duration, index) {
+        obj.time[index].push(duration)
+    });
+
+    data.size.forEach(function(len, index) {
+        obj.size[index].push(len)
+    });
+}
+
+function calculateStats(array) {
+    var max = Number.NEGATIVE_INFINITY;
+    var min = Number.POSITIVE_INFINITY;
+    var total = array.length;
+
+    var sum = array.reduce(function(prev, num) {
+
+        if (num > max) {
+            max = num;
+        }
+        if (num < min) {
+            min = num
+        }
+        return prev + num
+    }, 0);
+
+    var average = (sum / total).toFixed(2);
+
+    return {max: max, min: min, average: average};
+}
+
+function analyzeStats(logger, operations, obj) {
+    logger.info('calculating statistics');
+
+    var time = obj.time.map(function(arr) {
+        return calculateStats(arr);
+    });
+
+    var size = obj.size.map(function(arr) {
+        return calculateStats(arr);
+    });
+
+    time.forEach(function(data, index) {
+        logger.info('operation ' + operations[index]._op + '\n average completion time of: ' + data.average + ' ms, ' +
+            'min: ' + data.min + ' ms, and max: ' + data.max + 'ms \n' +
+            ' average size : ' + size[index].average + ', min: ' + size[index].min + ', and max: ' + size[index].max)
+    });
+
+}
+
 module.exports = {
     analyze: analyze,
-    insertAnalyzers: insertAnalyzers
+    insertAnalyzers: insertAnalyzers,
+    statContainer: statContainer,
+    addStats: addStats,
+    analyzeStats: analyzeStats
 };

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -108,6 +108,27 @@ function initializeLogger(context, job, loggerName) {
     return makeLogger(loggerName, job.name);
 }
 
+function initializeWorkers(context, validJob) {
+    if (validJob.progressive_start) {
+        var interval = Math.floor(validJob.progressive_start / validJob.workers) * 1000;
+
+        var rampUp = setInterval(function() {
+            var workers = Object.keys(context.cluster.workers);
+
+            if (workers.length < validJob.workers) {
+                context.foundation.startWorkers(1);
+            }
+            else {
+                clearInterval(rampUp);
+            }
+        }, interval)
+
+    }
+    else {
+        context.foundation.startWorkers(validJob.workers);
+    }
+}
+
 function initializeJob(context) {
     _context = context;
     var opPath = process.cwd() + '/lib';
@@ -131,7 +152,9 @@ function initializeJob(context) {
     var validJob = validateOperation(jobSchema, job, false);
 
     //generate workers
-    context.foundation.startWorkers(validJob.workers);
+    if (context.cluster.isMaster) {
+        initializeWorkers(context, validJob);
+    }
 
     //set number of workers to track for shutdown sequence
     workerCount = validJob.workers ? validJob.workers : cpuCount;
@@ -254,7 +277,7 @@ function genericPersistent() {
     }
 }
 
-function persistent(slicer, start, workerQueue, analyticsData) {
+function persistent(slicer, start, workerQueue, jobConfig, analyticsData) {
     var nextSlice = slicer;
     var start = start;
     var logger = _jobConfig.logger;

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -4,12 +4,14 @@ var moment = require('moment');
 var fs = require('fs');
 var path = require('path');
 var convict = require('convict');
+var _ = require('lodash');
+var convictFormats = require('./convict_utils');
+
 var jobSchema = require('../../jobSchema').jobSchema;
 var commonSchema = require('../../jobSchema').commonSchema;
-var convictFormats = require('./convict_utils');
-var convict = require('convict');
-var _ = require('lodash');
 var insertAnalyzers = require('./analytics').insertAnalyzers;
+var analyzeStats = require('./analytics').analyzeStats;
+
 var cpuCount = require('os').cpus().length;
 var workerCount = 0;
 var processDone = 0;
@@ -252,7 +254,7 @@ function genericPersistent() {
     }
 }
 
-function persistent(slicer, start, workerQueue) {
+function persistent(slicer, start, workerQueue, analyticsData) {
     var nextSlice = slicer;
     var start = start;
     var logger = _jobConfig.logger;
@@ -278,17 +280,22 @@ function persistent(slicer, start, workerQueue) {
 }
 
 
-function once(slicer, start, workerQueue) {
+function once(slicer, start, workerQueue, jobConfig, analyticsData) {
     var nextSlice = slicer;
     var start = start;
     var logger = _jobConfig.logger;
     var isProcessing = false;
+    var errorQueue = [];
 
     return function() {
 
         if (!isProcessing) {
             isProcessing = true;
             var worker = workerQueue.dequeue();
+
+            if (worker.error) {
+                errorQueue.push(worker);
+            }
 
             Promise.resolve(nextSlice(worker))
                 .then(function(data) {
@@ -302,6 +309,13 @@ function once(slicer, start, workerQueue) {
                         if (processDone === workerCount) {
                             var end = moment();
                             var time = (end - start ) / 1000;
+
+                            if (jobConfig.analytics) {
+                                analyzeStats(logger, jobConfig.operations, analyticsData);
+                            }
+                            if (errorQueue.length > 0) {
+                                logger.info('Errors have occurred processing the following slices: ', JSON.stringify(errorQueue, null, 4))
+                            }
 
                             logger.info('processing has finished in ' + time + ' seconds, will now exit');
                             process.exit()

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -314,6 +314,24 @@ function once(slicer, start, workerQueue) {
     }
 }
 
+function getClient(context, opConfig, type) {
+    var clientConfig = {};
+    clientConfig.type = type;
+
+    if (opConfig.hasOwnProperty('connection')) {
+        clientConfig.endpoint = opConfig.connection ? opConfig.connection : 'default';
+        clientConfig.cached = opConfig.connection_cache ? opConfig.connection_cache : true;
+
+    }
+    else {
+        clientConfig.endpoint = 'default';
+        clientConfig.cached = true;
+    }
+
+    return context.foundation.getConnection(clientConfig).client;
+
+}
+
 
 module.exports = {
     initializeJob: initializeJob,
@@ -326,5 +344,6 @@ module.exports = {
     lifecycle: lifecycle,
     periodic: periodic,
     persistent: persistent,
-    once: once
+    once: once,
+    getClient: getClient
 };

--- a/lib/utils/kafka.js
+++ b/lib/utils/kafka.js
@@ -1,19 +1,15 @@
 var kafka = require('kafka-node');
+var getClient = require('./config').getClient;
 
-function createClient(context) {
-    var config = context.sysconfig;
-
-    return context.foundation.getConnection({ type: 'kafka', cached: false }).client;
-}
 
 function producer(context, opConfig) {
-    var client = createClient(context);
+    var client = getClient(context, opConfig, 'kafka');
 
     return new kafka.Producer(client, { requireAcks: 1 });
 }
 
 function consumer(context, opConfig, partition) {
-    var client = createClient(context);
+    var client = getClient(context, opConfig, 'kafka');
 
     var topics = [{
         topic: opConfig.topic,

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -38,7 +38,7 @@ module.exports = function(context) {
 
             isDone = true;
             if (!isShuttingDown) {
-                process.send({message: 'ready', id: cluster.worker.id, slice: msg});
+                process.send({message: 'ready', id: cluster.worker.id, slice: msg, analytics: specData});
             }
         }
     }
@@ -76,7 +76,7 @@ module.exports = function(context) {
 
                         if (errorLog[msg] >= max_retries) {
                             logger.error('Max retires has been reached for: ', msg);
-                            process.send({message: 'ready', id: cluster.worker.id, slice: msg});
+                            process.send({message: 'ready', id: cluster.worker.id, slice: msg, error: true});
                         }
                         else {
                             runSlice(msg);
@@ -89,7 +89,7 @@ module.exports = function(context) {
                 }
                 //no retries, proceed to next slice
                 else {
-                    process.send({message: 'ready', id: cluster.worker.id, slice: msg});
+                    process.send({message: 'ready', id: cluster.worker.id, slice: msg, error: true});
                 }
 
             });


### PR DESCRIPTION
can now specify  "progressive_start": someNumber on the jobConfig level to slowly ramp up the number of workers evenly over that period of time.

you can also specify "connection" and "connection_cache" on the _op level of readers and senders to specify which endpoint to use as well as if the connection should be cached. It will default to the "default" endpoint and cached: true

if errors occured, they will be logged in the end of runs, if "analytics" is set to true, additional information will be logged after the job completes. This currently works for the "once" lifecycle setting as it is meant to terminate after completion. 