### PR TITLE
made sure queue order is maintained or restart resolves #334

### DIFF
--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -378,7 +378,6 @@ module.exports = function(context, cluster_service) {
         })
             .then(function() {
                 // Loads the initial pending jobs queue from storage.
-                // Currently this will not preserve the order. => maybe do it by timestamp if need order
                 return getExecutionContexts('pending', null, 10000, '_created:asc')
                     .each(function(job_spec) {
                         pendingExecutionQueue.enqueue(job_spec);

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -379,12 +379,20 @@ module.exports = function(context, cluster_service) {
             .then(function() {
                 // Loads the initial pending jobs queue from storage.
                 // Currently this will not preserve the order. => maybe do it by timestamp if need order
-                return getExecutionContexts('pending')
+                return getExecutionContexts('pending', null, 10000, '_created:asc')
                     .each(function(job_spec) {
                         pendingExecutionQueue.enqueue(job_spec);
                     })
                     .then(function() {
-                        logger.info(`Pending jobs initialization complete.`);
+                        let queueSize = pendingExecutionQueue.size();
+                        
+                        if (queueSize > 0) {
+                            logger.info(`Jobs queue initialization complete, ${pendingExecutionQueue.size()} pending jobs have been enqueued`);
+                        }
+                        else {
+                            logger.info(`Jobs queue initialization complete`);
+                        }
+
                         var allocateJobs = jobAllocator();
                         pendingJobsScheduler = setInterval(function() {
                             allocateJobs();

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -378,6 +378,7 @@ module.exports = function(context, cluster_service) {
         })
             .then(function() {
                 // Loads the initial pending jobs queue from storage.
+                // the limit for retrieving pending jobs is 10000
                 return getExecutionContexts('pending', null, 10000, '_created:asc')
                     .each(function(job_spec) {
                         pendingExecutionQueue.enqueue(job_spec);


### PR DESCRIPTION
simple fix, though it only returns the last 10k jobs, is this ok, should the limit be higher especially for systems that have a lot of jobs?