### PR TITLE
Slicer queue refactor

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,6 @@ name | Name for the cluster itself, its used for naming log files/indices | Stri
 state | Elasticsearch cluster where job state, analytics and logs are stored | Object | optional, defaults to {connection: 'default'},
 timeout | time in milliseconds to wait for a response when messaging node to node before throwing an error | Number | optional, defaults to 60000 ms
 slicer_port_range | range of ports that slicers will use per node | String | optional, defaults to range: '45678:46678'
-slicer_queue_length | this parameter determines the queue length of the slicer, if queue is full it will not produce more slices until it drop below this number | Number | optional, defaults to 10000
 
 ### terafoundation
 

--- a/docs/custom_operations.md
+++ b/docs/custom_operations.md
@@ -109,7 +109,7 @@ function post_validation(job, sysconfig) {
 }
 
 //optional, used to change the slicer queue length 
-function setQueueLength(jobConfig){
+function slicerQueueLength(jobConfig){
     // the fully validated job configuration file
     
    // should return a num >= 1
@@ -122,7 +122,7 @@ module.exports = {
   schema, schema,
   op_validation: op_validation,
   post_validation: post_validation,
-  setQueueLength: setQueueLength
+  slicerQueueLength: slicerQueueLength
 }
 
 ```

--- a/lib/cluster/slicer.js
+++ b/lib/cluster/slicer.js
@@ -658,8 +658,8 @@ module.exports = function(context) {
 
     function parseQueueLength(reader, jobConfig) {
         var length = 10000;
-        if (reader.setQueueLength) {
-            var results = reader.setQueueLength(jobConfig);
+        if (reader.slicerQueueLength) {
+            var results = reader.slicerQueueLength(jobConfig);
             if (results === 'QUEUE_MINIMUM_SIZE') {
                 dynamicQueueLength = true;
                 length = jobConfig.workers

--- a/lib/cluster/slicer.js
+++ b/lib/cluster/slicer.js
@@ -329,7 +329,7 @@ module.exports = function(context) {
 
             inRecoveryMode = true;
 
-            var numOfSlicersToRecover = slicer.parallelSlicers ? job.jobConfig.slicers : 1;
+            var numOfSlicersToRecover = job.jobConfig.slicers;
             for (var i = 0; i < numOfSlicersToRecover; i++) {
                 recoveredSlices.push(state_store.recoveryContext(ex_id, i))
             }
@@ -426,7 +426,7 @@ module.exports = function(context) {
                 logger.trace('slicers are being called');
 
                 scheduler.forEach(function(slicer) {
-                    slicer();
+                  //  slicer();
                 });
             }
         };

--- a/lib/cluster/slicer.js
+++ b/lib/cluster/slicer.js
@@ -18,27 +18,24 @@ var messageModule = require('./services/messaging');
 
 
 module.exports = function(context) {
-    var state_store;
+
     var ex_id = process.env.ex_id;
     var events = context.foundation.getEventEmitter();
     var job_runner = require('./runners/job')(context);
     var logger = context.foundation.makeLogger('slicer', 'slicer', {ex_id: ex_id, module: 'slicer'});
     var messaging = messageModule(context, logger);
-    var queueLength = context.sysconfig.teraslice.slicer_queue_length;
+
     //Stateful variables
     var start = moment();
     var engineCanRun = true;
-    var engine;
-    var scheduler;
     var slicerDone = 0;
     var totalSlicers = 0;
     var allSlicersDone = false;
-    var engineFn;
-    var retryData;
     var inRecoveryMode = false;
     var hasRecovered = false;
     var workerFound = false;
     var isShuttingDown = false;
+    var dynamicQueueLength = false;
 
     //temporary fix
     var retryState = {};
@@ -68,12 +65,17 @@ module.exports = function(context) {
         workers_disconnected: 0,
         workers_reconnected: 0
     };
-    var analyticsTimer;
 
+    var analyticsTimer;
+    var queueLength;
+    var engine;
+    var scheduler;
     var job;
     var slicer;
     var analyticsData;
-
+    var state_store;
+    var engineFn;
+    var retryData;
 
     //events can be fired from anything that instantiates a client, such as stores and slicers
     //needs to be setup before job_runner
@@ -165,6 +167,10 @@ module.exports = function(context) {
         workerFound = true;
         logger.info(`worker: ${worker_id} has joined slicer: ${ex_id}`);
         slicerAnalytics.workers_joined += 1;
+        //if there are more clients than the length of the queue, increase the queue size
+        if (dynamicQueueLength && messaging.getClientCounts() > queueLength) {
+            queueLength = messaging.getClientCounts();
+        }
         //messaging module will join connection
         workerQueue.enqueue(msg);
     });
@@ -212,6 +218,10 @@ module.exports = function(context) {
         slicerAnalytics.workers_disconnected += 1;
         logger.warn(`Worker: ${worker_id} has disconnected`);
         events.emit('network:disconnect', worker_id);
+        //if there are less clients than the length of the queue, decrease the queue size
+        if (dynamicQueueLength && messaging.getClientCounts() < queueLength) {
+            queueLength = messaging.getClientCounts();
+        }
         workerQueue.remove(worker_id);
         //only call if workers have connected before, and there are none left
         if (!isShuttingDown && workerFound && messaging.getClientCounts() === 0) {
@@ -303,6 +313,7 @@ module.exports = function(context) {
             .then(function(_job) {
                 job = _job;
                 slicer = _job.slicer;
+                queueLength = parseQueueLength(job.slicer, job.jobConfig);
                 analyticsData = statContainer(_job.jobs);
                 return require('./storage/state')(context)
             })
@@ -421,12 +432,12 @@ module.exports = function(context) {
             slicerAnalytics.workers_active = messaging.getClientCounts() - currentWorkers;
 
             //don't run slicers if recovering, all slices have been divided up or if the queue is too large
-            if (!inRecoveryMode && !allSlicersDone && slicerQueue.size() <= queueLength) {
+            if (!inRecoveryMode && !allSlicersDone && slicerQueue.size() < queueLength) {
                 //call slicers to enqueue into slicerQueue
                 logger.trace('slicers are being called');
 
                 scheduler.forEach(function(slicer) {
-                  //  slicer();
+                    slicer();
                 });
             }
         };
@@ -643,6 +654,24 @@ module.exports = function(context) {
                     })
             }
         }
+    }
+
+    function parseQueueLength(reader, jobConfig) {
+        var length = 10000;
+        if (reader.setQueueLength) {
+            var results = reader.setQueueLength(jobConfig);
+            if (results === 'QUEUE_MINIMUM_SIZE') {
+                dynamicQueueLength = true;
+                length = jobConfig.workers
+            }
+            else {
+                if (_.isNumber(results) && results >= 1) {
+                    length = results
+                }
+            }
+        }
+
+        return length;
     }
 
     function logFinishedJob(context, start, job, analyticsData) {

--- a/lib/cluster/slicer.js
+++ b/lib/cluster/slicer.js
@@ -659,14 +659,19 @@ module.exports = function(context) {
     function parseQueueLength(reader, jobConfig) {
         var length = 10000;
         if (reader.slicerQueueLength) {
-            var results = reader.slicerQueueLength(jobConfig);
-            if (results === 'QUEUE_MINIMUM_SIZE') {
-                dynamicQueueLength = true;
-                length = jobConfig.workers
+            if (typeof reader.slicerQueueLength !== 'function') {
+                logger.error('slicerQueueLength on the reader must be a function, defaulting to 10000')
             }
             else {
-                if (_.isNumber(results) && results >= 1) {
-                    length = results
+                var results = reader.slicerQueueLength(jobConfig);
+                if (results === 'QUEUE_MINIMUM_SIZE') {
+                    dynamicQueueLength = true;
+                    length = jobConfig.workers
+                }
+                else {
+                    if (_.isNumber(results) && results >= 1) {
+                        length = results
+                    }
                 }
             }
         }

--- a/lib/config/schemas/system.js
+++ b/lib/config/schemas/system.js
@@ -122,20 +122,6 @@ var schema = {
             }
         }
     },
-    slicer_queue_length: {
-        doc: 'this parameter determines the queue length of the slicer, if queue is full it will not produce more slices until it drop below this number',
-        default: 10000,
-        format: function(val) {
-            if (isNaN(val)) {
-                throw new Error('slicer_queue_length parameter for teraslice must be a number')
-            }
-            else {
-                if (val <= 0) {
-                    throw new Error('slicer_queue_length parameter for teraslice must be greater than zero')
-                }
-            }
-        }
-    },
     slicer_port_range: {
         doc: 'range of ports that slicers will use per node',
         default: '45679:46678',

--- a/lib/readers/elasticsearch_data_generator.js
+++ b/lib/readers/elasticsearch_data_generator.js
@@ -184,15 +184,13 @@ function post_validation(job, sysconfig) {
     }
 }
 
-var parallelSlicers = false;
 
 module.exports = {
     newReader: newReader,
     newSlicer: newSlicer,
     op_validation: op_validation,
     post_validation: post_validation,
-    schema: schema,
-    parallelSlicers: parallelSlicers
+    schema: schema
 };
 
 

--- a/lib/readers/elasticsearch_data_generator.js
+++ b/lib/readers/elasticsearch_data_generator.js
@@ -184,18 +184,13 @@ function post_validation(job, sysconfig) {
     }
 }
 
-function setQueueLength(stuff){
-    console.log('whats the stuff', stuff)
-    return 'QUEUE_MINIMUM_SIZE';
-}
 
 module.exports = {
     newReader: newReader,
     newSlicer: newSlicer,
     op_validation: op_validation,
     post_validation: post_validation,
-    schema: schema,
-    setQueueLength: setQueueLength
+    schema: schema
 };
 
 

--- a/lib/readers/elasticsearch_data_generator.js
+++ b/lib/readers/elasticsearch_data_generator.js
@@ -184,13 +184,18 @@ function post_validation(job, sysconfig) {
     }
 }
 
+function setQueueLength(stuff){
+    console.log('whats the stuff', stuff)
+    return 'QUEUE_MINIMUM_SIZE';
+}
 
 module.exports = {
     newReader: newReader,
     newSlicer: newSlicer,
     op_validation: op_validation,
     post_validation: post_validation,
-    schema: schema
+    schema: schema,
+    setQueueLength: setQueueLength
 };
 
 

--- a/lib/readers/elasticsearch_reader.js
+++ b/lib/readers/elasticsearch_reader.js
@@ -6,7 +6,6 @@ var dateOptions = require('../utils/date_utils').dateOptions;
 var dateMath = require('datemath-parser');
 var moment = require('moment');
 
-var parallelSlicers = true;
 
 function newSlicer(context, job, retryData, slicerAnalytics, logger) {
     var opConfig = getOpConfig(job.jobConfig, 'elasticsearch_reader');
@@ -209,6 +208,5 @@ module.exports = {
     newReader: newReader,
     newSlicer: newSlicer,
     schema: schema,
-    op_validation: op_validation,
-    parallelSlicers: parallelSlicers
+    op_validation: op_validation
 };

--- a/lib/readers/id_reader.js
+++ b/lib/readers/id_reader.js
@@ -4,7 +4,6 @@ var _ = require('lodash');
 var getClient = require('../utils/config').getClient;
 var getOpConfig = require('../utils/config').getOpConfig;
 
-var parallelSlicers = true;
 
 function newSlicer(context, job, retryData, slicerAnalytics, logger) {
     var opConfig = getOpConfig(job.jobConfig, 'id_reader');
@@ -127,6 +126,5 @@ module.exports = {
     newReader: newReader,
     newSlicer: newSlicer,
     post_validation: post_validation,
-    schema: schema,
-    parallelSlicers: parallelSlicers
+    schema: schema
 };

--- a/spec/readers/id_slicer-spec.js
+++ b/spec/readers/id_slicer-spec.js
@@ -58,7 +58,6 @@ describe('id_reader', function() {
         expect(reader.schema).toBeDefined();
         expect(reader.newReader).toBeDefined();
         expect(reader.post_validation).toBeDefined();
-        expect(reader.parallelSlicers).toEqual(true);
 
         expect(typeof reader.newSlicer).toEqual('function');
         expect(typeof reader.newReader).toEqual('function');


### PR DESCRIPTION
can not add another method to a reader to expose to determine the slicer queue length

`function slicerQueueLength(jobConfig){
    // the fully validated jobConfig
   // can return a num >= 1
   //or return  'QUEUE_MINIMUM_SIZE' which will make the queue dynamic to the number of workers
}

module.exports = {
  newReader: newReader,
  newSlicer: newSlicer,
  schema, schema,
  slicerQueueLength: slicerQueueLength
}
`

