### PR TITLE
fixed ex/ex_id/slicer api endpoint error resolves #660

### DIFF
--- a/lib/cluster/services/api.js
+++ b/lib/cluster/services/api.js
@@ -366,11 +366,7 @@ module.exports = function module(context, app) {
 
         _slicerStats(exId)
             .then(results => res.status(200).json(results))
-            .catch((err) => {
-                const errMsg = `could not get slicer statistics, error: ${parseError(err)}`;
-                logger.error(errMsg);
-                sendError(res, 500, errMsg);
-            });
+            .catch(err => sendError(res, err.code, err.message));
     });
 
     app.get('/cluster/stats', (req, res) => {


### PR DESCRIPTION
After testing it seemed that the endpoint works correctly. I got the error reported only when I used the job_id instead of the ex_id for that endpoint. Take note that you can call /jobs/:job_id/slicer with the job_id that is returned assuming you only have one invocation, if you dont you will just get multiple back. If you call /ex/:ex_id/slicer it must be with an actual ex_id, which you would have to dig around a bit. The error was not reporting back correctly so I fixed that