### PR TITLE
Make forValue return when it fails

### DIFF
--- a/integration-tests/spec/wait.js
+++ b/integration-tests/spec/wait.js
@@ -39,12 +39,12 @@ module.exports = function() {
                         if (result === value) {
                             return resolve(result);
                         }
-                        else {
-                            setTimeout(checkValue, 500);
-                        }
 
                         if (counter > iterations) {
                             reject(`forValue didn't find target value after ${iterations} iterations.`);
+                        }
+                        else {
+                            setTimeout(checkValue, 500);
                         }
                     })
             }


### PR DESCRIPTION
forValue shouldn't schedule itself to run again unless result isn't
equal to value AND counter does not exceed iterations.