### PR TITLE
Extract validateOperation from validators.job

### DIFF
--- a/lib/config/validators/config.js
+++ b/lib/config/validators/config.js
@@ -1,0 +1,39 @@
+var _ = require('lodash');
+var convict = require('convict');
+var convictFormats = require('../../utils/convict_utils');
+var commonSchema = require('../schemas/job').commonSchema();
+
+// Add custom teraslice formats
+convictFormats.forEach(function(format) {
+    convict.addFormat(format);
+});
+
+/**
+ * Merges the provided inputSchema with commonSchema and then validates the
+ * provided jobConfig or opConfig against the resultant schema.
+ * @param  {Object} inputSchema a convict compatible schema
+ * @param  {Object} inputConfig a jobConfig or opConfig object
+ * @return {Object}             a validated jobConfig or opConfig
+ */
+function validateConfig(inputSchema, inputConfig) {
+    var schema = inputConfig._op ? _.merge(inputSchema, commonSchema) : inputSchema;
+    var config = convict(schema);
+
+    try {
+        config.load(inputConfig);
+        config.validate(/* {strict: true} */);
+    } catch (err) {
+        if (config._op) {
+            throw new Error(`Validation failed for opConfig: ${inputConfig._op} - ${err.message}`);
+        }
+        throw err.stack;
+    }
+
+    return config.getProperties();
+}
+
+module.exports = function() {
+    return {
+        validateConfig: validateConfig
+    };
+};

--- a/lib/config/validators/job.js
+++ b/lib/config/validators/job.js
@@ -3,6 +3,8 @@
 var _ = require('lodash');
 var convict = require('convict');
 var convictFormats = require('../../utils/convict_utils');
+var configValidator = require('./config')();
+
 
 module.exports = function(context) {
     var logger = context.logger;
@@ -26,12 +28,12 @@ module.exports = function(context) {
         //this is used if an operation needs to provide additional validation beyond its own scope
         var topLevelJobValidators = [];
         //top level job validation occurs, but not operations
-        validJob = validateOperation(jobSchema, validJob, false);
+        validJob = configValidator.validateConfig(jobSchema, validJob);
 
         validJob.operations = job.operations.map(function(opConfig) {
             var operation = op_runner.load(opConfig._op, assetPath, jobAssets);
             hasSchema(operation, opConfig._op);
-            var validOP = validateOperation(operation.schema(), opConfig, true);
+            var validOP = configValidator.validateConfig(operation.schema(), opConfig);
 
             if (operation.op_validation) {
                 operation.op_validation(validOP)
@@ -60,25 +62,6 @@ module.exports = function(context) {
                 throw new Error(`${name} schema needs to return an object`)
             }
         }
-    }
-
-    function validateOperation(inputSchema, operation, isOp) {
-        var schema = isOp ? _.merge(inputSchema, commonSchema) : inputSchema;
-        var config = convict(schema);
-
-        try {
-            config.load(operation);
-
-            config.validate(/*{strict: true}*/);
-        }
-        catch (err) {
-            if (isOp) {
-                throw new Error(`Validation failed for operation: ${operation._op} - ${err.message}`);
-            }
-            throw err.stack;
-        }
-
-        return config.getProperties();
     }
 
     // Expose internal functions for unit testing.

--- a/spec/config/validators/config-spec.js
+++ b/spec/config/validators/config-spec.js
@@ -28,7 +28,6 @@ describe('system_schema', function() {
             analytics: true,
             max_retries: 3,
             slicers: 1,
-            workers: 4,
             operations: [
                 {_op: 'noop'},
                 {_op: 'noop'}
@@ -38,6 +37,7 @@ describe('system_schema', function() {
         };
 
         var jobConfig = configValidator.validateConfig(jobSchema, jobSpec);
+        delete jobConfig.workers;
         expect(jobConfig).toEqual(validJob);
     });
 });

--- a/spec/config/validators/config-spec.js
+++ b/spec/config/validators/config-spec.js
@@ -2,8 +2,8 @@
 
 var configValidator = require('../../../lib/config/validators/config')();
 
-describe('system_schema', function() {
-    it('schema has defaults', function() {
+describe('When passed a valid jobSchema and jobConfig', function() {
+    it('returns a completed and valid jobConfig', function() {
         var context = {
             sysconfig: {
                 teraslice: {

--- a/spec/config/validators/config-spec.js
+++ b/spec/config/validators/config-spec.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var configValidator = require('../../../lib/config/validators/config')();
+
+describe('system_schema', function() {
+    it('schema has defaults', function() {
+        var context = {
+            sysconfig: {
+                teraslice: {
+                    ops_directory: ''
+                }
+            }
+        };
+
+        var jobSchema = require('../../../lib/config/schemas/job').jobSchema(context);
+        var jobSpec = {
+            'operations': [{
+                    '_op': 'noop'
+                },
+                {
+                    '_op': 'noop'
+                }
+            ]
+        };
+        var validJob = {
+            name: 'Custom Job',
+            lifecycle: 'once',
+            analytics: true,
+            max_retries: 3,
+            slicers: 1,
+            workers: 4,
+            operations: [
+                {_op: 'noop'},
+                {_op: 'noop'}
+            ],
+            assets: null,
+            moderator: null
+        };
+
+        var jobConfig = configValidator.validateConfig(jobSchema, jobSpec);
+        expect(jobConfig).toEqual(validJob);
+    });
+});


### PR DESCRIPTION
To support development of the Teraslice Test harness, specifically
https://github.com/terascope/teraslice_op_test_harness/issues/2

I have extracted `validateOperation`.  It is renamed to
`validateConfig` since it handles both jobConfigs and opConfigs.

I have also removed the third argument, which was a boolean
that indicated whether the config passes was an operation or not.
I replaced it with a test for the presence of `._op` which should
be present on all operations.

**This is a work in progress.  If we want to go this route, a future commit should modify `lib/config/validators/job.js` to use the function added here.**