### PR TITLE
Text fix

### DIFF
--- a/lib/cluster/services/api.js
+++ b/lib/cluster/services/api.js
@@ -194,7 +194,13 @@ module.exports = function(context, app, cluster_service, jobs_service) {
 
     app.get('/txt/jobs', function(req, res) {
         var defaults = ['name', 'lifecycle', 'slicers', 'workers', '_status', "job_id"];
-        jobs_service.getJobs()
+        var size = 10000;
+
+        if (req.query.size && !isNaN(req.query.size) && req.query.size >= 0) {
+            size = req.query.size;
+        }
+
+        jobs_service.getJobs(null, null, size, '_updated:desc')
             .then(function(jobs) {
                 var tableStr = makeTable(req, defaults, jobs);
                 res.status(200).send(tableStr)

--- a/lib/cluster/services/api.js
+++ b/lib/cluster/services/api.js
@@ -171,14 +171,15 @@ module.exports = function(context, app, cluster_service, jobs_service) {
     });
 
     app.get('/txt/workers', function(req, res) {
+        var defaults = ['assignment', 'node_id', 'job_id', 'pid'];
         var workers = cluster_service.findAllWorkers();
 
-        var data = formatFields(req.query, workers);
-
-        res.status(200).send(Table.print(data))
+        var tableStr = makeTable(req, defaults, workers);
+        res.status(200).send(tableStr)
     });
 
     app.get('/txt/nodes', function(req, res) {
+        var defaults = ['node_id', 'hostname', 'total', 'active'];
         var nodes = cluster_service.getClusterState();
 
         var transform = _.map(nodes, function(node) {
@@ -187,21 +188,20 @@ module.exports = function(context, app, cluster_service, jobs_service) {
             return node;
         });
 
-        var data = formatFields(req.query, transform);
-
-        res.status(200).send(Table.print(data))
+        var tableStr = makeTable(req, defaults, transform);
+        res.status(200).send(tableStr)
     });
 
     app.get('/txt/jobs', function(req, res) {
         var defaults = ['name', 'lifecycle', 'slicers', 'workers', '_status', "job_id"];
         jobs_service.getJobs()
             .then(function(jobs) {
-                var data = formatFields(req.query, jobs, defaults);
-                res.status(200).send(Table.print(data))
+                var tableStr = makeTable(req, defaults, jobs);
+                res.status(200).send(tableStr)
             })
             .catch(function(err) {
                 //TODO decide how to log error
-                sendError(res, 500, "Could not access jobs");
+                sendError(res, 500, err.message);
             });
     });
 
@@ -215,7 +215,8 @@ module.exports = function(context, app, cluster_service, jobs_service) {
             'queued',
             'zero_slice_reduction',
             'processed',
-            'slicers'];
+            'slicers'
+        ];
 
         slicerStats()
             .then(function(results) {
@@ -226,38 +227,47 @@ module.exports = function(context, app, cluster_service, jobs_service) {
                     return slicer;
                 });
 
-                var data = formatFields(req.query, transform, defaults);
-                res.status(200).send(Table.print(data))
+                var tableStr = makeTable(req, defaults, transform);
+                res.status(200).send(tableStr)
+
             })
             .catch(function(err) {
                 sendError(res, err.code, err.message);
             })
-
     });
+
+    function makeTable(req, defaults, data) {
+        var query = fieldsQuery(req.query, defaults);
+        //used to create an empty table if there are no jobs
+        if (data.length === 0) {
+            data.push({})
+        }
+
+        return Table.print(data, function(item, cell) {
+            _.each(query, function(field) {
+                cell(field, item[field])
+            });
+        }, function(table) {
+            if (req.query.hasOwnProperty('headers') && req.query.headers === 'false') {
+                return table.print()
+            }
+            return table.toString()
+        });
+    }
 
     function fieldsQuery(query, defaults) {
         if (!query.fields) {
             return defaults ? defaults : [];
         }
         else {
-            return _.words(query.fields)
-        }
-    }
+            var results = _.words(query.fields);
 
-    var query = {};
-
-    function formatFields(query, data, defaults) {
-        var fields = fieldsQuery(query, defaults);
-
-        if (fields.length > 0) {
-            return _.map(data, function(results) {
-                return _.omitBy(results, function(value, key) {
-                    return !_.includes(fields, key)
-                })
-            })
-        }
-        else {
-            return data;
+            if (results.length === 0) {
+                return defaults
+            }
+            else {
+                return results;
+            }
         }
     }
 

--- a/lib/cluster/storage/jobs.js
+++ b/lib/cluster/storage/jobs.js
@@ -27,19 +27,19 @@ module.exports = function(context) {
         return backend.search(query, from, size);
     }
 
-    function getJobs(status, from, size) {
+    function getJobs(status, from, size, sort) {
         var query = '_status:*';
 
         if (status) query = '_status:' + status;
 
-        return backend.search(query, from, size);
+        return backend.search(query, from, size, sort);
     }
 
     function create(record) {
         // If this is a new job we'll need to allocate a new ID
-        if (! record.job_id) record.job_id = uuid.v4();
+        if (!record.job_id) record.job_id = uuid.v4();
         var date = new Date();
-        if (! record._created) record._created = date;
+        if (!record._created) record._created = date;
         record._updated = date;
 
         return backend.create(record)


### PR DESCRIPTION
this should deal with most of the txt api problems, one of the issues about submitting a job and it not showing up on the api might be a system problem since we stick it in the queue, and it waits in turn until it starts being initialized, which is how the jobAllocator works. 

jobs should be return sorted with the first one being the most recent job that has been updated

you can set headers=false if you do not want to see headers