### PR TITLE
Correcting update/upsert functionality and adding delete. fixes #87

### DIFF
--- a/lib/processors/elasticsearch_index_selector.js
+++ b/lib/processors/elasticsearch_index_selector.js
@@ -36,7 +36,7 @@ function newProcessor(context, opConfig, jobConfig) {
         if (!opConfig.type && !fromElastic) {
             throw ('type must be specified in elasticsearch index selector config if data is not from elasticsearch');
         }
-        var formated = [];
+        var formatted = [];
 
         function generateRequest(start) {
             var record;
@@ -60,31 +60,51 @@ function newProcessor(context, opConfig, jobConfig) {
                 meta._id = dataArray[start][opConfig.id_field];
             }
 
-            if (opConfig.update) {
+            if (opConfig.update || opConfig.upsert) {
                 indexSpec['update'] = meta;
+            }
+            else if (opConfig.delete) {
+                indexSpec['delete'] = meta;
             }
             else {
                 indexSpec['index'] = meta;
             }
 
-            formated.push(indexSpec);
+            formatted.push(indexSpec);
 
-            if (opConfig.update) {
-                var update = {
-                    doc: record
-                };
+            if (opConfig.update || opConfig.upsert) {
+                var update = {};
 
-                if (opConfig.upsert_fields) {
-                    update.upsert = {};
-                    opConfig.upsert_fields.forEach(function(field) {
-                        update.upsert[field] = record[field];
-                    })
+                if (opConfig.upsert) {
+                    // The upsert field is what is inserted if the key doesn't already exist
+                    update.upsert = record;
                 }
 
-                formated.push(update);
+                // This will merge this record with the existing record.
+                if (opConfig.update_fields.length > 0) {
+                    update.doc = {}
+                    opConfig.update_fields.forEach(function(field) {
+                        update.doc[field] = record[field];
+                    });
+                }
+                else if (opConfig.script_file) {
+                    update.script = {
+                        file: opConfig.script_file
+                    }
+
+                    update.script.params = {};
+                    _.forOwn(opConfig.script_params, function(field, key) {
+                        update.script.params[key] = record[field];
+                    });
+                }
+                else {
+                    update.doc = record;
+                }
+
+                formatted.push(update);
             }
-            else {
-                formated.push(record);
+            else if (opConfig.delete === false) {
+                formatted.push(record);
             }
         }
 
@@ -92,7 +112,7 @@ function newProcessor(context, opConfig, jobConfig) {
             generateRequest(i)
         }
 
-        return formated;
+        return formatted;
     }
 }
 
@@ -158,16 +178,36 @@ function schema() {
             default: '@timestamp',
             format: 'optional_String'
         },
-        update: {
-            doc: 'Specify if the data should update a the records or, if not it will index them',
+        delete: {
+            doc: 'Use the id_field from the incoming records to bulk delete documents.',
             default: false,
             format: Boolean
         },
-        upsert_fields: {
+        update: {
+            doc: 'Specify if the data should update the records or, if not it will index them',
+            default: false,
+            format: Boolean
+        },
+        upsert: {
+            doc: 'Specify if the incoming records should be used to perform an upsert. If update_fields is also specified then existing records will be updated with those fields otherwise the full incoming record will be inserted.',
+            default: false,
+            format: Boolean
+        },
+        update_fields: {
             doc: 'if you are updating the documents, you can specify fields to update here (it should be an array ' +
-            'containing all the field names you want), it defaults to sending the entire document',
+            'containing all the field names you want updated), it defaults to sending the entire document',
             default: [],
             format: Array
+        },
+        script_file: {
+            doc: 'Name of the script file to run as part of an update request.',
+            default: '',
+            format: 'optional_String'
+        },
+        script_params: {
+            doc: 'key -> value parameter mappings. The value will be extracted from the incoming data and passed to the script as param based on the key.',
+            default: {},
+            format: Object
         }
     };
 }


### PR DESCRIPTION
Renamed upsert_fields to update_fields and added 'delete', 'upsert', 'script_file' and 'script_params' parameters to fill out the list of operations.