### PR TITLE
fixed moderator with elasticsearch failuires resolves #377 resolves #376

### DIFF
--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -61,7 +61,6 @@ module.exports = function(context) {
         //TODO might need a verification from cluster_master that the pause/resume job actually worked
         return function() {
             if (!isChecking) {
-                console.log("im making a check");
                 isChecking = true;
                 moderator.check_service()
                     .then(function(results) {

--- a/lib/cluster/moderator/index.js
+++ b/lib/cluster/moderator/index.js
@@ -61,6 +61,7 @@ module.exports = function(context) {
         //TODO might need a verification from cluster_master that the pause/resume job actually worked
         return function() {
             if (!isChecking) {
+                console.log("im making a check");
                 isChecking = true;
                 moderator.check_service()
                     .then(function(results) {
@@ -78,7 +79,7 @@ module.exports = function(context) {
                     .catch(function(err) {
                         //error do to new nodes, so not true error, re-initialize
                         if (err.initialize) {
-                            initialize
+                            moderator.initialize()
                         }
                         var errMsg = parseError(err);
                         logger.error('Moderator error while checking services', errMsg);


### PR DESCRIPTION
It seems like the error occured when it tried to reinitialize itself, for some reason the call for the moderator to initialized was wrong. This would trigger when ever there was a new node, or major problems with elasticsearch