### PR TITLE
Fixing ex mapping to apply to ex type

### DIFF
--- a/lib/cluster/storage/backends/mappings/ex.json
+++ b/lib/cluster/storage/backends/mappings/ex.json
@@ -4,7 +4,7 @@
     "index.number_of_replicas": 1
   },
   "mappings": {
-    "job": {
+    "ex": {
       "_all": {
         "enabled": false
       },


### PR DESCRIPTION
The ex mapping was accidentally applying to the job type.  This
fixes that.