### PR TITLE
slicer can not direct slices to a particular worker resolves #624

### DIFF
--- a/lib/cluster/slicer.js
+++ b/lib/cluster/slicer.js
@@ -104,7 +104,7 @@ module.exports = function module(contextConfig) {
             logger.info(`slicer for job: ${exId} has received a pause notice`);
             engineCanRun = false;
             clearInterval(engine);
-            events.emit('job:pause');
+            events.emit('execution:pause');
             messaging.respond(msg);
         }
     });
@@ -115,7 +115,7 @@ module.exports = function module(contextConfig) {
             logger.info(`slicer for job: ${exId} has received a resume notice`);
             engine = setInterval(engineFn, 1);
             engineCanRun = true;
-            events.emit('job:resume');
+            events.emit('execution:resume');
             messaging.respond(msg);
         }
     });
@@ -164,6 +164,7 @@ module.exports = function module(contextConfig) {
                 queueLength = messaging.getClientCounts();
             }
             // messaging module will join connection
+            events.emit('worker:ready', workerId);
             workerQueue.enqueue(msg.payload);
         }
     });
@@ -472,6 +473,10 @@ module.exports = function module(contextConfig) {
         }));
     }
 
+    function workerSpecificSlice() {
+
+    }
+
     function slicerEngine(slicers) {
         if (!Array.isArray(slicers)) {
             throw new Error(`newSlicer from module ${job.jobConfig.operations[0]._op} needs to return an array of slicers`);
@@ -482,14 +487,23 @@ module.exports = function module(contextConfig) {
 
         engineFn = function slicerEngineExecution() {
             while (workerQueue.size() && slicerQueue.size()) {
-                const worker = workerQueue.dequeue();
                 const sliceData = slicerQueue.dequeue();
-                messaging.send({
-                    to: 'worker',
-                    address: worker.worker_id,
-                    message: 'slicer:slice:new',
-                    payload: sliceData
-                });
+                const messageData = { to: 'worker', message: 'slicer:slice:new', payload: sliceData };
+
+                if (sliceData.request.request_worker) {
+                    const worker = workerQueue.extract('worker_id', sliceData.request.request_worker);
+                    if (worker) {
+                        messageData.address = worker.worker_id;
+                        messaging.send(messageData);
+                    } else {
+                        events.emit('slice:invalid', sliceData.request);
+                        stateStore.updateState(sliceData.request, 'invalid');
+                    }
+                } else {
+                    const worker = workerQueue.dequeue();
+                    messageData.address = worker.worker_id;
+                    messaging.send(messageData);
+                }
             }
 
             const currentWorkers = workerQueue.size();
@@ -559,7 +573,7 @@ module.exports = function module(contextConfig) {
         clearInterval(engine);
         clearInterval(analyticsTimer);
         pushAnalytics();
-        events.emit('job:stop');
+        events.emit('execution:stop');
         Promise.resolve()
             .then(() => {
                 if (stateStore) {

--- a/lib/cluster/storage/state.js
+++ b/lib/cluster/storage/state.js
@@ -2,7 +2,6 @@
 
 const Promise = require('bluebird');
 const parseError = require('error_parser');
-const template = require('./backends/mappings/state.json');
 const timeseriesIndex = require('../../utils/date_utils').timeseriesIndex;
 
 // Module to manager job states in Elasticsearch.
@@ -56,7 +55,7 @@ module.exports = function module(context) {
 
     function recoveryContext(exId, slicerId) {
         const startQuery = `ex_id:${exId} AND slicer_id:${slicerId}`;
-        const retryQuery = `${startQuery} AND NOT state:completed`;
+        const retryQuery = `${startQuery} AND NOT (state:completed OR state:invalid)`;
 
         // Look for all slices that haven't been completed so they can be retried.
         return backend.refresh(indexName)


### PR DESCRIPTION
this needs to be paired with the pr in the queue package.

In order to send a slice to a specific worker you will need to add a key to the slice from the reader-slicer

example slice from elasticsearch date slicer
```   
{
    start: someStartDate,
    end: someEndDate,
    count: data.count,
    request_worker: '172.29.0.170__4'  // the actual workerId
}
```

events to listen to:

'slice:invalid' => returns the slice, itmeans the slice was not able to be allocated in the worker queue, the state slice will be marked as invalid and you will need to change request_worker to another worker

'worker:ready' => returns workerId, use this to determine what workers have connected and their actual id

'network:disconnect' => returns a workerId, tells you what worker has dropped a connection to the slicer

'slice:success' => slice, the slice has been reported back by the worker and was sucessfull

slice:failure' => slice, the slice failed