### PR TITLE
fixing a few bad api endpoints in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Please check the api docs at the bottom for a comprehensive in-depth list of all
 This will retrieve the job configuration including '\_status' which indicates the execution status of the job.
 
 ```
-curl YOU_MASTER_IP:5678/job/{job_id}/ex}
+curl YOU_MASTER_IP:5678/jobs/{job_id}/ex}
 ```
 
 ### Stopping a job
@@ -179,7 +179,7 @@ Stopping a job stops all execution and frees the workers being consumed
 by the job on the cluster.
 
 ```
-curl -XPOST YOU_MASTER_IP:5678/job/{job_id}/_stop
+curl -XPOST YOU_MASTER_IP:5678/jobs/{job_id}/_stop
 ```
 
 ### Starting a job
@@ -194,7 +194,7 @@ Starting a job with recover will attempt to replay any failed slices from previo
 slices the job will simply resume from where it was stopped.
 
 ```
-curl -XPOST YOU_MASTER_IP:5678/job/{job_id}/_recover
+curl -XPOST YOU_MASTER_IP:5678/jobs/{job_id}/_recover
 ```
 
 ### Pausing a job
@@ -204,7 +204,7 @@ release the workers being used by the job. It simply pauses the slicer and
 stops allocating work to the workers. Workers will complete the work they're doing then just sit idle until the job is resumed.
 
 ```
-curl -XPOST YOU_MASTER_IP:5678/job/{job_id}/_pause
+curl -XPOST YOU_MASTER_IP:5678/jobs/{job_id}/_pause
 ```
 
 ### Resuming a job
@@ -212,7 +212,7 @@ curl -XPOST YOU_MASTER_IP:5678/job/{job_id}/_pause
 Resuming a job restarts the slicer and the allocation of slices to workers.
 
 ```
-curl -XPOST YOU_MASTER_IP:5678/job/{job_id}/_resume
+curl -XPOST YOU_MASTER_IP:5678/jobs/{job_id}/_resume
 ```
 
 ### Viewing Slicer statistics for a job
@@ -221,7 +221,7 @@ This provides information related to the execution of the slicer and can be usef
 in monitoring and optimizing the execution of the job.
 
 ```
-curl YOU_MASTER_IP:5678/job/{job_id}/slicer
+curl YOU_MASTER_IP:5678/jobs/{job_id}/slicer
 ```
 
 ### Viewing cluster state
@@ -246,8 +246,6 @@ curl YOU_MASTER_IP:5678/cluster/state
 ## Configuration
 
  * [Teraslice configuration reference](./docs/configuration.md)
- 
+
 ## Services
  * [additional services](./docs/services.md)
-
-

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,7 +70,7 @@ submit a zip file containing custom readers/processors for jobs to use
 
 query:
  ```
-  curl -XPOST -H "Content-Type: application/octet-stream" localhost:5678/assets --data-binary @zipFile.zip 
+  curl -XPOST -H "Content-Type: application/octet-stream" localhost:5678/assets --data-binary @zipFile.zip
  ```
 
  response:
@@ -85,14 +85,14 @@ the _id returned is the id of elasticsearch document where the zip file has been
 The zip file must contain an asset.json containing a name for the asset bundle and a version number which can be used to query the asset besides using the _id
 ```javascript
  /enclosing_dir
-    asset_op 
+    asset_op
        index.js
     another_asset.cvs
     asset.json
-        
+
 ```
-   
-   
+
+
 You may zip the enclosing directory or piecemeal the file together
 
 ```javascript
@@ -167,7 +167,7 @@ query:
 
 updates a stored job that has the given job_id
 
-#### GET /job/:job_id/ex
+#### GET /jobs/:job_id/ex
 returns the current or latest job execution context that matches given job_id
 
    query:
@@ -595,8 +595,8 @@ response:
 ```
 name     version  id                                        _created                  description
 -------  -------  ----------------------------------------  ------------------------  ------------------------------
-zipfile  0.0.1    e7f338d0b0fe679698d781ef71b332915d020570  2017-05-30T18:19:18.638Z  Some description 
-otherzip 1.0.1    d94hy8d0b0fe679698d781ef71b332915d020570  2017-05-29T18:19:18.638Z  Some description 
+zipfile  0.0.1    e7f338d0b0fe679698d781ef71b332915d020570  2017-05-30T18:19:18.638Z  Some description
+otherzip 1.0.1    d94hy8d0b0fe679698d781ef71b332915d020570  2017-05-29T18:19:18.638Z  Some description
 
 ```
 
@@ -642,8 +642,8 @@ response:
 ```
 name     version  id                                        _created                  description
 -------  -------  ----------------------------------------  ------------------------  ------------------------------
-zipfile  1.0.1    e7f338d0b0fe679698d781ef71b332915d020570  2017-05-30T18:19:18.638Z  Some description 
-zipfile  0.3.1    e7f338d0b0fe679698d781ef71b332915d020570  2017-05-28T18:19:18.638Z  Some description 
+zipfile  1.0.1    e7f338d0b0fe679698d781ef71b332915d020570  2017-05-30T18:19:18.638Z  Some description
+zipfile  0.3.1    e7f338d0b0fe679698d781ef71b332915d020570  2017-05-28T18:19:18.638Z  Some description
 
 ```
 
@@ -688,7 +688,7 @@ response:
 ```
 name     version  id                                        _created                  description
 -------  -------  ----------------------------------------  ------------------------  ------------------------------
-zipfile  0.3.1    e7f338d0b0fe679698d781ef71b332915d020570  2017-05-28T18:19:18.638Z  Some description 
+zipfile  0.3.1    e7f338d0b0fe679698d781ef71b332915d020570  2017-05-28T18:19:18.638Z  Some description
 
 ```
 


### PR DESCRIPTION
There were several places where `/job/` was used as the jobs api endpoint ... mostly in the `README.md`

This PR addresses that.