### PR TITLE
if all workers disconnect, slicer will terminate resolves #253

### DIFF
--- a/lib/cluster/slicer.js
+++ b/lib/cluster/slicer.js
@@ -39,6 +39,7 @@ module.exports = function(context) {
     var inRecoveryMode = false;
     var hasRecovered = false;
     var workerFound = false;
+    var isShuttingDown = false;
 
     //temporary fix
     var retryState = {};
@@ -213,6 +214,15 @@ module.exports = function(context) {
         logger.warn(`Worker: ${worker_id} has disconnected`);
         events.emit('network:disconnect', worker_id);
         workerQueue.remove(worker_id);
+        //only call if workers have connected before, and there are none left
+        if (!isShuttingDown && workerFound && messaging.getClientCounts() === 0) {
+            //TODO this needs a refactor for when slicer controls ex state
+            messaging.send({
+                message: 'slicer:error:terminal',
+                error: `all workers from slicer #${ex_id} have disconnected`,
+                ex_id: ex_id
+            })
+        }
     });
 
     events.on('slicer:slice:recursion', function() {
@@ -464,7 +474,7 @@ module.exports = function(context) {
 
     function slicerShutdown(msg) {
         logger.info(`slicer for job: ${ex_id} has received a shutdown notice`);
-
+        isShuttingDown = true;
         engineCanRun = false;
         clearInterval(engine);
         clearInterval(analyticsTimer);
@@ -601,7 +611,7 @@ module.exports = function(context) {
     }
 
     function checkJobState(jobConfig) {
-        var query = 'ex_id:' + jobConfig.ex_id + ' AND state:error';
+        var query = `ex_id:${jobConfig.ex_id} AND (state:error OR state:start)`;
         return state_store.count(query, 0)
     }
 


### PR DESCRIPTION
- on job completion it now checks for all work that has been started as well as those that have errors

- If all workers have been disconnected, job will be marked as failed