### PR TITLE
Adding the ability to use inline scripts on es index selector

### DIFF
--- a/lib/processors/elasticsearch_index_selector.js
+++ b/lib/processors/elasticsearch_index_selector.js
@@ -125,14 +125,24 @@ function newProcessor(context, opConfig, jobConfig) {
                         update.doc[field] = record[field];
                     });
                 }
-                else if (opConfig.script_file) {
-                    update.script = {
-                        file: opConfig.script_file
-                    };
+                else if (opConfig.script_file || opConfig.script) {
+                    if (opConfig.script_file) {
+                        update.script = {
+                            file: opConfig.script_file
+                        };
+                    }
+
+                    if (opConfig.script) {
+                        update.script = {
+                            inline: opConfig.script
+                        };
+                    }
 
                     update.script.params = {};
                     _.forOwn(opConfig.script_params, function(field, key) {
-                        update.script.params[key] = record[field];
+                        if (record[field]) {
+                            update.script.params[key] = record[field];
+                        }
                     });
                 }
                 else {
@@ -266,6 +276,11 @@ function schema() {
         },
         script_file: {
             doc: 'Name of the script file to run as part of an update request.',
+            default: "",
+            format: 'optional_String'
+        },
+        script: {
+            doc: 'Inline script to include in each indexing request. Only very simple painless scripts are currently supported.',
             default: "",
             format: 'optional_String'
         },


### PR DESCRIPTION
This currently only works with painless scripts. It will mainly be useful on ES >5 where painless scripts are enabled by default.

script_params defines the field from the incoming document to copy automatically into params for the script. 

This API currently mirrors how ES it self does this. Ideally we can eventually come with something that is a little less cumbersome to use. Now that scripting is enabled by default there should be many cases where scripts will be useful.

Example usage

```
        {
            "_op": "elasticsearch_index_selector",
            "index": "myindex-v1",
            "type": "mytype",
            "upsert": true,
            "script": "
                ctx._source.count += params.count;
                if (params.myfield != null) ctx._source.myfield = params.myfield;
            ",
            "script_params" : {
                "count": "count",
                "myfield": "myfield"
            },
            "update_retry_on_conflict": 1
        },
```