### PR TITLE
fixed worker to properly exit on getClient errors resolves #405

### DIFF
--- a/lib/cluster/worker.js
+++ b/lib/cluster/worker.js
@@ -31,9 +31,6 @@ module.exports = function(context) {
         worker_id: ID
     });
 
-    //if worker cannot make client, job needs to shutdown, needs to be setup before job_runner
-    event.on('getClient:config_error', terminalShutdown);
-
     var job_runner = require('./runners/job')(context);
     var job = job_runner.initialize();
 
@@ -41,7 +38,10 @@ module.exports = function(context) {
     var max_retries = job.max_retries;
 
     var messaging = messagingFn(context, logger);
-
+    
+    //if worker cannot make client, job needs to shutdown, needs to be setup before job_runner
+    event.on('getClient:config_error', terminalShutdown);
+    
     var host = messaging.getHostUrl();
 
     logger.info(`worker ${ID} is online, communicating with host: ${host}`);


### PR DESCRIPTION
basically is was placed wrong, the messager was not fully ready by the time the callback was called