### PR TITLE
WIP: adding job lifecycle tests to test persistent jobs

### DIFF
--- a/integration-tests/spec/cases/jobs/lifecycle.js
+++ b/integration-tests/spec/cases/jobs/lifecycle.js
@@ -1,0 +1,66 @@
+'use strict';
+
+let misc = require('../../misc')();
+let teraslice = misc.teraslice;
+
+module.exports = function() {
+    describe('A once job should', function() {
+        fit('generate a 1000 docs and complete', function(done) {
+          let jobSpec = misc.newJob('gen');
+
+          teraslice().jobs.submit(jobSpec)
+            .then(function(job) {
+              return job
+                .waitForStatus('running')
+                .then(function() {
+                  return job.waitForStatus('completed');
+                })
+                .then(function() {
+                    return misc.indexStats(jobSpec.operations[1].index)
+                        .then(function(stats) {
+                            expect(stats.count).toBe(1000);
+                        });
+                });
+            })
+            .catch(fail)
+            .finally(function() {
+                misc.es().indices.delete({index: jobSpec.operations[1].index}),
+                done();
+            });
+        });
+    });
+
+    describe('A persistent job should', function() {
+        fit('generate data for ever, more than 1000 docs', function(done) {
+          let jobSpec = misc.newJob('gen');
+          jobSpec.lifecycle = 'persistent';
+          jobSpec.operations[1].index = 'gen-persistent-test';
+
+          teraslice().jobs.submit(jobSpec)
+            .then(function(job) {
+              return job
+                .waitForStatus('running')
+                .delay(5000)
+                .then(function() {
+                    return misc.indexStats(jobSpec.operations[1].index)
+                        .then(function(stats) {
+                            expect(stats.count).toBeGreaterThan(1000);
+                        });
+                })
+                .then(function() {
+                    return job.stop();
+                })
+                .then(function() {
+                    return job.waitForStatus('stopped');
+                });
+            })
+            .catch(fail)
+            .finally(function() {
+                misc.es().indices.delete(
+                  {index: jobSpec.operations[1].index}
+                ),
+                done();
+            });
+        });
+    });
+};

--- a/integration-tests/spec/fixtures/jobs/gen.json
+++ b/integration-tests/spec/fixtures/jobs/gen.json
@@ -1,0 +1,20 @@
+{
+  "name": "Reindex",
+  "lifecycle": "once",
+  "workers": 1,
+  "operations": [{
+      "_op": "elasticsearch_data_generator",
+      "size": 1000
+    },
+    {
+      "_op": "elasticsearch_index_selector",
+      "type": "change",
+      "index": "gen-once-test",
+      "id_field": "_key"
+    },
+    {
+      "_op": "elasticsearch_bulk",
+      "size": 1000
+    }
+  ]
+}

--- a/integration-tests/spec/setup.js
+++ b/integration-tests/spec/setup.js
@@ -183,4 +183,5 @@ describe('teraslice', function() {
     require('./cases/cluster/worker-allocation')();
     require('./cases/cluster/state')();
     require('./cases/validation/job')();
+    require('./cases/jobs/lifecycle')();
 });


### PR DESCRIPTION
This PR tries to test the job lifecycle behaviors of once and persistent jobs.  It does so by running essentially the same job, but letting the once job run to completion and letting the persistent job run a little longer and expecting the persistent job to end up with more docs than the once job.

In the persistent job I use `.delay(5000)` and then stop the job ASSUMING that it has run long enough to end up with more than 1000 docs.  I suppose there could be cases where that is not enough time.  It seems unlikely, but when I used a delay of 3000, the test actually failed once.

It might be better if I just looped and used a shorter delay and checked the doc count and just wait in that loop until the doc count exceeds 1000.  The test would be more reliable this way.