### PR TITLE
node master will now use SIGKILL on worker after timeout resolves #605

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -183,7 +183,14 @@ query:
 
 #### POST /jobs/{job_id}/_stop
 
-issues a stop command which will shutdown all slicers and workers for that job, marks the job execution context state as stopped
+parameter options:
+
+- timeout = [Number]
+
+issues a stop command which will shutdown all slicers and workers for that job, marks the job execution context state as stopped. You can optionally add a timeout query parameter to dynamically change how long it will wait as the time the slicer/readers will exit will vary. Note: the timeout your provide will be added to the network_latency_buffer for the final timeout used.
+
+query: 
+```curl -XPOST localhost:5678/jobs/{job_id}/_stop?timeout=120000```
 
 #### POST /jobs/{job_id}/_pause
 
@@ -298,7 +305,14 @@ size is the number of documents returned, from is how many documents in and sort
 
 #### POST /ex/{ex_id}/_stop
 
-issues a stop command which will shutdown all slicers and workers for that job, marks the job execution context state as stopped
+parameter options:
+
+- timeout = [Number]
+
+issues a stop command which will shutdown all slicers and workers for that job, marks the job execution context state as stopped. You can optionally add a timeout query parameter to dynamically change how long it will wait as the time the slicer/readers will exit will vary. Note: the timeout your provide will be added to the network_latency_buffer for the final timeout used.
+
+query: 
+```curl -XPOST localhost:5678/ex/{ex_id}/_stop?timeout=120000```
 
 #### POST /ex/{ex_id}/_pause
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,8 @@ The configuration file essentially has two main fields, configuration for terasl
 |:---------: | :--------: | :------: | :------:
 ops_directory | 'path/to/directory', to look for more readers and processors. Usually this is where you place your custom code not part of core, unless you want to leave your code in place. The directory should have a "readers" and "processors" folder mirroring teraslice| String | optional
 assets_directory | 'path/to/directory', to look for more custom readers and processors. Usually this is where you place your custom code not part of core, unless you want to leave your code in place. | String | optional
-network_timeout | time in milliseconds to wait for a response when messaging node to node before throwing an error | Number | optional, defaults to 60000 ms
+action_timeout | time in milliseconds for waiting for a action ( pause/stop job, etc) to complete before throwing an error | Number | optional, defaults to 300000 ms
+network_latency_buffer | time in milliseconds buffer which is combined with action_timeout to determine how long the cluster master will wait till it throws an error | Number | optional, defaults to 15000 ms
 worker_disconnect_timeout | time in milliseconds that the slicer will wait after all workers have disconnected before terminating the job | Number | optional, defaults to 300000 ms or 5 minutes
 node_disconnect_timeout | time in milliseconds that the cluster  will wait untill it drops that node from state and attempts to provision the lost workers | Number | optional, defaults to 300000 ms or 5 minutes
 shutdown_timeout | time in milliseconds, to allow workers and slicers to finish operations before forcefully shutting down when a shutdown signal occurs| Number | optional, defaults to 60 seconds (60000 ms)

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -188,7 +188,7 @@ module.exports = function module(context) {
         callback: (data) => {
             const intervalTime = 200;
             const filterFn = worker => worker.ex_id === data.ex_id;
-            let stopTime = data.timeout || config.network_timeout;
+            let stopTime = data.timeout || config.action_timeout;
 
             messageWorkers(data, { message: 'worker:shutdown' }, filterFn);
             // If this is coming from the api, we need to listen for it, else it just a blanket stop

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -190,7 +190,7 @@ module.exports = function module(context) {
             const filterFn = worker => worker.ex_id === data.ex_id;
             let stopTime = data.timeout || config.network_timeout;
 
-            messageWorkers(data, { message: 'worker:shutdownzzz' }, filterFn);
+            messageWorkers(data, { message: 'worker:shutdown' }, filterFn);
             // If this is coming from the api, we need to listen for it, else it just a blanket stop
             // and no reply is necessary
             if (data.response && data.to) {

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -21,6 +21,8 @@ module.exports = function module(context) {
     const systemPorts = portAllocator();
     const config = context.sysconfig.teraslice;
     const assetsPath = config.assets_directory;
+    const events = context.apis.foundation.getSystemEvents();
+
     // Need sendNodeState before we instantiate messaging
     const sendNodeState = _.debounce(() => {
         const state = getNodeState();
@@ -39,16 +41,12 @@ module.exports = function module(context) {
         return assetWorker.length === 1;
     }
 
-    function messageWorkers(clusterMsg, processMsg, filterFn, resultsFn) {
-        const workers = context.cluster.workers;
+    function messageWorkers(clusterMsg, processMsg, filterFn) {
         // sharing the unique msg id for each message sent
         processMsg.__msgId = clusterMsg.__msgId;
 
-        const allWorkersForJob = _.filter(workers, filterFn);
+        const allWorkersForJob = filterFn();
         _.each(allWorkersForJob, (worker) => {
-            if (resultsFn) {
-                resultsFn(worker);
-            }
             logger.trace(`sending message to worker ${worker.id}, ex_id: ${worker.ex_id}, msg:`, processMsg);
             worker.send(processMsg);
         });
@@ -183,80 +181,56 @@ module.exports = function module(context) {
 
     messaging.register({ event: 'cluster:node:state', callback: () => sendNodeState() });
 
+    // this fires when entire server will be shutdown
+    events.once('terafoundation:shutdown', () => {
+        const filterFn = () => context.cluster.workers;
+        const alreadySentShutdownMessage = true;
+        function actionCompleteFn() {
+            return getNodeState().active.length === 0;
+        }
+        const stopTime = config.shutdown_timeout;
+
+        shutdownProcesses({}, stopTime, filterFn, actionCompleteFn, alreadySentShutdownMessage);
+    });
+
     messaging.register({
         event: 'cluster:execution:stop',
-        callback: (data) => {
-            const intervalTime = 200;
-            const filterFn = worker => worker.ex_id === data.ex_id;
-            let stopTime = data.timeout || config.action_timeout;
-
-            messageWorkers(data, { message: 'worker:shutdown' }, filterFn);
-            // If this is coming from the api, we need to listen for it, else it just a blanket stop
-            // and no reply is necessary
-            if (data.response && data.to) {
-                const stop = setInterval(() => {
-                    const children = getNodeState().active;
-                    const workersForJob = _.filter(children, worker => worker.ex_id === data.ex_id);
-                    logger.debug(`waiting for ${workersForJob.length} to stop for ex: ${data.ex_id}`);
-                    if (workersForJob.length === 0) {
-                        clearInterval(stop);
-                        logger.debug('workers have stopped, relaying process message signal');
-
-                        messaging.respond(data);
-                    }
-                    // this is here for the sole purpose of cleanup of interval, top level promise
-                    // will have rejected by now
-                    if (stopTime <= 0) {
-                        clearInterval(stop);
-                        killWorkers(filterFn);
-                        messaging.respond(data);
-                    }
-
-                    stopTime -= intervalTime;
-                }, intervalTime);
+        callback: (networkMsg) => {
+            const filterFn = () => _.filter(
+                context.cluster.workers,
+                worker => worker.ex_id === networkMsg.ex_id
+            );
+            function actionCompleteFn() {
+                const children = getNodeState().active;
+                const workers = _.filter(children, worker => worker.ex_id === networkMsg.ex_id);
+                logger.debug(`waiting for ${workers.length} to stop for ex: ${networkMsg.ex_id}`);
+                return workers.length === 0;
             }
+            const stopTime = networkMsg.timeout || config.action_timeout;
+
+            shutdownProcesses(networkMsg, stopTime, filterFn, actionCompleteFn);
         }
     });
 
     messaging.register({
         event: 'cluster:workers:remove',
-        callback: (networkCall) => {
-            const data = networkCall.payload;
-            let counter = data.workers;
-            let stopTime = config.shutdown_timeout;
-            const intervalTime = 200;
-            const children = getNodeState();
-            const workerCount = _.filter(children.active, worker => worker.ex_id === data.ex_id && worker.assignment === 'worker').length;
-            const filterFn = (worker) => {
-                if (worker.ex_id === data.ex_id && worker.assignment === 'worker' && counter > 0) {
-                    counter -= 1;
-                    return worker;
-                }
-                return false;
-            };
+        callback: (networkMsg) => {
+            const numberToRemove = networkMsg.payload.workers;
+            const children = getNodeState().active;
+            const startingWorkerCount = _.filter(children, worker => worker.ex_id === networkMsg.ex_id && worker.assignment === 'worker').length;
+            const stopTime = config.shutdown_timeout;
+            const filterFn = () => _.filter(
+                context.cluster.workers,
+                worker => worker.ex_id === networkMsg.ex_id && worker.assignment === 'worker'
+            ).slice(0, numberToRemove);
 
-            messageWorkers(data, { message: 'worker:shutdown' }, filterFn);
-
-            const workerStop = setInterval(() => {
+            function actionCompleteFn() {
                 const childWorkers = getNodeState().active;
-                const workersForJob = _.filter(childWorkers, worker => worker.ex_id === data.ex_id && worker.assignment === 'worker');
+                const currentWorkersForJob = _.filter(childWorkers, worker => worker.ex_id === networkMsg.ex_id && worker.assignment === 'worker').length;
+                return currentWorkersForJob + numberToRemove <= startingWorkerCount;
+            }
 
-                if (workersForJob.length + data.workers <= workerCount) {
-                    clearInterval(workerStop);
-                    messaging.respond(networkCall);
-                }
-                // this is here for the sole purpose of cleanup of interval, top level promise will
-                // have rejected by now
-                if (stopTime <= 0) {
-                    clearInterval(workerStop);
-                    // resetting counter so filterFn can work
-                    counter = data.workers;
-                    killWorkers(filterFn);
-                    messaging.respond(data);
-                }
-
-                stopTime -= intervalTime;
-            }, intervalTime);
+            shutdownProcesses(networkMsg, stopTime, filterFn, actionCompleteFn);
         }
     });
 
@@ -299,10 +273,32 @@ module.exports = function module(context) {
     });
 
     function killWorkers(filterFn) {
-        const workers = context.cluster.workers;
-        const allWorkersForJob = _.filter(workers, filterFn);
+        const allWorkersForJob = filterFn();
+        _.each(allWorkersForJob, worker => {
+            logger.warn(`sending SIGKILL to process ${worker.process.pid}, assignment: ${worker.assignment}, ex_id: ${worker.ex_id}`)
+            worker.process.kill('SIGKILL')
+        });
+    }
 
-        allWorkersForJob.forEach(worker => worker.kill('SIGKILL'));
+    function shutdownProcesses(message, stoppingTime, filterFn, isActionCompleteFn, alreadySent) {
+        const intervalTime = 200;
+        const needsResponse = message.response && message.to;
+        let stopTime = stoppingTime;
+
+        if (!alreadySent) messageWorkers(message, { message: 'worker:shutdown' }, filterFn);
+        const stop = setInterval(() => {
+            if (isActionCompleteFn()) {
+                clearInterval(stop);
+                if (needsResponse) messaging.respond(message);
+            }
+            if (stopTime <= 0) {
+                clearInterval(stop);
+                killWorkers(filterFn);
+                if (needsResponse) messaging.respond(message);
+            }
+
+            stopTime -= intervalTime;
+        }, intervalTime);
     }
 
     function jobNeedsAssets(jobStr) {

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -187,8 +187,10 @@ module.exports = function module(context) {
         event: 'cluster:execution:stop',
         callback: (data) => {
             const intervalTime = 200;
-            let stopTime = config.network_timeout;
-            messageWorkers(data, { message: 'worker:shutdown' }, worker => worker.ex_id === data.ex_id);
+            const filterFn = worker => worker.ex_id === data.ex_id;
+            let stopTime = data.timeout || config.network_timeout;
+
+            messageWorkers(data, { message: 'worker:shutdownzzz' }, filterFn);
             // If this is coming from the api, we need to listen for it, else it just a blanket stop
             // and no reply is necessary
             if (data.response && data.to) {
@@ -206,6 +208,8 @@ module.exports = function module(context) {
                     // will have rejected by now
                     if (stopTime <= 0) {
                         clearInterval(stop);
+                        killWorkers(filterFn);
+                        messaging.respond(data);
                     }
 
                     stopTime -= intervalTime;
@@ -223,15 +227,15 @@ module.exports = function module(context) {
             const intervalTime = 200;
             const children = getNodeState();
             const workerCount = _.filter(children.active, worker => worker.ex_id === data.ex_id && worker.assignment === 'worker').length;
+            const filterFn = (worker) => {
+                if (worker.ex_id === data.ex_id && worker.assignment === 'worker' && counter > 0) {
+                    counter -= 1;
+                    return worker;
+                }
+                return false;
+            };
 
-            messageWorkers(data, { message: 'worker:shutdown' },
-                (worker) => {
-                    if (worker.ex_id === data.ex_id && worker.assignment === 'worker' && counter > 0) {
-                        counter -= 1;
-                        return worker;
-                    }
-                    return false;
-                });
+            messageWorkers(data, { message: 'worker:shutdown' }, filterFn);
 
             const workerStop = setInterval(() => {
                 const childWorkers = getNodeState().active;
@@ -245,6 +249,10 @@ module.exports = function module(context) {
                 // have rejected by now
                 if (stopTime <= 0) {
                     clearInterval(workerStop);
+                    // resetting counter so filterFn can work
+                    counter = data.workers;
+                    killWorkers(filterFn);
+                    messaging.respond(data);
                 }
 
                 stopTime -= intervalTime;
@@ -289,6 +297,13 @@ module.exports = function module(context) {
             }
         }
     });
+
+    function killWorkers(filterFn) {
+        const workers = context.cluster.workers;
+        const allWorkersForJob = _.filter(workers, filterFn);
+
+        allWorkersForJob.forEach(worker => worker.kill('SIGKILL'));
+    }
 
     function jobNeedsAssets(jobStr) {
         const job = typeof jobStr === 'string' ? JSON.parse(jobStr) : jobStr;

--- a/lib/cluster/services/api.js
+++ b/lib/cluster/services/api.js
@@ -152,7 +152,7 @@ module.exports = function module(context, app) {
         const jobId = req.params.job_id;
         logger.debug(`POST /jobs/:job_id/_stop endpoint has been called, job_id: ${jobId}, removing any pending workers for the job`);
 
-        jobsService.stopJob(jobId)
+        jobsService.stopJob(jobId, req.query.timeout)
             .then(status => res.status(200).json({ status }))
             .catch((err) => {
                 const errMsg = `could not stop execution, error: ${parseError(err)}`;
@@ -307,7 +307,7 @@ module.exports = function module(context, app) {
     app.post('/ex/:ex_id/_stop', (req, res) => {
         const exId = req.params.ex_id;
         logger.debug(`POST /ex/:ex_id/_stop endpoint has been called, ex_id: ${exId}, removing any pending workers for the job`);
-        executionService.stopExecution(exId)
+        executionService.stopExecution(exId, req.query.timeout)
             .then(() => res.status(200).json({ status: 'stopped' }))
             .catch((err) => {
                 const errMsg = `could not stop execution, error: ${parseError(err)}`;

--- a/lib/cluster/services/cluster/backends/native.js
+++ b/lib/cluster/services/cluster/backends/native.js
@@ -564,7 +564,8 @@ module.exports = function module(context, messaging, executionService) {
             to: 'node_master',
             address: key,
             message: 'cluster:workers:remove',
-            payload: { workers: val, ex_id: exId },
+            ex_id: exId,
+            payload: { workers: val },
             response: true
         }));
 
@@ -647,7 +648,7 @@ module.exports = function module(context, messaging, executionService) {
 
             timer = setTimeout(() => {
                 reject({ message: 'Timeout has occurred for query', code: 500 });
-            }, context.sysconfig.teraslice.network_timeout);
+            }, context.sysconfig.teraslice.action_timeout);
         }));
     }
 

--- a/lib/cluster/services/cluster/backends/native.js
+++ b/lib/cluster/services/cluster/backends/native.js
@@ -577,20 +577,24 @@ module.exports = function module(context, messaging, executionService) {
             });
     }
 
-    function _notifyNodesWithExecution(exId, message, slicerOnly, excludeNode) {
+    function _notifyNodesWithExecution(exId, messageData, slicerOnly, excludeNode) {
         return new Promise(((resolve, reject) => {
             const destination = slicerOnly ? 'slicer' : 'node_master';
             let nodes = _findNodesForExecution(exId, slicerOnly);
             if (excludeNode) {
                 nodes = nodes.filter(node => node.hostname !== excludeNode);
             }
-            return Promise.map(nodes, node => messaging.send({
-                to: destination,
-                address: node.node_id,
-                message,
-                ex_id: exId,
-                response: true
-            }))
+
+            return Promise.map(nodes, (node) => {
+                const sendingMsg = Object.assign({}, messageData, {
+                    to: destination,
+                    address: node.node_id,
+                    ex_id: exId,
+                    response: true
+                });
+
+                return messaging.send(sendingMsg);
+            })
                 .then(() => {
                     resolve(true);
                 })
@@ -663,18 +667,22 @@ module.exports = function module(context, messaging, executionService) {
         return metaData;
     }
 
-    function stopExecution(exId, exclude) {
+    function stopExecution(exId, timeout, exclude) {
         const excludeNode = exclude || null;
         pendingWorkerRequests.remove(exId);
-        return _notifyNodesWithExecution(exId, 'cluster:execution:stop', false, excludeNode);
+        const sendingMessage = { message: 'cluster:execution:stop' };
+        if (timeout) {
+            sendingMessage.timeout = timeout;
+        }
+        return _notifyNodesWithExecution(exId, sendingMessage, false, excludeNode);
     }
 
     function pauseExecution(exId) {
-        return _notifyNodesWithExecution(exId, 'cluster:execution:pause', true, null);
+        return _notifyNodesWithExecution(exId, { message: 'cluster:execution:pause' }, true, null);
     }
 
     function resumeExecution(exId) {
-        return _notifyNodesWithExecution(exId, 'cluster:execution:resume', true, null);
+        return _notifyNodesWithExecution(exId, { message: 'cluster:execution:resume' }, true, null);
     }
 
     const api = {

--- a/lib/cluster/services/execution.js
+++ b/lib/cluster/services/execution.js
@@ -69,7 +69,7 @@ module.exports = function module(context) {
                     // need to exclude sending a stop to cluster master host, the shutdown event
                     // has already been propagated this can cause a condition of it waiting for
                     // stop to return but it already has which pauses this service shutdown
-                    return stopExecution(execution.ex_id, 'terminated', context.sysconfig.teraslice.hostname);
+                    return stopExecution(execution.ex_id, null, 'terminated', context.sysconfig.teraslice.hostname);
                 }
                 return true;
             })
@@ -117,9 +117,9 @@ module.exports = function module(context) {
         return clusterService.removeWorkers(exId, workerNum);
     }
 
-    function stopExecution(exId, _status, excludeNode) {
+    function stopExecution(exId, timeout, _status, excludeNode) {
         const status = _status || 'stopped';
-        return clusterService.stopExecution(exId, excludeNode)
+        return clusterService.stopExecution(exId, timeout, excludeNode)
             .then(() => setExecutionStatus(exId, status))
             .then(() => ({ status }));
     }

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -107,9 +107,9 @@ module.exports = function module(context) {
             .catch(err => Promise.reject(parseError(err)));
     }
 
-    function stopJob(jobId) {
+    function stopJob(jobId, timeout) {
         return getLatestExecutionId(jobId)
-            .then(exId => executionService.stopExecution(exId))
+            .then(exId => executionService.stopExecution(exId, timeout))
             .catch(err => Promise.reject(parseError(err)));
     }
 

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -139,7 +139,8 @@ module.exports = function messaging(context, logger, childHookFn) {
     const config = makeConfigurations();
     const hostURL = config.hostURL;
     const events = context.apis.foundation.getSystemEvents();
-    const configTimeout = context.sysconfig.teraslice.network_timeout;
+    const configTimeout = context.sysconfig.teraslice.action_timeout;
+    const networkLatencyBuffer = context.sysconfig.teraslice.network_latency_buffer;
     const self = config.assignment;
     const selfMessages = getMessages(self);
 
@@ -359,6 +360,8 @@ module.exports = function messaging(context, logger, childHookFn) {
         }
         return new Promise(((resolve, reject) => {
             const msgID = shortid.generate();
+            const actionTimeout = messageSent.timeout || configTimeout;
+            const messageTimeout = _.toNumber(actionTimeout) + networkLatencyBuffer;
             messageSent.__msgId = msgID;
 
             events.on(msgID, (nodeMasterData) => {
@@ -376,7 +379,7 @@ module.exports = function messaging(context, logger, childHookFn) {
                 // remove listener to prevent memory leaks
                 events.removeAllListeners(msgID);
                 reject(`timeout error while communicating with node: ${messageSent.to}, msg: ${messageSent.message}, data: ${JSON.stringify(messageSent)}`);
-            }, configTimeout);
+            }, messageTimeout);
         }));
     }
 

--- a/lib/config/schemas/system.js
+++ b/lib/config/schemas/system.js
@@ -87,14 +87,25 @@ const schema = {
             }
         }
     },
-    network_timeout: {
-        doc: 'time in milliseconds for waiting for a response when messaging node_master before throwing an error',
+    action_timeout: {
+        doc: 'time in milliseconds for waiting for a action ( pause/stop job, etc) to complete before throwing an error',
         default: 300000,
         format(val) {
             if (isNaN(val)) {
-                throw new Error('network_timeout parameter for teraslice must be a number');
+                throw new Error('action_timeout parameter for teraslice must be a number');
             } else if (val <= 0) {
-                throw new Error('network_timeout parameter for teraslice must be greater than zero');
+                throw new Error('action_timeout parameter for teraslice must be greater than zero');
+            }
+        }
+    },
+    network_latency_buffer: {
+        doc: 'time in milliseconds buffer which is combined with action_timeout to determine how long the cluster master will wait till it throws an error',
+        default: 15000,
+        format(val) {
+            if (isNaN(val)) {
+                throw new Error('network_latency_buffer parameter for teraslice must be a number');
+            } else if (val <= 0) {
+                throw new Error('network_latency_buffer parameter for teraslice must be greater than zero');
             }
         }
     },


### PR DESCRIPTION
NOTE CONFIG SETTING CHANGES:

- changed `network_timeout` to `action_timeout`
- added `network_latency_buffer` (defaults to 15s) which combines with action_timeout to make the final network_timeout

- can now add a a timeout parameter to stop job which will take the place of action_timeout, note that `network_latency_buffer` will still be added to it for final timeout

```
curl -XPOST localhost:5678/jobs/8b9596db-db1b-4db4-8957-b2bdc4625335/_stop?timeout=120000
```
