### PR TITLE
fixed stop job timeout issues resolves #434

### DIFF
--- a/integration-tests/spec/cases/cluster/job-state.js
+++ b/integration-tests/spec/cases/cluster/job-state.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var _ = require('lodash');
+var Promise = require('bluebird');
+var misc = require('../../misc')();
+var wait = require('../../wait')();
+
+module.exports = function() {
+    var teraslice = misc.teraslice();
+    
+    describe('worker allocation', function() {
+
+        it('should cycle through after state changes with other jobs running', function(done) {
+            var job_spec1 = misc.newJob('generator');
+            var job_spec2 = misc.newJob('generator');
+            var job1_id;
+            var job2_id;
+            job_spec2.operations[1].name = 'second_generator';
+
+            Promise.all([teraslice.jobs.submit(job_spec1), teraslice.jobs.submit(job_spec2)])
+                .spread(function(job1, job2) {
+                    job1_id = job1.id();
+                    job2_id = job2.id();
+                    expect(job1_id).toBeDefined();
+                    expect(job2_id).toBeDefined();
+
+                    return job1.waitForStatus('running')
+                        .then(function() {
+                            return job1.pause();
+                        })
+                        .then(function() {
+                            return job1.waitForStatus('paused');
+                        })
+                        .then(function() {
+                            return job1.resume();
+                        })
+                        .then(function() {
+                            return job1.waitForStatus('running');
+                        })
+                        .then(function() {
+                            return job1.stop();
+                        })
+                        .then(function() {
+                            return job1.waitForStatus('stopped');
+                        })
+                        .then(function() {
+                            return job2.stop();
+                        })
+                        .then(function() {
+                            return job2.waitForStatus('stopped');
+                        })
+                })
+                .catch(fail)
+                .finally(done);
+        });
+    });
+
+};

--- a/integration-tests/spec/cases/data/reindex.js
+++ b/integration-tests/spec/cases/data/reindex.js
@@ -49,7 +49,7 @@ module.exports = function() {
                     fail()
                 })
                 .finally(done)
-        })
+        });
 
         it('should complete after lifecycle changes', function(done) {
             var job_spec = misc.newJob('reindex');

--- a/integration-tests/spec/fixtures/jobs/generator.json
+++ b/integration-tests/spec/fixtures/jobs/generator.json
@@ -1,0 +1,16 @@
+{
+  "name": "generator",
+  "slicers": 1,
+  "lifecycle": "persistent",
+  "workers": 3,
+  "operations": [
+    {
+      "_op": "elasticsearch_data_generator",
+      "size": 1000,
+      "stress_test": false
+    },
+    {
+      "_op": "noop"
+    }
+  ]
+}

--- a/integration-tests/spec/setup.js
+++ b/integration-tests/spec/setup.js
@@ -176,11 +176,13 @@ describe('teraslice', function() {
                 process.exit(2)
             })
     });
+    
+    require('./cases/cluster/job-state')();
 
-    require('./cases/data/id-reader')();
+    /*require('./cases/data/id-reader')();
     require('./cases/data/elasticsearch-bulk')();
     require('./cases/data/reindex')();
     require('./cases/cluster/worker-allocation')();
     require('./cases/cluster/state')();
-    require('./cases/validation/job')();
+    require('./cases/validation/job')();*/
 });

--- a/integration-tests/spec/setup.js
+++ b/integration-tests/spec/setup.js
@@ -178,11 +178,10 @@ describe('teraslice', function() {
     });
     
     require('./cases/cluster/job-state')();
-
-    /*require('./cases/data/id-reader')();
+    require('./cases/data/id-reader')();
     require('./cases/data/elasticsearch-bulk')();
     require('./cases/data/reindex')();
     require('./cases/cluster/worker-allocation')();
     require('./cases/cluster/state')();
-    require('./cases/validation/job')();*/
+    require('./cases/validation/job')();
 });

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -217,7 +217,7 @@ module.exports = function(context) {
         var intervalTime = 200;
 
         messageWorkers(context, data, {message: 'worker:shutdown'}, function(worker) {
-            if (worker.slicer_port) {
+            if (worker.ex_id === data.ex_id && worker.slicer_port) {
                 slicerFound = true;
             }
             return worker.ex_id === data.ex_id
@@ -364,7 +364,7 @@ module.exports = function(context) {
                 assignment: clusterWorkers[childID].assignment,
                 pid: clusterWorkers[childID].process.pid
             };
-            
+
             if (clusterWorkers[childID].ex_id) {
                 child.ex_id = clusterWorkers[childID].ex_id
             }

--- a/lib/cluster/services/cluster.js
+++ b/lib/cluster/services/cluster.js
@@ -339,7 +339,7 @@ module.exports = function(context, server) {
 
     function findNodesForJob(ex_id, slicer_only) {
         var nodes = [];
-
+        //TODO but what about disconnected nodes?
         _.forOwn(cluster_state, function(node) {
             var hasJob = node.active.filter(function(worker) {
                 if (slicer_only) {

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -567,7 +567,6 @@ module.exports = function(context, cluster_service) {
                 nodes = nodes.filter(node => node.hostname !== excludeNode);
             }
             nodes.forEach(function(node) {
-                console.log('what is this notify', node, message);
                 var messageNode = cluster_service.notifyNode(node.node_id, message, {
                     ex_id: ex_id
                 });

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -567,6 +567,7 @@ module.exports = function(context, cluster_service) {
                 nodes = nodes.filter(node => node.hostname !== excludeNode);
             }
             nodes.forEach(function(node) {
+                console.log('what is this notify', node, message);
                 var messageNode = cluster_service.notifyNode(node.node_id, message, {
                     ex_id: ex_id
                 });


### PR DESCRIPTION
The issue was found to reside in node_master code regarding the stop job event. A stop job event will notify each node_master and will expect a response back from each node indicating that it stop. In the case of the node where the actual slicer resides, the slicer handles the reply, but on other nodes where the workers reside, the node_master has special logic to reply itself when it sees all the appropriate child processes are gone. The issue happens in how the node_master monitors. If there is another slicer not relevant to the job being stopped on the same node as regular workers that should shutdown, the node_master would not properly execute the special logic, thus leading the job to hang even though it should have finished