### PR TITLE
Id slicer

### DIFF
--- a/lib/cluster/slicer.js
+++ b/lib/cluster/slicer.js
@@ -226,7 +226,7 @@ module.exports = function(context) {
                     });
 
                 }).catch(function(err) {
-                    return Promise.reject('Error on slicer initialization: ' + err.stack)
+                    return Promise.reject('Error on slicer initialization: ' + JSON.stringify(err))
                 });
         }).catch(function(err) {
             logger.error(err);

--- a/lib/cluster/storage/backends/elasticsearch.js
+++ b/lib/cluster/storage/backends/elasticsearch.js
@@ -47,89 +47,109 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size)
     }
 
     function search(query, from, size, sort) {
-        return new Promise(function(resolve, reject) {
-            client.search({
-                index: index_name,
-                q: query,
-                from: from,
-                size: size,
-                sort: sort
-            }).then(function(results) {
-                if (results._shards.failed > 0) {
-                    var reasons = _.uniq(_.flatMap(results._shards.failures, function(shard) {
-                        return shard.reason.type
-                    }));
+        var esQuery = {
+            index: index_name,
+            from: from,
+            size: size,
+            sort: sort
+        };
 
-                    if (reasons.length > 1 || reasons[0] !== 'es_rejected_execution_exception') {
-                        var errorReason = reasons.join(' | ');
-                        logger.error(errorReason);
-                        reject(errorReason)
+        if (typeof query === 'string') {
+            esQuery.q = query
+        }
+        else {
+            esQuery.body = query
+        }
+
+        return new Promise(function(resolve, reject) {
+            client.search(esQuery)
+                .then(function(results) {
+                    if (results._shards.failed > 0) {
+                        var reasons = _.uniq(_.flatMap(results._shards.failures, function(shard) {
+                            return shard.reason.type
+                        }));
+
+                        if (reasons.length > 1 || reasons[0] !== 'es_rejected_execution_exception') {
+                            var errorReason = reasons.join(' | ');
+                            logger.error(errorReason);
+                            reject(errorReason)
+                        }
+                        else {
+                            // Spot to recurse in the future, will reject for now
+                            var errorReason = reasons.join(' | ');
+                            logger.error(errorReason);
+                            reject(errorReason)
+                        }
                     }
                     else {
-                        // Spot to recurse in the future, will reject for now
-                        var errorReason = reasons.join(' | ');
-                        logger.error(errorReason);
-                        reject(errorReason)
-                    }
-                }
-                else {
-                    var final = _.map(results.hits.hits, function(hit) {
-                        return hit._source
-                    });
+                        var final = _.map(results.hits.hits, function(hit) {
+                            return hit._source
+                        });
 
-                    resolve(final)
-                }
-            }).catch(function(err) {
-                logger.error(err.body.error.type);
-                reject(err.body.error.type)
-            });
+                        resolve(final)
+                    }
+                })
+                .catch(function(err) {
+                    logger.error(err.body.error.type);
+                    reject(err.body.error.type)
+                });
         });
     }
 
     function count(query, from, sort) {
-        return new Promise(function(resolve, reject) {
-            client.search({
-                index: index_name,
-                q: query,
-                from: from,
-                sort: sort,
-                size: 0
-            }).then(function(results) {
-                if (results._shards.failed > 0) {
-                    var reasons = _.uniq(_.flatMap(results._shards.failures, function(shard) {
-                        return shard.reason.type
-                    }));
+        var esQuery = {
+            index: index_name,
+            from: from,
+            size: 0,
+            sort: sort
+        };
 
-                    if (reasons.length > 1 || reasons[0] !== 'es_rejected_execution_exception') {
-                        var errorReason = reasons.join(' | ');
-                        logger.error(errorReason);
-                        reject(errorReason)
+        if (typeof query === 'string') {
+            esQuery.q = query
+        }
+        else {
+            esQuery.body = query
+        }
+
+        return new Promise(function(resolve, reject) {
+            client.search(esQuery)
+                .then(function(results) {
+                    if (results._shards.failed > 0) {
+                        var reasons = _.uniq(_.flatMap(results._shards.failures, function(shard) {
+                            return shard.reason.type
+                        }));
+
+                        if (reasons.length > 1 || reasons[0] !== 'es_rejected_execution_exception') {
+                            var errorReason = reasons.join(' | ');
+                            logger.error(errorReason);
+                            reject(errorReason)
+                        }
+                        else {
+                            // Spot to recurse in the future, will reject for now
+                            var errorReason = reasons.join(' | ');
+                            logger.error(errorReason);
+                            reject(errorReason)
+                        }
                     }
                     else {
-                        // Spot to recurse in the future, will reject for now
-                        var errorReason = reasons.join(' | ');
-                        logger.error(errorReason);
-                        reject(errorReason)
+                        resolve(results.hits.total)
                     }
-                }
-                else {
-                    resolve(results.hits.total)
-                }
-            }).catch(function(err) {
-                if (err.body.error.type === 'reduce_search_phase_exception') {
-                    var retriableError = _.every(err.body.error.root_cause, function(shard) {
-                        return shard.type === 'es_rejected_execution_exception';
-                    });
-                    //scaffolding for retries, just reject for now                
-                    if (retriableError) {
+                })
+                .catch(function(err) {
+                    if (err.body.error.type === 'reduce_search_phase_exception') {
+                        var retriableError = _.every(err.body.error.root_cause, function(shard) {
+                            return shard.type === 'es_rejected_execution_exception';
+                        });
+                        //scaffolding for retries, just reject for now                
+                        if (retriableError) {
+                            reject(err.body.error.type)
+                        }
+                    }
+                    else {
+                        logger.error(err.body.error.type);
                         reject(err.body.error.type)
                     }
-                }
-                else {
-                    logger.error(err.body.error.type);
-                    reject(err.body.error.type)
-                }
-            });
+                });
         });
     }
 

--- a/lib/cluster/worker.js
+++ b/lib/cluster/worker.js
@@ -18,7 +18,7 @@ module.exports = function(context) {
     var isShuttingDown = false;
 
     var ID = context.sysconfig.teraslice.hostname + "__" + context.cluster.worker.id;
-
+    var logMessage = makeLog();
     var analytics_store;
     var job_runner, job;
 
@@ -66,7 +66,7 @@ module.exports = function(context) {
             isDone = false;
             //getting a slice means the previous message was handled
             sentMessage = false;
-            logger.info('Worker: '+ ID + ' has received slice: ' + msg.data.slice_id)
+            logger.info('Worker: ' + ID + ' has received slice: ' + msg.data.slice_id)
             runSlice(msg.data);
         });
 
@@ -121,7 +121,7 @@ module.exports = function(context) {
                                     });
                             }
 
-                            return logAnalytics(msg, specData)
+                            return logMessage(msg, specData)
                         }
                     }
                     else {
@@ -229,34 +229,19 @@ module.exports = function(context) {
 
     }
 
-    function logMessage(msg) {
-        console.log('whats the msg');
-        if (msg.start && msg.end && msg.key) {
-            logger.info('Worker: ' + ID + ' , pid: ' + process.pid + ' has processed: ' + msg.start +
-                ' : ' + msg.end + ' key: ' + msg.key);
+    function makeLog() {
+        var str = 'Worker: ' + ID + ' , pid: ' + process.pid + ' has processed: ';
+        return function(msg, specData) {
+            var dataStr = '';
+            _.forOwn(msg, function(value, key) {
+                dataStr += key + ' : ' + value + ' ';
+            });
 
-        }
-        else if (msg.start && msg.end) {
-            logger.info('Worker: ' + ID + ' , pid: ' + process.pid + ' has processed: ' + msg.start +
-                ' : ' + msg.end);
-        }
-        else {
-            logger.info('Worker: ' + ID + ' , pid: ' + process.pid + ' has processed: ' + msg)
-        }
-    }
+            _.forOwn(specData, function(value, key) {
+                dataStr += key + ' : ' + value + ' ';
+            });
 
-    function logAnalytics(msg, specData) {
-        if (msg.start && msg.end && msg.key) {
-            logger.info('Worker: ' + ID + ' , pid: ' + process.pid + ' has processed: ' + msg.start +
-                ' : ' + msg.end + ' key: ' + msg.key + ' time completion ' + specData.time + ' size: ' + specData.size)
-        }
-        else if (msg.start && msg.end) {
-            logger.info('Worker: ' + ID + ' , pid: ' + process.pid + ' has processed: ' + msg.start +
-                ' : ' + msg.end + ' time completion ' + specData.time + ' size: ' + specData.size)
-        }
-        else {
-            logger.info('Worker: ' + ID + ' , pid: ' + process.pid + ' has processed: ' + msg +
-                ' time completion ' + specData.time + ' size: ' + specData.size)
+            logger.info(str + dataStr);
         }
     }
 

--- a/lib/readers/elasticsearch_date_range/reader.js
+++ b/lib/readers/elasticsearch_date_range/reader.js
@@ -6,74 +6,44 @@ var _ = require('lodash');
 function newReader(context, opConfig, jobConfig, client) {
     var logger = jobConfig.logger;
 
-    if (opConfig.full_response) {
-        return function(msg) {
+    return function(msg) {
+        return new Promise(function(resolve, reject) {
             var query = buildQuery(opConfig, msg);
-            return new Promise(function(resolve, reject) {
-                client.search(query)
-                    .then(function(data) {
-                        if (data._shards.failed > 0) {
-                            var reasons = _.uniq(_.flatMap(data._shards.failures, function(shard) {
-                                return shard.reason.type
-                            }));
 
-                            if (reasons.length > 1 || reasons[0] !== 'es_rejected_execution_exception') {
-                                var errorReason = reasons.join(' | ');
-                                logger.error('Not all shards returned successful, shard errors: ', errorReason);
-                                reject(errorReason)
-                            }
-                            else {
-                                // Spot to recurse in the future, will reject for now
-                                var errorReason = reasons.join(' | ');
-                                logger.error('Not all shards returned successful, shard errors: ', errorReason);
-                                reject(errorReason)
-                            }
-                        }
-                        else {
-                            resolve(data)
-                        }
-                    }).catch(function(err) {
-                    logger.error(err.body.error.type);
-                    reject(err.body.error.type)
-                });
-            })
-        }
-    }
-    else {
-        return function(msg) {
-            return new Promise(function(resolve, reject) {
-                var query = buildQuery(opConfig, msg);
+            client.search(query).then(function(data) {
+                if (data._shards.failed > 0) {
+                    var reasons = _.uniq(_.flatMap(data._shards.failures, function(shard) {
+                        return shard.reason.type
+                    }));
 
-                client.search(query).then(function(data) {
-                    if (data._shards.failed > 0) {
-                        var reasons = _.uniq(_.flatMap(data._shards.failures, function(shard) {
-                            return shard.reason.type
-                        }));
-
-                        if (reasons.length > 1 || reasons[0] !== 'es_rejected_execution_exception') {
-                            var errorReason = reasons.join(' | ');
-                            logger.error('Not all shards returned successful, shard errors: ', errorReason);
-                            reject(errorReason)
-                        }
-                        else {
-                            // Spot to recurse in the future, will reject for now
-                            var errorReason = reasons.join(' | ');
-                            logger.error('Not all shards returned successful, shard errors: ', errorReason);
-                            reject(errorReason)
-                        }
+                    if (reasons.length > 1 || reasons[0] !== 'es_rejected_execution_exception') {
+                        var errorReason = reasons.join(' | ');
+                        logger.error('Not all shards returned successful, shard errors: ', errorReason);
+                        reject(errorReason)
+                    }
+                    else {
+                        // Spot to recurse in the future, will reject for now
+                        var errorReason = reasons.join(' | ');
+                        logger.error('Not all shards returned successful, shard errors: ', errorReason);
+                        reject(errorReason)
+                    }
+                }
+                else {
+                    if (opConfig.full_response) {
+                        resolve(data)
                     }
                     else {
                         resolve(_.map(data.hits.hits, function(hit) {
                             return hit._source
                         }));
                     }
-                }).catch(function(err) {
-                    var errMsg = JSON.stringify(err);
-                    logger.error(errMsg);
-                    reject(errMsg)
-                });
-            })
-        }
+                }
+            }).catch(function(err) {
+                var errMsg = JSON.stringify(err);
+                logger.error(errMsg);
+                reject(errMsg)
+            });
+        })
     }
 }
 

--- a/lib/readers/elasticsearch_date_range/slicer.js
+++ b/lib/readers/elasticsearch_date_range/slicer.js
@@ -1,18 +1,18 @@
 var Promise = require('bluebird');
 var moment = require('moment');
+var parser = require('datemath-parser');
+var _ = require('lodash');
 var processInterval = require('./../../utils/elastic_utils').processInterval;
 var buildQuery = require('./../../utils/elastic_utils').buildQuery;
 var buildRangeQuery = require('./../../utils/elastic_utils').buildRangeQuery;
 var dateOptions = require('./../../utils/elastic_utils').dateOptions;
 var dateFormatMS = require('./../../utils/elastic_utils').dateFormat;
 var dateFormatS = require('./../../utils/elastic_utils').dateFormatSeconds;
-var parser = require('datemath-parser');
-var _ = require('lodash');
+var getKeyArray = require('../../utils/id_utils').getKeyArray;
+var swapLastTwo = require('../../utils/id_utils').swapLastTwo;
+var transformIds = require('../../utils/id_utils').transformIds;
 var event = require('../../utils/events');
 
-var base64url = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w',
-    'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
-    'Y', 'Z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '\-', '_'];
 
 function newSlicer(context, job, retryData, client) {
     var opConfig = job.readerConfig;
@@ -221,23 +221,18 @@ function newSlicer(context, job, retryData, client) {
             })
     }
 
-    function swapLastTwo(str) {
-        var last = str.charAt(str.length - 1);
-        var secondToLast = str.charAt(str.length - 2);
-
-        return str.slice(0, -2) + last + secondToLast
-    }
-
     function makeKeyList(opConfig, data) {
         var multiplier = opConfig.subslice_key_multiplier;
         var results = [];
+        var keyArray = getKeyArray(opConfig);
+        var transformedKeyArray = transformIds(opConfig, keyArray);
 
         function recurse(arr) {
             return Promise.all(arr.map(function(key) {
                     return getCount(opConfig, data, key)
                         .then(function(count) {
                             if (count >= opConfig.size * multiplier) {
-                                return recurse(base64url.map(function(str) {
+                                return recurse(keyArray.map(function(str) {
                                     return swapLastTwo(key + str)
                                 }))
                             }
@@ -256,11 +251,10 @@ function newSlicer(context, job, retryData, client) {
             );
         }
 
-        return recurse(base64url.map(function(key) {
-            return opConfig.type + '#' + key + '*'
-        })).then(function() {
-            return results;
-        });
+        return recurse(transformedKeyArray)
+            .then(function() {
+                return results;
+            });
     }
 
     function nextChunk(opConfig, client, jobConfig, dates, retryData) {

--- a/lib/readers/elasticsearch_reader.js
+++ b/lib/readers/elasticsearch_reader.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var getClient = require('../utils/config').getClient;
 
 var parallelSlicers = true;
@@ -119,6 +121,11 @@ function schema() {
                     return obj[val]
                 }
             }
+        },
+        key_type: {
+            doc: 'The type of id used in index',
+            default: 'base64url',
+            format: ['base64url', 'hexadecimal']
         }
     };
 }

--- a/lib/readers/id_reader.js
+++ b/lib/readers/id_reader.js
@@ -129,7 +129,7 @@ function newSlicer(context, job, retryData) {
 
         function recurse(array, str, n) {
             if (str.length === n) {
-                idQueue.enqueue(opConfig.type + '#' + str + '*');
+                idQueue.enqueue({key: opConfig.type + '#' + str + '*'});
                 return
             }
             else {
@@ -165,7 +165,9 @@ function newSlicer(context, job, retryData) {
         slicerFn = buildKeys(keyArray, baseKeyArray, opConfig.key_depth)
     }
 
-    slicers.push(slicerFn);
+    for (var i = 0; i < job.jobConfig.slicers; i++) {
+        slicers.push(slicerFn);
+    }
 
     return Promise.resolve(slicers);
 }

--- a/lib/readers/id_reader.js
+++ b/lib/readers/id_reader.js
@@ -1,0 +1,255 @@
+'use strict';
+
+var Promise = require('bluebird');
+var _ = require('lodash');
+var base64url = require('../utils/id_utils').base64url;
+var hexadecimal = require('../utils/id_utils').hexadecimal;
+var swapLastTwo = require('../utils/id_utils').swapLastTwo;
+var getClient = require('../utils/config').getClient;
+var emitter = require('../utils/events');
+var Queue = require('../utils/queue');
+
+var idQueue = new Queue();
+
+var parallelSlicers = false;
+
+function newSlicer(context, job, retryData) {
+    var opConfig = job.readerConfig;
+    var logger = context.logger;
+     var client = getClient(context, opConfig, 'elasticsearch');
+    var slicers = [];
+
+    function recurseID(keyArray) {
+        var transformed = transformIds(opConfig, keyArray);
+
+        function recurse(arr) {
+            return Promise.all(_.map(arr, function(key) {
+                    var query = {
+                        index: opConfig.index,
+                        size: 0,
+                        body: {
+                            query: {
+                                wildcard: {
+                                    _uid: key
+                                }
+                            }
+                        }
+                    };
+
+                    return getCountForKey(query)
+                        .then(function(count) {
+                            console.log('should be running', count, key);
+
+                            if (count >= opConfig.size) {
+                                return recurse(_.map(keyArray, function(str) {
+                                    return swapLastTwo(key + str)
+                                }));
+                            }
+                            else {
+                                if (count !== 0) {
+                                    var data = {count: count, key: key};
+                                    emitter.emit('data', data);
+                                }
+                            }
+                        })
+                        .catch(function(err) {
+                            console.log('what to do here in error catch of recurseID', err);
+                        })
+                })
+            )
+        }
+
+        return recurse(transformed)
+    }
+
+    function getID(keyArray) {
+        var isDone = false;
+        //TODO need to make this unique
+        emitter.on('data', function(data) {
+            idQueue.push(data)
+        });
+
+        recurseID(keyArray)
+            .then(function() {
+                isDone = true;
+            });
+
+        return function() {
+            return new Promise(function(resolve, reject) {
+                var interval = setInterval(function() {
+                    if (idQueue.size()) {
+                        clearInterval(interval);
+                        resolve(idQueue.dequeue())
+                    }
+                    else {
+                        if (isDone) {
+                            clearInterval(interval);
+                            resolve(null);
+                        }
+                    }
+                }, 50)
+
+            });
+        }
+
+    }
+
+
+//duplicate
+    function getCountForKey(query) {
+        return new Promise(function(resolve, reject) {
+            client.search(query)
+                .then(function(results) {
+                    if (results._shards.failed > 0) {
+                        var reasons = _.uniq(_.flatMap(results._shards.failures, function(shard) {
+                            return shard.reason.type
+                        }));
+
+                        if (reasons.length > 1 || reasons[0] !== 'es_rejected_execution_exception') {
+                            var errorReason = reasons.join(' | ');
+                            logger.error(errorReason);
+                            reject(errorReason)
+                        }
+                        else {
+                            // Spot to recurse in the future, will reject for now
+                            var errorReason = reasons.join(' | ');
+                            logger.error(errorReason);
+                            reject(errorReason)
+                        }
+                    }
+                    else {
+                        resolve(results.hits.total)
+                    }
+                }).catch(function(err) {
+                var errMsg = JSON.stringify(err);
+                logger.error(errMsg);
+                reject(errMsg)
+            });
+        })
+    }
+
+    function transformIds(opConfig, arr) {
+        return arr.map(function(key) {
+            return opConfig.type + '#' + key + '*'
+        })
+    }
+
+    function getKeyArray(opConfig) {
+        if (opConfig.key_type === 'base64url') {
+            return  base64url;
+        }
+        else {
+            return hexadecimal;
+        }
+    }
+
+    slicers.push(getID(getKeyArray(opConfig)));
+
+    return Promise.resolve(slicers);
+}
+
+
+function newReader(context, opConfig, jobConfig) {
+    var client = getClient(context, opConfig, 'elasticsearch');
+    var logger = context.logger;
+
+    return function(msg) {
+        var query = {
+            index: opConfig.index,
+            size: msg.count,
+            body: {
+                query: {
+                    wildcard: {
+                        _uid: msg.key
+                    }
+                }
+            }
+        };
+        //Duplicate
+        return new Promise(function(resolve, reject) {
+            client.search(query)
+                .then(function(data) {
+                    if (data._shards.failed > 0) {
+                        var reasons = _.uniq(_.flatMap(data._shards.failures, function(shard) {
+                            return shard.reason.type
+                        }));
+
+                        if (reasons.length > 1 || reasons[0] !== 'es_rejected_execution_exception') {
+                            var errorReason = reasons.join(' | ');
+                            logger.error('Not all shards returned successful, shard errors: ', errorReason);
+                            reject(errorReason)
+                        }
+                        else {
+                            // Spot to recurse in the future, will reject for now
+                            var errorReason = reasons.join(' | ');
+                            logger.error('Not all shards returned successful, shard errors: ', errorReason);
+                            reject(errorReason)
+                        }
+                    }
+                    else {
+                        if (opConfig.full_response) {
+                            resolve(data)
+                        }
+                        else {
+                            resolve(_.map(data.hits.hits, function(hit) {
+                                return hit._source
+                            }));
+                        }
+                    }
+                }).catch(function(err) {
+                var errMsg = JSON.stringify(err);
+                logger.error(errMsg);
+                reject(errMsg)
+            });
+        })
+    }
+
+}
+
+function schema() {
+    return {
+        index: {
+            doc: 'Which index to read from',
+            default: '',
+            format: 'required_String'
+
+        },
+        type: {
+            doc: 'type of the document in the index, used for key searches',
+            default: '',
+            format: 'required_String'
+        },
+        size: {
+            doc: 'The limit to the number of docs pulled in a chunk, if the number of docs retrieved ' +
+            'by the interval exceeds this number, it will cause the function to recurse to provide a smaller batch',
+            default: 10000,
+            format: function(val) {
+                if (isNaN(val)) {
+                    throw new Error('size parameter for elasticsearch_reader must be a number')
+                }
+                else {
+                    if (val <= 0) {
+                        throw new Error('size parameter for elasticsearch_reader must be greater than zero')
+                    }
+                }
+            }
+        },
+        full_response: {
+            doc: 'Set to true to receive the full Elasticsearch query response including index metadata.',
+            default: false,
+            format: Boolean
+        },
+        key_type: {
+            doc: 'The type of id used in index',
+            default: 'base64url',
+            format: ['base64url', 'hexadecimal']
+        }
+    };
+}
+
+module.exports = {
+    newReader: newReader,
+    newSlicer: newSlicer,
+    schema: schema,
+    parallelSlicers: parallelSlicers
+};

--- a/lib/readers/id_reader.js
+++ b/lib/readers/id_reader.js
@@ -2,9 +2,9 @@
 
 var Promise = require('bluebird');
 var _ = require('lodash');
-var base64url = require('../utils/id_utils').base64url;
-var hexadecimal = require('../utils/id_utils').hexadecimal;
 var swapLastTwo = require('../utils/id_utils').swapLastTwo;
+var getKeyArray = require('../utils/id_utils').getKeyArray;
+var transformIds = require('../utils/id_utils').transformIds;
 var getClient = require('../utils/config').getClient;
 var emitter = require('../utils/events');
 var Queue = require('../utils/queue');
@@ -128,20 +128,8 @@ function newSlicer(context, job, retryData) {
         })
     }
 
-    function transformIds(opConfig, arr) {
-        return arr.map(function(key) {
-            return opConfig.type + '#' + key + '*'
-        })
-    }
-
-    function getKeyArray(opConfig) {
-        if (opConfig.key_type === 'base64url') {
-            return  base64url;
-        }
-        else {
-            return hexadecimal;
-        }
-    }
+    
+    
 
     slicers.push(getID(getKeyArray(opConfig)));
 

--- a/lib/readers/id_reader.js
+++ b/lib/readers/id_reader.js
@@ -16,10 +16,10 @@ var parallelSlicers = false;
 function newSlicer(context, job, retryData) {
     var opConfig = job.readerConfig;
     var logger = context.logger;
-     var client = getClient(context, opConfig, 'elasticsearch');
+    var client = getClient(context, opConfig, 'elasticsearch');
     var slicers = [];
 
-    function recurseID(keyArray) {
+    function recurseID(keyArray, baseArray) {
         var transformed = transformIds(opConfig, keyArray);
 
         function recurse(arr) {
@@ -38,10 +38,8 @@ function newSlicer(context, job, retryData) {
 
                     return getCountForKey(query)
                         .then(function(count) {
-                            console.log('should be running', count, key);
-
                             if (count >= opConfig.size) {
-                                return recurse(_.map(keyArray, function(str) {
+                                return recurse(_.map(baseArray, function(str) {
                                     return swapLastTwo(key + str)
                                 }));
                             }
@@ -53,7 +51,7 @@ function newSlicer(context, job, retryData) {
                             }
                         })
                         .catch(function(err) {
-                            console.log('what to do here in error catch of recurseID', err);
+                            return Promise.reject('Error in getCountForKey: ' + JSON.stringify(err))
                         })
                 })
             )
@@ -62,14 +60,14 @@ function newSlicer(context, job, retryData) {
         return recurse(transformed)
     }
 
-    function getID(keyArray) {
+    function getID(keyArray, baseArray) {
         var isDone = false;
         //TODO need to make this unique
         emitter.on('data', function(data) {
-            idQueue.push(data)
+            idQueue.enqueue(data)
         });
 
-        recurseID(keyArray)
+        recurseID(keyArray, baseArray)
             .then(function() {
                 isDone = true;
             });
@@ -94,8 +92,7 @@ function newSlicer(context, job, retryData) {
 
     }
 
-
-//duplicate
+    //duplicate
     function getCountForKey(query) {
         return new Promise(function(resolve, reject) {
             client.search(query)
@@ -128,10 +125,20 @@ function newSlicer(context, job, retryData) {
         })
     }
 
-    
-    
+    var keyRange = opConfig.key_range;
+    var baseKeyArray = getKeyArray(opConfig);
 
-    slicers.push(getID(getKeyArray(opConfig)));
+    if (keyRange) {
+        if (_.difference(keyRange, baseKeyArray).length > 0) {
+            return Promise.reject('key_range specified for id_reader contains keys not found in: ' + opConfig.key_type)
+        }
+        else {
+            slicers.push(getID(keyRange, baseKeyArray));
+        }
+    }
+    else {
+        slicers.push(getID(baseKeyArray, baseKeyArray));
+    }
 
     return Promise.resolve(slicers);
 }
@@ -208,8 +215,7 @@ function schema() {
             format: 'required_String'
         },
         size: {
-            doc: 'The limit to the number of docs pulled in a chunk, if the number of docs retrieved ' +
-            'by the interval exceeds this number, it will cause the function to recurse to provide a smaller batch',
+            doc: 'The keys will attempt to recurse until the chunk will be <= size',
             default: 10000,
             format: function(val) {
                 if (isNaN(val)) {
@@ -231,6 +237,17 @@ function schema() {
             doc: 'The type of id used in index',
             default: 'base64url',
             format: ['base64url', 'hexadecimal']
+        },
+        key_range: {
+            doc: 'if provided, slicer will only recurse on these given keys',
+            default: null,
+            format: function(val) {
+                if (val) {
+                    if (!_.isArray(val) && val.length === 0) {
+                        throw new Error('key_range for id_reader must be an array with length > 0')
+                    }
+                }
+            }
         }
     };
 }

--- a/lib/readers/id_reader.js
+++ b/lib/readers/id_reader.js
@@ -125,20 +125,47 @@ function newSlicer(context, job, retryData) {
         })
     }
 
+    function buildKeys(keyArray, baseArray) {
+
+        function recurse(array, str, n) {
+            if (str.length === n) {
+                idQueue.enqueue(opConfig.type + '#' + str + '*');
+                return
+            }
+            else {
+                for (var i = 0; i < array.length; i++) {
+                    recurse(array, str + array[i], n)
+                }
+            }
+        }
+
+        keyArray.forEach(function(key) {
+            recurse(baseArray, key, opConfig.key_depth);
+        });
+
+        return function() {
+            return idQueue.dequeue();
+        }
+    }
+
     var keyRange = opConfig.key_range;
     var baseKeyArray = getKeyArray(opConfig);
+    var keyArray = opConfig.key_range ? opConfig.key_range : baseKeyArray;
 
-    if (keyRange) {
-        if (_.difference(keyRange, baseKeyArray).length > 0) {
-            return Promise.reject('key_range specified for id_reader contains keys not found in: ' + opConfig.key_type)
-        }
-        else {
-            slicers.push(getID(keyRange, baseKeyArray));
-        }
+    if (_.difference(keyRange, baseKeyArray).length > 0) {
+        return Promise.reject('key_range specified for id_reader contains keys not found in: ' + opConfig.key_type)
+    }
+
+    var slicerFn;
+
+    if (opConfig.verify_count) {
+        slicerFn = getID(keyRange, baseKeyArray)
     }
     else {
-        slicers.push(getID(baseKeyArray, baseKeyArray));
+        slicerFn = buildKeys(keyArray, baseKeyArray, opConfig.key_depth)
     }
+
+    slicers.push(slicerFn);
 
     return Promise.resolve(slicers);
 }
@@ -151,7 +178,7 @@ function newReader(context, opConfig, jobConfig) {
     return function(msg) {
         var query = {
             index: opConfig.index,
-            size: msg.count,
+            size: msg.count || 200000,
             body: {
                 query: {
                     wildcard: {
@@ -219,11 +246,11 @@ function schema() {
             default: 10000,
             format: function(val) {
                 if (isNaN(val)) {
-                    throw new Error('size parameter for elasticsearch_reader must be a number')
+                    throw new Error('size parameter for id_reader must be a number')
                 }
                 else {
                     if (val <= 0) {
-                        throw new Error('size parameter for elasticsearch_reader must be greater than zero')
+                        throw new Error('size parameter for id_reader must be greater than zero')
                     }
                 }
             }
@@ -245,6 +272,25 @@ function schema() {
                 if (val) {
                     if (!_.isArray(val) && val.length === 0) {
                         throw new Error('key_range for id_reader must be an array with length > 0')
+                    }
+                }
+            }
+        },
+        verify_count: {
+            doc: 'check against elasticsearch to make sure keys have the right slice size',
+            default: true,
+            format: Boolean
+        },
+        key_depth: {
+            doc: 'used if verify_count is false, generates keys lengths equal to this number',
+            default: 5,
+            format: function(val) {
+                if (isNaN(val)) {
+                    throw new Error('key_depth parameter for id_reader must be a number')
+                }
+                else {
+                    if (val <= 0) {
+                        throw new Error('key_depth parameter for id_reader must be greater than zero')
                     }
                 }
             }

--- a/lib/utils/id_utils.js
+++ b/lib/utils/id_utils.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/lib/utils/id_utils.js
+++ b/lib/utils/id_utils.js
@@ -4,7 +4,7 @@ var base64url = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'
     'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
     'Y', 'Z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '\-', '_'];
 
-var hexadecimal = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9','A', 'B', 'C', 'D', 'E', 'F'];
+var hexadecimal = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'];
 
 
 function swapLastTwo(str) {
@@ -14,43 +14,25 @@ function swapLastTwo(str) {
     return str.slice(0, -2) + last + secondToLast
 }
 
-function makeKeyList(opConfig, data) {
-    var multiplier = opConfig.subslice_key_multiplier;
-    var results = [];
-
-    function recurse(arr) {
-        return Promise.all(arr.map(function(key) {
-                return getCount(opConfig, data, key)
-                    .then(function(count) {
-                        if (count >= opConfig.size * multiplier) {
-                            return recurse(base64url.map(function(str) {
-                                return swapLastTwo(key + str)
-                            }))
-                        }
-                        else {
-                            if (count !== 0) {
-                                results.push({
-                                    start: data.start.format(dateFormat),
-                                    end: data.end.format(dateFormat),
-                                    count: count,
-                                    key: key
-                                });
-                            }
-                        }
-                    })
-            })
-        );
+function getKeyArray(opConfig) {
+    if (opConfig.key_type === 'base64url') {
+        return base64url;
     }
+    else {
+        return hexadecimal;
+    }
+}
 
-    return recurse(base64url.map(function(key) {
+function transformIds(opConfig, arr) {
+    return arr.map(function(key) {
         return opConfig.type + '#' + key + '*'
-    })).then(function() {
-        return results;
-    });
+    })
 }
 
 module.exports = {
     base64url: base64url,
     hexadecimal: hexadecimal,
-    swapLastTwo: swapLastTwo
+    getKeyArray: getKeyArray,
+    swapLastTwo: swapLastTwo,
+    transformIds: transformIds
 };

--- a/lib/utils/id_utils.js
+++ b/lib/utils/id_utils.js
@@ -24,9 +24,15 @@ function getKeyArray(opConfig) {
 }
 
 function transformIds(opConfig, arr) {
-    return arr.map(function(key) {
-        return opConfig.type + '#' + key + '*'
-    })
+    var results = new Array(arr.length);
+    var counter = 0;
+
+    while (arr.length) {
+        results[counter] = opConfig.type + '#' + arr.pop() + '*';
+        counter++
+    }
+
+    return results;
 }
 
 module.exports = {

--- a/lib/utils/id_utils.js
+++ b/lib/utils/id_utils.js
@@ -1,1 +1,56 @@
 'use strict';
+
+var base64url = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w',
+    'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
+    'Y', 'Z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '\-', '_'];
+
+var hexadecimal = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9','A', 'B', 'C', 'D', 'E', 'F'];
+
+
+function swapLastTwo(str) {
+    var last = str.charAt(str.length - 1);
+    var secondToLast = str.charAt(str.length - 2);
+
+    return str.slice(0, -2) + last + secondToLast
+}
+
+function makeKeyList(opConfig, data) {
+    var multiplier = opConfig.subslice_key_multiplier;
+    var results = [];
+
+    function recurse(arr) {
+        return Promise.all(arr.map(function(key) {
+                return getCount(opConfig, data, key)
+                    .then(function(count) {
+                        if (count >= opConfig.size * multiplier) {
+                            return recurse(base64url.map(function(str) {
+                                return swapLastTwo(key + str)
+                            }))
+                        }
+                        else {
+                            if (count !== 0) {
+                                results.push({
+                                    start: data.start.format(dateFormat),
+                                    end: data.end.format(dateFormat),
+                                    count: count,
+                                    key: key
+                                });
+                            }
+                        }
+                    })
+            })
+        );
+    }
+
+    return recurse(base64url.map(function(key) {
+        return opConfig.type + '#' + key + '*'
+    })).then(function() {
+        return results;
+    });
+}
+
+module.exports = {
+    base64url: base64url,
+    hexadecimal: hexadecimal,
+    swapLastTwo: swapLastTwo
+};


### PR DESCRIPTION
made a few improvements by removing duplicated code, still more to do on this front

elasticsearch_reader now has a opConfig parameter of key_type, defaults to base64url, used to determine which type of key should the recursive key algorithm should use.

 id_reader  example config: {
        index: {
        },
        type: {
        },
        size: {
            doc: 'The keys will attempt to recurse until the chunk will be <= size',
            default: 10000
        },
        full_response: {
            default: false,
        },
        key_type: {
            doc: 'The type of id used in index',
            default: 'base64url',
            format: ['base64url', 'hexadecimal']
        },
        key_range: {
            doc: 'if provided, slicer will only recurse on these given keys',
            default: null,   // [ 'A', '3']
            }
      verify_count: {
            doc: 'check against elasticsearch to make sure keys have the right slice size',
            default: true,
        },
        key_depth: {
            doc: 'used if verify_count is false, generates keys lengths equal to this number',
            default: 5   
    };
 }

can work with multiple slicers

can generate all ranges of keys without counting if you set verify_count to false

also recovery does not quite work right, will need some changes to worker if we want it

future considerations are to add a timer on when it recurses so that it doesnt overwhelm elasticsearch