### PR TITLE
adding istanbul 2.0 code coverage to default test command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
 assets/*/
+.nyc_output/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "service.js",
   "scripts": {
     "lint": "eslint lib",
-    "test": "nyc -x spec/ jasmine"
+    "jasmine": "jasmine",
+    "test": "nyc -x spec/ --reporter=text-summary jasmine && nyc report --reporter=html",
+    "testcov": "nyc -x spec/ jasmine && nyc report --reporter=html",
+    "showcov": "open coverage/index.html"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "service.js",
   "scripts": {
     "lint": "eslint lib",
-    "test": "jasmine"
+    "test": "nyc -x spec/ jasmine"
   },
   "repository": {
     "type": "git",
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "jasmine-spec-reporter": "^4.2.1",
-    "json-schema-faker": "^0.3.7"
+    "json-schema-faker": "^0.3.7",
+    "nyc": "^11.2.1"
   }
 }


### PR DESCRIPTION
This changes out `npm test` command to use istanbul/nyc to check the code coverage of our tests.  The coverage report will be shown right after the test output by default.

It looks like this:

![screen shot 2017-09-08 at 5 41 44 am](https://user-images.githubusercontent.com/1249/30212178-a3334720-9458-11e7-97b8-f4b0d333e9cc.png)


closes #530 

