### PR TITLE
Id query

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -244,6 +244,8 @@ size | The limit to the number of docs pulled in a chunk, if the number of docs 
 full_response | If set to true, it will return the native response from elasticsearch with all meta-data included. If set to false it will return an array of the actual documents, no meta data included | Boolean | optional, defaults to false
 key_type | Used to specify the key type of the \_ids of the documents being queryed | String | optional, defaults to elasticsearch id generator (base64url)
 key_range | if provided, slicer will only recurse on these given keys | Array | optional
+fields | Used to restrict what is returned from elasticsearch. If used, only these fields on the documents are returned | Array | optional |
+query | specify any valid lucene query for elasticsearch to use in filtering| String | optional |
 
 ## Processors ##
 

--- a/lib/data_sources/elasticsearch.js
+++ b/lib/data_sources/elasticsearch.js
@@ -61,7 +61,7 @@ module.exports = function(client, logger, opConfig) {
 
         return {data: retry, error: false};
     }
-    
+
     function search(query) {
         let retryTimer = {start: 5000, limit: 10000};
         let isCounting = query.size === 0;
@@ -348,28 +348,32 @@ module.exports = function(client, logger, opConfig) {
 
 
     function _buildRangeQuery(opConfig, msg) {
-        var date_field_name = opConfig.date_field_name;
-        var dateObj = {};
-
-        dateObj[date_field_name] = {
-            gte: msg.start,
-            lt: msg.end
-        };
-
         var body = {
             query: {
                 bool: {
-                    must: [
-                        {range: dateObj}
-                    ]
+                    must: []
                 }
             }
         };
-        //TODO this is used for elasticsearch reader when size is to big, this is not called by id_reader as of yet
+        // is a range type query
+        if (msg.start && msg.end) {
+            var dateObj = {};
+            var date_field_name = opConfig.date_field_name;
+
+            dateObj[date_field_name] = {
+                gte: msg.start,
+                lt: msg.end
+            };
+
+            body.query.bool.must.push({range: dateObj});
+        }
+
+        //elasticsearch _id based query
         if (msg.key) {
             body.query.bool.must.push({wildcard: {_uid: msg.key}})
         }
 
+        //elasticsearch lucene based query
         if (opConfig.query) {
             body.query.bool.must.push({
                 query_string: {
@@ -388,7 +392,7 @@ module.exports = function(client, logger, opConfig) {
             size: msg.count,
             body: _buildRangeQuery(opConfig, msg)
         };
-        
+
         if (opConfig.fields) {
             query._source = opConfig.fields;
         }

--- a/lib/readers/elasticsearch_date_range/slicer.js
+++ b/lib/readers/elasticsearch_date_range/slicer.js
@@ -553,8 +553,11 @@ function newSlicer(context, opConfig, job, retryData, logger, client) {
         return Promise.resolve(slicers);
     }
     else {
+        logger.warn('checking elasticsearch')
         return checkElasticsearch(client)
             .then(function() {
+                logger.warn('checking dates')
+
                 return getDates(context, opConfig)
                     .then(function(esDates) {
                         //query with no results
@@ -567,6 +570,8 @@ function newSlicer(context, opConfig, job, retryData, logger, client) {
                         }
                         return getInterval(opConfig, esDates)
                             .then(function(interval) {
+                                logger.warn('checking interval');
+
                                 var dateRange = divideRange(esDates.start, esDates.limit, job);
                                 //nextChunk pulls config off of opConfig, not jobConfig so jobConfig is not mutated
                                 opConfig.interval = interval;

--- a/lib/readers/elasticsearch_date_range/slicer.js
+++ b/lib/readers/elasticsearch_date_range/slicer.js
@@ -553,11 +553,8 @@ function newSlicer(context, opConfig, job, retryData, logger, client) {
         return Promise.resolve(slicers);
     }
     else {
-        logger.warn('checking elasticsearch')
         return checkElasticsearch(client)
             .then(function() {
-                logger.warn('checking dates')
-
                 return getDates(context, opConfig)
                     .then(function(esDates) {
                         //query with no results
@@ -570,8 +567,6 @@ function newSlicer(context, opConfig, job, retryData, logger, client) {
                         }
                         return getInterval(opConfig, esDates)
                             .then(function(interval) {
-                                logger.warn('checking interval');
-
                                 var dateRange = divideRange(esDates.start, esDates.limit, job);
                                 //nextChunk pulls config off of opConfig, not jobConfig so jobConfig is not mutated
                                 opConfig.interval = interval;

--- a/lib/readers/id_reader.js
+++ b/lib/readers/id_reader.js
@@ -18,18 +18,8 @@ function newReader(context, opConfig, jobConfig) {
     var client = getClient(context, opConfig, 'elasticsearch');
 
     return function(msg, logger) {
-        var query = {
-            index: opConfig.index,
-            size: msg.count ? msg.count : 200000,
-            body: {
-                query: {
-                    wildcard: {
-                        _uid: msg.key
-                    }
-                }
-            }
-        };
         var elasticsearch = require('../data_sources/elasticsearch')(client, opConfig, logger);
+        var query = elasticsearch.buildQuery(opConfig, msg);
         return elasticsearch.search(query);
     };
 }
@@ -78,6 +68,32 @@ function schema() {
                 if (val) {
                     if (!_.isArray(val) && val.length === 0) {
                         throw new Error('key_range for id_reader must be an array with length > 0')
+                    }
+                }
+            }
+        },
+        query: {
+            doc: 'You may place a lucene query here, and the slicer will use it when making slices',
+            default: "",
+            format: 'optional_String'
+        },
+        fields: {
+            doc: 'used to only return fields that you are interested in',
+            default: null,
+            format: function(val) {
+                function isString(elem) {
+                    return typeof elem === 'string'
+                }
+
+                if (val === null) {
+                    return;
+                }
+                else {
+                    if (!Array.isArray(val)) {
+                        throw new Error("Fields parameter must be an array")
+                    }
+                    if (!val.every(isString)) {
+                        throw new Error("the values listed in the fields array must be of type string")
                     }
                 }
             }

--- a/lib/readers/id_slicer.js
+++ b/lib/readers/id_slicer.js
@@ -70,27 +70,18 @@ module.exports = function(client, job, opConfig, logger, retryData, range) {
         }
 
         let key = `${opConfig.type}#${data.value}*`;
+        let msg = {count: 0, key: key};
 
-        let query = {
-            index: opConfig.index,
-            size: 0,
-            body: {
-                query: {
-                    wildcard: {
-                        _uid: key
-                    }
-                }
-            }
-        };
-
+        //this is used by elasticsearch slicer if slice is to large and its set to break it up further by key
         if (rangeObj) {
-            var range = {
+            msg = {
                 start: rangeObj.start,
                 end: rangeObj.end,
                 key: key
             };
-            query = elasticsearch.buildQuery(opConfig, range)
         }
+
+        let query = elasticsearch.buildQuery(opConfig, msg);
 
         function getKeySlice(query) {
             return getCountForKey(query)


### PR DESCRIPTION
unified the buildQuery elasticsearch module function to be used to id reader and slicer, it now has the ability to further add the fields and query parameters to it as well