### PR TITLE
Data generator fix

### DIFF
--- a/lib/readers/elasticsearch_data_generator.js
+++ b/lib/readers/elasticsearch_data_generator.js
@@ -1,12 +1,11 @@
 'use strict';
 
 var jsf = require('json-schema-faker');
-var fs = require('fs');
-var dataSchema = require('../utils/data_utils');
+var parsedSchema = require('../utils/elastic_utils').parsedSchema;
 
 
 function newReader(context, opConfig, jobConfig) {
-    var schema = getSchema(opConfig);
+    var schema = parsedSchema(opConfig);
 
     return function(msg) {
         var results = [];
@@ -16,29 +15,6 @@ function newReader(context, opConfig, jobConfig) {
         }
 
         return results;
-    }
-}
-
-function getSchema(config) {
-
-    if (config.json_schema) {
-        var firstPath = config.json_schema;
-        var nextPath = process.cwd() + '/' + config.json_schema;
-
-        try {
-            if (fs.existsSync(firstPath)) {
-                return require(firstPath);
-            }
-            else {
-                return require(nextPath);
-            }
-        }
-        catch (e) {
-            throw new Error('Could not retrieve code for: ' + opConfig + '\n' + e);
-        }
-    }
-    else {
-        return dataSchema;
     }
 }
 

--- a/lib/readers/elasticsearch_reader.js
+++ b/lib/readers/elasticsearch_reader.js
@@ -11,6 +11,7 @@ var buildRangeQuery = require('./../utils/elastic_utils').buildRangeQuery;
 var buildQuery = require('./../utils/elastic_utils').buildQuery;
 var determineSlice = require('./../utils/elastic_utils').determineSlice;
 var dateFormat = require('./../utils/elastic_utils').dateFormat;
+var getDates = require('./../utils/elastic_utils').getDates;
 
 
 function newReader(context, opConfig, jobConfig) {
@@ -38,29 +39,19 @@ function newReader(context, opConfig, jobConfig) {
 }
 
 function nextChunk(opConfig, client) {
-    var client = client;
-    var config = opConfig;
-    var size = config.size;
-
-    if (!config.start || !config.end) {
-        throw  new Error('elasticsearch_reader start and/or end are not set')
-    }
-    if (moment(new Date(config.start)).isValid() && moment(new Date(config.end)).isValid()) {
-        var start = moment(config.start);
-        var limit = moment(config.end);
-        var interval = processInterval(config.interval);
-        var end = moment(config.start).add(interval[0], interval[1]);
-    }
-    else {
-        throw new Error('elasticsearch_reader start and/or end dates are invalid')
-    }
+    var size = opConfig.size;
+    var dates = getDates(opConfig);
+    var start = dates.start;
+    var limit = dates.limit;
+    var interval = processInterval(opConfig.interval);
+    var end = moment(start.format(dateFormat)).add(interval[0], interval[1]);
 
     return function(msg) {
         if (start >= limit) {
             return null;
         }
         else {
-            return determineSlice(client, config, start, end, size)
+            return determineSlice(client, opConfig, start, end, size)
                 .then(function(data) {
                     start = data.end;
                     if (moment(data.end).add(interval[0], interval[1]) > limit) {
@@ -78,19 +69,12 @@ function nextChunk(opConfig, client) {
 }
 
 function awaitChunk(opConfig, client, jobConfig) {
-    var client = client;
-    var config = opConfig;
-    var size = config.size;
-
-    if (!config.start || !config.end) {
-        throw  new Error('elasticsearch_reader start and/or end are not set')
-    }
-
+    var size = opConfig.size;
     var times = getTimes(opConfig);
     var start = moment(times.start);
     var lookAheadStart = moment(start).add(1, 'm');
     var lookAheadEnd = moment(start).add(2, 'm');
-    var interval = findInterval(config);
+    var interval = findInterval(opConfig);
     var end = moment(times.start).add(interval[0], interval[1]);
     var limit = moment(times.end).subtract(interval[0], interval[1]);
     var canRun = false;
@@ -104,7 +88,7 @@ function awaitChunk(opConfig, client, jobConfig) {
                 return null;
             }
             else {
-                return determineSlice(client, config, start, end, size)
+                return determineSlice(client, opConfig, start, end, size)
                     .then(function(data) {
                         start = data.end;
                         if (moment(data.end).add(interval[0], interval[1]) > limit) {
@@ -114,7 +98,11 @@ function awaitChunk(opConfig, client, jobConfig) {
                             end = moment(data.end).add(interval[0], interval[1]);
                         }
 
-                        return {start: data.start.format(dateFormat), end: data.end.format(dateFormat), count: data.count}
+                        return {
+                            start: data.start.format(dateFormat),
+                            end: data.end.format(dateFormat),
+                            count: data.count
+                        }
                     });
             }
         }
@@ -123,8 +111,11 @@ function awaitChunk(opConfig, client, jobConfig) {
                 isCounting = true;
 
                 client.count({
-                    index: config.index,
-                    body: buildRangeQuery(config, {start: lookAheadStart.format(dateFormat), end: lookAheadEnd.format(dateFormat)})
+                    index: opConfig.index,
+                    body: buildRangeQuery(opConfig, {
+                        start: lookAheadStart.format(dateFormat),
+                        end: lookAheadEnd.format(dateFormat)
+                    })
                 })
                     .then(function(data) {
                         if (data.count === 0) {

--- a/lib/readers/elasticsearch_reader.js
+++ b/lib/readers/elasticsearch_reader.js
@@ -10,6 +10,7 @@ var findInterval = require('./../utils/elastic_utils').findInterval;
 var buildRangeQuery = require('./../utils/elastic_utils').buildRangeQuery;
 var buildQuery = require('./../utils/elastic_utils').buildQuery;
 var determineSlice = require('./../utils/elastic_utils').determineSlice;
+var dateFormat = require('./../utils/elastic_utils').dateFormat;
 
 
 function newReader(context, opConfig, jobConfig) {
@@ -44,11 +45,11 @@ function nextChunk(opConfig, client) {
     if (!config.start || !config.end) {
         throw  new Error('elasticsearch_reader start and/or end are not set')
     }
-    if (moment.utc(new Date(config.start)).isValid() && moment.utc(new Date(config.end)).isValid()) {
-        var start = moment.utc(config.start);
-        var limit = moment.utc(config.end);
+    if (moment(new Date(config.start)).isValid() && moment(new Date(config.end)).isValid()) {
+        var start = moment(config.start);
+        var limit = moment(config.end);
         var interval = processInterval(config.interval);
-        var end = moment.utc(config.start).add(interval[0], interval[1]);
+        var end = moment(config.start).add(interval[0], interval[1]);
     }
     else {
         throw new Error('elasticsearch_reader start and/or end dates are invalid')
@@ -62,14 +63,14 @@ function nextChunk(opConfig, client) {
             return determineSlice(client, config, start, end, size)
                 .then(function(data) {
                     start = data.end;
-                    if (moment.utc(data.end).add(interval[0], interval[1]) > limit) {
-                        end = moment.utc(data.end).add(limit - data.end);
+                    if (moment(data.end).add(interval[0], interval[1]) > limit) {
+                        end = moment(data.end).add(limit - data.end);
                     }
                     else {
-                        end = moment.utc(data.end).add(interval[0], interval[1]);
+                        end = moment(data.end).add(interval[0], interval[1]);
                     }
 
-                    return {start: data.start.format(), end: data.end.format(), count: data.count}
+                    return {start: data.start.format(dateFormat), end: data.end.format(dateFormat), count: data.count}
                 }
             );
         }
@@ -86,12 +87,12 @@ function awaitChunk(opConfig, client, jobConfig) {
     }
 
     var times = getTimes(opConfig);
-    var start = moment.utc(times.start);
-    var lookAheadStart = moment.utc(start).add(1, 'm');
-    var lookAheadEnd = moment.utc(start).add(2, 'm');
+    var start = moment(times.start);
+    var lookAheadStart = moment(start).add(1, 'm');
+    var lookAheadEnd = moment(start).add(2, 'm');
     var interval = findInterval(config);
-    var end = moment.utc(times.start).add(interval[0], interval[1]);
-    var limit = moment.utc(times.end).subtract(interval[0], interval[1]);
+    var end = moment(times.start).add(interval[0], interval[1]);
+    var limit = moment(times.end).subtract(interval[0], interval[1]);
     var canRun = false;
     var isCounting = false;
 
@@ -106,14 +107,14 @@ function awaitChunk(opConfig, client, jobConfig) {
                 return determineSlice(client, config, start, end, size)
                     .then(function(data) {
                         start = data.end;
-                        if (moment.utc(data.end).add(interval[0], interval[1]) > limit) {
-                            end = moment.utc(data.end).add(limit - data.end);
+                        if (moment(data.end).add(interval[0], interval[1]) > limit) {
+                            end = moment(data.end).add(limit - data.end);
                         }
                         else {
-                            end = moment.utc(data.end).add(interval[0], interval[1]);
+                            end = moment(data.end).add(interval[0], interval[1]);
                         }
 
-                        return {start: data.start.format(), end: data.end.format(), count: data.count}
+                        return {start: data.start.format(dateFormat), end: data.end.format(dateFormat), count: data.count}
                     });
             }
         }
@@ -123,11 +124,11 @@ function awaitChunk(opConfig, client, jobConfig) {
 
                 client.count({
                     index: config.index,
-                    body: buildRangeQuery(config, {start: lookAheadStart.format(), end: lookAheadEnd.format()})
+                    body: buildRangeQuery(config, {start: lookAheadStart.format(dateFormat), end: lookAheadEnd.format(dateFormat)})
                 })
                     .then(function(data) {
                         if (data.count === 0) {
-                            var currentTime = moment.utc(new Date());
+                            var currentTime = moment(new Date());
 
                             //if no data in given interval point to next segment
                             if (currentTime.unix() > lookAheadStart.unix()) {

--- a/lib/readers/elasticsearch_reader.js
+++ b/lib/readers/elasticsearch_reader.js
@@ -44,7 +44,7 @@ function nextChunk(opConfig, client) {
     if (!config.start || !config.end) {
         throw  new Error('elasticsearch_reader start and/or end are not set')
     }
-    if (moment(new Date(config.start)).isValid() && moment(new Date(config.end)).isValid()) {
+    if (moment.utc(new Date(config.start)).isValid() && moment.utc(new Date(config.end)).isValid()) {
         var start = moment.utc(config.start);
         var limit = moment.utc(config.end);
         var interval = processInterval(config.interval);
@@ -62,11 +62,11 @@ function nextChunk(opConfig, client) {
             return determineSlice(client, config, start, end, size)
                 .then(function(data) {
                     start = data.end;
-                    if (moment(data.end).add(interval[0], interval[1]) > limit) {
-                        end = moment(data.end).add(limit - data.end);
+                    if (moment.utc(data.end).add(interval[0], interval[1]) > limit) {
+                        end = moment.utc(data.end).add(limit - data.end);
                     }
                     else {
-                        end = moment(data.end).add(interval[0], interval[1]);
+                        end = moment.utc(data.end).add(interval[0], interval[1]);
                     }
 
                     return {start: data.start.format(), end: data.end.format(), count: data.count}
@@ -106,11 +106,11 @@ function awaitChunk(opConfig, client, jobConfig) {
                 return determineSlice(client, config, start, end, size)
                     .then(function(data) {
                         start = data.end;
-                        if (moment(data.end).add(interval[0], interval[1]) > limit) {
-                            end = moment(data.end).add(limit - data.end);
+                        if (moment.utc(data.end).add(interval[0], interval[1]) > limit) {
+                            end = moment.utc(data.end).add(limit - data.end);
                         }
                         else {
-                            end = moment(data.end).add(interval[0], interval[1]);
+                            end = moment.utc(data.end).add(interval[0], interval[1]);
                         }
 
                         return {start: data.start.format(), end: data.end.format(), count: data.count}

--- a/lib/readers/elasticsearch_reader.js
+++ b/lib/readers/elasticsearch_reader.js
@@ -6,8 +6,6 @@ var processInterval = require('./../utils/elastic_utils').processInterval;
 var checkElasticsearch = require('./../utils/elastic_utils').checkElasticsearch;
 var getTimes = require('./../utils/elastic_utils').getTimes;
 var getClient = require('../utils/config').getClient;
-var findInterval = require('./../utils/elastic_utils').findInterval;
-var buildRangeQuery = require('./../utils/elastic_utils').buildRangeQuery;
 var buildQuery = require('./../utils/elastic_utils').buildQuery;
 var determineSlice = require('./../utils/elastic_utils').determineSlice;
 var dateFormat = require('./../utils/elastic_utils').dateFormat;
@@ -47,7 +45,7 @@ function nextChunk(opConfig, client) {
     var end = moment(start.format(dateFormat)).add(interval[0], interval[1]);
 
     return function(msg) {
-        if (start >= limit) {
+        if (start.isSameOrAfter(limit)) {
             return null;
         }
         else {
@@ -70,80 +68,42 @@ function nextChunk(opConfig, client) {
 
 function awaitChunk(opConfig, client, jobConfig) {
     var size = opConfig.size;
-    var times = getTimes(opConfig);
-    var start = moment(times.start);
-    var lookAheadStart = moment(start).add(1, 'm');
-    var lookAheadEnd = moment(start).add(2, 'm');
-    var interval = findInterval(opConfig);
-    var end = moment(times.start).add(interval[0], interval[1]);
-    var limit = moment(times.end).subtract(interval[0], interval[1]);
-    var canRun = false;
-    var isCounting = false;
+
+    var dates = getTimes(opConfig);
+    var delayTime = dates.delayTime;
+    var start = dates.start;
+    var end = dates.end;
+    var limit = dates.limit;
+    var interval = dates.interval;
+
+    setInterval(function() {
+        if (start.format(dateFormat) === end.format(dateFormat)) {
+            end.add(interval[0], interval[1])
+        }
+        limit.add(interval[0], interval[1])
+    }, delayTime);
 
     return function(msg) {
-
-        if (canRun) {
-            if (start >= limit) {
-                canRun = false;
-                return null;
-            }
-            else {
-                return determineSlice(client, opConfig, start, end, size)
-                    .then(function(data) {
-                        start = data.end;
-                        if (moment(data.end).add(interval[0], interval[1]) > limit) {
-                            end = moment(data.end).add(limit - data.end);
-                        }
-                        else {
-                            end = moment(data.end).add(interval[0], interval[1]);
-                        }
-
-                        return {
-                            start: data.start.format(dateFormat),
-                            end: data.end.format(dateFormat),
-                            count: data.count
-                        }
-                    });
-            }
+        if (start.isSameOrAfter(limit)) {
+            return null;
         }
         else {
-            if (!isCounting) {
-                isCounting = true;
 
-                client.count({
-                    index: opConfig.index,
-                    body: buildRangeQuery(opConfig, {
-                        start: lookAheadStart.format(dateFormat),
-                        end: lookAheadEnd.format(dateFormat)
-                    })
-                })
-                    .then(function(data) {
-                        if (data.count === 0) {
-                            var currentTime = moment(new Date());
+            return determineSlice(client, opConfig, start, end, size)
+                .then(function(data) {
 
-                            //if no data in given interval point to next segment
-                            if (currentTime.unix() > lookAheadStart.unix()) {
-                                start = start.add(1, 'm');
-                                end = end.add(1, 'm');
-                                lookAheadStart = lookAheadStart.add(1, 'm');
-                                lookAheadEnd = lookAheadEnd.add(1, 'm');
-                                limit = limit.add(interval[0], interval[1]);
-                            }
-                            isCounting = false;
-                            return null;
-                        }
-                        else {
-                            canRun = true;
-                            lookAheadStart = lookAheadStart.add(1, 'm');
-                            lookAheadEnd = lookAheadEnd.add(1, 'm');
-                            limit = limit.add(interval[0], interval[1]);
-                            isCounting = false;
-                        }
-                    });
-            }
-            else {
-                return null;
-            }
+                    start = data.end;
+                    if (moment(data.end).add(interval[0], interval[1]) > limit) {
+                        end = moment(data.end).add(limit - data.end);
+
+                    }
+                    else {
+                        end = moment(data.end).add(interval[0], interval[1]);
+                    }
+
+                    return {start: data.start.format(dateFormat), end: data.end.format(dateFormat), count: data.count}
+                }
+            );
         }
     };
 }

--- a/lib/utils/data_utils.js
+++ b/lib/utils/data_utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var jsf = require('json-schema-faker');
+var moment = require('moment');
 
 jsf.formats('isoBetween', function(gen, schema){
     var start = new Date(0);  //01 January, 1970 UTC
@@ -20,6 +21,10 @@ jsf.formats('isoBetween', function(gen, schema){
 
 jsf.formats('isoDate', function(gen, schema){
     return new Date().toISOString()
+});
+
+jsf.formats('utcDate', function(gen, schema){
+    return new moment().utc().format();
 });
 
 module.exports = {
@@ -43,9 +48,7 @@ module.exports = {
         },
         created: {
             type: 'string',
-            format: 'isoBetween',
-            "start":"2015-12-07T04:00:00",
-            "end":"2015-12-07T08:00:00"
+            format: 'utcDate'
         },
         ipv6: {
             type: 'string',

--- a/lib/utils/data_utils.js
+++ b/lib/utils/data_utils.js
@@ -2,10 +2,11 @@
 
 var jsf = require('json-schema-faker');
 var moment = require('moment');
+var dateFormat = require('./elastic_utils').dateFormat;
 
 jsf.formats('isoBetween', function(gen, schema){
-    var start = new Date(0);  //01 January, 1970 UTC
-    var date = new Date();
+    var start = moment(0);  //01 January, 1970 UTC
+    var date = moment();
 
     if(!schema.start) {
         schema.start = start
@@ -16,15 +17,33 @@ jsf.formats('isoBetween', function(gen, schema){
 
     var someDate = gen.faker.date.between(schema.start, schema.end);
 
-    return someDate.toISOString();
+    //ex.   "2016-01-19T13:48:08.426-07:00"
+    return moment(someDate).format(dateFormat);
 });
 
-jsf.formats('isoDate', function(gen, schema){
-    return new Date().toISOString()
+jsf.formats('utcBetween', function(gen, schema){
+    var start = moment(0);  //01 January, 1970 UTC
+    var date = moment();
+
+    if(!schema.start) {
+        schema.start = start
+    }
+    if(!schema.end) {
+        schema.end = date
+    }
+
+    var someDate = gen.faker.date.between(schema.start, schema.end);
+
+    //ex.   "2016-01-19T20:48:08.426Z"  , compare to isoBetween, same dates
+    return moment(someDate).toISOString();
 });
 
 jsf.formats('utcDate', function(gen, schema){
-    return new moment().utc().format();
+    return new Date().toISOString()
+});
+
+jsf.formats('dateNow', function(gen, schema){
+    return moment().format(dateFormat);
 });
 
 module.exports = {
@@ -48,7 +67,7 @@ module.exports = {
         },
         created: {
             type: 'string',
-            format: 'utcDate'
+            format: 'dateNow'
         },
         ipv6: {
             type: 'string',

--- a/lib/utils/elastic_utils.js
+++ b/lib/utils/elastic_utils.js
@@ -10,7 +10,8 @@ function dateOptions(value) {
 
     var timeInterval = value.toLowerCase();
     var options = {
-        months: 'M', month: 'M', mo: 'M', mos: 'M',
+        year: 'y', years: 'y', 'y': 'y',
+        months: 'M', month: 'M', mo: 'M', mos: 'M', M: 'M',
         weeks: 'w', week: 'w', wks: 'w', wk: 'w', w: 'w',
         days: 'd', day: 'd', d: 'd',
         hours: 'h', hour: 'h', hr: 'h', hrs: 'h', h: 'h',
@@ -28,10 +29,15 @@ function dateOptions(value) {
 }
 
 function processInterval(str) {
-    var interval = str.split("_");
+    //one or more digits, followed by one or more letters, case-insensitive
+    var regex = /(\d+)([a-z]+)/i;
+    var interval = regex.exec(str);
+    //dont need first parameter
+    interval.shift();
 
     if (interval.length !== 2) {
-        throw  new Error('elasticsearch_reader start and/or end are incorrectly formatted. Needs to follow 12_s format')
+        throw  new Error('elasticsearch_reader start and/or end are incorrectly formatted. Needs to follow ' +
+            '[number][letter\'s] format, e.g. "12s"')
     }
 
     interval[1] = dateOptions(interval[1]);
@@ -249,7 +255,7 @@ function getDates(opConfig) {
     return {start: start, limit: limit}
 }
 
-               //"2016-01-19T13:33:09.356-07:00"
+//"2016-01-19T13:33:09.356-07:00"
 var dateFormat = "YYYY-MM-DDTHH:mm:ss.SSSZ";
 
 module.exports = {

--- a/lib/utils/elastic_utils.js
+++ b/lib/utils/elastic_utils.js
@@ -2,6 +2,8 @@
 
 var Promise = require('bluebird');
 var moment = require('moment');
+var fs = require('fs');
+var dataSchema = require('./data_utils');
 
 function dateOptions(value) {
 
@@ -165,6 +167,51 @@ function recursiveSend(client, dataArray, limit) {
     return Promise.all(fnArray);
 }
 
+function getSchema(config) {
+
+    if (config.json_schema) {
+        var firstPath = config.json_schema;
+        var nextPath = process.cwd() + '/' + config.json_schema;
+
+        try {
+            if (fs.existsSync(firstPath)) {
+                return {schema: require(firstPath), isDefault: false};
+            }
+            else {
+                return {schema: require(nextPath), isDefault: false};
+            }
+        }
+        catch (e) {
+            throw new Error('Could not retrieve code for: ' + opConfig + '\n' + e);
+        }
+    }
+    else {
+        return {schema: dataSchema, isDefault: true};
+    }
+}
+
+function parsedSchema(opConfig) {
+    var results = getSchema(opConfig);
+    var schema = results.schema;
+    var created = schema.properties.created;
+
+    if (results.isDefault) {
+        if(opConfig.format){
+            created.format = opConfig.format;
+        }
+
+        if(opConfig.start){
+            created.start = opConfig.start;
+        }
+
+        if(opConfig.end){
+            created.end = opConfig.end;
+        }
+    }
+
+    return schema;
+}
+
 module.exports = {
     dateOptions: dateOptions,
     processInterval: processInterval,
@@ -175,5 +222,7 @@ module.exports = {
     buildQuery: buildQuery,
     checkElasticsearch: checkElasticsearch,
     determineSlice: determineSlice,
-    recursiveSend: recursiveSend
+    recursiveSend: recursiveSend,
+    getSchema: getSchema,
+    parsedSchema: parsedSchema
 };

--- a/lib/utils/elastic_utils.js
+++ b/lib/utils/elastic_utils.js
@@ -7,7 +7,6 @@ var dataSchema = require('./data_utils');
 var parser = require('datemath-parser');
 
 function dateOptions(value) {
-
     var timeInterval = value.toLowerCase();
     var options = {
         year: 'y', years: 'y', 'y': 'y',
@@ -29,19 +28,27 @@ function dateOptions(value) {
 }
 
 function processInterval(str) {
-    //one or more digits, followed by one or more letters, case-insensitive
-    var regex = /(\d+)([a-z]+)/i;
-    var interval = regex.exec(str);
-    //dont need first parameter
-    interval.shift();
 
-    if (interval.length !== 2) {
+    if (!moment(new Date(str)).isValid()) {
+        //one or more digits, followed by one or more letters, case-insensitive
+        var regex = /(\d+)([a-z]+)/i;
+        var interval = regex.exec(str);
+
+        if (interval === null) {
+            throw  new Error('elasticsearch_reader start and/or end are incorrectly formatted. Needs to follow ' +
+                '[number][letter\'s] format, e.g. "12s"')
+        }
+
+        //dont need first parameter, its the full string
+        interval.shift();
+
+        interval[1] = dateOptions(interval[1]);
+        return interval;
+    }
+    else {
         throw  new Error('elasticsearch_reader start and/or end are incorrectly formatted. Needs to follow ' +
             '[number][letter\'s] format, e.g. "12s"')
     }
-
-    interval[1] = dateOptions(interval[1]);
-    return interval;
 }
 
 function checkVersion(str) {
@@ -141,22 +148,19 @@ function determineSlice(client, config, start, end, size) {
             if (data.count > size) {
                 //find difference in milliseconds and divide in half
                 var diff = Math.floor(end.diff(start) / 2);
-                //must return an over sized chunk if time cannot split
-                if (diff === 0) {
-                    return {start: start, end: end, count: data.count};
+                var newEnd = moment(start).add(diff, 'ms');
+
+                //prevent recursive call if difference is one millisecond
+                if (diff < 2) {
+                    return {start: start, end: newEnd, count: data.count};
                 }
                 else {
-                    var newEnd = moment(start).add(diff, 'ms');
-                    //prevent recursive call if newEnd is same as start
-                    if (start.format(dateFormat) === newEnd.format(dateFormat)) {
-                        return {start: start, end: end, count: data.count};
-                    }
-                    else {
-                        return determineSlice(client, config, start, newEnd, size)
-                    }
+                    return determineSlice(client, config, start, newEnd, size)
                 }
+
             }
             else {
+
                 return {start: start, end: end, count: data.count};
             }
         })

--- a/lib/utils/elastic_utils.js
+++ b/lib/utils/elastic_utils.js
@@ -46,7 +46,7 @@ function processInterval(str) {
         return interval;
     }
     else {
-        throw  new Error('elasticsearch_reader start and/or end are incorrectly formatted. Needs to follow ' +
+        throw  new Error('elasticsearch_reader interval and/or delay are incorrectly formatted. Needs to follow ' +
             '[number][letter\'s] format, e.g. "12s"')
     }
 }
@@ -56,29 +56,20 @@ function checkVersion(str) {
     return num >= 210;
 }
 
-function getTimes(obj) {
-    //TODO check this
-    var time = moment().seconds(0).millisecond(0).format(dateFormat);
-    var startInterval = processInterval(obj.start);
-    var endInterval = processInterval(obj.end);
+function getTimes(opConfig) {
+    var interval = processInterval(opConfig.interval);
+    var delayInterval = processInterval(opConfig.delay);
+    var delayTime = getDelayTime(interval);
 
-    var start = moment(time).add(startInterval[0], startInterval[1]);
-    var end = moment(time).add(endInterval[0], endInterval[1]);
+    var delayedStart = moment().subtract(delayInterval[0], delayInterval[1]).format(dateFormat);
 
-    return {start: start.format(dateFormat), end: end.format(dateFormat)}
-}
-
-function findInterval(obj) {
-    var results = [];
-    var start = processInterval(obj.start);
-    var end = processInterval(obj.end);
-    var num = end[0] - start[0];
-
-    //starting point is inclusive so add one
-    results.push(num + 1);
-    results.push(end[1]);
-
-    return results;
+    return {
+        start: moment(delayedStart),
+        end: moment(delayedStart).add(interval[0], interval[1]),
+        limit: moment(delayedStart).add(interval[0], interval[1]),
+        interval: interval,
+        delayTime: delayTime
+    }
 }
 
 function buildRangeQuery(source, obj) {
@@ -259,6 +250,11 @@ function getDates(opConfig) {
     return {start: start, limit: limit}
 }
 
+function getDelayTime(interval) {
+    var times = {d: 86400000, h: 3600000, m: 60000, s: 1000, ms: 1};
+
+    return interval[0] * times[interval[1]]
+}
 //"2016-01-19T13:33:09.356-07:00"
 var dateFormat = "YYYY-MM-DDTHH:mm:ss.SSSZ";
 
@@ -267,7 +263,6 @@ module.exports = {
     processInterval: processInterval,
     checkVersion: checkVersion,
     getTimes: getTimes,
-    findInterval: findInterval,
     buildRangeQuery: buildRangeQuery,
     buildQuery: buildQuery,
     checkElasticsearch: checkElasticsearch,
@@ -276,5 +271,6 @@ module.exports = {
     getSchema: getSchema,
     parsedSchema: parsedSchema,
     dateFormat: dateFormat,
-    getDates: getDates
+    getDates: getDates,
+    getDelayTime: getDelayTime
 };

--- a/lib/utils/elastic_utils.js
+++ b/lib/utils/elastic_utils.js
@@ -43,15 +43,15 @@ function checkVersion(str) {
 }
 
 function getTimes(obj) {
-    var date = new Date();
-    var time = moment(date).seconds(0).millisecond(0).toISOString();
+    //TODO check this
+    var time = moment().seconds(0).millisecond(0).format(dateFormat);
     var startInterval = processInterval(obj.start);
     var endInterval = processInterval(obj.end);
 
     var start = moment(time).add(startInterval[0], startInterval[1]);
     var end = moment(time).add(endInterval[0], endInterval[1]);
 
-    return {start: start.toISOString(), end: end.toISOString()}
+    return {start: start.format(dateFormat), end: end.format(dateFormat)}
 }
 
 function findInterval(obj) {
@@ -124,7 +124,7 @@ function checkElasticsearch(client, opConfig, logger) {
 function determineSlice(client, config, start, end, size) {
     return client.count({
         index: config.index,
-        body: buildRangeQuery(config, {start: start.format(), end: end.format()})
+        body: buildRangeQuery(config, {start: start.format(dateFormat), end: end.format(dateFormat)})
     })
         .then(function(data) {
             if (data.count > size) {
@@ -137,7 +137,7 @@ function determineSlice(client, config, start, end, size) {
                 else {
                     var newEnd = moment(start).add(diff, 'ms');
                     //prevent recursive call if newEnd is same as start
-                    if (start.format() === newEnd.format()) {
+                    if (start.format(dateFormat) === newEnd.format(dateFormat)) {
                         return {start: start, end: end, count: data.count};
                     }
                     else {
@@ -212,6 +212,10 @@ function parsedSchema(opConfig) {
     return schema;
 }
 
+
+               //"2016-01-19T13:33:09.356-07:00"
+var dateFormat = "YYYY-MM-DDTHH:mm:ss.SSSZ";
+
 module.exports = {
     dateOptions: dateOptions,
     processInterval: processInterval,
@@ -224,5 +228,6 @@ module.exports = {
     determineSlice: determineSlice,
     recursiveSend: recursiveSend,
     getSchema: getSchema,
-    parsedSchema: parsedSchema
+    parsedSchema: parsedSchema,
+    dateFormat: dateFormat
 };

--- a/lib/utils/elastic_utils.js
+++ b/lib/utils/elastic_utils.js
@@ -4,6 +4,7 @@ var Promise = require('bluebird');
 var moment = require('moment');
 var fs = require('fs');
 var dataSchema = require('./data_utils');
+var parser = require('datemath-parser');
 
 function dateOptions(value) {
 
@@ -96,6 +97,10 @@ function buildQuery(source, msg) {
         size: msg.count,
         body: buildRangeQuery(source, msg)
     };
+
+    if (source.query) {
+        query.q = source.query;
+    }
 
     return query;
 }
@@ -196,15 +201,15 @@ function parsedSchema(opConfig) {
     var created = schema.properties.created;
 
     if (results.isDefault) {
-        if(opConfig.format){
+        if (opConfig.format) {
             created.format = opConfig.format;
         }
 
-        if(opConfig.start){
+        if (opConfig.start) {
             created.start = opConfig.start;
         }
 
-        if(opConfig.end){
+        if (opConfig.end) {
             created.end = opConfig.end;
         }
     }
@@ -212,6 +217,37 @@ function parsedSchema(opConfig) {
     return schema;
 }
 
+function parseDate(date) {
+    var result;
+
+    if (moment(new Date(date)).isValid()) {
+        result = moment(new Date(date));
+    }
+    else {
+        try {
+            var ms = parser.parse(date);
+            result = moment(date)
+        }
+        catch (e) {
+            throw new Error('elasticsearch_reader start and/or end dates are invalid')
+        }
+    }
+
+    return result;
+}
+
+
+function getDates(opConfig) {
+
+    if (!opConfig.start || !opConfig.end) {
+        throw  new Error('elasticsearch_reader start and/or end are not set')
+    }
+
+    var start = parseDate(opConfig.start);
+    var limit = parseDate(opConfig.end);
+
+    return {start: start, limit: limit}
+}
 
                //"2016-01-19T13:33:09.356-07:00"
 var dateFormat = "YYYY-MM-DDTHH:mm:ss.SSSZ";
@@ -229,5 +265,6 @@ module.exports = {
     recursiveSend: recursiveSend,
     getSchema: getSchema,
     parsedSchema: parsedSchema,
-    dateFormat: dateFormat
+    dateFormat: dateFormat,
+    getDates: getDates
 };

--- a/lib/utils/elastic_utils.js
+++ b/lib/utils/elastic_utils.js
@@ -35,7 +35,7 @@ function processInterval(str) {
         var interval = regex.exec(str);
 
         if (interval === null) {
-            throw  new Error('elasticsearch_reader start and/or end are incorrectly formatted. Needs to follow ' +
+            throw  new Error('elasticsearch_reader interval and/or delay are incorrectly formatted. Needs to follow ' +
                 '[number][letter\'s] format, e.g. "12s"')
         }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jasmine": "^2.3.2",
     "json-schema-faker": "^0.2.1",
     "lodash": "^3.10.1",
-    "moment": "^2.10.3",
+    "moment": "^2.11.1",
     "n-readlines": "^0.2.2",
     "node-webhdfs": "0.0.4",
     "socket.io": "^1.3.7",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "bluebird": "^2.9.34",
     "convict": "^1.0.1",
+    "datemath-parser": "^1.0.5",
     "jasmine": "^2.3.2",
     "json-schema-faker": "^0.2.1",
     "lodash": "^3.10.1",

--- a/spec/readers/elasticsearch_reader-spec.js
+++ b/spec/readers/elasticsearch_reader-spec.js
@@ -138,7 +138,7 @@ describe('elasticsearch_reader', function() {
             date_field_name: '@timestamp',
             size: 50,
             index: 'someIndex',
-            interval: '12_hrs',
+            interval: '12hrs',
             start: new Date(),
             end: new Date()
         };
@@ -156,9 +156,9 @@ describe('elasticsearch_reader', function() {
             date_field_name: '@timestamp',
             size: 100,
             index: 'someIndex',
-            interval: '2_hrs',
-            start: "2015-08-25",
-            end: "2015-08-26"
+            interval: '2hrs',
+            start: "2015-08-25T00:00:00Z",
+            end: "2015-08-26T00:00:00Z"
         };
 
         var jobConfig = {lifecycle: 'once'};
@@ -167,8 +167,8 @@ describe('elasticsearch_reader', function() {
 
         Promise.resolve(slicer()).then(function(data) {
             expect(data).toEqual({
-                start: '2015-08-25T00:00:00+00:00',
-                end: '2015-08-25T02:00:00+00:00',
+                start: '2015-08-24T17:00:00.000-07:00',
+                end: '2015-08-24T19:00:00.000-07:00',
                 count: 100
             });
 
@@ -183,7 +183,7 @@ describe('elasticsearch_reader', function() {
             date_field_name: '@timestamp',
             size: 100,
             index: 'someIndex',
-            interval: '2_hrs',
+            interval: '2hrs',
             start: "2015-08-25T00:00:00",
             end: "2015-08-25T00:02:00"
         };
@@ -207,7 +207,7 @@ describe('elasticsearch_reader', function() {
             date_field_name: '@timestamp',
             size: 100,
             index: 'someIndex',
-            interval: '2_hrs',
+            interval: '2hrs',
             start: "2015-08-25T00:00:00",
             end: "2015-08-25T00:02:00"
         };
@@ -216,7 +216,7 @@ describe('elasticsearch_reader', function() {
             date_field_name: '@timestamp',
             size: 100,
             index: 'someIndex',
-            interval: '2_hrs',
+            interval: '2hrs',
             start: "2015-08-25T00:00:00"
         };
 
@@ -224,24 +224,24 @@ describe('elasticsearch_reader', function() {
             date_field_name: '@timestamp',
             size: 100,
             index: 'someIndex',
-            interval: '2_hrs',
+            interval: '2hrs',
             end: "2015-08-25T00:02:00"
         };
 
         var opConfig4 = {
             index: 'someIndex',
-            start: "00_s",
-            end: "59_s"
+            start: "00s",
+            end: "59s"
         };
 
         var opConfig5 = {
             index: 'someIndex',
-            start: "00_s"
+            start: "00s"
         };
 
         var opConfig6 = {
             index: 'someIndex',
-            end: "59_s"
+            end: "59s"
         };
 
         var jobConfig1 = {lifecycle: 'once'};
@@ -250,7 +250,8 @@ describe('elasticsearch_reader', function() {
 
         expect(function() {
             es_reader.newSlicer(context, opConfig1, jobConfig2)
-        }).toThrowError('elasticsearch_reader start and/or end are incorrectly formatted. Needs to follow 12_s format');
+        }).toThrowError('elasticsearch_reader start and/or end are incorrectly formatted. Needs to follow ' +
+            '[number][letter\'s] format, e.g. "12s"');
 
         expect(function() {
             es_reader.newSlicer(context, opConfig2, jobConfig1)
@@ -266,12 +267,13 @@ describe('elasticsearch_reader', function() {
 
         expect(function() {
             es_reader.newSlicer(context, opConfig5, jobConfig2)
-        }).toThrowError('elasticsearch_reader start and/or end are not set');
+        }).toThrowError('elasticsearch_reader start and/or end are incorrectly formatted. Needs to follow ' +
+            '[number][letter\'s] format, e.g. "12s"');
 
         expect(function() {
             es_reader.newSlicer(context, opConfig6, jobConfig2)
-        }).toThrowError('elasticsearch_reader start and/or end are not set');
-
+        }).toThrowError('elasticsearch_reader start and/or end are incorrectly formatted. Needs to follow ' +
+            '[number][letter\'s] format, e.g. "12s"');
     });
 
 });

--- a/spec/senders/file_export-spec.js
+++ b/spec/senders/file_export-spec.js
@@ -87,7 +87,7 @@ describe('file_export', function() {
         var context = {};
         var op = {path: path};
         var operations = [{
-            interval: "5_mins",
+            interval: "5mins",
             start: "2015-07-08T07:00:00",
             end: "2015-07-08T07:10:00"
         }];
@@ -139,7 +139,7 @@ describe('file_export', function() {
         var context = {};
         var opConfig = {path: path};
         var operations = [{
-            interval: "5_mins",
+            interval: "5mins",
             start: "2015-07-08T07:00:00",
             end: "2015-07-08T07:10:00"
         }];

--- a/spec/utils/data_utils-spec.js
+++ b/spec/utils/data_utils-spec.js
@@ -63,7 +63,7 @@ describe('data_utils', function() {
         properties: {
             updated: {
                 type: 'string',
-                format: 'isoDate'
+                format: 'utcDate'
             }
 
         },
@@ -71,7 +71,7 @@ describe('data_utils', function() {
     };
 
 
-    it('format isoBetween creates an iso date between two dates', function(){
+    it('format isoBetween creates an iso date between two dates', function() {
         var date = jsf(testObjBetween1);
 
         expect(new Date(date.created)).toBeLessThan(new Date(testObjBetween1.properties.created.end));
@@ -79,7 +79,7 @@ describe('data_utils', function() {
 
     });
 
-    it('format isoBetween will default to current date if start or end is missing', function(){
+    it('format isoBetween will default to current date if start or end is missing', function() {
 
         var date2 = jsf(testObjBetween2);
         var date3 = jsf(testObjBetween3);
@@ -100,18 +100,18 @@ describe('data_utils', function() {
         expect(new Date(date4.created) <= testDate).toBeTruthy();
     });
 
-    it('isoDate will give you a new Date() in iso format', function(){
+    it('isoDate will give you a new Date() in iso format', function() {
 
         var date = jsf(testObjDate);
-        var testDate = new Date().toISOString().slice(0,19);
+        var testDate = new Date().toISOString().slice(0, 19);
 
         //removing milliseconds in iso date to check time, else testDate will always be older than date
 
-        expect(date.updated.slice(0,19)).toEqual(testDate);
+        expect(date.updated.slice(0, 19)).toEqual(testDate);
 
     });
 
-    it('default data creation', function(){
+    it('default data creation', function() {
 
         var data = jsf(schema);
 

--- a/spec/utils/elastic_utils-spec.js
+++ b/spec/utils/elastic_utils-spec.js
@@ -253,27 +253,16 @@ describe('elastic_utils', function() {
 
     });
 
-    it('findInterval will process the jobConfig to determine the interval to slice', function() {
-        var jobConfig1 = {start: '0s', end: '29s'};
-        var jobConfig2 = {start: '0s', end: '15s'};
-        var jobConfig3 = {start: '0s', end: '59s'};
-
-        expect(utils.findInterval(jobConfig1)).toEqual([30, 's']);
-        expect(utils.findInterval(jobConfig2)).toEqual([16, 's']);
-        expect(utils.findInterval(jobConfig3)).toEqual([60, 's']);
-
-    });
-
     it('getTimes returns valid iso dates', function() {
-        var jobConfig1 = {start: '0s', end: '29s'};
+        var jobConfig1 = {interval: '0s', delay: '29s'};
 
         var results = utils.getTimes(jobConfig1);
 
         expect(results).toBeDefined();
         expect(results.start).toBeDefined();
         expect(results.end).toBeDefined();
-        expect(typeof results.start).toEqual('string');
-        expect(typeof results.end).toEqual('string');
+        expect(typeof results.start).toEqual('object');
+        expect(typeof results.end).toEqual('object');
 
         expect(function() {
             new Date(results.start)

--- a/spec/utils/elastic_utils-spec.js
+++ b/spec/utils/elastic_utils-spec.js
@@ -3,6 +3,7 @@
 var utils = require('../../lib/utils/elastic_utils');
 var Promise = require('bluebird');
 var moment = require('moment');
+var dateFormat = utils.dateFormat;
 
 
 describe('elastic_utils', function() {
@@ -110,7 +111,7 @@ describe('elastic_utils', function() {
     it('processInterval takes a string and returns an array', function() {
         var processInterval = utils.processInterval;
 
-        var results = processInterval('5_min');
+        var results = processInterval('5min');
 
         expect(Array.isArray(results)).toBe(true);
 
@@ -118,7 +119,7 @@ describe('elastic_utils', function() {
 
     it('processInterval requires input to be a specific format', function() {
         var processInterval = utils.processInterval;
-        var results1 = processInterval('5_min');
+        var results1 = processInterval('5min');
 
         expect(results1[0]).toEqual('5');
         expect(results1[1]).toEqual('m');
@@ -197,8 +198,8 @@ describe('elastic_utils', function() {
                 expect(typeof data).toBe('object');
                 expect(data.start).toBeDefined();
                 expect(data.end).toBeDefined();
-                expect(data.start.format()).toEqual('2015-08-30T00:00:00-07:00');
-                expect(data.end.format()).toEqual('2015-08-31T00:00:00-07:00');
+                expect(data.start.format(dateFormat)).toEqual('2015-08-30T00:00:00.000-07:00');
+                expect(data.end.format(dateFormat)).toEqual('2015-08-31T00:00:00.000-07:00');
 
                 done();
             });
@@ -214,7 +215,7 @@ describe('elastic_utils', function() {
 
         Promise.resolve(utils.determineSlice(client, config, start, end, size))
             .then(function(data) {
-                expect(data.end.format()).toEqual('2015-08-30T12:00:00-07:00');
+                expect(data.end.format(dateFormat)).toEqual('2015-08-30T12:00:00.000-07:00');
                 done();
             });
 
@@ -229,8 +230,8 @@ describe('elastic_utils', function() {
 
         Promise.resolve(utils.determineSlice(client, config, start, end, size))
             .then(function(data) {
-                expect(data.start.format()).toEqual('2015-08-30T00:00:00-07:00');
-                expect(data.end.format()).toEqual('2015-08-30T00:00:01-07:00');
+                expect(data.start.format(dateFormat)).toEqual('2015-08-30T00:00:00.000-07:00');
+                expect(data.end.format(dateFormat)).toEqual('2015-08-30T00:00:00.001-07:00');
 
                 done();
             });
@@ -253,9 +254,9 @@ describe('elastic_utils', function() {
     });
 
     it('findInterval will process the jobConfig to determine the interval to slice', function() {
-        var jobConfig1 = {start: '0_s', end: '29_s'};
-        var jobConfig2 = {start: '0_s', end: '15_s'};
-        var jobConfig3 = {start: '0_s', end: '59_s'};
+        var jobConfig1 = {start: '0s', end: '29s'};
+        var jobConfig2 = {start: '0s', end: '15s'};
+        var jobConfig3 = {start: '0s', end: '59s'};
 
         expect(utils.findInterval(jobConfig1)).toEqual([30, 's']);
         expect(utils.findInterval(jobConfig2)).toEqual([16, 's']);
@@ -264,7 +265,7 @@ describe('elastic_utils', function() {
     });
 
     it('getTimes returns valid iso dates', function() {
-        var jobConfig1 = {start: '0_s', end: '29_s'};
+        var jobConfig1 = {start: '0s', end: '29s'};
 
         var results = utils.getTimes(jobConfig1);
 
@@ -301,5 +302,4 @@ describe('elastic_utils', function() {
             [{body: [{three: 'data'}]}]])
 
     });
-
 });


### PR DESCRIPTION
new additions: 
data generator will now take a "format", "start", and "end" key to change the schema
reader now accepts a "query" key where you can place a lucene query
reader "start" and "end" will now take date math options 
dates are now saved in this format "2016-01-19T13:33:09.356-07:00"
