### PR TITLE
removing the fit and fdescribe that disabled most of the tests

### DIFF
--- a/spec/moderator/elasticsearch-spec.js
+++ b/spec/moderator/elasticsearch-spec.js
@@ -3,7 +3,7 @@
 var esModerator = require('../../lib/cluster/moderator/modules/elasticsearch');
 var Promise = require('bluebird');
 
-fdescribe('elasticsearch moderator', function() {
+describe('elasticsearch moderator', function() {
 
     var logger = {
         error: function() {
@@ -138,7 +138,7 @@ fdescribe('elasticsearch moderator', function() {
             })
     });
 
-    fit('checkConnectionStates can return connections that need to be paused and resumed', function(done) {
+    it('checkConnectionStates can return connections that need to be paused and resumed', function(done) {
         var moderator = esModerator(context, logger);
         nodesStats.nodes.default.thread_pool.get.queue = 200;
         moderator.initialize()


### PR DESCRIPTION
It seems we've had our tests disabled again.  Not sure if this never got fixed last time I noticed it or what.  Regardless, this PR eliminates the errant `fit` and `fdescribe`.