### PR TITLE
Push slicer analytics to cluster master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 .DEFAULT_GOAL := help
-.PHONY: help lint test integration-tests run docker-image grep
+.PHONY: help lint test integration-tests master worker docker-image grep
 SHELL := bash
 
 APP_NAME := teraslice
@@ -19,6 +19,7 @@ help: ## show target summary
 
 node_modules: package.json
 	npm install
+	touch node_modules
 
 
 lint: node_modules ## run linters
@@ -33,8 +34,14 @@ integration-tests: ## run integration tests
 	make -C integration-tests test
 
 
-run: node_modules ## start listening to events
-	npm run start
+master: LOG=info# log level: debug, info, warn, error
+master: node_modules ## start teraslice master node
+	node service.js -c examples/config/processor-master.yaml | bunyan -o short -l $(LOG)
+
+
+worker: LOG=info# log level: debug, info, warn, error
+worker: node_modules ## start teraslice worker node
+	node service.js -c examples/config/processor-worker.yaml | bunyan -o short -l $(LOG)
 
 
 Dockerfile: Dockerfile.sh

--- a/integration-tests/config/processor-master.yaml
+++ b/integration-tests/config/processor-master.yaml
@@ -1,6 +1,6 @@
 terafoundation:
     environment: 'development'
-
+    log_level: info
     connectors:
         # ***********************
         # Elastic Search Configuration

--- a/integration-tests/config/processor-worker.yaml
+++ b/integration-tests/config/processor-worker.yaml
@@ -1,6 +1,6 @@
 terafoundation:
     environment: 'development'
-
+    log_level: info
     connectors:
         # ***********************
         # Elastic Search Configuration

--- a/integration-tests/spec/cases/data/reindex.js
+++ b/integration-tests/spec/cases/data/reindex.js
@@ -31,6 +31,26 @@ module.exports = function() {
                 .finally(done)
         });
 
+        it('should collect cluster level stats', function(done) {
+            teraslice.cluster.stats()
+                .then(function(stats) {
+                    expect(stats.slicer.processed).toBeGreaterThan(0);
+                    expect(stats.slicer.failed).toBe(0);
+                    expect(stats.slicer.queued).toBeDefined();
+                    expect(stats.slicer.job_duration).toBeGreaterThan(0);
+                    expect(stats.slicer.workers_joined).toBeGreaterThan(0);
+                    expect(stats.slicer.workers_disconnected).toBeDefined();
+                    expect(stats.slicer.workers_reconnected).toBeDefined();
+                    // executions: total, failed, active?
+                    // exceptions?
+                })
+                .catch(function(err) {
+                    console.log('what error', err);
+                    fail()
+                })
+                .finally(done)
+        })
+
         it('should complete after lifecycle changes', function(done) {
             var job_spec = misc.newJob('reindex');
             job_spec.name = 'reindex after lifecycle changes';

--- a/lib/cluster/services/api.js
+++ b/lib/cluster/services/api.js
@@ -404,6 +404,11 @@ module.exports = function(context, app, services) {
         // TODO: Impl.
     });
 
+    app.get('/cluster/stats', function(req, res) {
+        logger.debug(`GET /cluster/stats endpoint has been called`);
+        res.status(200).json(cluster_service.getClusterStats());
+    });
+
     app.get('/cluster/slicers', function(req, res) {
         logger.debug(`GET /cluster/slicers endpoint has been called`);
 

--- a/lib/cluster/services/cluster.js
+++ b/lib/cluster/services/cluster.js
@@ -15,6 +15,17 @@ module.exports = function(context, server) {
     var pendingWorkerRequests = new Queue();
     var moderator = null;
     var cluster_state = {};
+    var cluster_stats = {
+        slicer: {
+            processed: 0,
+            failed: 0,
+            queued: 0,
+            job_duration: 0,
+            workers_joined: 0,
+            workers_disconnected: 0,
+            workers_reconnected: 0
+        }
+    };
 
     //temporary holding spot used to attach nodes that are non responsive or disconnect before final cleanup
     var droppedNodes = {};
@@ -208,6 +219,17 @@ module.exports = function(context, server) {
         }
     });
 
+    messaging.register('cluster:analytics', function(msg) {
+        if (!cluster_stats[msg.kind]) {
+            logger.warn(`unrecognized cluster stats: ${msg.kind}`);
+            return;
+        }
+        _.forOwn(msg.stats, function(value, field) {
+            if (cluster_stats[msg.kind][field] !== undefined) {
+                cluster_stats[msg.kind][field] += value;
+            }
+        });
+    });
 
     messaging.initialize({server: server});
 
@@ -258,6 +280,10 @@ module.exports = function(context, server) {
 
     function getClusterState() {
         return _.cloneDeep(cluster_state);
+    }
+
+    function getClusterStats() {
+        return _.cloneDeep(cluster_stats);
     }
 
     function checkNode(node) {
@@ -717,6 +743,7 @@ module.exports = function(context, server) {
 
     var api = {
         getClusterState: getClusterState,
+        getClusterStats: getClusterStats,
         availableWorkers: availableWorkers,
         allWorkers: allWorkers,
         allNodes: allNodes,

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -14,6 +14,7 @@ var networkMapping = {
     'node:workers:over_allocated': 'node:workers:over_allocated',
     'cluster:moderator:connection_ok': 'cluster:moderator:connection_ok',
     'cluster:slicer:analytics': 'cluster:slicer:analytics',
+    'cluster:analytics': 'cluster:analytics',
     'cluster:slicer:create': 'cluster:slicer:create',
     'cluster:workers:create': 'cluster:workers:create',
     'cluster:workers:remove': 'cluster:workers:remove',

--- a/lib/cluster/slicer.js
+++ b/lib/cluster/slicer.js
@@ -58,6 +58,17 @@ module.exports = function(context) {
         subslice_by_key: 0,
         started: moment().format(dateFormat)
     };
+    //a place for tracking differences so collector (cluster master) does not have to manage extra state
+    var pushedAnalytics = {
+        processed: 0,
+        failed: 0,
+        queued: 0,
+        job_duration: 0,
+        workers_joined: 0,
+        workers_disconnected: 0,
+        workers_reconnected: 0
+    };
+    var analyticsTimer;
 
     var job;
     var slicer;
@@ -425,6 +436,21 @@ module.exports = function(context) {
             logger.debug('starting the slicer engine');
             engine = setInterval(engineFn, 1);
         }
+
+        //push analytics to cluster master to support cluster level analytics
+        analyticsTimer = setInterval(pushAnalytics, context.sysconfig.analytics_rate || 60000)
+    }
+
+    function pushAnalytics() {
+        //save a copy of what we push so we can emit diffs
+        var diffs = {};
+        var copy = {};
+        _.forOwn(pushedAnalytics, function(value, field) {
+            diffs[field] = slicerAnalytics[field] - value;
+            copy[field] = slicerAnalytics[field];
+        });
+        messaging.send({message: 'cluster:analytics', stats: diffs, kind: 'slicer'});
+        pushedAnalytics = copy;
     }
 
     function startSlicer() {
@@ -441,6 +467,8 @@ module.exports = function(context) {
 
         engineCanRun = false;
         clearInterval(engine);
+        clearInterval(analyticsTimer);
+        pushAnalytics();
         //functionally job:stop acts like a regular shutdown
         events.emit('job:stop');
         var shutdownInterval = setInterval(function() {

--- a/lib/config/schemas/system.js
+++ b/lib/config/schemas/system.js
@@ -152,6 +152,11 @@ var schema = {
 
         }
     },
+    analytics_rate: {
+        doc: 'Rate in ms in which to push analytics to cluster master',
+        default: 60000,
+        format: Number
+    },
     moderator: {
         doc: 'boolean for determining if moderator should live on this node',
         default: false,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "yargs": "^3.18.0"
   },
   "devDependencies": {
+    "jasmine-spec-reporter": "^4.2.1",
     "json-schema-faker": "^0.3.7"
   }
 }

--- a/spec/helpers/reporter.js
+++ b/spec/helpers/reporter.js
@@ -1,0 +1,11 @@
+
+if (process.stdout.isTTY) {
+    var SpecReporter = require('jasmine-spec-reporter').SpecReporter;
+    jasmine.getEnv().clearReporters();
+    jasmine.getEnv().addReporter(new SpecReporter({
+        spec: {
+            displayStacktrace: true,
+            displayDuration: true
+        }
+    }))
+}


### PR DESCRIPTION
Fixes #481: I chose `cluster:analytics` as the message key to reserve room for other
sub-systems to push their metrics.  The integration test assumes another test has
run that has exercised the slicer bits - not clean but didn't want to add even more
time to the test suite.

Needs client changes to be accepted for test to work: terascope/teraslice-client-js/pull/6