### PR TITLE
Setting eslint code standards using the airbnb standards as a base

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,20 @@
+{
+    "extends": "airbnb",
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "script",
+    },
+    "env": {
+        "node": true
+    },
+    "rules": {
+        "no-underscore-dangle": "off",
+        "indent": ["error", 4],
+        "no-param-reassign": ["error", { "props": false }],
+        "no-use-before-define": ["error", { "functions": false }],
+        "import/no-dynamic-require": "off",
+        "global-require": "off",
+        "strict": ["error", "global"],
+        "comma-dangle": "off"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
   "devDependencies": {
     "jasmine-spec-reporter": "^4.2.1",
     "json-schema-faker": "^0.3.7",
+    "eslint": "^4.6.1",
+    "eslint-config-airbnb": "^15.1.0",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-react": "^7.3.0",
     "nyc": "^11.2.1"
   }
 }


### PR DESCRIPTION
This uses https://github.com/airbnb/javascript as the baseline.

In difference to the airbnb standards we will continue with the following practices.

  * 4 space indention
  * Using _ at the beginning of functions intended to be private
  * Allowing require at places other than the top of a file
     * Although I think this is something we should probably change in the future
  * Allowing dynamic requires
  * Continuing to place "use strict" at the top of the module. This will be unnecessary in the future but while we're targeting node 4 it's still needed.

Additional conventions beyond this.

   * op configuration parameters exposed to jobs should not be camel case and should use _ as word separator
   * Fields in data records stored in ES and network messages should not be camel case and should use _ as word separator
   * In general follow the conventions used in a particular source file until that file can be fully converted to the standard


  
