### PR TITLE
fixed returns on retries to not immediatly complete resolves #549

### DIFF
--- a/lib/readers/elasticsearch_date_range/slicer.js
+++ b/lib/readers/elasticsearch_date_range/slicer.js
@@ -8,14 +8,16 @@ var dateOptions = require('./../../utils/date_utils').dateOptions;
 var dateFormatMS = require('./../../utils/date_utils').dateFormat;
 var dateFormatS = require('./../../utils/date_utils').dateFormatSeconds;
 var parseError = require('../../utils/error_utils').parseError;
+var retryModule = require('../../utils/error_utils').retryModule;
 
 function newSlicer(context, opConfig, job, retryData, logger, client) {
     var events = context.foundation.getEventEmitter();
     var jobConfig = job.jobConfig;
     var isPersistent = jobConfig.lifecycle === 'persistent';
     var slicers = [];
-    var numOfRetries = job.max_retries;
     var time_resolution = dateOptions(opConfig.time_resolution);
+    var retryError = retryModule(logger, job.max_retries);
+
 
     var dateFormat = time_resolution === 'ms' ? dateFormatMS : dateFormatS;
 
@@ -293,26 +295,6 @@ function newSlicer(context, opConfig, job, retryData, logger, client) {
         return getIdData(idSubslicer)
     }
 
-    function retryError(retry, dateObj, err, fn, msg) {
-        var errMessage = parseError(err);
-        logger.error('error while getting next slice', errMessage);
-        var startKey = dateObj.start.format(dateFormat);
-
-        if (!retry[startKey]) {
-            retry[startKey] = 1;
-            fn(msg)
-        }
-        else {
-            retry[startKey] += 1;
-            if (retry[startKey] > numOfRetries) {
-                return Promise.reject(`max_retries met for slice, start: ${startKey}`, errMessage);
-            }
-            else {
-                fn(msg)
-            }
-        }
-    }
-
     function nextChunk(opConfig, client, jobConfig, dates, slicer_id, retryData) {
         var shouldDivideByID = opConfig.subslice_by_key;
         var threshold = opConfig.subslice_key_threshold;
@@ -329,7 +311,6 @@ function newSlicer(context, opConfig, job, retryData, logger, client) {
         dateParams.end = moment(dateParams.start.format(dateFormat)).add(dateParams.interval[0], dateParams.interval[1]);
         logger.debug('all date configurations for date slicer', dateParams);
         //used to keep track of retried queries
-        var retry = {};
 
         return function sliceDate(msg) {
             if (dateParams.start.isSameOrAfter(dateParams.limit)) {
@@ -368,7 +349,7 @@ function newSlicer(context, opConfig, job, retryData, logger, client) {
                         }
                     })
                     .catch(function(err) {
-                        return retryError(retry, dateParams, err, sliceDate, msg)
+                        return retryError(dateParams.start.format(dateFormat), err, sliceDate, msg)
                     })
             }
         };
@@ -436,9 +417,6 @@ function newSlicer(context, opConfig, job, retryData, logger, client) {
 
         logger.debug('all date configurations for date slicer', dateParams);
 
-        //used to keep track of retried queries
-        var retry = {};
-
         //set a timer to add the next set it should process
         setInterval(function() {
             //keep a list of next batches in cases current batch is still running
@@ -495,7 +473,7 @@ function newSlicer(context, opConfig, job, retryData, logger, client) {
                             }
                         }
                             .catch(function(err) {
-                                return retryError(retry, dateParams, err, sliceDate, msg)
+                                return retryError(dateParams.start.format(dateFormat), err, sliceDate, msg)
                             })
                     );
             }

--- a/lib/readers/id_slicer.js
+++ b/lib/readers/id_slicer.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash');
 var parseError = require('../utils/error_utils').parseError;
+var retryModule = require('../utils/error_utils').retryModule;
 
 var base64url = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w',
     'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
@@ -18,27 +19,7 @@ module.exports = function(client, job, opConfig, logger, retryData, range) {
     var baseKeyArray = getKeyArray(opConfig);
     var keyArray = opConfig.key_range ? opConfig.key_range : baseKeyArray.slice();
     var elasticsearch = require('elasticsearch_api')(client, logger, opConfig);
-    var numOfRetries = job.max_retries;
-    var retry = {};
-
-    function retryKey(key, err, fn, msg) {
-        var errMessage = parseError(err);
-        logger.error('error while getting next slice', errMessage);
-
-        if (!retry[key]) {
-            retry[key] = 1;
-            fn(msg)
-        }
-        else {
-            retry[key] += 1;
-            if (retry[key] > numOfRetries) {
-                return Promise.reject(`max_retries met for slice, key: ${key}`, errMessage);
-            }
-            else {
-                fn(msg)
-            }
-        }
-    }
+    var retryError = retryModule(logger, job.max_retries);
 
     function getCountForKey(query) {
         return elasticsearch.search(query);
@@ -106,7 +87,7 @@ module.exports = function(client, job, opConfig, logger, retryData, range) {
 
                 })
                 .catch(function(err) {
-                    return retryKey(key, err, getKeySlice, query)
+                    return retryError(key, err, getKeySlice, query)
                 })
         }
 

--- a/lib/utils/error_utils.js
+++ b/lib/utils/error_utils.js
@@ -17,6 +17,29 @@ function parseError(err) {
     return err.response ? err.response : err;
 }
 
+function retryModule(logger, numOfRetries) {
+    let retry = {};
+    return function(key, err, fn, msg) {
+        var errMessage = parseError(err);
+        logger.error('error while getting next slice', errMessage);
+
+        if (!retry[key]) {
+            retry[key] = 1;
+            return fn(msg)
+        }
+        else {
+            retry[key] += 1;
+            if (retry[key] > numOfRetries) {
+                return Promise.reject(`max_retries met for slice, key: ${key}`, errMessage);
+            }
+            else {
+                return fn(msg)
+            }
+        }
+    }
+}
+
 module.exports = {
-    parseError: parseError
+    parseError: parseError,
+    retryModule: retryModule
 };


### PR DESCRIPTION
the main issue that I found was that when it entered the retry logic it would not properly return the called function, which the top calling function would then return undefined which singles to the slicer that it finished (even though it really didn't). There was duplicate logic in elasticsearch slicer as well so this had this pitfall as well. We need better intergration tests that can simulate a slight recoverable network issue as well as full blown failure to test more scenarios.