### PR TITLE
fix job with supplied start failure by converting str to moment

### DIFF
--- a/lib/readers/elasticsearch_date_range/slicer.js
+++ b/lib/readers/elasticsearch_date_range/slicer.js
@@ -159,7 +159,7 @@ function newSlicer(context, opConfig, job, retryData, logger, client) {
             var operations = JSON.parse(process.env.job).operations;
             operations.shift();
             var updatedOpConfig = Object.assign({}, opConfig, update);
-            updatedOpConfig.start = updatedOpConfig.start.format(dateFormat);
+            updatedOpConfig.start = moment(updatedOpConfig.start).format(dateFormat);
             updatedOpConfig.end = updatedOpConfig.end.format(dateFormat);
             operations.unshift(updatedOpConfig);
             events.emit('slicer:job:update', {update: operations})


### PR DESCRIPTION
Resolves #593 where if a job is supplied the start parameter it will fail