### PR TITLE
Time resolution

### DIFF
--- a/lib/cluster/storage/backends/mappings/state.json
+++ b/lib/cluster/storage/backends/mappings/state.json
@@ -28,7 +28,11 @@
                 },
                 "@timestamp": {
                     "type": "date"
-                }
+                },
+                "error": {
+                    "type": "string",
+                    "index" : "not_analyzed"
+                },
             }
         }
     }

--- a/lib/cluster/storage/backends/mappings/state.json
+++ b/lib/cluster/storage/backends/mappings/state.json
@@ -32,7 +32,7 @@
                 "error": {
                     "type": "string",
                     "index" : "not_analyzed"
-                },
+                }
             }
         }
     }

--- a/lib/cluster/storage/state.js
+++ b/lib/cluster/storage/state.js
@@ -29,7 +29,8 @@ module.exports = function(context) {
         };
 
         if (error) {
-            record.error = error;
+            var errMsg = typeof error === 'string' ? error : JSON.stringify(error);
+            record.error = errMsg;
         }
 
         // This is necessary for recovery to find the latest slice.

--- a/lib/readers/elasticsearch_date_range/slicer.js
+++ b/lib/readers/elasticsearch_date_range/slicer.js
@@ -3,7 +3,9 @@ var moment = require('moment');
 var processInterval = require('./../../utils/elastic_utils').processInterval;
 var buildQuery = require('./../../utils/elastic_utils').buildQuery;
 var buildRangeQuery = require('./../../utils/elastic_utils').buildRangeQuery;
-var dateFormat = require('./../../utils/elastic_utils').dateFormat;
+var dateOptions = require('./../../utils/elastic_utils').dateOptions;
+var dateFormatMS = require('./../../utils/elastic_utils').dateFormat;
+var dateFormatS = require('./../../utils/elastic_utils').dateFormatSeconds;
 var parser = require('datemath-parser');
 var _ = require('lodash');
 var event = require('../../utils/events');
@@ -17,6 +19,10 @@ function newSlicer(context, job, retryData, client) {
     var jobConfig = job.jobConfig;
     var isPersistent = jobConfig.lifecycle === 'persistent';
     var slicers = [];
+
+    var time_resolution = dateOptions(opConfig.time_resolution);
+
+    var dateFormat = time_resolution === 'ms' ? dateFormatMS : dateFormatS;
 
     function checkElasticsearch(client, opConfig, logger) {
         return client.cluster.stats({}).then(function(data) {
@@ -136,6 +142,18 @@ function newSlicer(context, job, retryData, client) {
             });
     }
 
+    function splitTime(start, end) {
+        var diff = Math.floor(end.diff(start) / 2);
+
+        if (time_resolution === 'ms') {
+            return diff;
+        }
+        else {
+            var secondDiff = Math.floor(diff / 1000);
+            return secondDiff > 1 ? secondDiff : 1
+        }
+    }
+
     function determineSlice(client, config, dateParams, isExpandedSlice) {
         return getCount(config, dateParams).then(function(count) {
 
@@ -147,8 +165,8 @@ function newSlicer(context, job, retryData, client) {
                     clonedParams.start = moment(dateParams.end).subtract(dateParams.interval[0], dateParams.interval[1]);
 
                     //get diff from new start
-                    var diff = Math.floor(dateParams.end.diff(clonedParams.start) / 2);
-                    clonedParams.end = moment(clonedParams.start).add(diff, 'ms');
+                    var diff = splitTime(clonedParams.start, dateParams.end);
+                    clonedParams.end = moment(clonedParams.start).add(diff, time_resolution);
 
                     //return the zero range start with the correct end
                     return Promise.resolve(determineSlice(client, config, clonedParams, false))
@@ -158,11 +176,11 @@ function newSlicer(context, job, retryData, client) {
                 }
                 else {
                     //find difference in milliseconds and divide in half
-                    var diff = Math.floor(dateParams.end.diff(dateParams.start) / 2);
-                    var newEnd = moment(dateParams.start).add(diff, 'ms');
+                    var diff = splitTime(dateParams.start, dateParams.end);
+                    var newEnd = moment(dateParams.start).add(diff, time_resolution);
 
                     //prevent recursive call if difference is one millisecond
-                    if (diff < 2) {
+                    if (diff <= 1) {
                         return {start: dateParams.start, end: newEnd, count: count};
                     }
                     else {
@@ -314,6 +332,9 @@ function newSlicer(context, job, retryData, client) {
             results.push(rangeObj);
         }
 
+        //make sure that end of last segment is always correct
+        results[results.length - 1].end = end;
+
         return results;
     }
 
@@ -321,7 +342,7 @@ function newSlicer(context, job, retryData, client) {
         var end = processInterval(opConfig.interval);
         var delayInterval = processInterval(opConfig.delay);
 
-        var delayTime = getMilliseconds(end);
+        var delayTime = getMilliseconds(opConfig, end);
 
         var delayedEnd = moment().subtract(delayInterval[0], delayInterval[1]).format(dateFormat);
         var delayedStart = moment(delayedEnd).subtract(end[0], end[1]).format(dateFormat);
@@ -466,7 +487,17 @@ function newSlicer(context, job, retryData, client) {
                 var timeRangeMilliseconds = esDates.limit.diff(esDates.start);
                 var millisecondInterval = Math.floor(timeRangeMilliseconds / numOfSlices);
 
-                return [millisecondInterval, 'ms'];
+                if (time_resolution === 's') {
+                    var seconds = Math.floor(millisecondInterval / 1000);
+                    if (seconds < 1) {
+                        seconds = 1;
+                    }
+                    return [seconds, 's'];
+
+                }
+                else {
+                    return [millisecondInterval, 'ms'];
+                }
             });
         }
     }

--- a/lib/readers/elasticsearch_reader.js
+++ b/lib/readers/elasticsearch_reader.js
@@ -103,6 +103,19 @@ function schema() {
                     }
                 }
             }
+        },
+        time_resolution: {
+            doc: 'indicate if data reading has second or millisecond resolutions',
+            default: 'ms',
+            format: function(val) {
+                var obj = {
+                    seconds: 's', second: 's', s: 's',
+                    milliseconds: 'ms', millisecond: 'ms', ms: 'ms'
+                };
+                if (!obj[val]) {
+                    throw new Error('time_resolution for elasticsearch_reader must be set in either "s"[seconds] or "ms"[milliseconds]')
+                }
+            }
         }
     };
 }

--- a/lib/readers/elasticsearch_reader.js
+++ b/lib/readers/elasticsearch_reader.js
@@ -115,6 +115,9 @@ function schema() {
                 if (!obj[val]) {
                     throw new Error('time_resolution for elasticsearch_reader must be set in either "s"[seconds] or "ms"[milliseconds]')
                 }
+                else {
+                    return obj[val]
+                }
             }
         }
     };

--- a/lib/utils/elastic_utils.js
+++ b/lib/utils/elastic_utils.js
@@ -208,6 +208,9 @@ function filterResponse(logger, data, results) {
 //"2016-01-19T13:33:09.356-07:00"
 var dateFormat = "YYYY-MM-DDTHH:mm:ss.SSSZ";
 
+//2016-06-29T12:44:57-07:00
+var dateFormatSeconds = "YYYY-MM-DDTHH:mm:ssZ";
+
 module.exports = {
     dateOptions: dateOptions,
     processInterval: processInterval,
@@ -216,6 +219,7 @@ module.exports = {
     getSchema: getSchema,
     parsedSchema: parsedSchema,
     dateFormat: dateFormat,
+    dateFormatSeconds: dateFormatSeconds,
     logState: logState,
     filterResponse: filterResponse,
     warn: warn


### PR DESCRIPTION
new reader config parameter:  time_resolution ,  it defaults to 'ms', you can specify 's' or 'seconds' for second resolution