### PR TITLE
added verison id to workers and slicers in node state resolves #440

### DIFF
--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -91,7 +91,11 @@ module.exports = function(context) {
 
     messaging.register('assets:loaded', function(assetsMsg) {
         messageWorkers(context, assetsMsg, assetsMsg, function(worker) {
-            return worker.ex_id === assetsMsg.identifier;
+            if (worker.ex_id === assetsMsg.identifier) {
+                //set all workers with the asset id's so it can show up in node state
+                worker.assets = assetsMsg.meta;
+                return true;
+            }
         });
     });
 
@@ -361,6 +365,10 @@ module.exports = function(context) {
 
             if (clusterWorkers[childID].ex_id) {
                 child.ex_id = clusterWorkers[childID].ex_id
+            }
+
+            if (clusterWorkers[childID].assets) {
+                child.assets = clusterWorkers[childID].assets.map(asset => asset.id);
             }
 
             active.push(child);


### PR DESCRIPTION
- Need to discuss if any of the /txt endpoints should default to showing assets or not, not all job will have assets. As it stand now you can still query the assets field but you would have to manually ask for it.

- For now we are displaying the asset id's and not the name and version. Name and version are not always passed, and even if they are they are only used to get the actual id which is used in the system. I might be able to add info on the name and version as well if thats truly needed. 

If a job has assets, the assets will show up in node state when all the assets have been downloaded. It is shown as an array of id's of all the assets used in the job since there may be multiple