### PR TITLE
Api job

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,6 @@ This will return the job_id (for access to the original job posted) and the job 
 ```
 {
     "job_id": "5a50580c-4a50-48d9-80f8-ac70a00f3dbd",
-    "ex_id":  "2b5dk70c-qw30-1459-bn47-zchjs80fexg3"
-
 }
 ```
 # Job Control
@@ -172,7 +170,7 @@ Please check the api docs at the bottom for a comprehensive in-depth list of all
 This will retrieve the job configuration including '\_status' which indicates the execution status of the job.
 
 ```
-curl YOU_MASTER_IP:5678/ex/{EX_ID}
+curl YOU_MASTER_IP:5678/job/{job_id}/ex}
 ```
 
 ### Stopping a job
@@ -181,7 +179,7 @@ Stopping a job stops all execution and frees the workers being consumed
 by the job on the cluster.
 
 ```
-curl -XPOST YOU_MASTER_IP:5678/ex/{EX_ID}/_stop
+curl -XPOST YOU_MASTER_IP:5678/job/{job_id}/_stop
 ```
 
 ### Starting a job
@@ -196,7 +194,7 @@ Starting a job with recover will attempt to replay any failed slices from previo
 slices the job will simply resume from where it was stopped.
 
 ```
-curl -XPOST YOU_MASTER_IP:5678/ex/{EX_ID}/_recover
+curl -XPOST YOU_MASTER_IP:5678/job/{job_id}/_recover
 ```
 
 ### Pausing a job
@@ -206,7 +204,7 @@ release the workers being used by the job. It simply pauses the slicer and
 stops allocating work to the workers. Workers will complete the work they're doing then just sit idle until the job is resumed.
 
 ```
-curl -XPOST YOU_MASTER_IP:5678/ex/{EX_ID}/_pause
+curl -XPOST YOU_MASTER_IP:5678/job/{job_id}/_pause
 ```
 
 ### Resuming a job
@@ -214,7 +212,7 @@ curl -XPOST YOU_MASTER_IP:5678/ex/{EX_ID}/_pause
 Resuming a job restarts the slicer and the allocation of slices to workers.
 
 ```
-curl -XPOST YOU_MASTER_IP:5678/ex/{EX_ID}/_resume
+curl -XPOST YOU_MASTER_IP:5678/job/{job_id}/_resume
 ```
 
 ### Viewing Slicer statistics for a job
@@ -223,7 +221,7 @@ This provides information related to the execution of the slicer and can be usef
 in monitoring and optimizing the execution of the job.
 
 ```
-curl YOU_MASTER_IP:5678/ex/{EX_ID}/slicer
+curl YOU_MASTER_IP:5678/job/{job_id}/slicer
 ```
 
 ### Viewing cluster state

--- a/docs/api.md
+++ b/docs/api.md
@@ -243,6 +243,35 @@ response:
     }
 ```
 
+#### GET /jobs/{job_id}/errors
+
+This endpoint will return an array of all errors from all executions from oldest to newest
+Note that elasticsearch has a window size limit of 10000, please use from to get more if needed
+parameter options:
+
+- from = [Number]
+- size = [Number]
+
+
+query:
+```curl -XGET localhost:5678/jobs/{job_id}/errors
+```
+
+
+#### GET /jobs/{job_id}/errors/{ex_id}
+
+This endpoint will return an array of all errors from the specified  execution from oldest to newest
+Note that elasticsearch has a window size limit of 10000, please use from to get more if needed
+parameter options:
+
+- from = [Number]
+- size = [Number]
+
+
+query:
+```curl -XGET localhost:5678/jobs/{job_id}/errors/{ex_id}
+```
+
 
 #### GET /ex
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -138,7 +138,6 @@ query:
  ```
  {
      "job_id": "5a50580c-4a50-48d9-80f8-ac70a00f3dbd",
-     "ex_id": "34502x78-1a20-dj8s-as34-acsef60f3asn"
  }
  ```
 
@@ -162,11 +161,17 @@ size is the number of documents returned, from is how many documents in and sort
 returns the job that matches given job_id
 
 query:
-``` curl localhost:5678/jobs/77c94621-48cf-459f-9d95-dfbccf010f5c```
+``` curl localhost:5678/jobs/5a50580c-4a50-48d9-80f8-ac70a00f3dbd```
 
 #### PUT /jobs/{job_id}
 
 updates a stored job that has the given job_id
+
+#### GET /job/:job_id/ex
+returns the current or latest job execution context that matches given job_id
+
+   query:
+   ``` curl localhost:5678/jobs/{job_id}/ex```
 
 #### POST /jobs/{job_id}/_start
 
@@ -174,6 +179,69 @@ issues a start command, this will start a fresh new job associated with the job_
 
 query:
 ``` curl -XPOST localhost:5678/jobs/{job_id}/_start```
+
+
+#### POST /jobs/{job_id}/_stop
+
+issues a stop command which will shutdown all slicers and workers for that job, marks the job execution context state as stopped
+
+#### POST /jobs/{job_id}/_pause
+
+issues a pause command, this will put the slicers on hold to prevent them from giving out more slices for workers, marks the job execution context state as paused
+
+#### POST /jobs/{job_id}/_resume
+
+issues a resume command, this allows the slicers to continue if they were in a paused state, marks the job execution context as running
+
+#### POST /jobs/{job_id}/_recover
+
+issues a recover command, this can only be run if the job is stopped, the job will attempt to retry failed slices and to resume where it previously left off
+
+
+#### POST /jobs/{job_id}/_workers
+
+you can dynamically change the amount of workers that are allocated for a specific job execution.
+
+parameter options:
+
+- add = [Number]
+- remove = [Number]
+- total = [Number]
+
+if you use total, it will dynamically determine if it needs to add or remove to reach the number of workers you set
+
+query:
+``` curl -XPOST localhost:5678/jobs/{job_id}/_workers?add=5```
+
+#### GET /jobs/{job_id}/slicer
+
+same concept as cluster/slicers, but only get stats on slicer associated with the given job_id
+
+query:
+```curl localhost:5678/jobs/{job_id}/slicer```
+
+response:
+```
+{
+        "node_id": "myCompName",
+        "job_id": "a8e2be53-fe17-4727-9336-c9f09db9485f",
+        "stats": {
+            "available_workers": 0,
+            "active_workers": 4,
+            "workers_joined": 4,
+            "reconnected_workers": 0,
+            "workers_disconnected": 0,
+            "failed": 0,
+            "subslices": 24,
+            "queued": 46,
+            "slice_range_expansion": 0,
+            "processed": 0,
+            "slicers": 2,
+            "subslice_by_key": 0,
+            "started": "2016-07-29T13:24:12.558-07:00"
+        }
+    }
+```
 
 
 #### GET /ex

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -142,6 +142,7 @@ module.exports = function(context) {
             job: createSlicerMsg.job,
             node_id: context.sysconfig._nodeName,
             ex_id: createSlicerMsg.ex_id,
+            job_id: createSlicerMsg.job_id,
             slicer_port: createSlicerMsg.slicer_port
         };
         //used to retry a job on startup after a stop command
@@ -188,7 +189,8 @@ module.exports = function(context) {
             assignment: 'worker',
             node_id: context.sysconfig._nodeName,
             job: createWorkerMsg.job,
-            ex_id: createWorkerMsg.ex_id
+            ex_id: createWorkerMsg.ex_id,
+            job_id: createWorkerMsg.job_id
         });
 
         //for workers on nodes that don't have the asset loading process already going
@@ -362,9 +364,13 @@ module.exports = function(context) {
                 assignment: clusterWorkers[childID].assignment,
                 pid: clusterWorkers[childID].process.pid
             };
-
+            
             if (clusterWorkers[childID].ex_id) {
                 child.ex_id = clusterWorkers[childID].ex_id
+            }
+
+            if (clusterWorkers[childID].job_id) {
+                child.job_id = clusterWorkers[childID].job_id
             }
 
             if (clusterWorkers[childID].assets) {

--- a/lib/cluster/services/api.js
+++ b/lib/cluster/services/api.js
@@ -20,7 +20,7 @@ module.exports = function(context, app, services) {
         }
     }));
 
-    app.use(function(err, req, res, next){
+    app.use(function(err, req, res, next) {
         if (err instanceof SyntaxError) {
             sendError(res, 400, `the json submitted is malformed`);
         } else {
@@ -123,6 +123,29 @@ module.exports = function(context, app, services) {
             });
     });
 
+    app.get('/jobs/:job_id/ex', function(req, res) {
+        var job_id = req.params.job_id;
+        logger.debug(`GET /jobs/:job_id endpoint has been called, job_id: ${job_id}`);
+
+        getLatestExecution(job_id)
+            .catch(function(err) {
+                var errMsg = parseError(err);
+                logger.error(errMsg);
+                sendError(res, 500, errMsg)
+            })
+            .then(function(ex_id) {
+                return jobs_service.getExecutionContext(ex_id)
+            })
+            .then(function(results) {
+                res.status(200).json(results);
+            })
+            .catch(function(err) {
+                var errMsg = parseError(err);
+                logger.error(`Error: could not retrieve list of execution contexts. ${errMsg}`);
+                sendError(res, 500, 'Error: could not retrieve list of execution contexts.');
+            })
+    });
+
     app.post('/jobs/:job_id/_start', function(req, res) {
         var job_id = req.params.job_id;
         if (!job_id) {
@@ -141,8 +164,111 @@ module.exports = function(context, app, services) {
             });
     });
 
+    app.post('/jobs/:job_id/_stop', function(req, res) {
+        logger.debug(`POST /jobs/:job_id/_stop endpoint has been called, job_id: ${req.params.job_id}, removing any pending workers for the job`);
+
+        getLatestExecution(req.params.job_id)
+            .catch(function(err) {
+                var errMsg = parseError(err);
+                logger.error(errMsg);
+                sendError(res, 500, errMsg)
+            })
+            .then(function(ex_id) {
+                cluster_service.removeFromQueue(ex_id);
+                _notifyExecutionContext(ex_id, 'stop', res);
+            });
+
+    });
+
+    app.post('/jobs/:job_id/_pause', function(req, res) {
+        logger.debug(`POST /jobs/:job_id/_pause endpoint has been called, job_id: ${req.params.job_id}`);
+
+        getLatestExecution(req.params.job_id)
+            .catch(function(err) {
+                var errMsg = parseError(err);
+                logger.error(errMsg);
+                sendError(res, 500, errMsg)
+            })
+            .then(function(ex_id) {
+                _notifyExecutionContext(ex_id, 'pause', res);
+            });
+    });
+
+    app.post('/jobs/:job_id/_resume', function(req, res) {
+        logger.debug(`POST /jobs/:job_id/_resume endpoint has been called, job_id: ${req.params.job_id}`);
+
+        getLatestExecution(req.params.job_id)
+            .catch(function(err) {
+                var errMsg = parseError(err);
+                logger.error(errMsg);
+                sendError(res, 500, errMsg)
+            })
+            .then(function(ex_id) {
+                _notifyExecutionContext(ex_id, 'resume', res);
+            });
+    });
+
+    app.post('/jobs/:job_id/_recover', function(req, res) {
+        logger.debug(`POST /jobs/:job_id/_recover endpoint has been called, job_id: ${req.params.job_id}`);
+
+        getLatestExecution(req.params.job_id)
+            .catch(function(err) {
+                var errMsg = parseError(err);
+                logger.error(errMsg);
+                sendError(res, 500, errMsg)
+            })
+            .then(function(ex_id) {
+                jobs_service.restartExecution(ex_id)
+            })
+            .then(function(status) {
+                res.status(200).json({status: status});
+            })
+            .catch(function(err) {
+                var errMsg = parseError(err);
+                logger.error(`Error: could not start job: ${errMsg}`);
+                sendError(res, 500, 'Could not start job');
+            });
+    });
+
+    app.post('/jobs/:job_id/_workers', function(req, res) {
+        logger.debug(`POST /jobs/:job_id/_workers endpoint has been called, query:`, req.query);
+
+        getLatestExecution(req.params.job_id)
+            .catch(function(err) {
+                var errMsg = parseError(err);
+                logger.error(errMsg);
+                sendError(res, 500, errMsg)
+            })
+            .then(function(ex_id) {
+                changeWorkers(req, res, ex_id);
+            });
+
+    });
+
+    app.get('/jobs/:job_id/slicer', function(req, res) {
+        logger.debug(`GET /jobs/:job_id/slicer endpoint has been called, job_id: ${req.params.job_id}`);
+
+        getLatestExecution(req.params.job_id)
+            .catch(function(err) {
+                var errMsg = parseError(err);
+                logger.error(errMsg);
+                sendError(res, 500, errMsg)
+            })
+            .then(function(ex_id) {
+                return slicerStats(ex_id)
+            })
+            .then(function(results) {
+                res.status(200).json(results);
+            })
+            .catch(function(err) {
+                var errMsg = parseError(err);
+                logger.error(`could not get slicer statistics, error: ${errMsg}`);
+                sendError(res, err.code, errMsg);
+            })
+    });
+
     app.get('/ex', function(req, res) {
-        logger.debug(`GET /jobs endpoint has been called, status: ${req.query.status}, from: ${req.query.from}, size: ${req.query.size}, sort: ${req.query.sort}`);
+        logger.debug(`GET /ex endpoint has been called, status: ${req.query.status}, from: ${req.query.from}, size: ${req.query.size}, sort: ${req.query.sort}`);
 
         jobs_service.getExecutionContexts(req.query.status, req.query.from, req.query.size, req.query.sort)
             .then(function(results) {
@@ -205,7 +331,7 @@ module.exports = function(context, app, services) {
 
     app.post('/ex/:ex_id/_workers', function(req, res) {
         logger.debug(`POST /ex/:id/_workers endpoint has been called, query:`, req.query);
-        changeWorkers(req, res);
+        changeWorkers(req, res, req.params.ex_id);
     });
 
     app.get('/ex/:ex_id/slicer', function(req, res) {
@@ -349,8 +475,11 @@ module.exports = function(context, app, services) {
 
         });
 
+    function getLatestExecution(job_id) {
+        return jobs_service.getLatestExecution(job_id)
+    }
 
-    function changeWorkers(req, res) {
+    function changeWorkers(req, res, ex_id) {
 
         if (!req.query) {
             sendError(res, 400, 'Must provide a query parameter in request');

--- a/lib/cluster/services/api.js
+++ b/lib/cluster/services/api.js
@@ -153,15 +153,29 @@ module.exports = function(context, app, services) {
         }
         logger.debug(`GET /jobs/:job_id/_start endpoint has been called, job_id: ${job_id}`);
 
-        jobs_service.startJob(job_id)
-            .then(function(ids) {
-                res.status(200).json(ids);
-            })
+        getLatestExecution(job_id, true)
             .catch(function(err) {
                 var errMsg = parseError(err);
-                logger.error(`Error: could not start job: ${errMsg}`);
-                sendError(res, 500, `Could not start job: ${job_id}`);
-            });
+                logger.error(errMsg);
+                sendError(res, 500, errMsg)
+            })
+            .then(function(isAlreadyRunning) {
+                if (isAlreadyRunning) {
+                    sendError(res, 400, `job_id: ${job_id} is currently running, cannot have the same job concurrently running`);
+                }
+                else {
+                    jobs_service.startJob(job_id)
+                        .then(function(ids) {
+                            res.status(200).json(ids);
+                        })
+                        .catch(function(err) {
+                            var errMsg = parseError(err);
+                            logger.error(`Error: could not start job: ${errMsg}`);
+                            sendError(res, 500, `Could not start job: ${job_id}`);
+                        });
+                }
+            })
+
     });
 
     app.post('/jobs/:job_id/_stop', function(req, res) {
@@ -475,8 +489,8 @@ module.exports = function(context, app, services) {
 
         });
 
-    function getLatestExecution(job_id) {
-        return jobs_service.getLatestExecution(job_id)
+    function getLatestExecution(job_id, bool) {
+        return jobs_service.getLatestExecution(job_id, bool)
     }
 
     function changeWorkers(req, res, ex_id) {

--- a/lib/cluster/services/api.js
+++ b/lib/cluster/services/api.js
@@ -436,7 +436,7 @@ module.exports = function(context, app, services) {
     app.get('/txt/workers', function(req, res) {
         logger.debug(`GET /txt/workers endpoint has been called`);
 
-        var defaults = ['assignment', 'ex_id', 'node_id', 'pid'];
+        var defaults = ['assignment', 'job_id', 'ex_id', 'node_id', 'pid'];
         var workers = cluster_service.findAllWorkers();
         var tableStr = makeTable(req, defaults, workers);
         res.status(200).send(tableStr)
@@ -507,6 +507,7 @@ module.exports = function(context, app, services) {
         logger.debug(`GET /txt/slicers endpoint has been called`);
 
         var defaults = [
+            'job_id',
             'ex_id',
             'workers_available',
             'workers_active',

--- a/lib/cluster/services/api.js
+++ b/lib/cluster/services/api.js
@@ -128,11 +128,6 @@ module.exports = function(context, app, services) {
         logger.debug(`GET /jobs/:job_id endpoint has been called, job_id: ${job_id}`);
 
         getLatestExecution(job_id)
-            .catch(function(err) {
-                var errMsg = parseError(err);
-                logger.error(errMsg);
-                sendError(res, 500, errMsg)
-            })
             .then(function(ex_id) {
                 return jobs_service.getExecutionContext(ex_id)
             })
@@ -154,11 +149,6 @@ module.exports = function(context, app, services) {
         logger.debug(`GET /jobs/:job_id/_start endpoint has been called, job_id: ${job_id}`);
 
         getLatestExecution(job_id, true)
-            .catch(function(err) {
-                var errMsg = parseError(err);
-                logger.error(errMsg);
-                sendError(res, 500, errMsg)
-            })
             .then(function(isAlreadyRunning) {
                 if (isAlreadyRunning) {
                     sendError(res, 400, `job_id: ${job_id} is currently running, cannot have the same job concurrently running`);
@@ -175,36 +165,39 @@ module.exports = function(context, app, services) {
                         });
                 }
             })
-
+            .catch(function(err) {
+                var errMsg = parseError(err);
+                logger.error(errMsg);
+                sendError(res, 500, errMsg)
+            })
     });
 
     app.post('/jobs/:job_id/_stop', function(req, res) {
         logger.debug(`POST /jobs/:job_id/_stop endpoint has been called, job_id: ${req.params.job_id}, removing any pending workers for the job`);
 
         getLatestExecution(req.params.job_id)
+            .then(function(ex_id) {
+                cluster_service.removeFromQueue(ex_id);
+                _notifyExecutionContext(ex_id, 'stop', res);
+            })
             .catch(function(err) {
                 var errMsg = parseError(err);
                 logger.error(errMsg);
                 sendError(res, 500, errMsg)
-            })
-            .then(function(ex_id) {
-                cluster_service.removeFromQueue(ex_id);
-                _notifyExecutionContext(ex_id, 'stop', res);
             });
-
     });
 
     app.post('/jobs/:job_id/_pause', function(req, res) {
         logger.debug(`POST /jobs/:job_id/_pause endpoint has been called, job_id: ${req.params.job_id}`);
 
         getLatestExecution(req.params.job_id)
+            .then(function(ex_id) {
+                _notifyExecutionContext(ex_id, 'pause', res);
+            })
             .catch(function(err) {
                 var errMsg = parseError(err);
                 logger.error(errMsg);
                 sendError(res, 500, errMsg)
-            })
-            .then(function(ex_id) {
-                _notifyExecutionContext(ex_id, 'pause', res);
             });
     });
 
@@ -212,13 +205,13 @@ module.exports = function(context, app, services) {
         logger.debug(`POST /jobs/:job_id/_resume endpoint has been called, job_id: ${req.params.job_id}`);
 
         getLatestExecution(req.params.job_id)
+            .then(function(ex_id) {
+                _notifyExecutionContext(ex_id, 'resume', res);
+            })
             .catch(function(err) {
                 var errMsg = parseError(err);
                 logger.error(errMsg);
                 sendError(res, 500, errMsg)
-            })
-            .then(function(ex_id) {
-                _notifyExecutionContext(ex_id, 'resume', res);
             });
     });
 
@@ -226,11 +219,6 @@ module.exports = function(context, app, services) {
         logger.debug(`POST /jobs/:job_id/_recover endpoint has been called, job_id: ${req.params.job_id}`);
 
         getLatestExecution(req.params.job_id)
-            .catch(function(err) {
-                var errMsg = parseError(err);
-                logger.error(errMsg);
-                sendError(res, 500, errMsg)
-            })
             .then(function(ex_id) {
                 jobs_service.restartExecution(ex_id)
             })
@@ -248,13 +236,13 @@ module.exports = function(context, app, services) {
         logger.debug(`POST /jobs/:job_id/_workers endpoint has been called, query:`, req.query);
 
         getLatestExecution(req.params.job_id)
+            .then(function(ex_id) {
+                changeWorkers(req, res, ex_id);
+            })
             .catch(function(err) {
                 var errMsg = parseError(err);
                 logger.error(errMsg);
                 sendError(res, 500, errMsg)
-            })
-            .then(function(ex_id) {
-                changeWorkers(req, res, ex_id);
             });
 
     });
@@ -263,11 +251,6 @@ module.exports = function(context, app, services) {
         logger.debug(`GET /jobs/:job_id/slicer endpoint has been called, job_id: ${req.params.job_id}`);
 
         getLatestExecution(req.params.job_id)
-            .catch(function(err) {
-                var errMsg = parseError(err);
-                logger.error(errMsg);
-                sendError(res, 500, errMsg)
-            })
             .then(function(ex_id) {
                 return slicerStats(ex_id)
             })

--- a/lib/cluster/services/api.js
+++ b/lib/cluster/services/api.js
@@ -552,7 +552,6 @@ module.exports = function(context, app, services) {
             return
         }
 
-        var ex_id = req.params.ex_id;
         var keyOptions = {add: true, remove: true, total: true};
         var jobState = {running: true, failing: true, paused: true};
         var queryKeys = Object.keys(req.query);

--- a/lib/cluster/services/api.js
+++ b/lib/cluster/services/api.js
@@ -281,6 +281,57 @@ module.exports = function(context, app, services) {
             })
     });
 
+    app.get('/jobs/:job_id/errors', function(req, res) {
+        var job_id = req.params.job_id;
+        var from = req.query.from;
+        var size = req.query.size ? req.query.size : 10000;
+
+        logger.debug(`GET /jobs/:job_id/errors endpoint has been called, job_id: ${job_id}, from: ${from}, size: ${size}`);
+
+        jobs_service.getExecutions(job_id)
+            .catch(function(err) {
+                var errMsg = parseError(err);
+                logger.error(errMsg);
+                sendError(res, 500, errMsg)
+            })
+            .then(function(ex_ids) {
+                if (ex_ids.length === 0) {
+                    return Promise.reject(`no executions were found for job: ${job_id}`);
+                }
+                var query = `state:error AND (${ex_ids.map(ex => `ex_id:${ex} `).join('OR').trim()})`;
+                return jobs_service.getJobStateRecords(query, from, size, '@timestamp:asc')
+            })
+            .then(function(errorStates) {
+                res.status(200).json(errorStates);
+            })
+            .catch(function(err) {
+                var errMsg = parseError(err);
+                logger.error(`could not get errors from job: ${job_id}, error: ${errMsg}`);
+                sendError(res, 400, errMsg);
+            })
+    });
+
+    app.get('/jobs/:job_id/errors/:ex_id', function(req, res) {
+        var job_id = req.params.job_id;
+        var ex_id = req.params.ex_id;
+        var from = req.query.from;
+        var size = req.query.size ? req.query.size : 10000;
+
+        logger.debug(`GET /jobs/:job_id/errors endpoint has been called, job_id: ${job_id}, ex_id: ${ex_id}, from: ${from}, size: ${size}`);
+
+        var query = `ex_id:${ex_id} AND state:error`;
+
+        jobs_service.getJobStateRecords(query, from, size, '@timestamp:asc')
+            .then(function(errorStates) {
+                res.status(200).json(errorStates);
+            })
+            .catch(function(err) {
+                var errMsg = parseError(err);
+                logger.error(`could not get errors from job: ${job_id}, ex_id: ${ex_id}, error: ${errMsg}`);
+                sendError(res, err.code, errMsg);
+            })
+    });
+
     app.get('/ex', function(req, res) {
         logger.debug(`GET /ex endpoint has been called, status: ${req.query.status}, from: ${req.query.from}, size: ${req.query.size}, sort: ${req.query.sort}`);
 

--- a/lib/cluster/services/cluster.js
+++ b/lib/cluster/services/cluster.js
@@ -362,8 +362,8 @@ module.exports = function(context, server) {
         return notifyNode(node_id, 'cluster:node:get_port', {});
     }
 
-    function removeFromQueue(id) {
-        pendingWorkerRequests.remove(id)
+    function removeFromQueue(id, key) {
+        pendingWorkerRequests.remove(id, key)
     }
 
     function addToQueue(data) {
@@ -424,6 +424,7 @@ module.exports = function(context, server) {
 
     function allocateWorker(job) {
         var ex_id = job.ex_id;
+        var job_id = job.job_id;
         var needsAssets = job.assets && job.assets.length > 0;
         var jobStr = JSON.stringify(job);
         var sortedNodes = _.sortByOrder(cluster_state, 'available', 'desc');
@@ -434,6 +435,7 @@ module.exports = function(context, server) {
         var data = {
             job: jobStr,
             ex_id: ex_id,
+            job_id: job_id,
             workers: 1,
             node_id: workerNodeID,
             assignment: 'worker',
@@ -446,6 +448,7 @@ module.exports = function(context, server) {
     //designed to allocate additional workers, not any future slicers
     function allocateWorkers(job, numOfWorkersRequested) {
         var ex_id = job.ex_id;
+        var job_id = job.job_id;
         var needsAssets = job.assets && job.assets.length > 0;
         var jobStr = JSON.stringify(job);
         var sortedNodes = _.orderBy(cluster_state, 'available', 'desc');
@@ -471,7 +474,7 @@ module.exports = function(context, server) {
             }
         }
         //if left over worker requests, enqueue them, queue works based off of id, so it redundantly references ex_id
-        var workerData = {job: jobStr, id: ex_id, ex_id: ex_id, workers: 1, assignment: 'worker'};
+        var workerData = {job: jobStr, id: ex_id, ex_id: ex_id, job_id: job_id, workers: 1, assignment: 'worker'};
 
         while (numOfWorkersRequested > 0) {
             logger.trace(`adding worker to pending queue for ex: ${ex_id}`);
@@ -485,6 +488,7 @@ module.exports = function(context, server) {
                 job: jobStr,
                 id: ex_id,
                 ex_id: ex_id,
+                job_id: job_id,
                 node_id: node_id,
                 workers: workerRequested,
                 assignment: 'worker',
@@ -516,11 +520,13 @@ module.exports = function(context, server) {
             logger.debug(`node ${cluster_state[slicerNodeID].hostname} has been elected for slicer, listening on port: ${portObj.port}`);
 
             var ex_id = job.ex_id;
+            var job_id = job.job_id;
             var needsAssets = job.assets && job.assets.length > 0;
             var jobStr = JSON.stringify(job);
             var data = {
                 job: jobStr,
                 ex_id: ex_id,
+                job_id: job_id,
                 workers: 1,
                 needsAssets: needsAssets,
                 slicer_port: portObj.port,

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -315,9 +315,10 @@ module.exports = function(context, cluster_service) {
                         return
                     }
 
-                    //need to normalize asset identifiers to their id form
-                    job_spec.assets = msg.assets;
-                    resolve(job_spec)
+                    //need to normalize asset identifiers to their id form, but not mutate original job_spec
+                    var parsedAssetJob = _.cloneDeep(job_spec);
+                    parsedAssetJob.assets = msg.assets;
+                    resolve(parsedAssetJob)
                 });
 
                 events.emit('jobs_service:verify_assets', {assets: job_spec.assets, _msgID: id});
@@ -327,16 +328,25 @@ module.exports = function(context, cluster_service) {
 
     function submitJob(job_spec, shouldRun) {
         return ensureAssets(job_spec)
-            .then(function(_job_spec) {
-                return _validateJob(job_spec)
+            .then(function(parsedAssetJob) {
+                return _validateJob(parsedAssetJob)
             })
             .then(function(validJob) {
+                var oldAssetNames = job_spec.assets;
+                var parsedAssets = validJob.assets;
+
+                // we want to keep old names on job so that assets can be changed dynamically
+                // this works since we passed ensureAssets that make sure we have valid assets 
+                validJob.assets = oldAssetNames;
+
                 return saveJob(validJob, 'job')
                     .then(function(job) {
                         if (!shouldRun) {
                             return {job_id: job.job_id}
                         }
                         else {
+                            //revert back to true asset identifiers for actual invocation
+                            job.assets = parsedAssets;
                             return createExecutionContext(job)
                         }
                     })

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -17,9 +17,12 @@ var moderatorPausedQueue = new Queue;
  failed - when there is an error while the job is running
  aborted - when a job was running at the point when the cluster shutsdown
  */
+
+
+//if changing VALID_STATUS, make sure to modify getLatestExecution, it expects first 7 values are active states and the rest are finished states
 var VALID_STATUS = [
     'pending', 'scheduling', 'initializing', 'running', 'failing', 'paused', 'moderator_paused',
-    'completed', 'stopped', 'rejected', 'failed', 'aborted'
+    'completed', 'stopped', 'rejected', 'failed', 'terminated'
 ];
 
 // Maps job notification to execution states
@@ -36,6 +39,7 @@ var MESSAGE_MAPPING = {
     'resume': 'cluster:job:resume',
     'restart': 'cluster:job:restart',
     'stop': 'cluster:job:stop',
+    'terminated': 'cluster:job:stop',
     'moderator_paused': 'cluster:job:pause'
 };
 
@@ -96,7 +100,7 @@ module.exports = function(context, cluster_service) {
     });
 
     events.on('slicer:job:update', function(updateSpec) {
-        //this is updating the opConfig for elasticsearch start and/or end dates for ex, this assuemes elasticsearch is first
+        //this is updating the opConfig for elasticsearch start and/or end dates for ex, this assumes elasticsearch is first
         updateEX(updateSpec.ex_id, {operations: updateSpec.update})
     });
 
@@ -435,11 +439,20 @@ module.exports = function(context, cluster_service) {
             });
     }
 
-    function getLatestExecution(job_id) {
-        var query = `job_id: ${job_id}`;
+    function getLatestExecution(job_id, checkIfActive) {
+        var query = `job_id: ${job_id} AND _context:ex`;
+
+        if (checkIfActive) {
+            var str = VALID_STATUS.slice(7).map(state => ` _status:${state} `).join('OR');
+            query = `job_id: ${job_id} AND _context:ex NOT (${str.trim()})`
+        }
+
         return ex_store.search(query, null, 1, '_created:desc')
             .then(function(ex) {
-                if (ex.length !== 1) {
+                if (ex.length === 0) {
+                    if (checkIfActive) {
+                        return false;
+                    }
                     return Promise.reject(`no execution context was found for job_id: ${job_id}`)
                 }
                 return ex[0].ex_id
@@ -590,7 +603,16 @@ module.exports = function(context, cluster_service) {
 
     function shutdown() {
         logger.info(`shutting down`);
-        return Promise.all([job_store.shutdown(), ex_store.shutdown()]);
+
+        var query = VALID_STATUS.slice(0, 7).map(str => `_status:${str}`).join(" OR ");
+        return ex_search(query)
+            .map(function(job) {
+                logger.warn(`marking job ${job.job_id}, ex_id: ${job.ex_id} as terminated`);
+                return _signalJobStateChange(job.ex_id, 'stop', 'terminated');
+            })
+            .finally(function() {
+                return Promise.all([job_store.shutdown(), ex_store.shutdown()]);
+            })
     }
 
     var api = {

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -279,7 +279,8 @@ module.exports = function(context, cluster_service) {
                     logger.warn(`job cannot be run due to throttled database connections`);
                     moderatorPausedQueue.enqueue(ex);
                 }
-                return {job_id: ex.job_id, ex_id: ex.ex_id};
+
+                return {job_id: ex.job_id};
             })
             .catch(function(err) {
                 var errMsg = parseError(err);
@@ -432,6 +433,17 @@ module.exports = function(context, cluster_service) {
             .catch(function(err) {
                 logger.error(`error getting execution context for ex: ${ex_id}`, err)
             });
+    }
+
+    function getLatestExecution(job_id) {
+        var query = `job_id: ${job_id}`;
+        return ex_store.search(query, null, 1, '_created:desc')
+            .then(function(ex) {
+                if (ex.length !== 1) {
+                    return Promise.reject(`no execution context was found for job_id: ${job_id}`)
+                }
+                return ex[0].ex_id
+            })
     }
 
     // Checks the queue of pending jobs and will allocate any workers required.
@@ -590,6 +602,7 @@ module.exports = function(context, cluster_service) {
         getJobs: getJobs,
         getExecutionContext: getExecutionContext,
         getExecutionContexts: getExecutionContexts,
+        getLatestExecution: getLatestExecution,
         startJob: startJob,
         restartExecution: restartExecution,
         shutdown: shutdown

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -392,7 +392,10 @@ module.exports = function(context, cluster_service) {
     function startJob(job_id) {
         return getJob(job_id)
             .then(function(job_spec) {
-                return createExecutionContext(job_spec);
+                return ensureAssets(job_spec);
+            })
+            .then(function(assetIdJob) {
+                return createExecutionContext(assetIdJob);
             })
             .catch(function(err) {
                 var errMsg = parseError(err);

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -439,6 +439,20 @@ module.exports = function(context, cluster_service) {
             });
     }
 
+    function getExecutions(job_id) {
+        var query = `job_id: ${job_id} AND _context:ex`;
+
+        //TODO only get 10000, need room to allow more
+        return ex_store.search(query, null, 10000)
+            .then(function(exs) {
+                return exs.map(ex => ex.ex_id)
+            })
+    }
+
+    function getJobStateRecords(query, from, size, sort) {
+        return job_store.getJobStateRecords(query, from, size, sort)
+    }
+
     function getLatestExecution(job_id, checkIfActive) {
         var query = `job_id: ${job_id} AND _context:ex`;
 
@@ -624,6 +638,8 @@ module.exports = function(context, cluster_service) {
         getJobs: getJobs,
         getExecutionContext: getExecutionContext,
         getExecutionContexts: getExecutionContexts,
+        getExecutions: getExecutions,
+        getJobStateRecords: getJobStateRecords,
         getLatestExecution: getLatestExecution,
         startJob: startJob,
         restartExecution: restartExecution,

--- a/lib/cluster/storage/backends/elasticsearch_store.js
+++ b/lib/cluster/storage/backends/elasticsearch_store.js
@@ -47,7 +47,7 @@ module.exports = function(context, index_name, record_type, id_field, bulk_size,
         if (fields) {
             esQuery._source = fields;
         }
-
+        
         return elasticsearch.search(esQuery)
     }
 

--- a/lib/cluster/storage/jobs.js
+++ b/lib/cluster/storage/jobs.js
@@ -50,8 +50,7 @@ module.exports = function(context, jobType) {
         }
 
         record._context = jobType;
-
-        if (!record._created) record._created = date;
+        record._created = date;
         record._updated = date;
 
         return backend.create(record)

--- a/lib/cluster/storage/jobs.js
+++ b/lib/cluster/storage/jobs.js
@@ -22,8 +22,8 @@ module.exports = function(context, jobType) {
         return backend.get(record_id);
     }
 
-    function search(query, from, size) {
-        return backend.search(query, from, size);
+    function search(query, from, size, sort) {
+        return backend.search(query, from, size, sort);
     }
 
     function getExecutionContexts(status, from, size, sort) {

--- a/lib/cluster/storage/jobs.js
+++ b/lib/cluster/storage/jobs.js
@@ -13,7 +13,7 @@ var _ = require('lodash');
 module.exports = function(context, jobType) {
     var logger = context.foundation.makeLogger(`${jobType}_storage`, `${jobType}_storage`, {module: `${jobType}_storage`});
     var config = context.sysconfig.teraslice;
-
+    var state_store;
     var jobs_index = config.name + '__jobs';
 
     var backend;
@@ -72,6 +72,10 @@ module.exports = function(context, jobType) {
         return backend.shutdown();
     }
 
+    function getJobStateRecords(query, from, size, sort) {
+        return state_store.search(query, from, size, sort)
+    }
+
     var api = {
         get: get,
         search: search,
@@ -80,7 +84,8 @@ module.exports = function(context, jobType) {
         create: create,
         update: update,
         remove: remove,
-        shutdown: shutdown
+        shutdown: shutdown,
+        getJobStateRecords: getJobStateRecords
     };
 
     var jobArgs = [context, jobs_index];
@@ -92,11 +97,11 @@ module.exports = function(context, jobType) {
         jobArgs.push('job', 'ex_id')
     }
 
-    return require('./backends/elasticsearch_store').apply(null, jobArgs)
-        .then(function(elasticsearch) {
+    return Promise.all([require('./state')(context), require('./backends/elasticsearch_store').apply(null, jobArgs)])
+        .spread(function(state, elasticsearch) {
             logger.info(`Initializing`);
             backend = elasticsearch;
-
+            state_store = state;
             return api;
         });
 };


### PR DESCRIPTION
- added job_id to show up in node_state
- updated docs
- kept all ex endpoints and added their equivalents using jobs/{job_id}/{_action}
- added jobs/{job_id}/ex to get the latest active ex
- shutting down cluster master now shuts down all active jobs and marks them as 'terminated'