### PR TITLE
Moderator

### DIFF
--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -48,7 +48,8 @@ module.exports = function(context) {
     //query db, set up any stateful instances to track ie ES => queue sizes
     moderator.initialize()
         .then(function() {
-            logger.info('moderator has initialize');
+            //this logger message is used in testing, check logger.info fn of moderator_elasticsearch-spec.js file
+            logger.info('moderator has initialized');
             moderatorEngine = setInterval(checkService, interval);
         })
         .catch(function(err) {

--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -42,15 +42,13 @@ module.exports = function(context) {
     messaging.register('process:SIGINT', noOP);
     messaging.register('worker:shutdown', moderatorShutdown);
 
-    messaging.initialize();
-
-
     //query db, set up any stateful instances to track ie ES => queue sizes
     moderator.initialize()
         .then(function() {
             //this logger message is used in testing, check logger.info fn of moderator_elasticsearch-spec.js file
             logger.info('moderator has initialized');
             moderatorEngine = setInterval(checkService, interval);
+            messaging.initialize();
         })
         .catch(function(err) {
             var errMsg = elasticError(err);

--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -25,6 +25,7 @@ module.exports = function(context) {
     var moderator = getModerator(context, logger);
     var moderatorEngine;
 
+    //query db, set up any stateful instances to track ie ES => queue sizes
     moderator.initialize()
         .then(function() {
             moderatorEngine = setInterval(checkService, 300);
@@ -36,8 +37,10 @@ module.exports = function(context) {
         });
 
     function checkService() {
+        //health checks are called here
         moderator.check_service()
             .then(function(results) {
+                //results is an obj with keys that either are set to null, or an array of connections
                 if (results.pause) {
                     messaging.send('moderator:pause_jobs', results.pause)
                 }

--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -10,7 +10,7 @@ module.exports = function(context) {
     var messaging = messageModule(context, logger);
     var host = messaging.getHostUrl();
 
-    messaging.register('moderator:cluster:connect', function() {
+    messaging.register('network:connect', function() {
         //TODO verify this logic here on separate machine
         logger.info(`moderator has successfully connected to: ${host}`);
         messaging.send('moderator:online', {moderator: true})

--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -21,15 +21,14 @@ module.exports = function(context) {
         messaging.send('moderator:online', {moderator: 'moderator:elasticsearch'});
     });
 
-    messaging.register('cluster_master:check_moderator', function(msg) {
+    messaging.register('cluster:moderator:connection_ok', function(msg) {
         logger.info(`i got the message checking the job queue`, msg);
-        var canRun = _.every(msg.data, function(conn) {
-            return moderator.checkState(conn).throttle === false;
-        });
-
+        var canRun = moderator.checkConnectionStates(msg.data);
+        
         messaging.respond(msg, {
             message: 'node:message:processed',
             action: 'cluster_master:check_moderator',
+            connections: msg.data,
             canRun: canRun
         });
     });

--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -13,7 +13,7 @@ module.exports = function(context) {
     messaging.register('network:connect', function() {
         //TODO verify this logic here on separate machine
         logger.info(`moderator has successfully connected to: ${host}`);
-        messaging.send('moderator:online', {moderator: true})
+        messaging.send('moderator:online', {moderator: 'moderator:elasticsearch'})
     });
 
     messaging.register('process:SIGTERM', noOP);

--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -2,18 +2,17 @@
 
 var messageModule = require('./../services/messaging');
 var elasticError = require('../../utils/error_utils').elasticError;
-var getClient = require('../../utils/config').getClient;
 
 
-module.exports = function(context){
+module.exports = function(context) {
     var logger = context.foundation.makeLogger('moderator', 'moderator', {module: 'moderator'});
 
     var messaging = messageModule(context, logger);
     var host = messaging.getHostUrl();
 
-    messaging.register('moderator:cluster:connect', function(){
+    messaging.register('moderator:cluster:connect', function() {
         logger.info(`moderator has successfully connected to: ${host}`);
-       // messaging.send('moderator:online', {hello:'there'})
+        // messaging.send('moderator:online', {hello:'there'})
     });
 
     messaging.register('process:SIGTERM', noOP);
@@ -22,44 +21,46 @@ module.exports = function(context){
 
     messaging.initialize();
 
-    //replace null wil actual connections config
-    var client = getClient(context, null, 'elasticsearch');
+    var moderator = getModerator(context, logger);
+    var moderatorEngine;
 
-    //nodes.stats
-    //maybe _cat/nodes to check ram, cpu and heap sizes later
-
-   /* client.cat.threadPool({v:true,h:'active,size,bulk.queue,bulk.queueSize,min,max,queueSize'})
-        .then(function(results){
-            logger.info(results);
+    moderator.initialize()
+        .then(function() {
+            console.log('im all ready to go');
+            moderatorEngine = setInterval(checkService, 3000);
         })
-        .catch(function(err){
-            logger.error(err)
-        });*/
-
-   /* client.cat.threadPool({v:true,h:'active,size,queue,queue_size,min,max,queueSize'})
-        .then(function(results){
-            logger.info(results);
-        })
-        .catch(function(err){
-            logger.error(err)
-        });*/
-
-    client.nodes.stats()
-        .then(function(results){
-            logger.info(results);
-        })
-        .catch(function(err){
-            logger.error(err)
+        .catch(function(err) {
+            var errMsg = elasticError(err);
+            logger.error(errMsg);
+            //TODO what to do from here?
         });
 
-    
-    function moderatorShutdown(){
+    function checkService() {
+        moderator.check_service()
+            .then(function(throttleJobs) {
+                if (throttleJobs) {
+                    messaging.send('moderator:pause_jobs',{connections: throttleJobs})
+                }
+            })
+            .catch(function(err) {
+                var errMsg = elasticError(err);
+                logger.error('Moderator error while checking services', errMsg);
+                //TODO what to do from here
+            })
+    }
+
+
+    function moderatorShutdown() {
         logger.warn('moderator is shutting down');
         process.exit();
     }
 
     //to catch signal propagation, but cleanup through msg sent from master
     function noOP() {
+    }
+
+    function getModerator(context, logger) {
+        return require('./modules/elasticsearch')(context, logger)
     }
 
 };

--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -27,7 +27,7 @@ module.exports = function(context) {
     moderator.initialize()
         .then(function() {
             console.log('im all ready to go');
-            moderatorEngine = setInterval(checkService, 3000);
+            moderatorEngine = setInterval(checkService, 300);
         })
         .catch(function(err) {
             var errMsg = elasticError(err);
@@ -37,9 +37,13 @@ module.exports = function(context) {
 
     function checkService() {
         moderator.check_service()
-            .then(function(throttleJobs) {
-                if (throttleJobs) {
-                    messaging.send('moderator:pause_jobs',{connections: throttleJobs})
+            .then(function(results) {
+                if (results.pause) {
+                    messaging.send('moderator:pause_jobs', results.pause)
+                }
+
+                if (results.resume) {
+                    messaging.send('moderator:resume_jobs', results.resume)
                 }
             })
             .catch(function(err) {

--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -24,7 +24,7 @@ module.exports = function(context) {
     messaging.register('cluster:moderator:connection_ok', function(msg) {
         logger.info(`i got the message checking the job queue`, msg);
         var canRun = moderator.checkConnectionStates(msg.data);
-        
+
         messaging.respond(msg, {
             message: 'node:message:processed',
             action: 'cluster_master:check_moderator',
@@ -48,6 +48,7 @@ module.exports = function(context) {
     //query db, set up any stateful instances to track ie ES => queue sizes
     moderator.initialize()
         .then(function() {
+            logger.info('moderator has initialize');
             moderatorEngine = setInterval(checkService, interval);
         })
         .catch(function(err) {
@@ -66,6 +67,7 @@ module.exports = function(context) {
                 isChecking = true;
                 moderator.check_service()
                     .then(function(results) {
+                        logger.debug('results from moderator check_service', results);
                         //results is an obj with keys that either are set to null, or an array of connections
                         if (results.pause) {
                             messaging.send('moderator:pause_jobs', results.pause)

--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -6,7 +6,7 @@ var elasticError = require('../../utils/error_utils').elasticError;
 
 module.exports = function(context) {
     var logger = context.foundation.makeLogger('moderator', 'moderator', {module: 'moderator'});
-
+    var interval = context.sysconfig.teraslice.moderator_interval;
     var messaging = messageModule(context, logger);
     var host = messaging.getHostUrl();
 
@@ -28,7 +28,7 @@ module.exports = function(context) {
     //query db, set up any stateful instances to track ie ES => queue sizes
     moderator.initialize()
         .then(function() {
-            moderatorEngine = setInterval(checkService, 300);
+            moderatorEngine = setInterval(checkService, interval);
         })
         .catch(function(err) {
             var errMsg = elasticError(err);
@@ -38,6 +38,7 @@ module.exports = function(context) {
 
     function checkService() {
         //health checks are called here
+        //TODO might need a verification from cluster_master that the pause/resume job actually worked
         moderator.check_service()
             .then(function(results) {
                 //results is an obj with keys that either are set to null, or an array of connections

--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -11,8 +11,9 @@ module.exports = function(context) {
     var host = messaging.getHostUrl();
 
     messaging.register('moderator:cluster:connect', function() {
+        //TODO verify this logic here on separate machine
         logger.info(`moderator has successfully connected to: ${host}`);
-        // messaging.send('moderator:online', {hello:'there'})
+        messaging.send('moderator:online', {moderator: true})
     });
 
     messaging.register('process:SIGTERM', noOP);
@@ -26,7 +27,6 @@ module.exports = function(context) {
 
     moderator.initialize()
         .then(function() {
-            console.log('im all ready to go');
             moderatorEngine = setInterval(checkService, 300);
         })
         .catch(function(err) {

--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -10,26 +10,33 @@ module.exports = function(context) {
     var messaging = messageModule(context, logger);
     var host = messaging.getHostUrl();
 
+    var moderator = getModerator(context, logger);
+    var moderatorEngine;
+
+    var checkService = queryService();
+
     messaging.register('network:connect', function() {
         //TODO verify this logic here on separate machine
         logger.info(`moderator has successfully connected to: ${host}`);
-        //TODO need logic for moderator disconnect on both sides
-        messaging.send('moderator:online', {moderator: 'moderator:elasticsearch'})
+        messaging.send('moderator:online', {moderator: 'moderator:elasticsearch'});
     });
 
     messaging.register('cluster_master:check_moderator', function(msg) {
-        //TODO verify this logic here on separate machine
-
         logger.info(`i got the message checking the job queue`, msg);
         var canRun = _.every(msg.data, function(conn) {
             return moderator.checkState(conn).throttle === false;
         });
-        
+
         messaging.respond(msg, {
             message: 'node:message:processed',
             action: 'cluster_master:check_moderator',
             canRun: canRun
         });
+    });
+
+    messaging.register('network:disconnect', function() {
+        logger.warn(`moderator has disconnected to: ${host}`);
+        //TODO verify what else to be here
     });
 
     messaging.register('process:SIGTERM', noOP);
@@ -38,8 +45,6 @@ module.exports = function(context) {
 
     messaging.initialize();
 
-    var moderator = getModerator(context, logger);
-    var moderatorEngine;
 
     //query db, set up any stateful instances to track ie ES => queue sizes
     moderator.initialize()
@@ -48,29 +53,41 @@ module.exports = function(context) {
         })
         .catch(function(err) {
             var errMsg = elasticError(err);
-            logger.error(errMsg);
-            //TODO what to do from here?
+            //TODO changed fixed message to whatever module its actually using
+            logger.error(`Error initializing moderator for elasticsearch`, errMsg);
+            process.exit()
         });
 
-    function checkService() {
+    function queryService() {
+        var isChecking = false;
         //health checks are called here
         //TODO might need a verification from cluster_master that the pause/resume job actually worked
-        moderator.check_service()
-            .then(function(results) {
-                //results is an obj with keys that either are set to null, or an array of connections
-                if (results.pause) {
-                    messaging.send('moderator:pause_jobs', results.pause)
-                }
+        return function() {
+            if (!isChecking) {
+                isChecking = true;
+                moderator.check_service()
+                    .then(function(results) {
+                        //results is an obj with keys that either are set to null, or an array of connections
+                        if (results.pause) {
+                            messaging.send('moderator:pause_jobs', results.pause)
+                        }
 
-                if (results.resume) {
-                    messaging.send('moderator:resume_jobs', results.resume)
-                }
-            })
-            .catch(function(err) {
-                var errMsg = elasticError(err);
-                logger.error('Moderator error while checking services', errMsg);
-                //TODO what to do from here
-            })
+                        if (results.resume) {
+                            messaging.send('moderator:resume_jobs', results.resume)
+                        }
+                        isChecking = false;
+                    })
+                    .catch(function(err) {
+                        //error do to new nodes, so not true error, re-initialize
+                        if (err.initialize) {
+                            initialize
+                        }
+                        var errMsg = elasticError(err);
+                        logger.error('Moderator error while checking services', errMsg);
+                        isChecking = false;
+                    })
+            }
+        }
     }
 
 
@@ -84,6 +101,7 @@ module.exports = function(context) {
     }
 
     function getModerator(context, logger) {
+        //TODO make this dynamic
         return require('./modules/elasticsearch')(context, logger)
     }
 

--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -2,7 +2,7 @@
 
 var messageModule = require('./../services/messaging');
 var elasticError = require('../../utils/error_utils').elasticError;
-
+var _ = require('lodash');
 
 module.exports = function(context) {
     var logger = context.foundation.makeLogger('moderator', 'moderator', {module: 'moderator'});
@@ -13,7 +13,23 @@ module.exports = function(context) {
     messaging.register('network:connect', function() {
         //TODO verify this logic here on separate machine
         logger.info(`moderator has successfully connected to: ${host}`);
+        //TODO need logic for moderator disconnect on both sides
         messaging.send('moderator:online', {moderator: 'moderator:elasticsearch'})
+    });
+
+    messaging.register('cluster_master:check_moderator', function(msg) {
+        //TODO verify this logic here on separate machine
+
+        logger.info(`i got the message checking the job queue`, msg);
+        var canRun = _.every(msg.data, function(conn) {
+            return moderator.checkState(conn).throttle === false;
+        });
+        
+        messaging.respond(msg, {
+            message: 'node:message:processed',
+            action: 'cluster_master:check_moderator',
+            canRun: canRun
+        });
     });
 
     messaging.register('process:SIGTERM', noOP);

--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var messageModule = require('./../services/messaging');
+var elasticError = require('../../utils/error_utils').elasticError;
+var getClient = require('../../utils/config').getClient;
+
+
+module.exports = function(context){
+    var logger = context.foundation.makeLogger('moderator', 'moderator', {module: 'moderator'});
+
+    var messaging = messageModule(context, logger);
+    var host = messaging.getHostUrl();
+
+    messaging.register('moderator:cluster:connect', function(){
+        logger.info(`moderator has successfully connected to: ${host}`);
+       // messaging.send('moderator:online', {hello:'there'})
+    });
+
+    messaging.register('process:SIGTERM', noOP);
+    messaging.register('process:SIGINT', noOP);
+    messaging.register('worker:shutdown', moderatorShutdown);
+
+    messaging.initialize();
+
+    //replace null wil actual connections config
+    var client = getClient(context, null, 'elasticsearch');
+
+    //nodes.stats
+    //maybe _cat/nodes to check ram, cpu and heap sizes later
+
+   /* client.cat.threadPool({v:true,h:'active,size,bulk.queue,bulk.queueSize,min,max,queueSize'})
+        .then(function(results){
+            logger.info(results);
+        })
+        .catch(function(err){
+            logger.error(err)
+        });*/
+
+   /* client.cat.threadPool({v:true,h:'active,size,queue,queue_size,min,max,queueSize'})
+        .then(function(results){
+            logger.info(results);
+        })
+        .catch(function(err){
+            logger.error(err)
+        });*/
+
+    client.nodes.stats()
+        .then(function(results){
+            logger.info(results);
+        })
+        .catch(function(err){
+            logger.error(err)
+        });
+
+    
+    function moderatorShutdown(){
+        logger.warn('moderator is shutting down');
+        process.exit();
+    }
+
+    //to catch signal propagation, but cleanup through msg sent from master
+    function noOP() {
+    }
+
+};

--- a/lib/cluster/moderator/modules/elasticsearch.js
+++ b/lib/cluster/moderator/modules/elasticsearch.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/lib/cluster/moderator/modules/elasticsearch.js
+++ b/lib/cluster/moderator/modules/elasticsearch.js
@@ -42,7 +42,6 @@ module.exports = function(context, logger) {
                                     let threshold = state[client_name][node_name][key].threshold;
                                     let queue = val.queue;
 
-                                    //TODO make this a config option
                                     //if queue is over threshold and connection is not already throttled, add to paused list
                                     if (queue / threshold >= limit && !state[client_name].throttle) {
                                         state[client_name].throttle = true;
@@ -52,7 +51,6 @@ module.exports = function(context, logger) {
                                         })
                                     }
 
-                                    //TODO make this a config option
                                     if (queue / threshold < resume && state[client_name].throttle) {
                                         state[client_name].throttle = false;
                                         resumeJobs.push({
@@ -64,7 +62,7 @@ module.exports = function(context, logger) {
                             })
                         }
                         else {
-                            //TODO need to decide what to do
+                            //TODO need to decide what to do, this happens if a new node pops up
                         }
                     });
 

--- a/lib/cluster/moderator/modules/elasticsearch.js
+++ b/lib/cluster/moderator/modules/elasticsearch.js
@@ -25,7 +25,7 @@ module.exports = function(context, logger) {
 
         return clientState
     }
-    
+
     function check_service() {
         let throttleJobs = [];
         let resumeJobs = [];
@@ -121,8 +121,13 @@ module.exports = function(context, logger) {
 
     }
 
+    function checkState(conn) {
+        return state[conn];
+    }
+
     return {
         initialize: initialize,
-        check_service: check_service
+        check_service: check_service,
+        checkState: checkState
     }
 };

--- a/lib/cluster/moderator/modules/elasticsearch.js
+++ b/lib/cluster/moderator/modules/elasticsearch.js
@@ -36,9 +36,7 @@ module.exports = function(context, logger) {
                                     let queue = val.queue;
 
                                     //TODO make this a config option
-                                 //   logger.warn('what am i checking', key, queue, threshold, queue / threshold > 0.85);
-                                    if (queue / threshold >= 0.5) {
-                                        logger.error('i shold be in here')
+                                    if (queue / threshold >= 0.85) {
                                         state[nodeName][key].throttle = true;
                                         throttleJobs.push({
                                             type: 'elasticsearch',
@@ -48,17 +46,17 @@ module.exports = function(context, logger) {
                                             rate: `${queue}/${threshold}`
                                         })
                                     }
-                                    
+
                                     //TODO make this a config option
                                     if (queue / threshold < 0.5 && state[nodeName][key].throttle) {
-                                       /* state[nodeName][key].throttle = false;
+                                        state[nodeName][key].throttle = false;
                                         resumeJobs.push({
                                             type: 'elasticsearch',
                                             connection: client.__esConnection,
                                             nodeName: nodeName,
                                             thread_pool: key,
                                             rate: `${queue}/${threshold}`
-                                        })*/
+                                        })
                                     }
                                 }
                             })
@@ -108,14 +106,12 @@ module.exports = function(context, logger) {
                                 if (!state[nodeName][key]) {
                                     state[nodeName][key] = {};
                                 }
-                                console.log('whats the val', config);
                                 state[nodeName][key].threshold = config.queue_size;
                                 state[nodeName][key].throttle = false;
                             }
                         })
                     });
 
-                    // console.log(state)
                 })
                 .catch(function(err) {
                     logger.error(err)

--- a/lib/cluster/moderator/modules/elasticsearch.js
+++ b/lib/cluster/moderator/modules/elasticsearch.js
@@ -23,6 +23,7 @@ module.exports = function(context, logger) {
 
     function check_service() {
         let throttleJobs = [];
+        let resumeJobs = [];
 
         return Promise.map(clients, function(client) {
             return client.nodes.stats()
@@ -35,12 +36,29 @@ module.exports = function(context, logger) {
                                     let queue = val.queue;
 
                                     //TODO make this a config option
-                                    if (queue / threshold > 0.85) {
+                                 //   logger.warn('what am i checking', key, queue, threshold, queue / threshold > 0.85);
+                                    if (queue / threshold >= 0.5) {
+                                        logger.error('i shold be in here')
+                                        state[nodeName][key].throttle = true;
                                         throttleJobs.push({
+                                            type: 'elasticsearch',
+                                            connection: client.__esConnection,
                                             nodeName: nodeName,
                                             thread_pool: key,
                                             rate: `${queue}/${threshold}`
                                         })
+                                    }
+                                    
+                                    //TODO make this a config option
+                                    if (queue / threshold < 0.5 && state[nodeName][key].throttle) {
+                                       /* state[nodeName][key].throttle = false;
+                                        resumeJobs.push({
+                                            type: 'elasticsearch',
+                                            connection: client.__esConnection,
+                                            nodeName: nodeName,
+                                            thread_pool: key,
+                                            rate: `${queue}/${threshold}`
+                                        })*/
                                     }
                                 }
                             })
@@ -49,21 +67,27 @@ module.exports = function(context, logger) {
                             //TODO need to decide what to do
                         }
                     });
-                    throttleJobs.push({
-                        connection: client.__esConnection,
-                        nodeName: 'ehhlp',
-                        thread_pool: 'bulk',
-                        rate: '123/125'
-                    });
+
                     return true;
                 })
                 .catch(function(err) {
+                    //TODO flesh this out
                     logger.error(err)
                 })
         })
             .then(function() {
-                console.log('getting here', throttleJobs);
-                return throttleJobs
+                //TODO verify if the possiblility of both jobs exists in pause and resume and prevent that if needed
+                let results = {pause: false, resume: false};
+
+                if (throttleJobs.length > 0) {
+                    logger.error('should be returning results of throttle', throttleJobs)
+
+                    results.pause = throttleJobs;
+                }
+                if (resumeJobs.length > 0) {
+                    results.resume = resumeJobs;
+                }
+                return results
             })
             .catch(function(err) {
                 logger.error('check service error', err)
@@ -79,12 +103,14 @@ module.exports = function(context, logger) {
                         if (!state[nodeName]) {
                             state[nodeName] = {};
                         }
-                        _.forOwn(stats.thread_pool, function(val, key) {
+                        _.forOwn(stats.thread_pool, function(config, key) {
                             if (keyDict[key]) {
                                 if (!state[nodeName][key]) {
                                     state[nodeName][key] = {};
                                 }
-                                state[nodeName][key].threshold = val;
+                                console.log('whats the val', config);
+                                state[nodeName][key].threshold = config.queue_size;
+                                state[nodeName][key].throttle = false;
                             }
                         })
                     });

--- a/lib/cluster/moderator/modules/elasticsearch.js
+++ b/lib/cluster/moderator/modules/elasticsearch.js
@@ -12,12 +12,12 @@ module.exports = function(context, logger) {
     //list of queue's to pay attention to
     var keyDict = {index: true, search: true, get: true, bulk: true};
 
-    //list of clients which are set in initialize
+    //list of clients which will be used in checkModerator, it is set in initialize
     var clients = [];
 
     var state = {};
 
-
+    //used to set state and queue size limits
     function initializeConnection(client) {
         return client.nodes.info()
             .then(function(results) {
@@ -44,6 +44,10 @@ module.exports = function(context, logger) {
             })
     }
 
+    // initialize attempts to set up each connection and resolves when all are tried at least once
+    // if connection is set up, its added to the client array which is used to monitor stats
+    // connections that aren't successful retry individually with exponential back-off until succeeds
+
     function initialize(client) {
         let retryTimer = {start: 5000, limit: 10000};
 
@@ -55,13 +59,11 @@ module.exports = function(context, logger) {
             return new Promise(function(resolve, reject) {
                 _.forOwn(context.sysconfig.terafoundation.connectors.elasticsearch, function(val, key) {
                     let client = getClient(context, {connection: key}, 'elasticsearch');
-                    console.log('what key', key);
                     client.__esConnection = key;
 
                     initializeConnection(client)
                         .then(function() {
                             clientCounter += 1;
-                            console.log('whats put in', client.__esConnection);
                             clients.push(client);
                         })
                         .catch(function(err) {
@@ -95,13 +97,9 @@ module.exports = function(context, logger) {
             });
         }
         else {
-            console.log('still trying', client.__esConnection);
-
             //need to initialize specific client
             return initializeConnection(client)
                 .then(function() {
-                    console.log('whats put in other', client.__esConnection);
-
                     clients.push(client);
                 })
                 .catch(function(err) {
@@ -123,6 +121,7 @@ module.exports = function(context, logger) {
         }
     }
 
+    //compares node stats to limits, returns list of connections that need to be throttled or resumed
     function check_service() {
         let throttleJobs = [];
         let resumeJobs = [];
@@ -131,9 +130,8 @@ module.exports = function(context, logger) {
             return client.nodes.stats()
                 .then(function(results) {
                     let client_name = client.__esConnection;
-                    console.log('making a check', client_name);
                     _.forOwn(results.nodes, function(stats, node_name) {
-                        if (_.get(state, `[${client_name}][${node_name}]` )) {
+                        if (_.get(state, `[${client_name}][${node_name}]`)) {
                             _.forOwn(stats.thread_pool, function(val, key) {
                                 if (_.get(state, `[${client_name}][${node_name}][${key}]`)) {
                                     let threshold = state[client_name][node_name][key].threshold;
@@ -204,6 +202,8 @@ module.exports = function(context, logger) {
             })
     }
 
+    //TODO verify how much to actually expose beyond module
+    // Primarily used to see if connection is throttled
     function checkState(conn) {
         return state[conn];
     }

--- a/lib/cluster/moderator/modules/elasticsearch.js
+++ b/lib/cluster/moderator/modules/elasticsearch.js
@@ -132,29 +132,39 @@ module.exports = function(context, logger) {
                     let client_name = client.__esConnection;
                     _.forOwn(results.nodes, function(stats, node_name) {
                         if (_.get(state, `[${client_name}][${node_name}]`)) {
-                            _.forOwn(stats.thread_pool, function(val, key) {
+
+                            let nodeIsHealthy = _.every(stats.thread_pool, function(val, key) {
                                 if (_.get(state, `[${client_name}][${node_name}][${key}]`)) {
                                     let threshold = state[client_name][node_name][key].threshold;
                                     let queue = val.queue;
+                                    let ratio = queue / threshold;
                                     logger.trace(`connection: ${client_name} , node: ${node_name} , thread_pool: ${key} , queue: ${queue}, threshold: ${threshold}`);
-                                    //if queue is over threshold and connection is not already throttled, add to paused list
-                                    if (queue / threshold >= limit && !state[client_name].throttle) {
-                                        state[client_name].throttle = true;
-                                        throttleJobs.push({
-                                            type: 'elasticsearch',
-                                            connection: client_name
-                                        })
-                                    }
 
-                                    if (queue / threshold < resume && state[client_name].throttle) {
-                                        state[client_name].throttle = false;
-                                        resumeJobs.push({
-                                            type: 'elasticsearch',
-                                            connection: client_name
-                                        })
+                                    if (ratio < limit) {
+                                        return true;
                                     }
+                                    return false;
                                 }
-                            })
+                                //if no key, return true to not conflict
+                                return true;
+                            });
+
+                            if (nodeIsHealthy && state[client_name].throttle) {
+                                //node is now healthy 
+                                state[client_name].throttle = false;
+                                resumeJobs.push({
+                                    type: 'elasticsearch',
+                                    connection: client_name
+                                })
+                            }
+
+                            if (nodeIsHealthy === false) {
+                                state[client_name].throttle = true;
+                                throttleJobs.push({
+                                    type: 'elasticsearch',
+                                    connection: client_name
+                                })
+                            }
                         }
                         else {
                             logger.warn(`${node_name} is new to the elasticsearch cluster, re-initializing`);

--- a/lib/cluster/moderator/modules/elasticsearch.js
+++ b/lib/cluster/moderator/modules/elasticsearch.js
@@ -7,9 +7,7 @@ var _ = require('lodash');
 module.exports = function(context, logger) {
     //list of queue's to pay attention to
     var keyDict = {index: true, search: true, get: true, bulk: true};
-
     var state = {};
-
     var clients = collectClient(context);
 
 
@@ -33,34 +31,31 @@ module.exports = function(context, logger) {
         return Promise.map(clients, function(client) {
             return client.nodes.stats()
                 .then(function(results) {
+                    let client_name = client.__esConnection;
+
                     _.forOwn(results.nodes, function(stats, node_name) {
-                        if (state[node_name]) {
+                        if (state[client_name][node_name]) {
                             _.forOwn(stats.thread_pool, function(val, key) {
-                                if (state[node_name][key]) {
-                                    let threshold = state[node_name][key].threshold;
+                                if (state[client_name][node_name][key]) {
+                                    let threshold = state[client_name][node_name][key].threshold;
                                     let queue = val.queue;
 
                                     //TODO make this a config option
-                                    if (queue / threshold >= 0.85) {
-                                        state[node_name][key].throttle = true;
+                                    //if queue is over threshold and connection is not already throttled, add to paused list
+                                    if (queue / threshold >= 0.85 && !state[client_name].throttle) {
+                                        state[client_name].throttle = true;
                                         throttleJobs.push({
                                             type: 'elasticsearch',
-                                            connection: client.__esConnection,
-                                            node_name: node_name,
-                                            thread_pool: key,
-                                            rate: `${queue}/${threshold}`
+                                            connection: client_name
                                         })
                                     }
 
                                     //TODO make this a config option
-                                    if (queue / threshold < 0.5 && state[node_name][key].throttle) {
-                                        state[node_name][key].throttle = false;
+                                    if (queue / threshold < 0.5 && state[client_name].throttle) {
+                                        state[client_name].throttle = false;
                                         resumeJobs.push({
                                             type: 'elasticsearch',
-                                            connection: client.__esConnection,
-                                            nodeName: node_name,
-                                            thread_pool: key,
-                                            rate: `${queue}/${threshold}`
+                                            connection: client_name
                                         })
                                     }
                                 }
@@ -95,21 +90,22 @@ module.exports = function(context, logger) {
     }
 
     //TODO need to handle when clients are not available
+    //TODO veirfy if new nodes (id's) are made live, could effect how initialize happens
     function initialize() {
         return Promise.map(clients, function(client) {
             return client.nodes.info()
                 .then(function(results) {
-                    _.forOwn(results.nodes, function(stats, nodeName) {
-                        if (!state[nodeName]) {
-                            state[nodeName] = {};
-                        }
+                    let client_name = client.__esConnection;
+                    //top level connection name
+                    state[client_name] = {throttle: false};
+                    _.forOwn(results.nodes, function(stats, node_name) {
+                        //add correct node info per connection
+                        state[client_name][node_name] = {};
                         _.forOwn(stats.thread_pool, function(config, key) {
                             if (keyDict[key]) {
-                                if (!state[nodeName][key]) {
-                                    state[nodeName][key] = {};
-                                }
-                                state[nodeName][key].threshold = config.queue_size;
-                                state[nodeName][key].throttle = false;
+                                //specific thread_pool that we are interested in
+                                state[client_name][node_name][key] = {};
+                                state[client_name][node_name][key].threshold = config.queue_size;
                             }
                         })
                     });

--- a/lib/cluster/moderator/modules/elasticsearch.js
+++ b/lib/cluster/moderator/modules/elasticsearch.js
@@ -1,1 +1,108 @@
 'use strict';
+var getClient = require('../../../utils/config').getClient;
+var Promise = require('bluebird');
+var _ = require('lodash');
+
+
+module.exports = function(context, logger) {
+    var clients = collectClient(context);
+    var state = {};
+    var keyDict = {index: true, search: true, get: true, bulk: true};
+
+    function collectClient(context) {
+        let clientState = [];
+
+        _.forOwn(context.sysconfig.terafoundation.connectors.elasticsearch, function(val, key) {
+            let client = getClient(context, {connection: key}, 'elasticsearch');
+            client.__esConnection = key;
+            clientState.push(client)
+        });
+
+        return clientState
+    }
+
+    function check_service() {
+        let throttleJobs = [];
+
+        return Promise.map(clients, function(client) {
+            return client.nodes.stats()
+                .then(function(results) {
+                    _.forOwn(results.nodes, function(stats, nodeName) {
+                        if (state[nodeName]) {
+                            _.forOwn(stats.thread_pool, function(val, key) {
+                                if (state[nodeName][key]) {
+                                    let threshold = state[nodeName][key].threshold;
+                                    let queue = val.queue;
+
+                                    //TODO make this a config option
+                                    if (queue / threshold > 0.85) {
+                                        throttleJobs.push({
+                                            nodeName: nodeName,
+                                            thread_pool: key,
+                                            rate: `${queue}/${threshold}`
+                                        })
+                                    }
+                                }
+                            })
+                        }
+                        else {
+                            //TODO need to decide what to do
+                        }
+                    });
+                    throttleJobs.push({
+                        connection: client.__esConnection,
+                        nodeName: 'ehhlp',
+                        thread_pool: 'bulk',
+                        rate: '123/125'
+                    });
+                    return true;
+                })
+                .catch(function(err) {
+                    logger.error(err)
+                })
+        })
+            .then(function() {
+                console.log('getting here', throttleJobs);
+                return throttleJobs
+            })
+            .catch(function(err) {
+                logger.error('check service error', err)
+            })
+    }
+
+    //TODO need to handle when clients are not available
+    function initialize() {
+        return Promise.map(clients, function(client) {
+            return client.nodes.info()
+                .then(function(results) {
+                    _.forOwn(results.nodes, function(stats, nodeName) {
+                        if (!state[nodeName]) {
+                            state[nodeName] = {};
+                        }
+                        _.forOwn(stats.thread_pool, function(val, key) {
+                            if (keyDict[key]) {
+                                if (!state[nodeName][key]) {
+                                    state[nodeName][key] = {};
+                                }
+                                state[nodeName][key].threshold = val;
+                            }
+                        })
+                    });
+
+                    // console.log(state)
+                })
+                .catch(function(err) {
+                    logger.error(err)
+                });
+        })
+            .catch(function(err) {
+                console.log('this is the outer error', err.stack);
+            })
+
+    }
+
+    return {
+        initialize: initialize,
+        check_service: check_service
+    }
+};

--- a/lib/cluster/moderator/modules/elasticsearch.js
+++ b/lib/cluster/moderator/modules/elasticsearch.js
@@ -40,6 +40,7 @@ module.exports = function(context, logger) {
                         }
                     })
                 });
+                logger.debug(`connection: ${client.__esConnection} has initialized, state`, state)
             })
     }
 
@@ -135,7 +136,7 @@ module.exports = function(context, logger) {
                                 if (_.get(state, `[${client_name}][${node_name}][${key}]`)) {
                                     let threshold = state[client_name][node_name][key].threshold;
                                     let queue = val.queue;
-
+                                    logger.trace(`connection: ${client_name} , node: ${node_name} , thread_pool: ${key} , queue: ${queue}, threshold: ${threshold}`);
                                     //if queue is over threshold and connection is not already throttled, add to paused list
                                     if (queue / threshold >= limit && !state[client_name].throttle) {
                                         state[client_name].throttle = true;

--- a/lib/cluster/moderator/modules/elasticsearch.js
+++ b/lib/cluster/moderator/modules/elasticsearch.js
@@ -5,10 +5,15 @@ var _ = require('lodash');
 
 
 module.exports = function(context, logger) {
-    var clients = collectClient(context);
-    var state = {};
+    //list of queue's to pay attention to
     var keyDict = {index: true, search: true, get: true, bulk: true};
 
+    var state = {};
+
+    var clients = collectClient(context);
+
+
+    //makes client for all elasticsearch connections listed in system configuration
     function collectClient(context) {
         let clientState = [];
 
@@ -28,32 +33,32 @@ module.exports = function(context, logger) {
         return Promise.map(clients, function(client) {
             return client.nodes.stats()
                 .then(function(results) {
-                    _.forOwn(results.nodes, function(stats, nodeName) {
-                        if (state[nodeName]) {
+                    _.forOwn(results.nodes, function(stats, node_name) {
+                        if (state[node_name]) {
                             _.forOwn(stats.thread_pool, function(val, key) {
-                                if (state[nodeName][key]) {
-                                    let threshold = state[nodeName][key].threshold;
+                                if (state[node_name][key]) {
+                                    let threshold = state[node_name][key].threshold;
                                     let queue = val.queue;
 
                                     //TODO make this a config option
                                     if (queue / threshold >= 0.85) {
-                                        state[nodeName][key].throttle = true;
+                                        state[node_name][key].throttle = true;
                                         throttleJobs.push({
                                             type: 'elasticsearch',
                                             connection: client.__esConnection,
-                                            nodeName: nodeName,
+                                            node_name: node_name,
                                             thread_pool: key,
                                             rate: `${queue}/${threshold}`
                                         })
                                     }
 
                                     //TODO make this a config option
-                                    if (queue / threshold < 0.5 && state[nodeName][key].throttle) {
-                                        state[nodeName][key].throttle = false;
+                                    if (queue / threshold < 0.5 && state[node_name][key].throttle) {
+                                        state[node_name][key].throttle = false;
                                         resumeJobs.push({
                                             type: 'elasticsearch',
                                             connection: client.__esConnection,
-                                            nodeName: nodeName,
+                                            nodeName: node_name,
                                             thread_pool: key,
                                             rate: `${queue}/${threshold}`
                                         })
@@ -74,16 +79,13 @@ module.exports = function(context, logger) {
                 })
         })
             .then(function() {
-                //TODO verify if the possiblility of both jobs exists in pause and resume and prevent that if needed
-                let results = {pause: false, resume: false};
+                let results = {pause: null, resume: null};
 
                 if (throttleJobs.length > 0) {
-                    logger.error('should be returning results of throttle', throttleJobs)
-
-                    results.pause = throttleJobs;
+                    results.pause = _.uniqBy(throttleJobs, 'connection');
                 }
                 if (resumeJobs.length > 0) {
-                    results.resume = resumeJobs;
+                    results.resume = _.uniqBy(resumeJobs, 'connection');
                 }
                 return results
             })

--- a/lib/cluster/moderator/modules/elasticsearch.js
+++ b/lib/cluster/moderator/modules/elasticsearch.js
@@ -1,29 +1,126 @@
 'use strict';
 var getClient = require('../../../utils/config').getClient;
 var Promise = require('bluebird');
+var elasticError = require('../../../utils/error_utils').elasticError;
 var _ = require('lodash');
 
 
 module.exports = function(context, logger) {
-    //list of queue's to pay attention to
-    var keyDict = {index: true, search: true, get: true, bulk: true};
-    var state = {};
-    var clients = collectClient(context);
     var limit = context.sysconfig.teraslice.moderator_limit;
     var resume = context.sysconfig.teraslice.moderator_resume;
 
+    //list of queue's to pay attention to
+    var keyDict = {index: true, search: true, get: true, bulk: true};
 
-    //makes client for all elasticsearch connections listed in system configuration
-    function collectClient(context) {
-        let clientState = [];
+    //list of clients which are set in initialize
+    var clients = [];
 
-        _.forOwn(context.sysconfig.terafoundation.connectors.elasticsearch, function(val, key) {
-            let client = getClient(context, {connection: key}, 'elasticsearch');
-            client.__esConnection = key;
-            clientState.push(client)
-        });
+    var state = {};
 
-        return clientState
+
+    function initializeConnection(client) {
+        return client.nodes.info()
+            .then(function(results) {
+                let client_name = client.__esConnection;
+                //top level connection name
+                if (!state[client_name]) {
+                    state[client_name] = {throttle: false};
+                }
+                _.forOwn(results.nodes, function(stats, node_name) {
+                    //add correct node info per connection
+                    if (!state[client_name][node_name]) {
+                        state[client_name][node_name] = {};
+                    }
+                    _.forOwn(stats.thread_pool, function(config, key) {
+                        if (keyDict[key]) {
+                            //specific thread_pool that we are interested in
+                            if (!state[client_name][node_name][key]) {
+                                state[client_name][node_name][key] = {};
+                            }
+                            state[client_name][node_name][key].threshold = config.queue_size;
+                        }
+                    })
+                });
+            })
+    }
+
+    function initialize(client) {
+        let retryTimer = {start: 5000, limit: 10000};
+
+        if (!client) {
+            //need to initialize everything
+            let clientCounter = 0;
+            let totalClients = Object.keys(context.sysconfig.terafoundation.connectors.elasticsearch).length;
+
+            return new Promise(function(resolve, reject) {
+                _.forOwn(context.sysconfig.terafoundation.connectors.elasticsearch, function(val, key) {
+                    let client = getClient(context, {connection: key}, 'elasticsearch');
+                    console.log('what key', key);
+                    client.__esConnection = key;
+
+                    initializeConnection(client)
+                        .then(function() {
+                            clientCounter += 1;
+                            console.log('whats put in', client.__esConnection);
+                            clients.push(client);
+                        })
+                        .catch(function(err) {
+                            var errMsg = elasticError(err);
+                            logger.error(`error initializing client ${client.__esConnection}`, errMsg);
+                            let timer = Math.floor(Math.random() * (retryTimer.limit - retryTimer.start) + retryTimer.start);
+
+                            if (retryTimer.limit < 60000) {
+                                retryTimer.limit += 10000
+                            }
+                            if (retryTimer.start < 30000) {
+                                retryTimer.start += 5000
+                            }
+                            setTimeout(function() {
+                                initialize(client);
+                            }, timer);
+
+                            //attempt made 
+                            clientCounter += 1;
+                        });
+                });
+
+                //check to see if all clients connections have been processed at least once
+                var initInterval = setInterval(function() {
+                    if (clientCounter === totalClients) {
+                        clearInterval(initInterval);
+                        resolve(Promise.resolve(true))
+                    }
+                }, 250)
+
+            });
+        }
+        else {
+            console.log('still trying', client.__esConnection);
+
+            //need to initialize specific client
+            return initializeConnection(client)
+                .then(function() {
+                    console.log('whats put in other', client.__esConnection);
+
+                    clients.push(client);
+                })
+                .catch(function(err) {
+                    var errMsg = elasticError(err);
+                    logger.error(`error initializing client ${client.__esConnection}`, errMsg);
+
+                    let timer = Math.floor(Math.random() * (retryTimer.limit - retryTimer.start) + retryTimer.start);
+
+                    if (retryTimer.limit < 60000) {
+                        retryTimer.limit += 10000
+                    }
+                    if (retryTimer.start < 30000) {
+                        retryTimer.start += 5000
+                    }
+                    setTimeout(function() {
+                        initialize(client);
+                    }, timer);
+                });
+        }
     }
 
     function check_service() {
@@ -34,11 +131,11 @@ module.exports = function(context, logger) {
             return client.nodes.stats()
                 .then(function(results) {
                     let client_name = client.__esConnection;
-
+                    console.log('making a check', client_name);
                     _.forOwn(results.nodes, function(stats, node_name) {
-                        if (state[client_name][node_name]) {
+                        if (_.get(state, `[${client_name}][${node_name}]` )) {
                             _.forOwn(stats.thread_pool, function(val, key) {
-                                if (state[client_name][node_name][key]) {
+                                if (_.get(state, `[${client_name}][${node_name}][${key}]`)) {
                                     let threshold = state[client_name][node_name][key].threshold;
                                     let queue = val.queue;
 
@@ -62,15 +159,24 @@ module.exports = function(context, logger) {
                             })
                         }
                         else {
-                            //TODO need to decide what to do, this happens if a new node pops up
+                            logger.warn(`${node_name} is new to the elasticsearch cluster, re-initializing`);
+                            return Promise.reject({initialize: true})
                         }
                     });
 
                     return true;
                 })
                 .catch(function(err) {
-                    //TODO flesh this out
-                    logger.error(err)
+                    //new node came online, need to re-initialize
+                    if (err.initialize) {
+                        return Promise.reject(err)
+                    }
+                    else {
+                        //real error, pass it along
+                        var errMsg = elasticError(err);
+                        logger.error(`error with client ${client.__esConnection}`, errMsg);
+                        return Promise.reject(errMsg);
+                    }
                 })
         })
             .then(function() {
@@ -85,40 +191,17 @@ module.exports = function(context, logger) {
                 return results
             })
             .catch(function(err) {
-                logger.error('check service error', err)
+                if (err.initialize) {
+                    //new node came online, need to re-initialize
+                    return Promise.reject(err)
+                }
+                else {
+                    //real error, pass it along
+                    var errMsg = elasticError(err);
+                    logger.error('check service error', errMsg);
+                    return Promise.reject(err)
+                }
             })
-    }
-
-    //TODO need to handle when clients are not available
-    //TODO veirfy if new nodes (id's) are made live, could effect how initialize happens
-    function initialize() {
-        return Promise.map(clients, function(client) {
-            return client.nodes.info()
-                .then(function(results) {
-                    let client_name = client.__esConnection;
-                    //top level connection name
-                    state[client_name] = {throttle: false};
-                    _.forOwn(results.nodes, function(stats, node_name) {
-                        //add correct node info per connection
-                        state[client_name][node_name] = {};
-                        _.forOwn(stats.thread_pool, function(config, key) {
-                            if (keyDict[key]) {
-                                //specific thread_pool that we are interested in
-                                state[client_name][node_name][key] = {};
-                                state[client_name][node_name][key].threshold = config.queue_size;
-                            }
-                        })
-                    });
-
-                })
-                .catch(function(err) {
-                    logger.error(err)
-                });
-        })
-            .catch(function(err) {
-                console.log('this is the outer error', err.stack);
-            })
-
     }
 
     function checkState(conn) {

--- a/lib/cluster/moderator/modules/elasticsearch.js
+++ b/lib/cluster/moderator/modules/elasticsearch.js
@@ -9,6 +9,8 @@ module.exports = function(context, logger) {
     var keyDict = {index: true, search: true, get: true, bulk: true};
     var state = {};
     var clients = collectClient(context);
+    var limit = context.sysconfig.teraslice.moderator_limit;
+    var resume = context.sysconfig.teraslice.moderator_resume;
 
 
     //makes client for all elasticsearch connections listed in system configuration
@@ -23,7 +25,7 @@ module.exports = function(context, logger) {
 
         return clientState
     }
-
+    
     function check_service() {
         let throttleJobs = [];
         let resumeJobs = [];
@@ -42,7 +44,7 @@ module.exports = function(context, logger) {
 
                                     //TODO make this a config option
                                     //if queue is over threshold and connection is not already throttled, add to paused list
-                                    if (queue / threshold >= 0.85 && !state[client_name].throttle) {
+                                    if (queue / threshold >= limit && !state[client_name].throttle) {
                                         state[client_name].throttle = true;
                                         throttleJobs.push({
                                             type: 'elasticsearch',
@@ -51,7 +53,7 @@ module.exports = function(context, logger) {
                                     }
 
                                     //TODO make this a config option
-                                    if (queue / threshold < 0.5 && state[client_name].throttle) {
+                                    if (queue / threshold < resume && state[client_name].throttle) {
                                         state[client_name].throttle = false;
                                         resumeJobs.push({
                                             type: 'elasticsearch',

--- a/lib/cluster/moderator/modules/elasticsearch.js
+++ b/lib/cluster/moderator/modules/elasticsearch.js
@@ -8,7 +8,6 @@ var _ = require('lodash');
 module.exports = function(context, logger) {
     var limit = context.sysconfig.teraslice.moderator_limit;
     var resume = context.sysconfig.teraslice.moderator_resume;
-
     //list of queue's to pay attention to
     var keyDict = {index: true, search: true, get: true, bulk: true};
 
@@ -202,15 +201,17 @@ module.exports = function(context, logger) {
             })
     }
 
-    //TODO verify how much to actually expose beyond module
     // Primarily used to see if connection is throttled
-    function checkState(conn) {
-        return state[conn];
+    function checkConnectionStates(conns) {
+        //state connection defaults are added in job service at job check
+        return _.every(conns, function(conn) {
+            return state[conn].throttle === false;
+        });
     }
 
     return {
         initialize: initialize,
         check_service: check_service,
-        checkState: checkState
+        checkConnectionStates: checkConnectionStates
     }
 };

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -97,12 +97,12 @@ module.exports = function(context) {
         });
     }
 
-    messaging.register('node:cluster:connect', function() {
+    messaging.register('network:connect', function() {
         logger.info(`node has successfully connected to: ${host}`);
         messaging.send('node:online', getNodeState(context))
     });
 
-    messaging.register('node:cluster:disconnect', function() {
+    messaging.register('network:disconnect', function() {
         logger.info(`node has disconnected from: ${host}`)
     });
 
@@ -280,7 +280,7 @@ module.exports = function(context) {
         messaging.send('node:message:processed', msg);
     });
 
-    messaging.register('node:connection:error', function(err) {
+    messaging.register('network:error', function(err) {
         logger.warn(`Attempting to connect to cluster_master: ${host}`, err)
     });
 

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -316,4 +316,9 @@ module.exports = function(context) {
         context.foundation.startWorkers(1, {assignment: 'cluster_master', node_id: context.sysconfig._nodeName});
     }
 
+    if (context.sysconfig.teraslice.moderator) {
+        logger.debug(`node ${context.sysconfig._nodeName} is creating the moderator`);
+        context.foundation.startWorkers(1, {assignment: 'moderator', node_id: context.sysconfig._nodeName});
+    }
+
 };

--- a/lib/cluster/services/cluster.js
+++ b/lib/cluster/services/cluster.js
@@ -42,12 +42,13 @@ module.exports = function(context, server) {
     });
 
     //TODO need hooks for moderator
-    messaging.register('moderator:online', function(val) {
-        logger.warn('i got the val', val)
+    messaging.register('moderator:online', 'moderator', function(val) {
+        //registers moderator to socket behind the scenes
+        logger.info(`moderator has connected to cluster_master`)
     });
 
     messaging.register('moderator:pause_jobs', function(connectionList) {
-        logger.error('cluster master getting the pause job ebent')
+        logger.error('cluster master getting the pause job event');
         logger.debug('cluster_master receiving pause job events from moderator', connectionList);
         events.emit('moderate_jobs:pause', connectionList)
     });
@@ -158,25 +159,32 @@ module.exports = function(context, server) {
         logger.error(`Error : cluster_master had an error with one of its connections`, err)
     });
 
-    messaging.register('node:disconnect', 'node_id', function(msg, node_id) {
-        console.log(node_id)
-        if (node_id && cluster_state[node_id]) {
-            if (cluster_state[node_id].active.length === 0) {
-                logger.warn(`node ${node_id} has disconnected`);
-                delete cluster_state[node_id];
+    messaging.register('cluster_master:disconnect', ['node_id', 'moderator'], function(msg, identifier, id) {
+        if (identifier) {
+            //is a node_id
+            if (identifier === 'node_id' && cluster_state[id]) {
+                let node_id = id;
+                if (cluster_state[node_id].active.length === 0) {
+                    logger.warn(`node ${node_id} has disconnected`);
+                    delete cluster_state[node_id];
+                }
+                else {
+                    cluster_state[node_id].state = 'disconnected';
+
+                    var timer = setTimeout(function() {
+                        cleanUpNode(node_id);
+                    }, 5000);
+
+                    droppedNodes[node_id] = timer;
+                }
             }
-            else {
-                cluster_state[node_id].state = 'disconnected';
 
-                var timer = setTimeout(function() {
-                    cleanUpNode(node_id);
-                }, 5000);
-
-                droppedNodes[node_id] = timer;
+            if (identifier === 'moderator') {
+                logger.warn('The moderator has disconnected from cluster_master')
             }
         }
         else {
-            logger.error(`cluster got a node_master disconnect events, but no node_id or state was found. might be a network issue, node_id: ${node_id}`, cluster_state[node_id])
+            logger.error(`cluster_master got a disconnect event on a unidentified connection. might be a network/service communication issue, msg: ${msg}`)
         }
     });
 
@@ -687,7 +695,6 @@ module.exports = function(context, server) {
 };
 
 
-
 /*
 
  curl -XPUT -sS localhost:9200/_cluster/settings -d '{ "transient" : {
@@ -695,4 +702,4 @@ module.exports = function(context, server) {
  "threadpool.bulk.queue_size" : "1" } }'
 
 
-* */
+ * */

--- a/lib/cluster/services/cluster.js
+++ b/lib/cluster/services/cluster.js
@@ -165,6 +165,7 @@ module.exports = function(context, server) {
     });
 
     messaging.register('network:disconnect', ['node_id', 'moderator'], function(msg, id, identifier) {
+        console.log(msg, id, identifier)
         if (identifier) {
             //is a node_id
             if (identifier === 'node_id' && cluster_state[id]) {

--- a/lib/cluster/services/cluster.js
+++ b/lib/cluster/services/cluster.js
@@ -155,11 +155,11 @@ module.exports = function(context, server) {
         events.emit('slicer:job:update', ex_Update);
     });
 
-    messaging.register('cluster:connection:error', function(err, other) {
+    messaging.register('network:error', function(err, other) {
         logger.error(`Error : cluster_master had an error with one of its connections`, err)
     });
 
-    messaging.register('cluster_master:disconnect', ['node_id', 'moderator'], function(msg, identifier, id) {
+    messaging.register('network:disconnect', ['node_id', 'moderator'], function(msg, identifier, id) {
         if (identifier) {
             //is a node_id
             if (identifier === 'node_id' && cluster_state[id]) {

--- a/lib/cluster/services/cluster.js
+++ b/lib/cluster/services/cluster.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash');
 var Promise = require('bluebird');
-var event = require('../../utils/events');
+var events = require('../../utils/events');
 var shortid = require('shortid');
 var Queue = require('../../utils/queue');
 
@@ -17,8 +17,8 @@ module.exports = function(context, server) {
     //temporary holding spot used to attach nodes that are non responsive or disconnect before final cleanup
     var droppedNodes = {};
 
-    //event can be fired from anything that instantiates a client, such as stores
-    event.on('client config error', terminalShutdown);
+    //events can be fired from anything that instantiates a client, such as stores
+    events.on('client config error', terminalShutdown);
 
     //to catch signal propagation, but cleanup through msg sent from master
     function noOP() {
@@ -29,11 +29,32 @@ module.exports = function(context, server) {
         messaging.send({message: 'cluster:error:terminal'});
     }
 
+    /*
+     * Should take note that since job_service is instantiated after cluster service, the mode to interact with
+     * job_service is through events emitters
+     * */
+
     messaging.register('process:SIGTERM', noOP);
     messaging.register('process:SIGINT', noOP);
 
     messaging.register('worker:shutdown', function(msg) {
-        event.emit('cluster_master:shutdown')
+        events.emit('cluster_master:shutdown')
+    });
+
+    //TODO need hooks for moderator
+    messaging.register('moderator:online', function(val) {
+        logger.warn('i got the val', val)
+    });
+
+    messaging.register('moderator:pause_jobs', function(connectionList) {
+        logger.error('cluster master getting the pause job ebent')
+        logger.debug('cluster_master receiving pause job events from moderator', connectionList);
+        events.emit('moderate_jobs:pause', connectionList)
+    });
+
+    messaging.register('moderator:resume_jobs', function(connectionList) {
+        logger.debug('cluster_master receiving resume job events from moderator', connectionList);
+        events.emit('moderate_jobs:resume', connectionList)
     });
 
     messaging.register('node:online', 'node_id', function(data, node_id) {
@@ -48,20 +69,20 @@ module.exports = function(context, server) {
         logger.trace(`node ${node_id} has state:`, data);
         cluster_state[node_id] = data;
         //if new node comes online, check if jobs need more workers
-        event.emit('cluster:available_workers')
+        events.emit('cluster:available_workers')
     });
 
     messaging.register('node:state', function(data) {
         cluster_state[data.node_id] = data;
         logger.debug(`node ${data.node_id} state is being updated`);
         logger.trace(`node ${data.node_id} has updated state:`, data);
-        event.emit('cluster:available_workers')
+        events.emit('cluster:available_workers')
     });
 
     messaging.register('node:message:processed', function(data) {
         //emitting the unique msg id to allow easier listener cleanup
         logger.debug(`node message ${data._msgID} has been processed`);
-        event.emit(data._msgID, data);
+        events.emit(data._msgID, data);
     });
 
     messaging.register('node:workers:over_allocated', function(requestData) {
@@ -77,16 +98,16 @@ module.exports = function(context, server) {
         pendingWorkerRequests.remove(data.ex_id);
 
         messaging.send('cluster:job:stop', data);
-        //if errors in slices, emit error event
+        //if errors in slices, emit error events
         if (data.errorCount > 0) {
             var message = `job: ${data.ex_id} had ${data.errorCount} slice failures during processing`;
             data.error = message;
 
             logger.warn(message);
-            event.emit('cluster:job_failure', data)
+            events.emit('cluster:job_failure', data)
         }
         else {
-            event.emit('cluster:job_finished', data);
+            events.emit('cluster:job_finished', data);
         }
     });
 
@@ -95,7 +116,7 @@ module.exports = function(context, server) {
         logger.debug(`slicer for execution: ${data.ex_id} has failed on recovery`);
         pendingWorkerRequests.remove(data.ex_id);
         messaging.send('cluster:job:stop', {ex_id: data.ex_id});
-        event.emit('cluster:job_failure', data);
+        events.emit('cluster:job_failure', data);
     });
 
     messaging.register('job:error:terminal', function(data) {
@@ -103,7 +124,7 @@ module.exports = function(context, server) {
 
         pendingWorkerRequests.remove(data.ex_id);
         messaging.send('cluster:job:stop', {ex_id: data.ex_id});
-        event.emit('cluster:job_failure', data);
+        events.emit('cluster:job_failure', data);
     });
 
     messaging.register('slicer:error:terminal', function(data) {
@@ -111,26 +132,26 @@ module.exports = function(context, server) {
 
         pendingWorkerRequests.remove(data.ex_id);
         messaging.send('cluster:job:stop', {ex_id: data.ex_id});
-        event.emit('cluster:slicer_failure', data);
+        events.emit('cluster:slicer_failure', data);
     });
 
     messaging.register('slicer:processing:error', function(data) {
         logger.debug(`an error has occurred processing a slice, ex_id: ${data.ex_id}`);
         logger.trace(`error processing slice,ex_id: ${data.ex_id}, message:`, data);
-        event.emit('slicer:processing:error', data)
+        events.emit('slicer:processing:error', data)
     });
 
     messaging.register('slicer:initialized', function(data) {
         logger.debug(`slicer has initialized, ex_id: ${data.ex_id}`);
         logger.trace(`slicer initialized, ex_id: ${data.ex_id}, message:`, data);
 
-        event.emit('slicer:initialized', data)
+        events.emit('slicer:initialized', data)
     });
 
     messaging.register('slicer:job:update', function(ex_Update) {
         logger.debug(`updating ex: ${ex_Update.ex_id}`);
         logger.trace(`updating ex: ${ex_Update.ex_id}, message:`, ex_Update);
-        event.emit('slicer:job:update', ex_Update);
+        events.emit('slicer:job:update', ex_Update);
     });
 
     messaging.register('cluster:connection:error', function(err, other) {
@@ -138,6 +159,7 @@ module.exports = function(context, server) {
     });
 
     messaging.register('node:disconnect', 'node_id', function(msg, node_id) {
+        console.log(node_id)
         if (node_id && cluster_state[node_id]) {
             if (cluster_state[node_id].active.length === 0) {
                 logger.warn(`node ${node_id} has disconnected`);
@@ -154,7 +176,7 @@ module.exports = function(context, server) {
             }
         }
         else {
-            logger.error(`cluster got a node_master disconnect event, but no node_id or state was found. might be a network issue, node_id: ${node_id}`, cluster_state[node_id])
+            logger.error(`cluster got a node_master disconnect events, but no node_id or state was found. might be a network issue, node_id: ${node_id}`, cluster_state[node_id])
         }
     });
 
@@ -177,7 +199,7 @@ module.exports = function(context, server) {
 
                 var data = {ex_id: ex_id, error: 'node_master where slicer resided has disconnected'};
                 pendingWorkerRequests.remove(ex_id);
-                event.emit('cluster:job_failure', data);
+                events.emit('cluster:job_failure', data);
                 messaging.send('cluster:job:stop', {ex_id: ex_id});
             });
         }
@@ -190,7 +212,7 @@ module.exports = function(context, server) {
                     return worker.ex_id === value;
                 }).length;
 
-                event.emit('cluster_service:cleanup_job', {
+                events.emit('cluster_service:cleanup_job', {
                     ex_id: value,
                     id: value,
                     node_id: node_id,
@@ -347,9 +369,9 @@ module.exports = function(context, server) {
 
             //set up the listener, since there is no clean way to have a dynamically named function or variable to
             //identify the correct function to remove on cleanup, we are listening on and emitting the unique id as key
-            event.on(msgData._msgID, function(nodeMasterData) {
+            events.on(msgData._msgID, function(nodeMasterData) {
                 //remove listener to prevent memory leaks
-                event.removeAllListeners(msgData._msgID);
+                events.removeAllListeners(msgData._msgID);
 
                 if (nodeMasterData.error) {
                     reject(`Error: ${nodeMasterData.error} occured on node: ${nodeMasterData.node_id}`)
@@ -367,7 +389,7 @@ module.exports = function(context, server) {
             //reject if timeout has been reached
             setTimeout(function() {
                 //remove listener to prevent memory leaks
-                event.removeAllListeners(msgData._msgID);
+                events.removeAllListeners(msgData._msgID);
                 reject(`Error communicating with node: ${node_id}, Could not send msg: ${msg}, data: ${JSON.stringify(msgData)}`)
             }, configTimeout)
         })
@@ -516,7 +538,7 @@ module.exports = function(context, server) {
         }
     }, 500, {leading: false, trailing: true});
 
-    event.on('cluster:available_workers', schedulePendingRequests);
+    events.on('cluster:available_workers', schedulePendingRequests);
 
 
     function shutdown() {
@@ -664,3 +686,13 @@ module.exports = function(context, server) {
     return _initialize();
 };
 
+
+
+/*
+
+ curl -XPUT -sS localhost:9200/_cluster/settings -d '{ "transient" : {
+ "threadpool.bulk.size" : "1",
+ "threadpool.bulk.queue_size" : "1" } }'
+
+
+* */

--- a/lib/cluster/services/cluster.js
+++ b/lib/cluster/services/cluster.js
@@ -41,7 +41,6 @@ module.exports = function(context, server) {
         events.emit('cluster_master:shutdown')
     });
 
-    //TODO need hooks for moderator
     messaging.register('moderator:online', 'moderator', function(modMessage) {
         if (!moderator) {
             moderator = {};
@@ -165,7 +164,6 @@ module.exports = function(context, server) {
     });
 
     messaging.register('network:disconnect', ['node_id', 'moderator'], function(msg, id, identifier) {
-        console.log(msg, id, identifier)
         if (identifier) {
             //is a node_id
             if (identifier === 'node_id' && cluster_state[id]) {

--- a/lib/cluster/services/cluster.js
+++ b/lib/cluster/services/cluster.js
@@ -18,7 +18,7 @@ module.exports = function(context, server) {
     var droppedNodes = {};
 
     //events can be fired from anything that instantiates a client, such as stores
-    events.on('client config error', terminalShutdown);
+    events.on('getClient:config_error', terminalShutdown);
 
     //to catch signal propagation, but cleanup through msg sent from master
     function noOP() {

--- a/lib/cluster/services/cluster.js
+++ b/lib/cluster/services/cluster.js
@@ -693,13 +693,3 @@ module.exports = function(context, server) {
 
     return _initialize();
 };
-
-
-/*
-
- curl -XPUT -sS localhost:9200/_cluster/settings -d '{ "transient" : {
- "threadpool.bulk.size" : "1",
- "threadpool.bulk.queue_size" : "1" } }'
-
-
- * */

--- a/lib/cluster/services/cluster.js
+++ b/lib/cluster/services/cluster.js
@@ -625,6 +625,10 @@ module.exports = function(context, server) {
 
         //connectionList is array of arrays => [['elasticsearch', [default, conn2], ['otherDB', [default, conn2]]]
         return Promise.map(connectionList, function(conn) {
+            //only check if right moderator is online
+            if (!moderator[conn[0]]) {
+                return Promise.resolve(true)
+            }
             return notifyNode(`moderator:${conn[0]}`, 'cluster:moderator:connection_ok', {data: conn[1]})
         });
 

--- a/lib/cluster/services/cluster.js
+++ b/lib/cluster/services/cluster.js
@@ -620,15 +620,12 @@ module.exports = function(context, server) {
     //currently if job is submitted before moderator comes online, job will be made but paused later
     function checkModerator(connectionList) {
         if (!moderator) {
-            console.log('do i not exitst?');
             return Promise.resolve(true)
         }
 
         //connectionList is array of arrays => [['elasticsearch', [default, conn2], ['otherDB', [default, conn2]]]
         return Promise.map(connectionList, function(conn) {
-            //node_id, msg, msgData
-            console.log('i should be asking', `moderator:${conn[0]}`, conn);
-            return notifyNode(`moderator:${conn[0]}`, 'cluster_master:check_moderator', {data: conn[1]})
+            return notifyNode(`moderator:${conn[0]}`, 'cluster:moderator:connection_ok', {data: conn[1]})
         });
 
     }

--- a/lib/cluster/services/cluster.js
+++ b/lib/cluster/services/cluster.js
@@ -11,7 +11,7 @@ module.exports = function(context, server) {
     var logger = context.foundation.makeLogger('cluster', 'cluster', {module: 'cluster_service'});
     var configTimeout = context.sysconfig.teraslice.timeout;
     var pendingWorkerRequests = new Queue();
-
+    var moderator = null;
     var cluster_state = {};
 
     //temporary holding spot used to attach nodes that are non responsive or disconnect before final cleanup
@@ -42,9 +42,14 @@ module.exports = function(context, server) {
     });
 
     //TODO need hooks for moderator
-    messaging.register('moderator:online', 'moderator', function(val) {
+    messaging.register('moderator:online', 'moderator', function(modMessage) {
+        if (!moderator) {
+            moderator = {};
+        }
+        var type = modMessage.moderator.split(':')[1];
+        moderator[type] = true;
         //registers moderator to socket behind the scenes
-        logger.info(`moderator has connected to cluster_master`)
+        logger.info(`moderator for ${type} has connected to cluster_master`)
     });
 
     messaging.register('moderator:pause_jobs', function(connectionList) {
@@ -159,7 +164,7 @@ module.exports = function(context, server) {
         logger.error(`Error : cluster_master had an error with one of its connections`, err)
     });
 
-    messaging.register('network:disconnect', ['node_id', 'moderator'], function(msg, identifier, id) {
+    messaging.register('network:disconnect', ['node_id', 'moderator'], function(msg, id, identifier) {
         if (identifier) {
             //is a node_id
             if (identifier === 'node_id' && cluster_state[id]) {
@@ -180,7 +185,11 @@ module.exports = function(context, server) {
             }
 
             if (identifier === 'moderator') {
-                logger.warn('The moderator has disconnected from cluster_master')
+                logger.warn(`Moderator ${id} has disconnected from cluster_master`);
+                delete moderator[id];
+                if (Object.keys(moderator).length === 0) {
+                    moderator = null;
+                }
             }
         }
         else {
@@ -608,6 +617,22 @@ module.exports = function(context, server) {
         return iterate_state(slicerByID)
     }
 
+    //currently if job is submitted before moderator comes online, job will be made but paused later
+    function checkModerator(connectionList) {
+        if (!moderator) {
+            console.log('do i not exitst?');
+            return Promise.resolve(true)
+        }
+
+        //connectionList is array of arrays => [['elasticsearch', [default, conn2], ['otherDB', [default, conn2]]]
+        return Promise.map(connectionList, function(conn) {
+            //node_id, msg, msgData
+            console.log('i should be asking', `moderator:${conn[0]}`, conn);
+            return notifyNode(`moderator:${conn[0]}`, 'cluster_master:check_moderator', {data: conn[1]})
+        });
+
+    }
+
     function removeWorkers(res, ex_id, workerNum) {
         var dispatch = makeDispatch();
         var workers = findWorkersByExecutionID(ex_id);
@@ -679,7 +704,8 @@ module.exports = function(context, server) {
         removeFromQueue: removeFromQueue,
         addToQueue: addToQueue,
         removeWorkers: removeWorkers,
-        shutdown: shutdown
+        shutdown: shutdown,
+        checkModerator: checkModerator
     };
 
     function _initialize() {

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -18,7 +18,7 @@ var pendingExecutionQueue;
  aborted - when a job was running at the point when the cluster shutsdown
  */
 var VALID_STATUS = [
-    'pending', 'scheduling', 'initializing', 'running', 'failing', 'paused',
+    'pending', 'scheduling', 'initializing', 'running', 'failing', 'paused', 'moderator_paused',
     'completed', 'stopped', 'rejected', 'failed', 'aborted'
 ];
 
@@ -26,7 +26,8 @@ var VALID_STATUS = [
 var STATE_MAPPING = {
     'stop': 'stopped',
     'pause': 'paused',
-    'resume': 'running'
+    'resume': 'running',
+    'moderator_paused': 'moderator_paused'
 };
 
 // Maps job control messages into cluster control messages.
@@ -34,7 +35,8 @@ var MESSAGE_MAPPING = {
     'pause': 'cluster:job:pause',
     'resume': 'cluster:job:resume',
     'restart': 'cluster:job:restart',
-    'stop': 'cluster:job:stop'
+    'stop': 'cluster:job:stop',
+    'moderator_paused': 'cluster:job:pause'
 };
 
 module.exports = function(context, cluster_service) {
@@ -122,7 +124,7 @@ module.exports = function(context, cluster_service) {
             .then(function(results) {
                 return Promise.map(results, function(job) {
                     jobList.push(job.ex_id);
-                    return notify(job.ex_id, 'pause')
+                    return notify(job.ex_id, 'moderator_paused')
                 });
             })
             .then(function(results) {
@@ -140,7 +142,7 @@ module.exports = function(context, cluster_service) {
         let str = connectionList.map(function(db) {
             return `moderator.${db.type}:${db.connection}`
         });
-        let query = `_status:pause AND (${(str.join(' OR '))})`;
+        let query = `_status:moderator_paused AND (${(str.join(' OR '))})`;
 
         findJobs(query)
             .then(function(results) {
@@ -374,7 +376,7 @@ module.exports = function(context, cluster_service) {
 
     function _notifyCluster(ex_id, notice) {
         var slicerOnly = false;
-        if (notice === 'pause' || notice === 'resume') slicerOnly = true;
+        if (notice === 'pause' || notice === 'resume' || notice === 'moderator_paused') slicerOnly = true;
 
         if (!MESSAGE_MAPPING[notice]) {
             throw new Error(`JobsService: invalid notification message`);

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -41,7 +41,7 @@ var MESSAGE_MAPPING = {
 
 module.exports = function(context, cluster_service) {
     var logger = context.foundation.makeLogger('jobs', 'jobs', {module: 'jobs_service'});
-
+    var esConnectionState = context.sysconfig.teraslice.state.connection;
     var job_store;
     var ex_store;
     var job_validator = require('../../config/validators/job')(context);
@@ -191,17 +191,39 @@ module.exports = function(context, cluster_service) {
         pendingExecutionQueue.enqueue(ex);
     }
 
+    //check to see if state connection is listed, if not add it for moderator checks
+    function connectionDefaults(array) {
+        let wasFound = false;
+        _.each(array, function(conn) {
+            if (conn[0] === 'elasticsearch') {
+                wasFound = true;
+                let stateConn = _.find(conn[1], function(conn) {
+                    return conn === esConnectionState;
+                });
+
+                if (!stateConn) {
+                    conn[1].push(esConnectionState)
+                }
+            }
+        });
+
+        if (!wasFound) {
+            array.push(['elasticsearch', [esConnectionState]])
+        }
+
+        return array
+    }
+
     function checkModerator(job) {
         //if nothing to track, return true
         if (!job.moderator) {
             return Promise.resolve(true)
         }
-
-        var connectionList = _.toPairs(job.moderator);
+        var connectionList = connectionDefaults(_.toPairs(job.moderator));
 
         return cluster_service.checkModerator(connectionList)
             .catch(function(err) {
-                //TODO do somehitng with error
+                //TODO do something with error
                 return false;
             })
     }

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -461,7 +461,7 @@ module.exports = function(context, cluster_service) {
 
     return Promise.all([require('../storage/jobs')(context, 'job'), require('../storage/jobs')(context, 'ex')])
         .spread(function(job, ex) {
-            logger.info("initializing");
+            logger.info("Initializing");
             job_store = job;
             ex_store = ex;
 

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -159,7 +159,6 @@ module.exports = function(context, cluster_service) {
                         logger.error(`error checking moderator while attempting to remove job from moderatorPausedQueue`, errMsg);
                     })
             });
-            pendingExecutionQueue.shiftQueue(moderatorPausedQueue)
         }
 
         findJobs(query)

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -113,15 +113,13 @@ module.exports = function(context, cluster_service) {
     //TODO probably need to have conditional logic on restarts on moderator pause vs user pause, so don't restart
     events.on('moderate_jobs:pause', function(connectionList) {
         let jobList = [];
-        var str = connectionList.map(function(db) {
+        let str = connectionList.map(function(db) {
             return `moderator.${db.type}:${db.connection}`
         });
-        var query = `(_status:running OR _status:failing) AND (${(str.join(' OR '))})`;
-        logger.error('doing the pause', query)
+        let query = `(_status:running OR _status:failing) AND (${(str.join(' OR '))})`;
 
         findJobs(query)
             .then(function(results) {
-                console.log('got the results', results);
                 return Promise.map(results, function(job) {
                     jobList.push(job.ex_id);
                     return notify(job.ex_id, 'pause')
@@ -139,12 +137,11 @@ module.exports = function(context, cluster_service) {
 
     events.on('moderate_jobs:resume', function(connectionList) {
         let jobList = [];
-
-        var str = connectionList.map(function(db) {
+        let str = connectionList.map(function(db) {
             return `moderator.${db.type}:${db.connection}`
         });
+        let query = `_status:pause AND (${(str.join(' OR '))})`;
 
-        var query = `_status:pause AND (${(str.join(' OR '))})`;
         findJobs(query)
             .then(function(results) {
                 return Promise.map(results, function(job) {
@@ -162,10 +159,8 @@ module.exports = function(context, cluster_service) {
     });
 
     function findJobs(query) {
-        logger.warn('what query', query);
         return ex_store.search(query, null, 10000)
             .then(function(jobs) {
-                logger.warn('what jobs', jobs);
                 return jobs
             })
             .catch(function(err) {

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -110,6 +110,71 @@ module.exports = function(context, cluster_service) {
         });
     });
 
+    //TODO probably need to have conditional logic on restarts on moderator pause vs user pause, so don't restart
+    events.on('moderate_jobs:pause', function(connectionList) {
+        let jobList = [];
+        var str = connectionList.map(function(db) {
+            return `moderator.${db.type}:${db.connection}`
+        });
+        var query = `(_status:running OR _status:failing) AND (${(str.join(' OR '))})`;
+        logger.error('doing the pause', query)
+
+        findJobs(query)
+            .then(function(results) {
+                console.log('got the results', results);
+                return Promise.map(results, function(job) {
+                    jobList.push(job.ex_id);
+                    return notify(job.ex_id, 'pause')
+                });
+            })
+            .then(function(results) {
+                logger.warn(`The following jobs have been paused by the moderator: ${jobList.join(' , ')}`)
+            })
+            .catch(function(err) {
+                var errMsg = elasticError(err);
+                logger.error(`could not pause job for moderator`, errMsg);
+                return Promise.reject(errMsg);
+            })
+    });
+
+    events.on('moderate_jobs:resume', function(connectionList) {
+        let jobList = [];
+
+        var str = connectionList.map(function(db) {
+            return `moderator.${db.type}:${db.connection}`
+        });
+
+        var query = `_status:pause AND (${(str.join(' OR '))})`;
+        findJobs(query)
+            .then(function(results) {
+                return Promise.map(results, function(job) {
+                    jobList.push(job.ex_id);
+                    return notify(job.ex_id, 'resume')
+                });
+            })
+            .then(function(results) {
+                logger.warn(`The following jobs have been resumed by the moderator: ${jobList.join(' , ')}`)
+            })
+            .catch(function(err) {
+                var errMsg = elasticError(err);
+                logger.error(`could not resume job for moderator`, errMsg);
+            })
+    });
+
+    function findJobs(query) {
+        logger.warn('what query', query);
+        return ex_store.search(query, null, 10000)
+            .then(function(jobs) {
+                logger.warn('what jobs', jobs);
+                return jobs
+            })
+            .catch(function(err) {
+                var errMsg = elasticError(err);
+                logger.error(`could not findJob`, errMsg);
+                return Promise.reject(errMsg);
+            })
+    }
+
     function saveJob(job, jobType) {
         if (jobType === 'job') {
             return job_store.create(job)

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -112,13 +112,13 @@ module.exports = function(context, cluster_service) {
         });
     });
 
-    //TODO probably need to have conditional logic on restarts on moderator pause vs user pause, so don't restart
     events.on('moderate_jobs:pause', function(connectionList) {
         let jobList = [];
         let str = connectionList.map(function(db) {
             return `moderator.${db.type}:${db.connection}`
         });
         let query = `(_status:running OR _status:failing) AND (${(str.join(' OR '))})`;
+        logger.trace(`moderator is attempting to pause jobs, query ${query}`);
 
         findJobs(query)
             .then(function(results) {
@@ -132,8 +132,7 @@ module.exports = function(context, cluster_service) {
             })
             .catch(function(err) {
                 var errMsg = elasticError(err);
-                logger.error(`could not pause job for moderator`, errMsg);
-                return Promise.reject(errMsg);
+                logger.error(`could not pause job for moderator, query: ${query}`, errMsg);
             })
     });
 
@@ -143,6 +142,25 @@ module.exports = function(context, cluster_service) {
             return `moderator.${db.type}:${db.connection}`
         });
         let query = `_status:moderator_paused AND (${(str.join(' OR '))})`;
+        logger.trace(`moderator is attempting to resume jobs, query ${query}`);
+
+        //add any side-lined jobs back to the main job queue
+        if (moderatorPausedQueue.size()) {
+            moderatorPausedQueue.each(function(job) {
+                checkModerator(job)
+                    .then(function(canRun) {
+                        if (canRun) {
+                            moderatorPausedQueue.remove(job.ex_id, 'ex_id');
+                            pendingExecutionQueue.shift(job);
+                        }
+                    })
+                    .catch(function(err) {
+                        var errMsg = elasticError(err);
+                        logger.error(`error checking moderator while attempting to remove job from moderatorPausedQueue`, errMsg);
+                    })
+            });
+            pendingExecutionQueue.shiftQueue(moderatorPausedQueue)
+        }
 
         findJobs(query)
             .then(function(results) {
@@ -152,17 +170,11 @@ module.exports = function(context, cluster_service) {
                 });
             })
             .then(function(results) {
-                logger.warn(`The following jobs have been resumed by the moderator: ${jobList.join(' , ')}`)
-            })
-            .then(function() {
-                //TODO totally naive approach
-                while (moderatorPausedQueue.size()) {
-                    pendingExecutionQueue.enqueue(moderatorPausedQueue.dequeue())
-                }
+                logger.warn(`The following jobs have been resumed by the moderator: ${jobList.join(' , ')}`);
             })
             .catch(function(err) {
                 var errMsg = elasticError(err);
-                logger.error(`could not resume job for moderator`, errMsg);
+                logger.error(`could not resume job for moderator, query ${query}`, errMsg);
             })
     });
 
@@ -223,8 +235,9 @@ module.exports = function(context, cluster_service) {
 
         return cluster_service.checkModerator(connectionList)
             .catch(function(err) {
-                //TODO do something with error
-                return false;
+                var errMsg = elasticError(err);
+                logger.error(`could not check moderator`, errMsg);
+                return Promise.reject(errMsg)
             })
     }
 
@@ -250,7 +263,8 @@ module.exports = function(context, cluster_service) {
             })
             .catch(function(err) {
                 var errMsg = elasticError(err);
-                logger.error(`could not create execution context`, errMsg)
+                logger.error(`could not create execution context`, errMsg);
+                return Promise.reject(errMsg)
             });
     }
 

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -8,7 +8,7 @@ var exceptions = require('../../utils/exceptions');
 
 // Queue of jobs pending processing
 var pendingExecutionQueue;
-
+var moderatorPausedQueue;
 /*
  Job Life Cycle for _status
  pending -> scheduling -> running -> [ paused -> running ] -> [ stopped | completed ]
@@ -154,6 +154,12 @@ module.exports = function(context, cluster_service) {
             .then(function(results) {
                 logger.warn(`The following jobs have been resumed by the moderator: ${jobList.join(' , ')}`)
             })
+            .then(function() {
+                //TODO totally naive approach
+                while (moderatorPausedQueue.size()) {
+                    pendingExecutionQueue.enqueue(moderatorPausedQueue.dequeue())
+                }
+            })
             .catch(function(err) {
                 var errMsg = elasticError(err);
                 logger.error(`could not resume job for moderator`, errMsg);
@@ -185,13 +191,39 @@ module.exports = function(context, cluster_service) {
         pendingExecutionQueue.enqueue(ex);
     }
 
+    function checkModerator(job) {
+        //if nothing to track, return true
+        if (!job.moderator) {
+            return Promise.resolve(true)
+        }
+
+        var connectionList = _.toPairs(job.moderator);
+
+        return cluster_service.checkModerator(connectionList)
+            .catch(function(err) {
+                //TODO do somehitng with error
+                return false;
+            })
+    }
+
     function createExecutionContext(job) {
         return saveJob(job, 'ex')
             .then(function(ex) {
-                return _setStatus(ex, 'pending')
-            }).then(function(ex) {
-                logger.debug(`enqueueing job to be processed, job`, ex);
-                pendingExecutionQueue.enqueue(ex);
+                return Promise.all([_setStatus(ex, 'pending'), checkModerator(job)])
+            })
+            .spread(function(ex, moderatorResponse) {
+                var canRun = _.every(moderatorResponse, function(db) {
+                    return db.canRun === true
+                });
+
+                if (canRun) {
+                    logger.debug(`enqueueing job to be processed, job`, ex);
+                    pendingExecutionQueue.enqueue(ex);
+                }
+                else {
+                    logger.warn(`job cannot be run due to throttled database connections`);
+                    moderatorPausedQueue.enqueue(ex);
+                }
                 return {job_id: ex.job_id, ex_id: ex.ex_id};
             })
             .catch(function(err) {
@@ -471,7 +503,7 @@ module.exports = function(context, cluster_service) {
 
     function _initialize() {
         pendingExecutionQueue = new Queue;
-
+        moderatorPausedQueue = new Queue;
         // Reschedule any persistent jobs that were running.
         // There may be some additional subtlety required here.
         return getExecutionContexts('running').each(function(job) {

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -3,18 +3,16 @@
 var makeHostName = require('../../utils/cluster').makeHostName;
 
 var networkMapping = {
-    'moderator:cluster:connect': 'connect',
+    'network:connect': 'connect',
+    'network:disconnect': 'disconnect',
+    'network:error': 'error',
     'moderator:online': 'moderator:online',
     'moderator:pause_jobs': 'moderator:pause_jobs',
     'moderator:resume_jobs': 'moderator:resume_jobs',
-    'node:cluster:connect': 'connect',
-    'node:cluster:disconnect': 'disconnect',
     'node:online': 'node:online',
-    'cluster_master:disconnect': 'disconnect',
     'node:state': 'node:state',
     'node:message:processed': 'node:message:processed',
     'node:workers:over_allocated': 'node:workers:over_allocated',
-    'node:connection:error': 'error',
     'cluster:slicer:analytics': 'cluster:slicer:analytics',
     'cluster:slicer:create': 'cluster:slicer:create',
     'cluster:workers:create': 'cluster:workers:create',
@@ -25,7 +23,6 @@ var networkMapping = {
     'cluster:job:resume': 'cluster:job:resume',
     'cluster:job:restart': 'cluster:job:restart',
     'cluster:node:get_port': 'cluster:node:get_port',
-    'cluster:connection:error': 'error',
     'slicer:recovery:failed': 'slicer:recovery:failed',
     'slicer:job:finished': 'slicer:job:finished',
     'slicer:processing:error': 'slicer:processing:error',
@@ -36,9 +33,6 @@ var networkMapping = {
     'slicer:error:terminal': 'slicer:error:terminal',
     'worker:ready': 'worker:ready',
     'worker:slice:complete': 'worker:slice:complete',
-    'worker:disconnect': 'disconnect',
-    'worker:connection:error': 'error',
-    'worker:slicer:connect': 'connect',
     'job:error:terminal': 'job:error:terminal'
 };
 

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -10,7 +10,7 @@ var networkMapping = {
     'node:cluster:connect': 'connect',
     'node:cluster:disconnect': 'disconnect',
     'node:online': 'node:online',
-    'node:disconnect': 'disconnect',
+    'cluster_master:disconnect': 'disconnect',
     'node:state': 'node:state',
     'node:message:processed': 'node:message:processed',
     'node:workers:over_allocated': 'node:workers:over_allocated',
@@ -111,20 +111,63 @@ module.exports = function messaging(context, logger) {
         processContext = context.cluster
     }
 
+    function register(key, fnArg, arg3) {
+        var fn = fnArg;
+        var id;
+
+        if (arg3) {
+            fn = arg3;
+            id = fnArg;
+        }
+
+        if (processMapping[key] || respondingMapping[key] && config.assignment === 'slicer') {
+            var realKey = respondingMapping[key] ? respondingMapping[key] : processMapping[key];
+
+            processContext.on(realKey, fn)
+        }
+        else if (networkMapping[key]) {
+            //we attach events etc later when the connection is made, this is async while others are sync registration
+            if (id) {
+                fn.__wrapper = id;
+                functionMapping[networkMapping[key]] = fn;
+            }
+            else {
+                functionMapping[networkMapping[key]] = fn;
+            }
+        }
+        else {
+            throw new Error(`Error registering event: "${key}" in messaging model, could not find it, need to define message in message service`)
+        }
+    }
 
     function registerFns(socket) {
         for (let key in functionMapping) {
             let func = functionMapping[key];
             if (func.__wrapper) {
                 socket.on(key, function(msg) {
-                    var identifier = func.__wrapper;
-                    var id = msg[identifier];
-                    //if already set, pass set value into fn, else set it
-                    if (socket[identifier]) {
-                        id = socket[identifier];
+                    var wrapper = func.__wrapper;
+                    var identifier;
+                    var id;
+
+                    if (typeof wrapper === 'string') {
+                        identifier = wrapper;
+                        id = msg[identifier];
+                        //if already set, extract value else set it on socket
+                        if (socket[identifier]) {
+                            id = socket[identifier];
+                        }
+                        else {
+                            socket[identifier] = id;
+                        }
                     }
                     else {
-                        socket[identifier] = id;
+                        //this is only used by cluster_master disconnect event so far to determine which services are exiting
+                        wrapper.forEach(function(tag) {
+                            if (socket[identifier] !== 'undefined') {
+                                identifier = tag;
+                                id = socket[tag];
+                            }
+                        })
                     }
 
                     // if network host (slicer, cluster_master) and connection  or retry event, join room
@@ -135,7 +178,7 @@ module.exports = function messaging(context, logger) {
 
                     //not all events have messages, if so then pass it, else just pass identifier
                     if (msg) {
-                        func(msg, id)
+                        func(msg, identifier, id)
                     }
                     else {
                         func(id)
@@ -203,35 +246,6 @@ module.exports = function messaging(context, logger) {
                 io.listen(port);
                 logger.debug(`slicer is online and listening on port ${port}`)
             }
-        }
-    }
-
-    function register(key, fnArg, arg3) {
-        var fn = fnArg;
-        var id;
-
-        if (arg3) {
-            fn = arg3;
-            id = fnArg;
-        }
-
-        if (processMapping[key] || respondingMapping[key] && config.assignment === 'slicer') {
-            var realKey = respondingMapping[key] ? respondingMapping[key] : processMapping[key];
-
-            processContext.on(realKey, fn)
-        }
-        else if (networkMapping[key]) {
-            //we attach events etc later when the connection is made, this is async while others are sync registration
-            if (id) {
-                fn.__wrapper = id;
-                functionMapping[networkMapping[key]] = fn;
-            }
-            else {
-                functionMapping[networkMapping[key]] = fn;
-            }
-        }
-        else {
-            throw new Error(`Error registering event: "${key}" in messaging model, could not find it, need to define message in message service`)
         }
     }
 

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -66,7 +66,7 @@ function makeConfigurations(context) {
         moderator: {networkClient: true, ipcClient: true}
     };
 
-    var env = process.env;
+    var env = context.__testingModule ? context.__testingModule.env : process.env;
     var config = {};
 
     config.clients = options[env.assignment];
@@ -99,7 +99,7 @@ module.exports = function messaging(context, logger) {
 
     if (config.clients.ipcClient) {
         //all children of node_master
-        processContext = process
+        processContext = context.__testingModule ? context.__testingModule : process
     }
     else {
         //node_master

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -3,6 +3,10 @@
 var makeHostName = require('../../utils/cluster').makeHostName;
 
 var networkMapping = {
+    'moderator:cluster:connect': 'connect',
+    'moderator:online': 'moderator:online',
+    'moderator:pause_jobs': 'moderator:pause_jobs',
+    'moderator:resume_jobs': 'moderator:resume_jobs',
     'node:cluster:connect': 'connect',
     'node:cluster:disconnect': 'disconnect',
     'node:online': 'node:online',
@@ -63,7 +67,8 @@ function makeConfigurations(context) {
         node_master: {networkClient: true, ipcClient: false},
         cluster_master: {networkClient: false, ipcClient: true},
         slicer: {networkClient: false, ipcClient: true},
-        worker: {networkClient: true, ipcClient: true}
+        worker: {networkClient: true, ipcClient: true},
+        moderator: {networkClient: true, ipcClient: true}
     };
 
     var env = process.env;
@@ -71,7 +76,7 @@ function makeConfigurations(context) {
 
     config.clients = options[env.assignment];
     if (config.clients.networkClient) {
-        if (env.assignment === 'node_master') {
+        if (env.assignment === 'node_master' || env.assignment === 'moderator') {
             host = context.sysconfig.teraslice.master_hostname;
             port = context.sysconfig.teraslice.port;
         }

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -173,7 +173,7 @@ module.exports = function messaging(context, logger) {
 
                     //not all events have messages, if so then pass it, else just pass identifier
                     if (msg) {
-                        func(msg, identifier, id)
+                        func(msg, id, identifier)
                     }
                     else {
                         func(id)

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -13,6 +13,7 @@ var networkMapping = {
     'node:state': 'node:state',
     'node:message:processed': 'node:message:processed',
     'node:workers:over_allocated': 'node:workers:over_allocated',
+    'cluster_master:check_moderator': 'cluster_master:check_moderator',
     'cluster:slicer:analytics': 'cluster:slicer:analytics',
     'cluster:slicer:create': 'cluster:slicer:create',
     'cluster:workers:create': 'cluster:workers:create',

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -165,7 +165,7 @@ module.exports = function messaging(context, logger) {
                     }
 
                     // if network host (slicer, cluster_master) and connection  or retry event, join room
-                    if (key === 'worker:ready' || key === 'node:online' || (msg.retry && key === 'worker:slice:complete')) {
+                    if (key === 'worker:ready' || key === 'node:online' || key === 'moderator:online' || (msg.retry && key === 'worker:slice:complete')) {
                         logger.debug(`joining room ${id}`);
                         socket.join(id)
                     }

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -13,7 +13,7 @@ var networkMapping = {
     'node:state': 'node:state',
     'node:message:processed': 'node:message:processed',
     'node:workers:over_allocated': 'node:workers:over_allocated',
-    'cluster_master:check_moderator': 'cluster_master:check_moderator',
+    'cluster:moderator:connection_ok': 'cluster:moderator:connection_ok',
     'cluster:slicer:analytics': 'cluster:slicer:analytics',
     'cluster:slicer:create': 'cluster:slicer:create',
     'cluster:workers:create': 'cluster:workers:create',

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -158,11 +158,11 @@ module.exports = function messaging(context, logger) {
                     else {
                         //this is only used by cluster_master disconnect event so far to determine which services are exiting
                         wrapper.forEach(function(tag) {
-                            if (socket[identifier] !== 'undefined') {
+                            if (socket[tag]) {
                                 identifier = tag;
                                 id = socket[tag];
                             }
-                        })
+                        });
                     }
 
                     // if network host (slicer, cluster_master) and connection  or retry event, join room
@@ -197,7 +197,6 @@ module.exports = function messaging(context, logger) {
         if (arg3) {
             //id, msg, data
             logger.debug(`sending a network message to ${arg1}`, arg2, arg3);
-
             io.sockets.in(arg1).emit(arg2, arg3);
             return;
         }

--- a/lib/cluster/slicer.js
+++ b/lib/cluster/slicer.js
@@ -191,7 +191,7 @@ module.exports = function(context) {
         }
     });
 
-    messaging.register('worker:disconnect', 'worker_id', function(worker_id) {
+    messaging.register('network:disconnect', 'worker_id', function(worker_id) {
         slicerAnalytics.workers_disconnected += 1;
         logger.warn(`Worker: ${worker_id} has disconnected`);
         workerQueue.remove(worker_id);

--- a/lib/cluster/slicer.js
+++ b/lib/cluster/slicer.js
@@ -61,7 +61,7 @@ module.exports = function(context) {
 
     //event can be fired from anything that instantiates a client, such as stores and slicers
     //needs to be setup before job_runner
-    event.on('client config error', terminalShutdown);
+    event.on('getClient:config_error', terminalShutdown);
 
     //these need to be synchronous, so stop/pause/resume actions actually have job defined at all times
     var job_runner = require('./runners/job')(context);

--- a/lib/cluster/storage/backends/elasticsearch.js
+++ b/lib/cluster/storage/backends/elasticsearch.js
@@ -26,32 +26,50 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size)
 
     function get(record_id) {
         logger.trace(`getting record id: ${record_id}`);
+        let retryTimer = {start: 5000, limit: 10000};
+
         return new Promise(function(resolve, reject) {
-            client.get({
-                index: index_name,
-                type: record_type,
-                id: record_id
-            })
-                .then(function(result) {
-                    resolve(result._source)
+            function getRecord() {
+                client.get({
+                    index: index_name,
+                    type: record_type,
+                    id: record_id
                 })
-                .catch(function(err) {
-                    if (_.get(err, 'body.error.type') === 'es_rejected_execution_exception') {
-                        get(record_id)
-                    }
-                    else {
-                        var errMsg = elasticError(err);
-                        logger.error(`error getting record id: ${record_id}`);
-                        logger.error(errMsg);
-                        reject(errMsg)
-                    }
-                });
+                    .then(function(result) {
+                        resolve(result._source)
+                    })
+                    .catch(function(err) {
+                        if (_.get(err, 'body.error.type') === 'es_rejected_execution_exception') {
+                            let timer = Math.floor(Math.random() * (retryTimer.limit - retryTimer.start) + retryTimer.start);
+
+                            if (retryTimer.limit < 60000) {
+                                retryTimer.limit += 10000
+                            }
+                            if (retryTimer.start < 30000) {
+                                retryTimer.start += 5000
+                            }
+                            setTimeout(function() {
+                                getRecord();
+                            }, timer);
+                        }
+                        else {
+                            var errMsg = elasticError(err);
+                            logger.error(`error getting record id: ${record_id}`);
+                            logger.error(errMsg);
+                            reject(errMsg)
+                        }
+                    });
+            }
+
+            getRecord();
         })
 
     }
 
     function search(query, from, size, sort) {
         logger.trace(`elasticsearch search call, sort: ${sort}, from: ${from}, size: ${size}, query: `, query);
+        let retryTimer = {start: 5000, limit: 10000};
+
         var esQuery = {
             index: index_name,
             from: from,
@@ -67,39 +85,51 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size)
         }
 
         return new Promise(function(resolve, reject) {
-            client.search(esQuery)
-                .then(function(results) {
-                    if (results._shards.failed > 0) {
-                        var reasons = _.uniq(_.flatMap(results._shards.failures, function(shard) {
-                            return shard.reason.type
-                        }));
+            function searchES() {
+                client.search(esQuery)
+                    .then(function(results) {
+                        if (results._shards.failed > 0) {
+                            var reasons = _.uniq(_.flatMap(results._shards.failures, function(shard) {
+                                return shard.reason.type
+                            }));
 
-                        if (reasons.length > 1 || reasons[0] !== 'es_rejected_execution_exception') {
-                            var errorReason = reasons.join(' | ');
-                            logger.error(errorReason);
-                            reject(errorReason)
+                            if (reasons.length > 1 || reasons[0] !== 'es_rejected_execution_exception') {
+                                var errorReason = reasons.join(' | ');
+                                logger.error(errorReason);
+                                reject(errorReason)
+                            }
+                            else {
+                                let timer = Math.floor(Math.random() * (retryTimer.limit - retryTimer.start) + retryTimer.start);
+
+                                if (retryTimer.limit < 60000) {
+                                    retryTimer.limit += 10000
+                                }
+                                if (retryTimer.start < 30000) {
+                                    retryTimer.start += 5000
+                                }
+                                setTimeout(function() {
+                                    searchES()
+                                }, timer)
+
+                            }
                         }
                         else {
-                            // Spot to recurse in the future, will reject for now
-                            var errorReason = reasons.join(' | ');
-                            logger.error(errorReason);
-                            reject(errorReason)
-                        }
-                    }
-                    else {
-                        var final = _.map(results.hits.hits, function(hit) {
-                            return hit._source
-                        });
+                            var final = _.map(results.hits.hits, function(hit) {
+                                return hit._source
+                            });
 
-                        resolve(final)
-                    }
-                })
-                .catch(function(err) {
-                    var errMsg = elasticError(err);
-                    logger.error(`error elasticsearch search call, sort: ${sort}, from: ${from}, size: ${size}, query: `, query);
-                    logger.error(errMsg);
-                    reject(errMsg)
-                });
+                            resolve(final)
+                        }
+                    })
+                    .catch(function(err) {
+                        var errMsg = elasticError(err);
+                        logger.error(`error elasticsearch search call, sort: ${sort}, from: ${from}, size: ${size}, query: `, query);
+                        logger.error(errMsg);
+                        reject(errMsg)
+                    });
+            }
+
+            searchES();
         });
     }
 
@@ -111,6 +141,7 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size)
             size: 0,
             sort: sort
         };
+        let retryTimer = {start: 5000, limit: 10000};
 
         if (typeof query === 'string') {
             esQuery.q = query
@@ -120,47 +151,59 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size)
         }
 
         return new Promise(function(resolve, reject) {
-            client.search(esQuery)
-                .then(function(results) {
-                    if (results._shards.failed > 0) {
-                        var reasons = _.uniq(_.flatMap(results._shards.failures, function(shard) {
-                            return shard.reason.type
-                        }));
+            function getCount() {
+                client.search(esQuery)
+                    .then(function(results) {
+                        if (results._shards.failed > 0) {
+                            var reasons = _.uniq(_.flatMap(results._shards.failures, function(shard) {
+                                return shard.reason.type
+                            }));
 
-                        if (reasons.length > 1 || reasons[0] !== 'es_rejected_execution_exception') {
-                            var errorReason = reasons.join(' | ');
-                            logger.error(errorReason);
-                            reject(errorReason)
+                            if (reasons.length > 1 || reasons[0] !== 'es_rejected_execution_exception') {
+                                var errorReason = reasons.join(' | ');
+                                logger.error(errorReason);
+                                reject(errorReason)
+                            }
+                            else {
+                                let timer = Math.floor(Math.random() * (retryTimer.limit - retryTimer.start) + retryTimer.start);
+
+                                if (retryTimer.limit < 60000) {
+                                    retryTimer.limit += 10000
+                                }
+                                if (retryTimer.start < 30000) {
+                                    retryTimer.start += 5000
+                                }
+                                setTimeout(function() {
+                                    getCount();
+                                }, timer)
+
+                            }
                         }
                         else {
-                            // Spot to recurse in the future, will reject for now
-                            var errorReason = reasons.join(' | ');
-                            logger.error(errorReason);
-                            reject(errorReason)
+                            resolve(results.hits.total)
                         }
-                    }
-                    else {
-                        resolve(results.hits.total)
-                    }
-                })
-                .catch(function(err) {
-                    if (_.get(err, 'body.error.type') === 'reduce_search_phase_exception') {
-                        var retriableError = _.every(err.body.error.root_cause, function(shard) {
-                            return shard.type === 'es_rejected_execution_exception';
-                        });
-                        //scaffolding for retries, just reject for now                
-                        if (retriableError) {
-                            reject(err.body.error.type)
+                    })
+                    .catch(function(err) {
+                        if (_.get(err, 'body.error.type') === 'reduce_search_phase_exception') {
+                            var retriableError = _.every(err.body.error.root_cause, function(shard) {
+                                return shard.type === 'es_rejected_execution_exception';
+                            });
+                            //scaffolding for retries, just reject for now                
+                            if (retriableError) {
+                                reject(err.body.error.type)
+                            }
                         }
-                    }
-                    else {
-                        var errMsg = elasticError(err);
-                        logger.trace(`error elasticsearch count call, sort: ${sort}, from: ${from}, query:`, query);
-                        logger.error(errMsg);
+                        else {
+                            var errMsg = elasticError(err);
+                            logger.trace(`error elasticsearch count call, sort: ${sort}, from: ${from}, query:`, query);
+                            logger.error(errMsg);
 
-                        reject(errMsg)
-                    }
-                });
+                            reject(errMsg)
+                        }
+                    });
+            }
+
+            getCount();
         });
     }
 
@@ -170,27 +213,43 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size)
      */
     function index(record) {
         logger.trace(`indexing record`, record);
+        let retryTimer = {start: 5000, limit: 10000};
+
         return new Promise(function(resolve, reject) {
-            client.index({
-                index: index_name,
-                type: record_type,
-                body: record,
-                refresh: true
-            })
-                .then(function(result) {
-                    resolve(record);
+            function indexRecord() {
+                client.index({
+                    index: index_name,
+                    type: record_type,
+                    body: record,
+                    refresh: true
                 })
-                .catch(function(err) {
-                    if (_.get(err, 'body.error.type') === 'es_rejected_execution_exception') {
-                        index(record)
-                    }
-                    else {
-                        var errMsg = elasticError(err);
-                        logger.error(`error indexing record`, record);
-                        logger.error(errMsg);
-                        reject(errMsg)
-                    }
-                });
+                    .then(function(result) {
+                        resolve(record);
+                    })
+                    .catch(function(err) {
+                        if (_.get(err, 'body.error.type') === 'es_rejected_execution_exception') {
+                            let timer = Math.floor(Math.random() * (retryTimer.limit - retryTimer.start) + retryTimer.start);
+
+                            if (retryTimer.limit < 60000) {
+                                retryTimer.limit += 10000
+                            }
+                            if (retryTimer.start < 30000) {
+                                retryTimer.start += 5000
+                            }
+                            setTimeout(function() {
+                                indexRecord();
+                            }, timer)
+                        }
+                        else {
+                            var errMsg = elasticError(err);
+                            logger.error(`error indexing record`, record);
+                            logger.error(errMsg);
+                            reject(errMsg)
+                        }
+                    });
+            }
+
+            indexRecord();
         })
     }
 
@@ -200,28 +259,44 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size)
      */
     function indexWithId(record_id, record) {
         logger.trace(`indexWithId call with id: ${record_id}, record`, record);
+        let retryTimer = {start: 5000, limit: 10000};
+
         return new Promise(function(resolve, reject) {
-            client.index({
-                index: index_name,
-                type: record_type,
-                id: record_id,
-                body: record,
-                refresh: true
-            })
-                .then(function(result) {
-                    resolve(record);
+            function indexRecordID() {
+                client.index({
+                    index: index_name,
+                    type: record_type,
+                    id: record_id,
+                    body: record,
+                    refresh: true
                 })
-                .catch(function(err) {
-                    if (_.get(err, 'body.error.type') === 'es_rejected_execution_exception') {
-                        indexWithId(record_id, record)
-                    }
-                    else {
-                        var errMsg = elasticError(err);
-                        logger.error(`error indexWithId call with id: ${record_id}, record`, record);
-                        logger.error(errMsg);
-                        reject(errMsg)
-                    }
-                });
+                    .then(function(result) {
+                        resolve(record);
+                    })
+                    .catch(function(err) {
+                        if (_.get(err, 'body.error.type') === 'es_rejected_execution_exception') {
+                            let timer = Math.floor(Math.random() * (retryTimer.limit - retryTimer.start) + retryTimer.start);
+
+                            if (retryTimer.limit < 60000) {
+                                retryTimer.limit += 10000
+                            }
+                            if (retryTimer.start < 30000) {
+                                retryTimer.start += 5000
+                            }
+                            setTimeout(function() {
+                                indexRecordID();
+                            }, timer);
+                        }
+                        else {
+                            var errMsg = elasticError(err);
+                            logger.error(`error indexWithId call with id: ${record_id}, record`, record);
+                            logger.error(errMsg);
+                            reject(errMsg)
+                        }
+                    });
+            }
+
+            indexRecordID();
         })
     }
 
@@ -231,58 +306,91 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size)
      */
     function create(record) {
         logger.trace('creating record', record);
+        let retryTimer = {start: 5000, limit: 10000};
+
         return new Promise(function(resolve, reject) {
-            client.create({
-                index: index_name,
-                type: record_type,
-                id: record[id_field],
-                body: record,
-                refresh: true
-            })
-                .then(function(result) {
-                    resolve(record);
+            function createRecord() {
+                client.create({
+                    index: index_name,
+                    type: record_type,
+                    id: record[id_field],
+                    body: record,
+                    refresh: true
                 })
-                .catch(function(err) {
-                    if (_.get(err, 'body.error.type') === 'es_rejected_execution_exception') {
-                        create(record)
-                    }
-                    else {
-                        var errMsg = elasticError(err);
-                        logger.error('error creating record', record);
-                        logger.error(errMsg);
-                        reject(errMsg)
-                    }
-                });
+                    .then(function(result) {
+                        resolve(record);
+                    })
+                    .catch(function(err) {
+                        if (_.get(err, 'body.error.type') === 'es_rejected_execution_exception') {
+                            let timer = Math.floor(Math.random() * (retryTimer.limit - retryTimer.start) + retryTimer.start);
+
+                            if (retryTimer.limit < 60000) {
+                                retryTimer.limit += 10000
+                            }
+                            if (retryTimer.start < 30000) {
+                                retryTimer.start += 5000
+                            }
+                            setTimeout(function() {
+                                createRecord()
+                            }, timer);
+                        }
+                        else {
+                            var errMsg = elasticError(err);
+                            logger.error('error creating record', record);
+                            logger.error(errMsg);
+                            reject(errMsg)
+                        }
+                    });
+            }
+
+            createRecord();
         })
     }
 
     function update(record_id, update_spec) {
         logger.trace(`updating record ${record_id}, `, update_spec);
+        let retryTimer = {start: 5000, limit: 10000};
+
         return new Promise(function(resolve, reject) {
-            client.update({
-                index: index_name,
-                type: record_type,
-                id: record_id,
-                body: {
-                    doc: update_spec
-                },
-                refresh: true,
-                retryOnConflict: 3
-            })
-                .then(function(result) {
-                    resolve(update_spec);
+            function updateRecord() {
+                client.update({
+                    index: index_name,
+                    type: record_type,
+                    id: record_id,
+                    body: {
+                        doc: update_spec
+                    },
+                    refresh: true,
+                    retryOnConflict: 3
                 })
-                .catch(function(err) {
-                    if (_.get(err, 'body.error.type') === 'es_rejected_execution_exception') {
-                        update(record_id, update_spec)
-                    }
-                    else {
-                        var errMsg = elasticError(err);
-                        logger.error(`updating record ${record_id}, `, update_spec);
-                        logger.error(errMsg);
-                        reject(errMsg)
-                    }
-                });
+                    .then(function(result) {
+                        resolve(update_spec);
+                    })
+                    .catch(function(err) {
+                        if (_.get(err, 'body.error.type') === 'es_rejected_execution_exception') {
+                            let timer = Math.floor(Math.random() * (retryTimer.limit - retryTimer.start) + retryTimer.start);
+
+                            if (retryTimer.limit < 60000) {
+                                retryTimer.limit += 10000
+                            }
+                            if (retryTimer.start < 30000) {
+                                retryTimer.start += 5000
+                            }
+                            setTimeout(function() {
+                                updateRecord()
+                            }, timer);
+                        }
+                        else {
+                            var errMsg = elasticError(err);
+                            logger.error(`updating record ${record_id}, `, update_spec);
+                            logger.error(errMsg);
+                            reject(errMsg)
+                        }
+                    });
+
+            }
+
+            updateRecord();
         })
     }
 
@@ -311,28 +419,45 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size)
 
     function remove(record_id) {
         logger.trace(`removing record ${record_id}`);
+        let retryTimer = {start: 5000, limit: 10000};
+
         return new Promise(function(resolve, reject) {
-            client.delete({
-                index: index_name,
-                type: record_type,
-                id: record_id,
-                refresh: true
-            })
-                .then(function(result) {
-                    resolve(result.found);
+            function removeRecord() {
+                client.delete({
+                    index: index_name,
+                    type: record_type,
+                    id: record_id,
+                    refresh: true
                 })
-                .catch(function(err) {
-                    if (_.get(err, 'body.error.type') === 'es_rejected_execution_exception') {
-                        remove(record_id)
-                    }
-                    else {
-                        var errMsg = elasticError(err);
-                        logger.error(`error removing record ${record_id}`);
-                        logger.error(errMsg);
-                        reject(errMsg)
-                    }
-                });
+                    .then(function(result) {
+                        resolve(result.found);
+                    })
+                    .catch(function(err) {
+                        if (_.get(err, 'body.error.type') === 'es_rejected_execution_exception') {
+                            let timer = Math.floor(Math.random() * (retryTimer.limit - retryTimer.start) + retryTimer.start);
+
+                            if (retryTimer.limit < 60000) {
+                                retryTimer.limit += 10000
+                            }
+                            if (retryTimer.start < 30000) {
+                                retryTimer.start += 5000
+                            }
+                            setTimeout(function() {
+                                removeRecord()
+                            }, timer);
+                        }
+                        else {
+                            var errMsg = elasticError(err);
+                            logger.error(`error removing record ${record_id}`);
+                            logger.error(errMsg);
+                            reject(errMsg)
+                        }
+                    });
+            }
+
+            removeRecord();
         });
+
     }
 
     function shutdown() {
@@ -343,9 +468,11 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size)
 
         if (bulkQueue.length > 0 && !savingBulk) {
             savingBulk = true;
+
             var bulkRequest = bulkQueue;
             bulkQueue = [];
 
+            let retryTimer = {start: 5000, limit: 10000};
             var warning = warn(logger, 'The elasticsearch cluster queues are overloaded, resubmitting failed queries from bulk');
 
             return new Promise(function(resolve, reject) {
@@ -360,8 +487,24 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size)
                                     reject(response.error)
                                 }
                                 else {
-                                    warning();
-                                    return send(response.data)
+                                    //may get doc already created error, if so just return
+                                    if (response.data.length === 0) {
+                                        resolve(results)
+                                    }
+                                    else {
+                                        let timer = Math.floor(Math.random() * (retryTimer.limit - retryTimer.start) + retryTimer.start);
+
+                                        if (retryTimer.limit < 60000) {
+                                            retryTimer.limit += 10000
+                                        }
+                                        if (retryTimer.start < 30000) {
+                                            retryTimer.start += 5000
+                                        }
+                                        warning();
+                                        setTimeout(function() {
+                                            send(response.data)
+                                        }, timer)
+                                    }
                                 }
                             }
                             else {

--- a/lib/cluster/storage/backends/elasticsearch.js
+++ b/lib/cluster/storage/backends/elasticsearch.js
@@ -65,7 +65,7 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size)
         else {
             esQuery.body = query
         }
-
+logger.warn('whats final query', query);
         return new Promise(function(resolve, reject) {
             client.search(esQuery)
                 .then(function(results) {
@@ -300,7 +300,7 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size)
 
         // We only flush once enough records have accumulated for it to make sense.
         if (bulkQueue.length >= bulkSize) {
-            logger.trace(`flushing bulk queue ${bulkQueue.size()}`);
+            logger.trace(`flushing bulk queue ${bulkQueue.length}`);
             return _flush();
         }
 

--- a/lib/cluster/storage/backends/elasticsearch.js
+++ b/lib/cluster/storage/backends/elasticsearch.js
@@ -65,7 +65,7 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size)
         else {
             esQuery.body = query
         }
-logger.warn('whats final query', query);
+
         return new Promise(function(resolve, reject) {
             client.search(esQuery)
                 .then(function(results) {

--- a/lib/cluster/storage/jobs.js
+++ b/lib/cluster/storage/jobs.js
@@ -94,7 +94,7 @@ module.exports = function(context, jobType) {
 
     return require('./backends/elasticsearch').apply(null, jobArgs)
         .then(function(elasticsearch) {
-            logger.info(`initializing`);
+            logger.info(`Initializing`);
             backend = elasticsearch;
 
             return api;

--- a/lib/cluster/storage/state.js
+++ b/lib/cluster/storage/state.js
@@ -56,7 +56,7 @@ module.exports = function(context) {
                     slicer_id: slicer_id,
                     ex_id: ex_id
                 };
-                logger.debug(`retry for slicer_id ${slicer_id}, ex_id: ${ex_id} has ${retryList.length} slices`)
+                logger.debug(`retry for slicer_id ${slicer_id}, ex_id: ${ex_id} has ${retryList.length} slices`);
 
                 // Find the newest record to see where to start processing from
                 return backend.search(startQuery, 0, 1, 'slicer_order:desc')

--- a/lib/cluster/worker.js
+++ b/lib/cluster/worker.js
@@ -34,7 +34,7 @@ module.exports = function(context) {
     });
 
     //if worker cannot make client, job needs to shutdown, needs to be setup before job_runner
-    event.on('client config error', terminalShutdown);
+    event.on('getClient:config_error', terminalShutdown);
 
     var job_runner = require('./runners/job')(context);
     var job = job_runner.initialize();

--- a/lib/cluster/worker.js
+++ b/lib/cluster/worker.js
@@ -71,15 +71,15 @@ module.exports = function(context) {
         sentMessage = false;
     });
 
-    messaging.register('worker:connection:error', function(err) {
+    messaging.register('network:error', function(err) {
         logger.error('Error in worker socket: ', err)
     });
 
-    messaging.register('worker:disconnect', function(e) {
-        logger.error(`worker ${ID} had disconnected from slicer ex_id ${process.env.ex_id}`, e);
+    messaging.register('network:disconnect', function(e) {
+        logger.error(`worker ${ID} has disconnected from slicer ex_id ${process.env.ex_id}`, e);
     });
 
-    messaging.register('worker:slicer:connect', function() {
+    messaging.register('network:connect', function() {
         if (sentMessage) {
             logger.warn('reconnecting to slicer, previous slice: ', sentMessage);
             sentMessage.retry = true;

--- a/lib/cluster/worker.js
+++ b/lib/cluster/worker.js
@@ -101,9 +101,6 @@ module.exports = function(context) {
     messaging.register('process:SIGTERM', noOP);
     messaging.register('process:SIGINT', noOP);
 
-
-    logger.info(`connecting to host: ${host}`);
-
     require('./storage/state')(context)
         .then(function(store) {
             state_store = store;
@@ -112,6 +109,7 @@ module.exports = function(context) {
         })
         .then(function(store) {
             analytics_store = store;
+            logger.info(`connecting to host: ${host}`);
             messaging.initialize();
         })
         .catch(function(err) {

--- a/lib/config/schemas/job.js
+++ b/lib/config/schemas/job.js
@@ -2,92 +2,142 @@
 
 var cpuCount = require('os').cpus().length;
 var workers = cpuCount < 5 ? cpuCount : 5;
+var _ = require('lodash');
 
-module.exports.jobSchema = {
-    name: {
-        doc: 'Name for specific job',
-        default: 'Custom Job',
-        format: function(val) {
-            if (!val) {
-                throw new Error('name for job is required')
-            }
-            else {
-                if (typeof val !== 'string') {
-                    throw new Error(' name for job must be a string')
+function jobSchema(context) {
+    return {
+        name: {
+            doc: 'Name for specific job',
+            default: 'Custom Job',
+            format: function(val) {
+                if (!val) {
+                    throw new Error('name for job is required')
+                }
+                else {
+                    if (typeof val !== 'string') {
+                        throw new Error(' name for job must be a string')
+                    }
                 }
             }
-        }
-    },
-    lifecycle: {
-        doc: 'Job lifecycle behavior, determines if it should exit on completion or remain active',
-        default: 'once',
-        format: ['once', 'persistent']
-    },
-    analytics: {
-        doc: 'logs the time it took in milliseconds for each action, as well as the number of docs it receives',
-        default: true,
-        format: Boolean
-    },
-    max_retries: {
-        doc: 'the number of times a worker will attempt to process the same slice after a error has occurred',
-        default: 3,
-        format: function(val) {
-            if (isNaN(val)) {
-                throw new Error('max_retries parameter for job must be a number')
-            }
-            else {
-                if (val < 0) {
-                    throw new Error('max_retries for job must be >= zero')
+        },
+        lifecycle: {
+            doc: 'Job lifecycle behavior, determines if it should exit on completion or remain active',
+            default: 'once',
+            format: ['once', 'persistent']
+        },
+        analytics: {
+            doc: 'logs the time it took in milliseconds for each action, as well as the number of docs it receives',
+            default: true,
+            format: Boolean
+        },
+        max_retries: {
+            doc: 'the number of times a worker will attempt to process the same slice after a error has occurred',
+            default: 3,
+            format: function(val) {
+                if (isNaN(val)) {
+                    throw new Error('max_retries parameter for job must be a number')
+                }
+                else {
+                    if (val < 0) {
+                        throw new Error('max_retries for job must be >= zero')
+                    }
                 }
             }
-        }
-    },
-    slicers: {
-        doc: 'how many parallel slicer contexts that will run within the slicer',
-        default: 1,
-        format: function(val) {
-            if (isNaN(val)) {
-                throw new Error('slicers parameter for job must be a number')
-            }
-            else {
-                if (val < 1) {
-                    throw new Error('slicers for job must be >= one')
+        },
+        slicers: {
+            doc: 'how many parallel slicer contexts that will run within the slicer',
+            default: 1,
+            format: function(val) {
+                if (isNaN(val)) {
+                    throw new Error('slicers parameter for job must be a number')
+                }
+                else {
+                    if (val < 1) {
+                        throw new Error('slicers for job must be >= one')
+                    }
                 }
             }
-        }
-    },
-    workers: {
-        doc: 'the number of workers dedicated for the job',
-        default: workers,
-        format: function(val) {
-            if (isNaN(val)) {
-                throw new Error('workers parameter for job must be a number')
-            }
-            else {
-                if (val < 1) {
-                    throw new Error('workers for job must be >= one')
+        },
+        workers: {
+            doc: 'the number of workers dedicated for the job',
+            default: workers,
+            format: function(val) {
+                if (isNaN(val)) {
+                    throw new Error('workers parameter for job must be a number')
+                }
+                else {
+                    if (val < 1) {
+                        throw new Error('workers for job must be >= one')
+                    }
                 }
             }
-        }
-    },
-    operations: {
-        doc: 'An array of actions to execute, typically the first is a reader and the last is a sender with ' +
-        'any number of processing function in-between',
-        default: [],
-        format: function checkJobProcess(arr) {
-            if (!(Array.isArray(arr) && arr.length >= 2)) {
-                throw new Error('operations need to be of type array with at least two operations in it')
+        },
+        operations: {
+            doc: 'An array of actions to execute, typically the first is a reader and the last is a sender with ' +
+            'any number of processing function in-between',
+            default: [],
+            format: function checkJobProcess(arr) {
+                if (!(Array.isArray(arr) && arr.length >= 2)) {
+                    throw new Error('operations need to be of type array with at least two operations in it')
+                }
             }
-        }
+        },
+        moderator: {
+            doc: 'specify on job if it is to be moderated to not overwhelm their respective databases',
+            default: null,
+            format: function(val) {
+                if (val) {
+                    if (typeof val === 'object') {
+                        let configConnectors = context.sysconfig.terafoundation.connectors;
+                        _.forOwn(val, function(config, key) {
+                            if (!configConnectors[key]) {
+                                throw new Error(`Moderator specified on job is marked as using ${key}, but it cannot be found in terafoundation.connectors system configuration`)
+                            }
 
+                            var connections = Object.keys(configConnectors[key]);
+                            var isArray = Array.isArray(config);
+                            var isString = typeof config === 'string';
+
+                            if (isString || isArray) {
+                                if (isString) {
+                                    var isFound = connections.find(type => type === config);
+                                    if (!isFound) {
+                                        throw new Error(`Moderator specified on job is marked as using ${key} with connection ${config}, but no ${config} connection was found`)
+                                    }
+                                }
+                                else {
+                                    var diff = _.difference(config, connections);
+                                    if (diff.length > 0) {
+                                        throw new Error(`Moderator specified on job is marked as using ${key} with connection ${diff}, but the following ${diff} connections were not found`)
+                                    }
+                                }
+                            }
+                            else {
+                                throw new Error(`Error in validating moderator, `)
+                            }
+
+                        })
+                    }
+                    else {
+                        throw new Error('Moderator on the job must be set to an object')
+                    }
+                }
+            }
+        }
     }
+}
 
-};
-
-module.exports.commonSchema = {
-    _op: {
-        doc: 'Name of operation, it must reflect the name of the file',
-        default: '',
-        format: 'required_String'
+function commonSchema() {
+    return {
+        _op: {
+            doc: 'Name of operation, it must reflect the name of the file',
+            default: '',
+            format: 'required_String'
+        }
     }
+}
+
+module.exports = {
+    commonSchema: commonSchema,
+    jobSchema: jobSchema
 };

--- a/lib/config/schemas/system.js
+++ b/lib/config/schemas/system.js
@@ -137,6 +137,21 @@ var schema = {
         doc: 'boolean for determining if moderator should live on this node',
         default: false,
         format: Boolean
+    },
+    moderator_limit: {
+        doc: 'boolean for determining if moderator should live on this node',
+        default: 0.85,
+        format: Number
+    },
+    moderator_resume: {
+        doc: 'boolean for determining if moderator should live on this node',
+        default: 0.5,
+        format: Number
+    },
+    moderator_interval: {
+        doc: 'boolean for determining if moderator should live on this node',
+        default: 3000,
+        format: Number
     }
 };
 

--- a/lib/config/schemas/system.js
+++ b/lib/config/schemas/system.js
@@ -132,6 +132,11 @@ var schema = {
             })
 
         }
+    },
+    moderator: {
+        doc: 'boolean for determining if moderator should live on this node',
+        default: false,
+        format: Boolean
     }
 };
 

--- a/lib/config/validators/job.js
+++ b/lib/config/validators/job.js
@@ -2,16 +2,15 @@
 
 var _ = require('lodash');
 var convict = require('convict');
-
-var jobSchema = require('../schemas/job').jobSchema;
-var commonSchema = require('../schemas/job').commonSchema;
 var convictFormats = require('../../utils/convict_utils');
 
 module.exports = function(context) {
     var logger = context.logger;
-
     var op_runner = require('../../cluster/runners/op')(context);
 
+    var jobSchema = require('../schemas/job').jobSchema(context);
+    var commonSchema = require('../schemas/job').commonSchema();
+    
     // This function will validate the job and return a clone with all
     // default parameters expanded.
     function validate(job) {
@@ -20,7 +19,7 @@ module.exports = function(context) {
         convictFormats.forEach(function(format) {
             convict.addFormat(format)
         });
-
+        
         //this is used if an operation needs to provide additional validation beyond its own scope
         var topLevelJobValidators = [];
         //top level job validation occurs, but not operations

--- a/lib/processors/elasticsearch_bulk.js
+++ b/lib/processors/elasticsearch_bulk.js
@@ -83,6 +83,7 @@ function newProcessor(context, opConfig, jobConfig) {
 
     function send(client, data) {
         var warning = warn(logger, 'The elasticsearch cluster queues are overloaded, resubmitting failed queries from bulk');
+        let retryTimer = {start: 5000, limit: 10000};
 
         return new Promise(function(resolve, reject) {
             function sendData(client, data) {
@@ -100,10 +101,18 @@ function newProcessor(context, opConfig, jobConfig) {
                                     resolve(results)
                                 }
                                 else {
+                                    let timer = Math.floor(Math.random() * (retryTimer.limit - retryTimer.start) + retryTimer.start);
+
+                                    if (retryTimer.limit < 60000) {
+                                        retryTimer.limit += 10000
+                                    }
+                                    if (retryTimer.start < 30000) {
+                                        retryTimer.start += 5000
+                                    }
                                     warning();
                                     setTimeout(function() {
                                         sendData(client, response.data)
-                                    }, 3000)
+                                    }, timer)
                                 }
                             }
                         }
@@ -147,7 +156,7 @@ function newProcessor(context, opConfig, jobConfig) {
             var meta = data[i];
             var record = null;
             // If this is a delete operation there will be no associated data record
-            if (! meta.delete) {
+            if (!meta.delete) {
                 record = data[i + 1];
             }
 

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -58,7 +58,7 @@ function getClient(context, config, type) {
     catch (err) {
         var errMsg = `No configuration for endpoint ${clientConfig.endpoint} was found in the terafoundation connectors config, error: ${err.stack}`;
         context.logger.error(errMsg);
-        emitter.emit('client config error', {err: errMsg})
+        emitter.emit('getClient:config_error', {err: errMsg})
     }
 }
 

--- a/lib/utils/elastic_utils.js
+++ b/lib/utils/elastic_utils.js
@@ -187,7 +187,7 @@ function filterResponse(logger, data, results) {
             else {
                 if (item.error.type !== 'document_already_exists_exception' && item.error.type !== 'document_missing_exception') {
                     nonRetriableError = true;
-                    reason = item.error.reason;
+                    reason = `${item.error.type}--${item.error.reason}`;
                     break;
                 }
             }

--- a/lib/utils/queue.js
+++ b/lib/utils/queue.js
@@ -26,6 +26,22 @@ Queue.prototype.enqueue = function(value) {
     this._size++;
 };
 
+//this assumes the otherQueue has nodes that need to be in front of this current queue
+Queue.prototype.shiftQueue = function(otherQueue) {
+    let temp = [];
+    while (otherQueue.size()) {
+        temp.push(otherQueue.dequeue())
+    }
+
+    while (this.size()) {
+        temp.push(this.dequeue())
+    }
+
+    temp.forEach((node) => {
+        this.enqueue(node)
+    })
+};
+
 Queue.prototype.dequeue = function() {
     if (this._size === 0) {
         return null

--- a/lib/utils/queue.js
+++ b/lib/utils/queue.js
@@ -36,22 +36,6 @@ Queue.prototype.shift = function(value) {
     this._size++;
 };
 
-//this assumes the otherQueue has nodes that need to be in front of this current queue
-Queue.prototype.shiftQueue = function(otherQueue) {
-    let temp = [];
-    while (otherQueue.size()) {
-        temp.push(otherQueue.dequeue())
-    }
-
-    while (this.size()) {
-        temp.push(this.dequeue())
-    }
-
-    temp.forEach((node) => {
-        this.enqueue(node)
-    })
-};
-
 Queue.prototype.dequeue = function() {
     if (this._size === 0) {
         return null

--- a/lib/utils/queue.js
+++ b/lib/utils/queue.js
@@ -26,6 +26,16 @@ Queue.prototype.enqueue = function(value) {
     this._size++;
 };
 
+Queue.prototype.shift = function(value) {
+    var currentNode = this.head;
+    var node = new Node(value, null, currentNode);
+    this.head = node;
+    if (this.tail === null) {
+        this.tail = node;
+    }
+    this._size++;
+};
+
 //this assumes the otherQueue has nodes that need to be in front of this current queue
 Queue.prototype.shiftQueue = function(otherQueue) {
     let temp = [];
@@ -60,6 +70,17 @@ Queue.prototype.dequeue = function() {
     }
 
     return head.value;
+};
+
+Queue.prototype.each = function(fn) {
+    var currentNode = this.head;
+    if (currentNode) {
+        fn(currentNode.value);
+    }
+    while (currentNode && currentNode.next) {
+        currentNode = currentNode.next;
+        fn(currentNode.value)
+    }
 };
 
 Queue.prototype.remove = function(id, keyForID) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teraslice",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Slice and dice your Elasticsearch data",
   "main": "service.js",
   "scripts": {

--- a/service.js
+++ b/service.js
@@ -4,6 +4,8 @@ var worker = require('./lib/cluster/worker');
 var slicer = require('./lib/cluster/slicer');
 var master = require('./lib/master');
 var cluster_master = require('./lib/cluster/cluster_master');
+var moderator = require('./lib/cluster/moderator');
+
 var config_schema = require('./lib/config/schemas/system').config_schema;
 var emitter = require('./lib/utils/events');
 var schema_formats = require('./lib/utils/convict_utils');
@@ -36,7 +38,8 @@ var foundation = require('terafoundation')({
     slicer: slicer,
     shutdownMessaging: true,
     cluster_master: cluster_master,
-    descriptors: {slicer: true, worker: true, cluster_master: true},
+    moderator: moderator,
+    descriptors: {slicer: true, worker: true, cluster_master: true, moderator: true},
     start_workers: false,
     config_schema: config_schema,
     schema_formats: schema_formats,

--- a/spec/moderator/elasticsearch-spec.js
+++ b/spec/moderator/elasticsearch-spec.js
@@ -3,7 +3,7 @@
 var esModerator = require('../../lib/cluster/moderator/modules/elasticsearch');
 var Promise = require('bluebird');
 
-fdescribe('elasticsearch moderator', function() {
+describe('elasticsearch moderator', function() {
 
     var logger = {
         error: function() {

--- a/spec/moderator/elasticsearch-spec.js
+++ b/spec/moderator/elasticsearch-spec.js
@@ -1,0 +1,132 @@
+'use strict';
+
+var esModerator = require('../../lib/cluster/moderator/modules/elasticsearch');
+var Promise = require('bluebird');
+
+fdescribe('elasticsearch moderator', function() {
+
+    var express = require('express');
+    var fakeElasticsearch = express();
+    fakeElasticsearch.get('*', function(req, res) {
+        console.log('getting called');
+        res.send('hello')
+    });
+    fakeElasticsearch.listen(9200);
+
+    var logger = {
+        error: function() {
+        },
+        debug: function() {
+        },
+        info: function() {
+        },
+        warn: function() {
+        }
+    };
+
+    var keyDict = {index: true, search: true, get: true, bulk: true};
+
+
+    var nodes = {
+        first: {
+            nodes: {
+                node1: {
+                    thread_pool: {
+                        index: {queue_size: 100, other: 300},
+                        search: {queue_size: 100, other: 300},
+                        get: {queue_size: 100, other: 300},
+                        bulk: {queue_size: 100, other: 300},
+                        other: {queue_size: 100, other: 300}
+                    }
+                },
+                node2: {
+                    thread_pool: {
+                        index: {queue_size: 100, other: 300},
+                        search: {queue_size: 100, other: 300},
+                        get: {queue_size: 100, other: 300},
+                        bulk: {queue_size: 100, other: 300},
+                        other: {queue_size: 100, other: 300}
+                    }
+                }
+            }
+        },
+        second: {
+            nodes: {
+                node1: {
+                    thread_pool: {
+                        index: {queue_size: 100, other: 300},
+                        search: {queue_size: 100, other: 300},
+                        get: {queue_size: 100, other: 300},
+                        bulk: {queue_size: 100, other: 300},
+                        other: {queue_size: 100, other: 300}
+                    }
+                },
+                node2: {
+                    thread_pool: {
+                        index: {queue_size: 100, other: 300},
+                        search: {queue_size: 100, other: 300},
+                        get: {queue_size: 100, other: 300},
+                        bulk: {queue_size: 100, other: 300},
+                        other: {queue_size: 100, other: 300}
+                    }
+                }
+            }
+        }
+    };
+
+    var context = {
+        sysconfig: {
+            teraslice: {
+                moderator_limit: 0.8,
+                moderator_resume: 0.5
+            },
+            terafoundation: {
+                connectors: {
+                    elasticsearch: {
+                        default: {
+                            host: [
+                                "127.0.0.1:9200"
+                            ],
+                            keepAlive: true,
+                            maxRetries: 5,
+                            maxSockets: 20
+                        }
+                    }
+                }
+            }
+        },
+        foundation: {
+            getConnection: function() {
+                return {
+                    client: {
+                        nodes: {
+                            info: function() {
+                                return Promise.resolve()
+                            },
+                            stats: function() {
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        logger: logger
+    };
+
+
+    var moderator = esModerator(context, logger);
+
+
+    fit('can run', function(done) {
+        moderator.initialize()
+            .then(function(results) {
+                console.log('results', results);
+                done()
+            })
+            .catch(function(err) {
+                console.log('err', err);
+                done()
+            })
+    })
+
+});

--- a/spec/moderator/moderator_elasticsearch-spec.js
+++ b/spec/moderator/moderator_elasticsearch-spec.js
@@ -42,12 +42,7 @@ describe('elasticsearch moderator', function() {
         },
         debug: function() {
         },
-        info: function(strMsg) {
-            if (strMsg === 'moderator has initialized') {
-                //don't have a real hook into when moderator is online and initialized,
-                //checkConnection function could run before setup properly
-                eventEmitter.emit('moderator:initialized')
-            }
+        info: function() {
         },
         warn: function() {
         },
@@ -176,7 +171,7 @@ describe('elasticsearch moderator', function() {
             fakeClusterMaster.emit('cluster:moderator:connection_ok', {data: ['default']});
         }
 
-        waitForEvent('moderator:initialized')
+        waitForEvent('moderator:online')
             .then(function() {
                 return waitForEvent('node:message:processed', checkConnection);
             })
@@ -220,7 +215,7 @@ describe('elasticsearch moderator', function() {
             fakeClusterMaster.emit('cluster:moderator:connection_ok', {data: ['default']});
         }
 
-        waitForEvent('moderator:initialized')
+        waitForEvent('moderator:online')
             .then(function() {
                 return delayTime()
             })

--- a/spec/moderator/moderator_elasticsearch-spec.js
+++ b/spec/moderator/moderator_elasticsearch-spec.js
@@ -1,0 +1,240 @@
+'use strict';
+
+var esModerator = require('../../lib/cluster/moderator/index');
+var Promise = require('bluebird');
+
+describe('elasticsearch moderator', function() {
+
+    var events = require('events');
+    var eventEmitter = new events.EventEmitter();
+
+    var fakeClusterMaster = require('socket.io')();
+
+    fakeClusterMaster.on('connection', function(socket) {
+        socket.on('moderator:online', function(data) {
+            eventEmitter.emit('moderator:online', data)
+        });
+        socket.on('moderator:pause_jobs', function(data) {
+            eventEmitter.emit('moderator:pause_jobs', data)
+        });
+        socket.on('moderator:resume_jobs', function(data) {
+            eventEmitter.emit('moderator:resume_jobs', data)
+        });
+    });
+
+    fakeClusterMaster.listen(9999);
+
+    function waitForEvent(eventName, fn) {
+        return new Promise(function(resolve, reject) {
+            eventEmitter.on(eventName, function(data) {
+                resolve(data)
+            });
+            if (fn) {
+                fn();
+            }
+        })
+    }
+
+    var registeredProcessEvents = {};
+
+    var logger = {
+        error: function() {
+        },
+        debug: function() {
+        },
+        info: function(strMsg) {
+            if (strMsg === 'moderator has initialized') {
+                //don't have a real hook into when moderator is online and initialized,
+                //checkConnection function could run before setup properly
+                eventEmitter.emit('moderator:initialized')
+            }
+        },
+        warn: function() {
+        },
+        trace: function() {
+        }
+    };
+
+    var nodes = {
+        nodes: {
+            default: {
+                thread_pool: {
+                    index: {queue_size: 100, other: 300},
+                    search: {queue_size: 100, other: 300},
+                    get: {queue_size: 100, other: 300},
+                    bulk: {queue_size: 100, other: 300},
+                    other: {queue_size: 100, other: 300}
+                }
+            }
+        }
+    };
+
+    var nodesStats = {
+        nodes: {
+            default: {
+                thread_pool: {
+                    index: {queue: 10},
+                    search: {queue: 10},
+                    get: {queue: 10},
+                    bulk: {queue: 10},
+                    other: {queue: 10}
+                }
+            }
+        }
+    };
+
+    var context = {
+        sysconfig: {
+            teraslice: {
+                moderator_limit: 0.8,
+                moderator_resume: 0.5,
+                moderator_interval: 10,
+                master_hostname: 'localhost',
+                port: 9999
+            },
+            terafoundation: {
+                connectors: {
+                    elasticsearch: {
+                        default: {
+                            host: [
+                                "127.0.0.1:9200"
+                            ],
+                            keepAlive: true,
+                            maxRetries: 5,
+                            maxSockets: 20
+                        }
+                    }
+                }
+            }
+        },
+        foundation: {
+            getConnection: function() {
+                return {
+                    client: {
+                        nodes: {
+                            info: function() {
+                                return Promise.resolve(nodes)
+                            },
+                            stats: function() {
+                                return Promise.resolve(nodesStats)
+                            }
+                        }
+                    }
+                }
+            },
+            makeLogger: function() {
+                return logger
+            }
+        },
+        logger: logger,
+        __testingModule: {
+            env: {
+                assignment: 'moderator'
+            },
+            send: function(data) {
+                eventEmitter.emit('node:message:processed', data)
+            },
+            on: function(key, fn) {
+                registeredProcessEvents[key] = fn
+            }
+        }
+    };
+
+    //used to make sure the moderator engine has time to run
+    function delayTime() {
+        return new Promise(function(resolve, reject) {
+            setTimeout(function() {
+                resolve()
+            }, 70)
+        });
+    }
+
+
+    beforeEach(function() {
+        nodesStats.nodes.default.thread_pool.get.queue = 10;
+    });
+
+    it('can initialize', function(done) {
+        var moderator = esModerator(context, logger);
+
+        waitForEvent('moderator:online')
+            .then(function(results) {
+                expect(results).toEqual({moderator: 'moderator:elasticsearch'});
+                done();
+            })
+            .catch(function(err) {
+                console.log('Error with initializing moderator', err);
+                done();
+            });
+    });
+
+
+    it('can check connections', function(done) {
+        var moderator = esModerator(context, logger);
+
+        function checkConnection() {
+            fakeClusterMaster.emit('cluster:moderator:connection_ok', {data: ['default']});
+        }
+
+        waitForEvent('moderator:initialized')
+            .then(function() {
+                return waitForEvent('node:message:processed', checkConnection);
+            })
+            .then(function(results) {
+                expect(results.canRun).toEqual(true);
+                done()
+            })
+            .catch(function(err) {
+                console.log('Error with connection ok function for the moderator', err);
+                done();
+            });
+    });
+
+    it('can send pause and resume jobs events', function(done) {
+        nodesStats.nodes.default.thread_pool.get.queue = 200;
+
+        var moderator = esModerator(context, logger);
+
+        waitForEvent('moderator:pause_jobs')
+            .then(function(results) {
+                expect(results).toEqual([{type: 'elasticsearch', connection: 'default'}]);
+                nodesStats.nodes.default.thread_pool.get.queue = 10;
+                return waitForEvent('moderator:resume_jobs')
+            })
+            .then(function(results) {
+                expect(results).toEqual([{type: 'elasticsearch', connection: 'default'}]);
+                done()
+            })
+            .catch(function(err) {
+                console.log('Error with pause job test for the moderator', err);
+                done();
+            });
+    });
+
+    it('can query to check of bad connections', function(done) {
+        nodesStats.nodes.default.thread_pool.get.queue = 200;
+
+        var moderator = esModerator(context, logger);
+
+        function checkConnection() {
+            fakeClusterMaster.emit('cluster:moderator:connection_ok', {data: ['default']});
+        }
+
+        waitForEvent('moderator:initialized')
+            .then(function() {
+                return delayTime()
+            })
+            .then(function() {
+                return waitForEvent('node:message:processed', checkConnection);
+            })
+            .then(function(results) {
+                expect(results.canRun).toEqual(false);
+                done()
+            })
+            .catch(function(err) {
+                console.log('Error with connection ok function for the moderator', err);
+                done();
+            });
+    });
+
+});

--- a/spec/utils/queue-spec.js
+++ b/spec/utils/queue-spec.js
@@ -1,4 +1,3 @@
-
 'use strict';
 var Queue = require('../../lib/utils/queue');
 
@@ -25,12 +24,42 @@ describe('Queue', function() {
         expect(first).toEqual('first')
     });
 
-    it('can remove from queue based on id', function(){
+    it('can shift', function() {
+        var queue = new Queue();
+        queue.enqueue(2);
+        queue.enqueue(3);
+        queue.shift(1);
+
+        expect(queue.size()).toEqual(3);
+        expect(queue.dequeue()).toEqual(1);
+        expect(queue.dequeue()).toEqual(2);
+        expect(queue.dequeue()).toEqual(3);
+        expect(queue.dequeue()).toEqual(null);
+    });
+
+    it('has an each method', function() {
+        var results = [];
+        var queue = new Queue();
+        queue.enqueue(1);
+        queue.enqueue(2);
+        queue.enqueue(3);
+
+        queue.each(function(val) {
+            results.push(val)
+        });
+
+        expect(results.length).toEqual(3);
+        expect(results[0]).toEqual(1);
+        expect(results[1]).toEqual(2);
+        expect(results[2]).toEqual(3);
+    });
+
+    it('can remove from queue based on id', function() {
         var queue = new Queue();
         queue.enqueue({data: 'first', id: 'id1'});
-        queue.enqueue({data:'second', id: 'id2'});
-        queue.enqueue({data:'three', id: 'id3'});
-        queue.enqueue({data:'four', id: 'id2'});
+        queue.enqueue({data: 'second', id: 'id2'});
+        queue.enqueue({data: 'third', id: 'id3'});
+        queue.enqueue({data: 'fourth', id: 'id2'});
 
         var len = queue.size();
 
@@ -39,8 +68,25 @@ describe('Queue', function() {
         expect(len).toEqual(4);
         expect(queue.size()).toEqual(2);
         expect(queue.dequeue()).toEqual({data: 'first', id: 'id1'});
-        expect(queue.dequeue()).toEqual({data: 'three', id: 'id3'});
+        expect(queue.dequeue()).toEqual({data: 'third', id: 'id3'});
     });
 
+    it('can remove from queue based on a key and id', function() {
+        var queue = new Queue();
+        queue.enqueue({data: 'first', id: 'id1'});
+        queue.enqueue({data: 'second', id: 'id2'});
+        queue.enqueue({data: 'third', ex_id: 'id3'});
+        queue.enqueue({data: 'fourth', job_id: 'id2'});
+
+        var len = queue.size();
+
+        queue.remove('id2', 'job_id');
+
+        expect(len).toEqual(4);
+        expect(queue.size()).toEqual(3);
+        expect(queue.dequeue()).toEqual({data: 'first', id: 'id1'});
+        expect(queue.dequeue()).toEqual({data: 'second', id: 'id2'});
+        expect(queue.dequeue()).toEqual({data: 'third', ex_id: 'id3'});
+    });
 });
 


### PR DESCRIPTION
This is meant to be a standing PR so you can check code/implementation etc

in teraslice config set "moderator": true

and on job you must set at top level configuration to:
```
"moderator": {
    "elasticsearch": ["es5", "default"]
  },
```

the array is the list of connections that correspond to terafoundation database connection names

TODO:
- [x] better error handling and abrupt connection loss logic on moderator
- [x] logic concerning when user specifies a pause command vs moderator resumes it
- [x] monitor state connection and logic to handle that
- [x] verify connection names actually exist on job vs config
- [x] remove repeat pause/resume commands
- [x] make pause and resume limits configurable
- [x] additional hooks into a job submission to check if a connection is ok to start a job
- [ ] documentation
- [x] testing
- [x] exponential backoff with randomness for workers on queue overloads
- [ ] (either now or later) moderator can adjust with slicer the amount of workers to should use
- [ ] (later) hooks into slicer to slow slicer at a intermediate level so there is no abrupt pause command

Questions:
 - should the moderator configuration live outside teraslice namespace and have its own seperate top level config? thinking not only about this but about any future services as well

Additional testing tips:
- lower the queue settings on bulk:
```
 curl -XPUT -sS localhost:9200/_cluster/settings -d '{ "transient" : {
 "threadpool.bulk.size" : "5",
 "threadpool.bulk.queue_size" : "5" } }'
```
- run a data generator job with stress_test set to true
