### PR TITLE
setting doc_values=false for asset blob field

### DIFF
--- a/lib/cluster/storage/backends/mappings/asset.json
+++ b/lib/cluster/storage/backends/mappings/asset.json
@@ -12,7 +12,8 @@
       "properties": {
         "blob": {
           "type": "string",
-          "index": "no"
+          "index": "no",
+          "doc_values": false
         },
         "name": {
           "type": "string",


### PR DESCRIPTION
On ES5 I received the following error when uploading a larger asset:

```
  "error": "[illegal_argument_exception] DocValuesField \"blob\" is too large, must be <= 32766"
```

This PR addresses that by setting `doc_values=true` on the `blob` field.
