### PR TITLE
fixed schema validation and faulty regex

### DIFF
--- a/lib/readers/elasticsearch_date_range/slicer.js
+++ b/lib/readers/elasticsearch_date_range/slicer.js
@@ -35,7 +35,7 @@ function newSlicer(context, opConfig, job, retryData, logger, client) {
     function processInterval(str, esDates, opConfig) {
         if (!moment(new Date(str)).isValid()) {
             //one or more digits, followed by one or more letters, case-insensitive
-            var regex = /(\d+)([a-z]+)/i;
+            var regex = /(\d+)(\D+)/i;
             var interval = regex.exec(str);
 
             if (interval === null) {

--- a/lib/readers/elasticsearch_date_range/slicer.js
+++ b/lib/readers/elasticsearch_date_range/slicer.js
@@ -377,7 +377,8 @@ function newSlicer(context, opConfig, job, retryData, logger, client) {
         }
 
         //make sure that end of last segment is always correct
-        results[results.length - 1].end = end.format(dateFormat);
+        const endingDate = end.format ? end.format(dateFormat) : moment(end).format(dateFormat);
+        results[results.length - 1].end = endingDate;
 
         return results;
     }
@@ -471,11 +472,10 @@ function newSlicer(context, opConfig, job, retryData, logger, client) {
                                     count: data.count
                                 }
                             }
-                        }
-                            .catch(function(err) {
-                                return retryError(dateParams.start.format(dateFormat), err, sliceDate, msg)
-                            })
-                    );
+                        })
+                    .catch(function(err) {
+                        return retryError(dateParams.start.format(dateFormat), err, sliceDate, msg)
+                    });
             }
         };
     }

--- a/lib/readers/elasticsearch_reader.js
+++ b/lib/readers/elasticsearch_reader.js
@@ -109,7 +109,10 @@ function schema() {
             default: 'auto',
             format: function(val) {
                 if (val === 'auto') return;
-                dateOptions(val)
+                var regex = /(\d+)(\D+)/i;
+                var interval = regex.exec(val);
+                if (!interval) throw new Error('date interval is not formatted correctly');
+                dateOptions(interval[2]);
             }
         },
         full_response: {

--- a/lib/utils/date_utils.js
+++ b/lib/utils/date_utils.js
@@ -18,7 +18,7 @@ function dateOptions(value) {
         return options[value];
     }
     else {
-        throw new Error('date interval is not formatted correctly')
+        throw new Error('the time descriptor for the interval is malformed');
     }
 }
 


### PR DESCRIPTION
i switched the regex to /(\d+)(\D+)/i which looks for numbers next to non-number characters. It looks like the schema failed becuase it did not split the numbers from the time selectors when it was being passed to dateOptions. We really need to test our schema seperate. the unit tests did not cover schema validations, we should test those in the future