### PR TITLE
Stagger worker recycle

### DIFF
--- a/lib/cluster/worker.js
+++ b/lib/cluster/worker.js
@@ -20,7 +20,7 @@ module.exports = function(context) {
     var max_retries;
     var job;
     var recycle;
-
+    var recycleWorkerRandomFactor = _.random(75, 100)
 
     //this will be used to keep track of the previously sent message just in case of a disconnect
     var sentMessage = false;
@@ -322,7 +322,7 @@ module.exports = function(context) {
             if (job.jobConfig.recycle_worker) {
                 sliceCount += 1;
                 // recycle worker between 75% and 100% of job.jobConfig.recycle_worker
-                var recycleCount = _.random(75, 100)/100 * job.jobConfig.recycle_worker;
+                var recycleCount = Math.trunc(recycleWorkerRandomFactor/100 * job.jobConfig.recycle_worker);
                 if (sliceCount >= recycleCount && !isShuttingDown) {
                     logger.info(`worker: ${ID} recycled after processing ${sliceCount} slices`);
                     //still need to signal that slice completed and not be enqueued

--- a/lib/cluster/worker.js
+++ b/lib/cluster/worker.js
@@ -318,8 +318,10 @@ module.exports = function(context) {
         return function() {
             if (job.jobConfig.recycle_worker) {
                 sliceCount += 1;
-                if (sliceCount >= job.jobConfig.recycle_worker && !isShuttingDown) {
-                    logger.info(`worker: ${ID} will now reinstantiate`);
+                // recycle worker between 75% and 100% of job.jobConfig.recycle_worker
+                var recycleCount = _.random(75, 100)/100 * job.jobConfig.recycle_worker;
+                if (sliceCount >= recycleCount && !isShuttingDown) {
+                    logger.info(`worker: ${ID} recycled after processing ${sliceCount} slices`);
                     //still need to signal that slice completed and not be enqueued
                     sentMessage.isShuttingDown = true;
                     messaging.send('worker:slice:complete', sentMessage);


### PR DESCRIPTION
When the user sets recycle_worker on a job the workers are
recycled after they hit that slice count.  These can tend to
happen around the same time for all workers.  In the case of
kafka workers, the time it takes to rebalance partitions takes
some time.  By recycling so many workers in a short period of
time we end up accumulating a lot of lag.

This PR tries to stagger the recycle times by comparing
sliceCount with somewhere between 75% and 100% of the
random_worker setting.