### PR TITLE
WIP: Refactoring asset loading to be sequenced more explicitly

### DIFF
--- a/lib/cluster/assets_loader.js
+++ b/lib/cluster/assets_loader.js
@@ -17,7 +17,7 @@ module.exports = function module(context) {
         // first step we normalize all identifiers to their proper id
         return assetStore.parseAssetsArray(assetsArray)
             .then(idArray => Promise.map(idArray, (assetIdentifier) => {
-                if (!alreadyDownloaded(assetIdentifier)) {
+                if (!existsSync(`${assetsDir}/${assetIdentifier}`)) {
                     return assetStore.get(assetIdentifier)
                         .then((assetRecord) => {
                             logger.info(`loading assets: ${assetIdentifier}`);
@@ -29,10 +29,6 @@ module.exports = function module(context) {
                 // need to return the id to the assets array sent back
                 return { id: assetIdentifier };
             }));
-    }
-
-    function alreadyDownloaded(assetID) {
-        return existsSync(`${clusterConfig.assets_directory}/${assetID}`);
     }
 
     // TODO currently any job asset that doesn't exist in elasticsearch is ignored

--- a/lib/cluster/assets_loader.js
+++ b/lib/cluster/assets_loader.js
@@ -7,7 +7,7 @@ const saveAsset = require('../utils/file_utils').saveAsset;
 const parseError = require('error_parser');
 
 // this is a child process spawned by node_master to download assets
-module.exports = function (context) {
+module.exports = function module(context) {
     const logger = context.apis.foundation.makeLogger({ module: 'asset_manager' });
     const clusterConfig = context.sysconfig.teraslice;
     const assetsDir = clusterConfig.assets_directory;

--- a/lib/cluster/assets_loader.js
+++ b/lib/cluster/assets_loader.js
@@ -40,6 +40,10 @@ module.exports = function module(context) {
     const job = JSON.parse(process.env.job);
     const exId = job.ex_id;
     const msgId = process.env.__msgId;
+
+    // If no assets are defined just feed it through as an empty array.
+    if (!job.assets) job.assets = [];
+
     // need to mock incoming message for response since this is dynamically created
     const respondingData = { __source: 'cluster_master', __msgId: msgId };
     Promise.resolve(require('./storage/assets')(context))
@@ -48,7 +52,7 @@ module.exports = function module(context) {
             if (process.env.preload) {
                 messaging.respond(respondingData, { message: 'assets:preloaded', meta: assetArray });
             } else {
-                messaging.send({ to: 'execution', message: 'assets:loaded', ex_id: exId, meta: assetArray });
+                messaging.send({ to: 'node_master', message: 'assets:loaded', payload: { ex_id: exId }, meta: assetArray });
             }
             return true;
         })
@@ -65,7 +69,7 @@ module.exports = function module(context) {
             if (process.env.preload) {
                 messaging.respond(respondingData, { message: 'assets:preloaded', error: errMsg });
             } else {
-                messaging.send({ to: 'execution', message: 'assets:loaded', ex_id: exId, error: errMsg });
+                messaging.send({ to: 'node_master', message: 'assets:loaded', payload: { ex_id: exId }, error: errMsg });
             }
 
             process.exit(0);

--- a/lib/cluster/execution_controller/engine.js
+++ b/lib/cluster/execution_controller/engine.js
@@ -7,14 +7,16 @@ const parseError = require('error_parser');
 const moment = require('moment');
 const _ = require('lodash');
 
-module.exports = function module(context, messaging, exStore, stateStore, executionContext) {
-    const executionConfig = executionContext.config;
+module.exports = function module(context, messaging, exStore, stateStore, executionRunner) {
+    let executionContext;
+    let executionConfig;
+
     const start = moment();
     const events = context.apis.foundation.getSystemEvents();
     let exId = process.env.ex_id;
     const jobId = process.env.job_id;
     const logger = context.apis.foundation.makeLogger({ module: 'execution_engine', ex_id: exId, job_id: jobId });
-    const slicerModule = executionContext.slicer;
+
 
     let executionAnalytics;
     let slicerAnalytics;
@@ -123,7 +125,26 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
 
     messaging.register({
         event: 'assets:loaded',
-        callback: ipcMessage => events.emit('execution:assets_loaded', ipcMessage)
+        callback: (ipcMessage) => {
+            if (ipcMessage.error) {
+                logger.error(`Error while loading assets, error: ${ipcMessage.error}`);
+                shutdown();
+            } else if (!executionContext) {
+                executionRunner.initialize()
+                    .then((exContext) => {
+                        executionContext = exContext;
+                        executionConfig = executionContext.config;
+
+                        // Now that we have a valid execution context we can
+                        // fire up the engine to start processing slices.
+                        initialize();
+                    })
+                    .catch((err) => {
+                        logger.error('error initializing execution', err.message);
+                        shutdown();
+                    });
+            }
+        }
     });
 
     events.on('slicer:execution:update', (data) => {
@@ -188,7 +209,7 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
     }
 
     function _slicerInit(startingPointStateRecords) {
-        return slicerModule.newSlicer(context, executionContext, startingPointStateRecords, logger);
+        return executionContext.slicer.newSlicer(context, executionContext, startingPointStateRecords, logger);
     }
 
     function _slicerInitRetry(slicerError) {
@@ -273,14 +294,15 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
         };
 
         // send message that execution is in running state
-        logger.info(`execution: ${exId} has initialized and is listening on port ${executionConfig.slicer_port}`);
         exStore.setStatus(exId, 'running');
+
         if (!executionAnalytics) executionAnalytics = require('./execution_analytics')(context, messaging);
         if (!slicerAnalytics) slicerAnalytics = require('./slice_analytics')(context, executionContext);
         _setQueueLength(executionContext);
         if (!recovery) recovery = require('./recovery')(context, messaging, executionAnalytics, exStore, stateStore, executionContext);
 
         messaging.listen({ port: executionContext.config.slicer_port });
+        logger.info(`execution: ${exId} has initialized and is listening on port ${executionConfig.slicer_port}`);
 
         // start the engine
         if (engineCanRun) {
@@ -322,7 +344,7 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
         // checking if lifecycle is 'once' and not in recovery mode
         const isOnce = (lifecycle === 'once') && recovery.recoveryComplete();
 
-        return function () {
+        return () => {
             if (!isProcessing && !hasCompleted) {
                 logger.trace(`slicer ${slicerId} is being called`);
                 isProcessing = true;

--- a/lib/cluster/execution_controller/engine.js
+++ b/lib/cluster/execution_controller/engine.js
@@ -39,6 +39,30 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
     let queueLength;
 
     messaging.register({
+        event: 'assets:loaded',
+        callback: (ipcMessage) => {
+            if (ipcMessage.error) {
+                logger.error(`Error while loading assets, error: ${ipcMessage.error}`);
+                shutdown();
+            } else if (!executionContext) {
+                executionRunner.initialize()
+                    .then((exContext) => {
+                        executionContext = exContext;
+                        executionConfig = executionContext.config;
+
+                        // Now that we have a valid execution context we can
+                        // fire up the engine to start processing slices.
+                        initialize();
+                    })
+                    .catch((err) => {
+                        logger.error('error initializing execution', err.message);
+                        shutdown();
+                    });
+            }
+        }
+    });
+
+    messaging.register({
         event: 'cluster:execution:pause',
         callback: (msg) => {
             _pause();
@@ -123,30 +147,6 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
         }
     });
 
-    messaging.register({
-        event: 'assets:loaded',
-        callback: (ipcMessage) => {
-            if (ipcMessage.error) {
-                logger.error(`Error while loading assets, error: ${ipcMessage.error}`);
-                shutdown();
-            } else if (!executionContext) {
-                executionRunner.initialize()
-                    .then((exContext) => {
-                        executionContext = exContext;
-                        executionConfig = executionContext.config;
-
-                        // Now that we have a valid execution context we can
-                        // fire up the engine to start processing slices.
-                        initialize();
-                    })
-                    .catch((err) => {
-                        logger.error('error initializing execution', err.message);
-                        shutdown();
-                    });
-            }
-        }
-    });
-
     events.on('slicer:execution:update', (data) => {
         logger.debug('slicer sending a execution update', data.update);
         // this is updating the opConfig for elasticsearch start and/or end dates for ex,
@@ -209,7 +209,8 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
     }
 
     function _slicerInit(startingPointStateRecords) {
-        return executionContext.slicer.newSlicer(context, executionContext, startingPointStateRecords, logger);
+        return executionContext.slicer.newSlicer(context, executionContext,
+            startingPointStateRecords, logger);
     }
 
     function _slicerInitRetry(slicerError) {

--- a/lib/cluster/execution_controller/engine.js
+++ b/lib/cluster/execution_controller/engine.js
@@ -39,30 +39,6 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
     let queueLength;
 
     messaging.register({
-        event: 'assets:loaded',
-        callback: (ipcMessage) => {
-            if (ipcMessage.error) {
-                logger.error(`Error while loading assets, error: ${ipcMessage.error}`);
-                shutdown();
-            } else if (!executionContext) {
-                executionRunner.initialize()
-                    .then((exContext) => {
-                        executionContext = exContext;
-                        executionConfig = executionContext.config;
-
-                        // Now that we have a valid execution context we can
-                        // fire up the engine to start processing slices.
-                        initialize();
-                    })
-                    .catch((err) => {
-                        logger.error('error initializing execution', err.message);
-                        shutdown();
-                    });
-            }
-        }
-    });
-
-    messaging.register({
         event: 'cluster:execution:pause',
         callback: (msg) => {
             _pause();
@@ -174,7 +150,7 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
         }
     }
 
-    function initialize() {
+    function run() {
         return Promise.resolve()
             .then(_engineSetup)
             .then(_executionRecovery)
@@ -242,6 +218,7 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
     }
 
     function _terminalError(err) {
+console.log(err)
         const errMsg = parseError(err);
         const executionStats = executionAnalytics.getAnalytics();
         const errorMeta = exStore.failureMetaData(errMsg, executionStats);
@@ -294,24 +271,37 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
             }
         };
 
-        // send message that execution is in running state
-        exStore.setStatus(exId, 'running');
+        return executionRunner.initialize()
+            .then((exContext) => {
+                executionContext = exContext;
+                executionConfig = executionContext.config;
 
-        if (!executionAnalytics) executionAnalytics = require('./execution_analytics')(context, messaging);
-        if (!slicerAnalytics) slicerAnalytics = require('./slice_analytics')(context, executionContext);
-        _setQueueLength(executionContext);
-        if (!recovery) recovery = require('./recovery')(context, messaging, executionAnalytics, exStore, stateStore, executionContext);
+                // send message that execution is in running state
+                exStore.setStatus(exId, 'running');
 
-        messaging.listen({ port: executionContext.config.slicer_port });
-        logger.info(`execution: ${exId} has initialized and is listening on port ${executionConfig.slicer_port}`);
+                if (!executionAnalytics) executionAnalytics = require('./execution_analytics')(context, messaging);
+                if (!slicerAnalytics) slicerAnalytics = require('./slice_analytics')(context, executionContext);
 
-        // start the engine
-        if (engineCanRun) {
-            logger.debug('starting the slicer engine');
-            engine = setInterval(engineFn, 1);
-        }
+                _setQueueLength(executionContext);
 
-        _startWorkerConnectionWatchDog();
+                if (!recovery) recovery = require('./recovery')(context, messaging, executionAnalytics, exStore, stateStore, executionContext);
+
+                messaging.listen({ port: executionContext.config.slicer_port });
+
+                logger.info(`execution: ${exId} has initialized and is listening on port ${executionConfig.slicer_port}`);
+
+                // start the engine
+                if (engineCanRun) {
+                    logger.debug('starting the slicer engine');
+                    engine = setInterval(engineFn, 1);
+                }
+
+                _startWorkerConnectionWatchDog();
+            })
+            .catch((err) => {
+                logger.error('error initializing execution', err.message);
+                shutdown();
+            });
     }
 
     function _allocateSlice(sliceRequest, slicerId, slicerOrder) {
@@ -634,7 +624,7 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
     }
 
     return {
-        initialize,
+        run,
         shutdown,
         __test_context: testContext
     };

--- a/lib/cluster/execution_controller/engine.js
+++ b/lib/cluster/execution_controller/engine.js
@@ -218,7 +218,6 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
     }
 
     function _terminalError(err) {
-console.log(err)
         const errMsg = parseError(err);
         const executionStats = executionAnalytics.getAnalytics();
         const errorMeta = exStore.failureMetaData(errMsg, executionStats);

--- a/lib/cluster/execution_controller/engine.js
+++ b/lib/cluster/execution_controller/engine.js
@@ -299,7 +299,7 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
             })
             .catch((err) => {
                 logger.error('error initializing execution', err.message);
-                shutdown();
+                return Promise.reject(`error initializing execution: ${err.message}`);
             });
     }
 

--- a/lib/cluster/execution_controller/engine.js
+++ b/lib/cluster/execution_controller/engine.js
@@ -594,11 +594,16 @@ module.exports = function module(context, messaging, exStore, stateStore, execut
             });
     }
 
-    function testContext(_executionAnalytics, _slicerAnalytics, _recovery, _exId, _testRecovery) {
+    function testContext(_executionAnalytics, _slicerAnalytics, _recovery, _exId, _testRecovery, _executionContext) {
         if (_executionAnalytics) executionAnalytics = _executionAnalytics;
         if (_slicerAnalytics) slicerAnalytics = _slicerAnalytics;
         if (_recovery) recovery = _recovery;
         if (_testRecovery) testRecovery = _testRecovery;
+        if (_executionContext) {
+            executionContext = _executionContext;
+            executionConfig = executionContext.config;
+        }
+
         exId = _exId;
 
         return {

--- a/lib/cluster/execution_controller/index.js
+++ b/lib/cluster/execution_controller/index.js
@@ -32,11 +32,6 @@ module.exports = function module(contextConfig) {
     // failure scenario inside engineInit is self contained inside engine
     function initializeExecutionController() {
         Promise.resolve(executionInit())
-            .catch(terminalShutdown)
-            .then((_engine) => {
-                engine = _engine;
-                engine.initialize();
-            })
             .catch(terminalShutdown);
     }
 
@@ -48,12 +43,18 @@ module.exports = function module(contextConfig) {
         }
         // assets store is loaded first so it can register apis before executionRunner is called
         return Promise.resolve(require('../storage/assets')(context))
-            .then(() => Promise.all([executionRunner.initialize(events, logger), require('../storage/state')(context), require('../storage/execution')(context)]))
-            .spread((executionContext, _stateStore, _exStore) => {
+            .then(() => Promise.all([
+                require('../storage/state')(context),
+                require('../storage/execution')(context)
+            ]))
+            .spread((_stateStore, _exStore) => {
                 logger.trace('stateStore and jobStore for slicer has been initialized');
                 stateStore = _stateStore;
                 exStore = _exStore;
-                return require('./engine')(context, messaging, exStore, stateStore, executionContext);
+                engine = require('./engine')(context, messaging, exStore, stateStore, executionRunner);
+console.log("Attempting to send message from slicer")
+                // TODO: this should really be synchronized to the loading of the engine.
+                messaging.send({ to: 'node_master', message: 'worker:online', ex_id: exId });
             });
     }
 

--- a/lib/cluster/execution_controller/index.js
+++ b/lib/cluster/execution_controller/index.js
@@ -52,7 +52,7 @@ module.exports = function module(contextConfig) {
                 stateStore = _stateStore;
                 exStore = _exStore;
                 engine = require('./engine')(context, messaging, exStore, stateStore, executionRunner);
-console.log("Attempting to send message from slicer")
+
                 // TODO: this should really be synchronized to the loading of the engine.
                 messaging.send({ to: 'node_master', message: 'worker:online', ex_id: exId });
             });

--- a/lib/cluster/execution_controller/index.js
+++ b/lib/cluster/execution_controller/index.js
@@ -51,10 +51,9 @@ module.exports = function module(contextConfig) {
                 logger.trace('stateStore and jobStore for slicer has been initialized');
                 stateStore = _stateStore;
                 exStore = _exStore;
-                engine = require('./engine')(context, messaging, exStore, stateStore, executionRunner);
-
-                // TODO: this should really be synchronized to the loading of the engine.
-                messaging.send({ to: 'node_master', message: 'worker:online', ex_id: exId });
+                engine = require('./engine')(context, messaging, exStore,
+                    stateStore, executionRunner);
+                engine.run();
             });
     }
 

--- a/lib/cluster/execution_controller/index.js
+++ b/lib/cluster/execution_controller/index.js
@@ -27,13 +27,7 @@ module.exports = function module(contextConfig) {
     // emitted after final cleanup of execution is complete
     events.on('execution:shutdown', () => process.exit());
 
-    initializeExecutionController();
-
-    // failure scenario inside engineInit is self contained inside engine
-    function initializeExecutionController() {
-        Promise.resolve(executionInit())
-            .catch(terminalShutdown);
-    }
+    executionInit();
 
     function executionInit() {
         // if slicer has restart by itself, terminate execution, need to wait for registration
@@ -53,8 +47,9 @@ module.exports = function module(contextConfig) {
                 exStore = _exStore;
                 engine = require('./engine')(context, messaging, exStore,
                     stateStore, executionRunner);
-                engine.run();
-            });
+                return engine.run();
+            })
+            .catch(terminalShutdown);
     }
 
     function terminalShutdown(errObj) {

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -99,7 +99,7 @@ module.exports = function module(context) {
         event: 'cluster:execution_controller:create',
         callback: (createSlicerRequest) => {
             const createSlicerMsg = createSlicerRequest.payload;
-            const needAssets = jobNeedsAssets(createSlicerMsg.job);
+            // const needAssets = jobNeedsAssets(createSlicerMsg.job);
 
             const controllerContext = {
                 assignment: 'execution_controller',
@@ -114,9 +114,11 @@ module.exports = function module(context) {
                 controllerContext.recover_execution = createSlicerMsg.recover_execution;
             }
             logger.trace('starting a execution controller', controllerContext);
-            context.foundation.startWorkers(1, controllerContext);
+            const workers = context.foundation.startWorkers(1, controllerContext);
 
-            if (needAssets) {
+            _loadAssets(workers);
+
+            /* if (needAssets) {
                 logger.info(`node ${context.sysconfig._nodeName} is checking assets for job ${createSlicerMsg.ex_id}`);
                 context.foundation.startWorkers(1, {
                     assignment: 'assets_loader',
@@ -124,7 +126,12 @@ module.exports = function module(context) {
                     job: createSlicerMsg.job,
                     ex_id: createSlicerMsg.ex_id
                 });
-            }
+            } else {
+                setTimeout(() => {
+    console.log("Firing assets:loaded")
+                    messaging.send({ to: 'execution', message: 'assets:loaded', ex_id: createSlicerMsg.ex_id });
+                }, 5000);
+            } */
 
             // need to update cluster_master immediately so it can balance workers correctly
             // and prevent wrong allocations
@@ -139,7 +146,7 @@ module.exports = function module(context) {
         callback: (createWorkerRequest) => {
             const createWorkerMsg = createWorkerRequest.payload;
             const numOfCurrentWorkers = Object.keys(context.cluster.workers).length;
-            const needAssets = jobNeedsAssets(createWorkerMsg.job);
+            // const needAssets = jobNeedsAssets(createWorkerMsg.job);
             let newWorkers = createWorkerMsg.workers;
             logger.info(`Attempting to allocate ${newWorkers} workers.`);
 
@@ -155,7 +162,7 @@ module.exports = function module(context) {
             }
             logger.trace(`starting ${newWorkers} workers`, createWorkerMsg.ex_id);
 
-            context.foundation.startWorkers(newWorkers, {
+            const workers = context.foundation.startWorkers(newWorkers, {
                 assignment: 'worker',
                 node_id: context.sysconfig._nodeName,
                 job: createWorkerMsg.job,
@@ -163,8 +170,10 @@ module.exports = function module(context) {
                 job_id: createWorkerMsg.job_id
             });
 
+            _loadAssets(workers);
+
             // for workers on nodes that don't have the asset loading process already going
-            if (needAssets && !assetIsLoading(createWorkerMsg.ex_id)) {
+            /* if (needAssets && !assetIsLoading(createWorkerMsg.ex_id)) {
                 logger.info(`node ${context.sysconfig._nodeName} is checking assets for job ${createWorkerMsg.ex_id}`);
                 context.foundation.startWorkers(1, {
                     assignment: 'assets_loader',
@@ -172,7 +181,12 @@ module.exports = function module(context) {
                     job: createWorkerMsg.job,
                     ex_id: createWorkerMsg.ex_id
                 });
-            }
+            } else {
+                setTimeout(() => {
+    console.log("Firing assets:loaded")
+                    messaging.send({ to: 'execution', message: 'assets:loaded', ex_id: createWorkerMsg.ex_id });
+                }, 5000);
+            } */
 
             messaging.respond(createWorkerRequest);
         }
@@ -355,6 +369,30 @@ module.exports = function module(context) {
         return state;
     }
 
+    function _loadAssets(workers) {
+        workers.forEach((worker) => {
+            // for workers on nodes that don't have the asset loading process already going
+            if (jobNeedsAssets(worker.job) && !assetIsLoading(worker.ex_id)) {
+                logger.info(`node ${context.sysconfig._nodeName} is checking assets for job ${worker.ex_id}`);
+                context.foundation.startWorkers(1, {
+                    assignment: 'assets_loader',
+                    node_id: context.sysconfig._nodeName,
+                    job: worker.job,
+                    ex_id: worker.ex_id
+                });
+            } else {
+                // Wait for ackowledgement from the worker that it is online.
+                // TODO: not sure how to use the messaging service to receive this message.
+                worker.on('message', (message) => {
+                    if (message.message == 'worker:online' && message.ex_id === worker.ex_id) {
+console.log("Firing assets:loaded from worker:online" + worker.id);
+                        messaging.send({ to: 'execution', message: 'assets:loaded', ex_id: worker.ex_id });
+                    }
+                });
+            }
+        });
+    }
+
     messaging.listen();
 
     if (context.sysconfig.teraslice.master) {
@@ -390,8 +428,6 @@ module.exports = function module(context) {
             setTimeout(() => process.exit(), 100);
         }
 
-        const needAssets = jobNeedsAssets(ex);
-
         const childContext = {
             assignment: workerType,
             job: jobStr,
@@ -406,9 +442,10 @@ module.exports = function module(context) {
             childContext.recover_execution = ex.recover_execution;
         }
 
-        context.foundation.startWorkers(1, childContext);
+        const workers = context.foundation.startWorkers(1, childContext);
 
-        if (needAssets) {
+        _loadAssets(workers);
+        /*if (jobNeedsAssets(ex)) {
             logger.info(`node ${context.sysconfig._nodeName} is checking assets for job ${ex.ex_id}`);
             context.foundation.startWorkers(1, {
                 assignment: 'assets_loader',
@@ -416,6 +453,10 @@ module.exports = function module(context) {
                 job: ex.job,
                 ex_id: ex.ex_id
             });
-        }
+        } else {
+            setTimeout(() => {
+                messaging.send({ to: 'execution', message: 'assets:loaded', ex_id: ex.ex_id });
+            }, 2000);
+        }*/
     }
 };

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -114,6 +114,7 @@ module.exports = function module(context) {
                 controllerContext.recover_execution = createSlicerMsg.recover_execution;
             }
 
+            // Queue the worker request until after assets have completed loading.
             _queueWorkerRequest(createSlicerRequest, controllerContext);
 
             _loadAssets(createSlicerMsg.job, createSlicerMsg.ex_id);
@@ -137,7 +138,6 @@ module.exports = function module(context) {
             // Queue the worker request until after assets have completed loading.
             _queueWorkerRequest(createWorkerRequest, request);
 
-            // Kickoff asset loading if needed.
             _loadAssets(createWorkerMsg.job, createWorkerMsg.ex_id);
         }
     });
@@ -320,11 +320,6 @@ module.exports = function module(context) {
         }, intervalTime);
     }
 
-    /* function jobNeedsAssets(jobStr) {
-        const job = typeof jobStr === 'string' ? JSON.parse(jobStr) : jobStr;
-        return job.assets && job.assets.length > 0;
-    } */
-
     function portAllocator() {
         const portConfig = context.sysconfig.teraslice.slicer_port_range;
         const dataArray = portConfig.split(':');
@@ -392,10 +387,6 @@ module.exports = function module(context) {
 
     function _loadAssets(job, exId) {
         // for workers on nodes that don't have the asset loading process already going
-        // This has a race condition since there is latency between the time
-        // assets:loaded fires and the assets loader process exits. This uses the
-        // process state to determine if it's already running.
-    //    if (jobNeedsAssets(job) && !assetIsLoading(exId)) {
         if (!pendingWorkerRequests[exId].assets_loading) {
             pendingWorkerRequests[exId].assets_loading = true;
 
@@ -461,7 +452,6 @@ module.exports = function module(context) {
         // Queue the worker request until after assets have completed loading.
         _queueWorkerRequest(null, childContext);
 
-        // Kickoff asset loading if needed.
         _loadAssets(jobStr, ex.ex_id);
     }
 };

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -270,7 +270,7 @@ module.exports = function module(context) {
 
                 // mutative
                 originalMessage.workers = workerCount;
-                messaging.send({ to: 'cluster_master', message: 'node:workers:over_allocated', payload: originalMessage });
+                messaging.send({ to: 'cluster_master', message: 'node:workers:over_allocated', payload: originalMessage.payload });
                 logger.warn(`Worker allocation request would exceed maximum number of workers - ${configWorkerLimit}`);
                 logger.warn(`Reducing allocation to ${workerCount} workers.`);
             }

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -25,9 +25,15 @@ module.exports = function module(context) {
     // Need sendNodeState before we instantiate messaging
     const sendNodeState = _.debounce(() => {
         const state = getNodeState();
-        messaging.send({ to: 'cluster_master', message: 'node:state', node_id: state.node_id, payload: state });
+        messaging.send({
+            to: 'cluster_master',
+            message: 'node:state',
+            node_id: state.node_id,
+            payload: state
+        });
     }, 500, { leading: false, trailing: true });
 
+    // TODO: this sendNodeState being passed here looks fishy.
     const messaging = messageModule(context, logger, sendNodeState);
     const host = messaging.getHostUrl();
 
@@ -99,7 +105,6 @@ module.exports = function module(context) {
         event: 'cluster:execution_controller:create',
         callback: (createSlicerRequest) => {
             const createSlicerMsg = createSlicerRequest.payload;
-            // const needAssets = jobNeedsAssets(createSlicerMsg.job);
 
             const controllerContext = {
                 assignment: 'execution_controller',
@@ -118,21 +123,6 @@ module.exports = function module(context) {
 
             _loadAssets(workers);
 
-            /* if (needAssets) {
-                logger.info(`node ${context.sysconfig._nodeName} is checking assets for job ${createSlicerMsg.ex_id}`);
-                context.foundation.startWorkers(1, {
-                    assignment: 'assets_loader',
-                    node_id: context.sysconfig._nodeName,
-                    job: createSlicerMsg.job,
-                    ex_id: createSlicerMsg.ex_id
-                });
-            } else {
-                setTimeout(() => {
-    console.log("Firing assets:loaded")
-                    messaging.send({ to: 'execution', message: 'assets:loaded', ex_id: createSlicerMsg.ex_id });
-                }, 5000);
-            } */
-
             // need to update cluster_master immediately so it can balance workers correctly
             // and prevent wrong allocations
             const state = getNodeState();
@@ -146,7 +136,7 @@ module.exports = function module(context) {
         callback: (createWorkerRequest) => {
             const createWorkerMsg = createWorkerRequest.payload;
             const numOfCurrentWorkers = Object.keys(context.cluster.workers).length;
-            // const needAssets = jobNeedsAssets(createWorkerMsg.job);
+
             let newWorkers = createWorkerMsg.workers;
             logger.info(`Attempting to allocate ${newWorkers} workers.`);
 
@@ -171,22 +161,6 @@ module.exports = function module(context) {
             });
 
             _loadAssets(workers);
-
-            // for workers on nodes that don't have the asset loading process already going
-            /* if (needAssets && !assetIsLoading(createWorkerMsg.ex_id)) {
-                logger.info(`node ${context.sysconfig._nodeName} is checking assets for job ${createWorkerMsg.ex_id}`);
-                context.foundation.startWorkers(1, {
-                    assignment: 'assets_loader',
-                    node_id: context.sysconfig._nodeName,
-                    job: createWorkerMsg.job,
-                    ex_id: createWorkerMsg.ex_id
-                });
-            } else {
-                setTimeout(() => {
-    console.log("Firing assets:loaded")
-                    messaging.send({ to: 'execution', message: 'assets:loaded', ex_id: createWorkerMsg.ex_id });
-                }, 5000);
-            } */
 
             messaging.respond(createWorkerRequest);
         }
@@ -384,8 +358,7 @@ module.exports = function module(context) {
                 // Wait for ackowledgement from the worker that it is online.
                 // TODO: not sure how to use the messaging service to receive this message.
                 worker.on('message', (message) => {
-                    if (message.message == 'worker:online' && message.ex_id === worker.ex_id) {
-console.log("Firing assets:loaded from worker:online" + worker.id);
+                    if (message.message === 'worker:online' && message.ex_id === worker.ex_id) {
                         messaging.send({ to: 'execution', message: 'assets:loaded', ex_id: worker.ex_id });
                     }
                 });
@@ -445,18 +418,5 @@ console.log("Firing assets:loaded from worker:online" + worker.id);
         const workers = context.foundation.startWorkers(1, childContext);
 
         _loadAssets(workers);
-        /*if (jobNeedsAssets(ex)) {
-            logger.info(`node ${context.sysconfig._nodeName} is checking assets for job ${ex.ex_id}`);
-            context.foundation.startWorkers(1, {
-                assignment: 'assets_loader',
-                node_id: context.sysconfig._nodeName,
-                job: ex.job,
-                ex_id: ex.ex_id
-            });
-        } else {
-            setTimeout(() => {
-                messaging.send({ to: 'execution', message: 'assets:loaded', ex_id: ex.ex_id });
-            }, 2000);
-        }*/
     }
 };

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -449,7 +449,7 @@ module.exports = function module(context) {
             setTimeout(() => process.exit(), 100);
         }
 
-        const childContext = {
+        const request = {
             assignment: workerType,
             job: jobStr,
             node_id: context.sysconfig._nodeName,
@@ -460,12 +460,10 @@ module.exports = function module(context) {
         // TODO need to set recover_execution somehow
         // used to retry a job on startup after a stop command
         if (ex.recover_execution && workerType === 'execution_controller') {
-            childContext.recover_execution = ex.recover_execution;
+            request.recover_execution = ex.recover_execution;
         }
-
+        const kubernetesCreationMsg = { payload: { job: jobStr, ex_id: ex.ex_id } };
         // Queue the worker request until after assets have completed loading.
-        _queueWorkerRequest(null, childContext);
-
-        _loadAssets(jobStr, ex.ex_id);
+        _setupExecutionProcesses(request, kubernetesCreationMsg);
     }
 };

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -22,6 +22,8 @@ module.exports = function module(context) {
     const assetsPath = config.assets_directory;
     const events = context.apis.foundation.getSystemEvents();
 
+    const pendingWorkerRequests = {};
+
     // Need sendNodeState before we instantiate messaging
     const sendNodeState = _.debounce(() => {
         const state = getNodeState();
@@ -38,13 +40,6 @@ module.exports = function module(context) {
     const host = messaging.getHostUrl();
 
     logger.info(`node ${context.sysconfig._nodeName} is attempting to connect to cluster_master: ${host}`);
-
-    function assetIsLoading(exId) {
-        const workers = context.cluster.workers;
-        const assetWorker = _.filter(workers, worker => worker.assignment === 'assets_loader' && worker.ex_id === exId);
-
-        return assetWorker.length === 1;
-    }
 
     function messageWorkers(clusterMsg, processMsg, filterFn) {
         // sharing the unique msg id for each message sent
@@ -118,16 +113,12 @@ module.exports = function module(context) {
             if (createSlicerMsg.recover_execution) {
                 controllerContext.recover_execution = createSlicerMsg.recover_execution;
             }
-            logger.trace('starting a execution controller', controllerContext);
-            const workers = context.foundation.startWorkers(1, controllerContext);
 
-            _loadAssets(workers);
+            _queueWorkerRequest(createSlicerRequest, controllerContext);
 
-            // need to update cluster_master immediately so it can balance workers correctly
-            // and prevent wrong allocations
-            const state = getNodeState();
-            messaging.send({ to: 'cluster_master', message: 'node:state', node_id: state.node_id, payload: state });
-            messaging.respond(createSlicerRequest);
+            _loadAssets(createSlicerMsg.job, createSlicerMsg.ex_id);
+
+            logger.trace('starting an execution controller', controllerContext);
         }
     });
 
@@ -135,34 +126,19 @@ module.exports = function module(context) {
         event: 'cluster:workers:create',
         callback: (createWorkerRequest) => {
             const createWorkerMsg = createWorkerRequest.payload;
-            const numOfCurrentWorkers = Object.keys(context.cluster.workers).length;
-
-            let newWorkers = createWorkerMsg.workers;
-            logger.info(`Attempting to allocate ${newWorkers} workers.`);
-
-            // if there is an over allocation, send back rest to be enqueued
-            if (configWorkerLimit < numOfCurrentWorkers + newWorkers) {
-                newWorkers = configWorkerLimit - numOfCurrentWorkers;
-
-                // mutative
-                createWorkerMsg.workers -= newWorkers;
-                messaging.send({ to: 'cluster_master', message: 'node:workers:over_allocated', payload: createWorkerMsg });
-                logger.warn(`Worker allocation request would exceed maximum number of workers - ${configWorkerLimit}`);
-                logger.warn(`Reducing allocation to ${newWorkers} workers.`);
-            }
-            logger.trace(`starting ${newWorkers} workers`, createWorkerMsg.ex_id);
-
-            const workers = context.foundation.startWorkers(newWorkers, {
+            const request = {
                 assignment: 'worker',
                 node_id: context.sysconfig._nodeName,
                 job: createWorkerMsg.job,
                 ex_id: createWorkerMsg.ex_id,
                 job_id: createWorkerMsg.job_id
-            });
+            };
 
-            _loadAssets(workers);
+            // Queue the worker request until after assets have completed loading.
+            _queueWorkerRequest(createWorkerRequest, request);
 
-            messaging.respond(createWorkerRequest);
+            // Kickoff asset loading if needed.
+            _loadAssets(createWorkerMsg.job, createWorkerMsg.ex_id);
         }
     });
 
@@ -244,6 +220,77 @@ module.exports = function module(context) {
         callback: () => sendNodeState()
     });
 
+    messaging.register({
+        event: 'assets:loaded',
+        callback: (ipcMessage) => {
+            if (ipcMessage.error) {
+                if (pendingWorkerRequests[ipcMessage.payload.ex_id]) {
+                    pendingWorkerRequests[ipcMessage.payload.ex_id].assets_loading = false;
+                }
+                logger.error(`Error while loading assets, error: ${ipcMessage.error}`);
+            } else {
+                if (!ipcMessage.payload.ex_id) {
+                    logger.error('Error while loading assets, no ex_id in response from assets_loader');
+                }
+
+                const exId = ipcMessage.payload.ex_id;
+
+                if (!pendingWorkerRequests[exId]) {
+                    logger.error('Error while loading assets, no pending worker requests for exId');
+                } else {
+                    pendingWorkerRequests[exId].assets_loading = false;
+                    const pending = pendingWorkerRequests[exId].pending;
+                    // Clear this before processing just in case another request
+                    // arrives before all workers allocate.
+                    delete pendingWorkerRequests[exId];
+                    pending.forEach(_allocateWorkers);
+
+                    // need to update cluster_master immediately so it can balance workers correctly
+                    // and prevent wrong allocations
+                    const state = getNodeState();
+                    messaging.send({ to: 'cluster_master', message: 'node:state', node_id: state.node_id, payload: state });
+                }
+            }
+        }
+    });
+
+    function _allocateWorkers(request) {
+        const numOfCurrentWorkers = Object.keys(context.cluster.workers).length;
+
+        let workerCount = request.originalMessage.payload.workers;
+        const type = request.config.assignment === 'worker' ? 'workers' : request.config.assignment;
+        logger.info(`Attempting to allocate ${workerCount} ${type}.`);
+
+        // if there is an over allocation, send back rest to be enqueued
+        // TODO: confirm this check won't break things if triggered by execution_controller
+        if (configWorkerLimit < numOfCurrentWorkers + workerCount) {
+            workerCount = configWorkerLimit - numOfCurrentWorkers;
+
+            // mutative
+            request.workers -= workerCount;
+            messaging.send({ to: 'cluster_master', message: 'node:workers:over_allocated', payload: request.config });
+            logger.warn(`Worker allocation request would exceed maximum number of workers - ${configWorkerLimit}`);
+            logger.warn(`Reducing allocation to ${workerCount} workers.`);
+        }
+        logger.trace(`starting ${workerCount} ${type}`, request.config.ex_id);
+
+        context.foundation.startWorkers(workerCount, request.config);
+
+        if (request.originalMessage) messaging.respond(request.originalMessage);
+    }
+
+    function _queueWorkerRequest(originalMessage, request) {
+        if (!pendingWorkerRequests[request.ex_id]) {
+            _.set(pendingWorkerRequests, `${request.ex_id}.pending`, []);
+            _.set(pendingWorkerRequests, `${request.ex_id}.assets_loading`, false);
+        }
+
+        pendingWorkerRequests[request.ex_id].pending.push({
+            config: request,
+            originalMessage
+        });
+    }
+
     function killWorkers(filterFn) {
         const allWorkersForJob = filterFn();
         _.each(allWorkersForJob, (worker) => {
@@ -273,10 +320,10 @@ module.exports = function module(context) {
         }, intervalTime);
     }
 
-    function jobNeedsAssets(jobStr) {
+    /* function jobNeedsAssets(jobStr) {
         const job = typeof jobStr === 'string' ? JSON.parse(jobStr) : jobStr;
         return job.assets && job.assets.length > 0;
-    }
+    } */
 
     function portAllocator() {
         const portConfig = context.sysconfig.teraslice.slicer_port_range;
@@ -343,27 +390,23 @@ module.exports = function module(context) {
         return state;
     }
 
-    function _loadAssets(workers) {
-        workers.forEach((worker) => {
-            // for workers on nodes that don't have the asset loading process already going
-            if (jobNeedsAssets(worker.job) && !assetIsLoading(worker.ex_id)) {
-                logger.info(`node ${context.sysconfig._nodeName} is checking assets for job ${worker.ex_id}`);
-                context.foundation.startWorkers(1, {
-                    assignment: 'assets_loader',
-                    node_id: context.sysconfig._nodeName,
-                    job: worker.job,
-                    ex_id: worker.ex_id
-                });
-            } else {
-                // Wait for ackowledgement from the worker that it is online.
-                // TODO: not sure how to use the messaging service to receive this message.
-                worker.on('message', (message) => {
-                    if (message.message === 'worker:online' && message.ex_id === worker.ex_id) {
-                        messaging.send({ to: 'execution', message: 'assets:loaded', ex_id: worker.ex_id });
-                    }
-                });
-            }
-        });
+    function _loadAssets(job, exId) {
+        // for workers on nodes that don't have the asset loading process already going
+        // This has a race condition since there is latency between the time
+        // assets:loaded fires and the assets loader process exits. This uses the
+        // process state to determine if it's already running.
+    //    if (jobNeedsAssets(job) && !assetIsLoading(exId)) {
+        if (!pendingWorkerRequests[exId].assets_loading) {
+            pendingWorkerRequests[exId].assets_loading = true;
+
+            logger.info(`node ${context.sysconfig._nodeName} is checking assets for job ${exId}`);
+            context.foundation.startWorkers(1, {
+                assignment: 'assets_loader',
+                node_id: context.sysconfig._nodeName,
+                job,
+                ex_id: exId
+            });
+        }
     }
 
     messaging.listen();
@@ -415,8 +458,10 @@ module.exports = function module(context) {
             childContext.recover_execution = ex.recover_execution;
         }
 
-        const workers = context.foundation.startWorkers(1, childContext);
+        // Queue the worker request until after assets have completed loading.
+        _queueWorkerRequest(null, childContext);
 
-        _loadAssets(workers);
+        // Kickoff asset loading if needed.
+        _loadAssets(jobStr, ex.ex_id);
     }
 };

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -6,6 +6,7 @@ const _ = require('lodash');
 const messageModule = require('./services/messaging');
 const parseError = require('error_parser');
 const deleteDir = require('../utils/file_utils').deleteDir;
+const existsSync = require('../utils/file_utils').existsSync;
 
 const nodeVersion = process.version;
 const terasliceVersion = require('../../package.json').version;
@@ -21,10 +22,12 @@ module.exports = function module(context) {
     const config = context.sysconfig.teraslice;
     const assetsPath = config.assets_directory;
     const events = context.apis.foundation.getSystemEvents();
-
+    const assetsDir = context.sysconfig.teraslice.assets_directory;
     const pendingWorkerRequests = {};
 
-    // Need sendNodeState before we instantiate messaging
+    const messaging = messageModule(context, logger);
+    const host = messaging.getHostUrl();
+
     const sendNodeState = _.debounce(() => {
         const state = getNodeState();
         messaging.send({
@@ -35,10 +38,7 @@ module.exports = function module(context) {
         });
     }, 500, { leading: false, trailing: true });
 
-    // TODO: this sendNodeState being passed here looks fishy.
-    const messaging = messageModule(context, logger, sendNodeState);
-    const host = messaging.getHostUrl();
-
+    messaging.registerChildOnlineHook(sendNodeState);
     logger.info(`node ${context.sysconfig._nodeName} is attempting to connect to cluster_master: ${host}`);
 
     function messageWorkers(clusterMsg, processMsg, filterFn) {
@@ -101,7 +101,7 @@ module.exports = function module(context) {
         callback: (createSlicerRequest) => {
             const createSlicerMsg = createSlicerRequest.payload;
 
-            const controllerContext = {
+            const request = {
                 assignment: 'execution_controller',
                 job: createSlicerMsg.job,
                 node_id: context.sysconfig._nodeName,
@@ -111,15 +111,10 @@ module.exports = function module(context) {
             };
             // used to retry a job on startup after a stop command
             if (createSlicerMsg.recover_execution) {
-                controllerContext.recover_execution = createSlicerMsg.recover_execution;
+                request.recover_execution = createSlicerMsg.recover_execution;
             }
 
-            // Queue the worker request until after assets have completed loading.
-            _queueWorkerRequest(createSlicerRequest, controllerContext);
-
-            _loadAssets(createSlicerMsg.job, createSlicerMsg.ex_id);
-
-            logger.trace('starting an execution controller', controllerContext);
+            _setupExecutionProcesses(request, createSlicerRequest);
         }
     });
 
@@ -135,26 +130,11 @@ module.exports = function module(context) {
                 job_id: createWorkerMsg.job_id
             };
 
-            // Queue the worker request until after assets have completed loading.
-            _queueWorkerRequest(createWorkerRequest, request);
-
-            _loadAssets(createWorkerMsg.job, createWorkerMsg.ex_id);
+            _setupExecutionProcesses(request, createWorkerRequest);
         }
     });
 
     messaging.register({ event: 'cluster:node:state', callback: () => sendNodeState() });
-
-    // this fires when entire server will be shutdown
-    events.once('terafoundation:shutdown', () => {
-        const filterFn = () => context.cluster.workers;
-        const alreadySentShutdownMessage = true;
-        function actionCompleteFn() {
-            return getNodeState().active.length === 0;
-        }
-        const stopTime = config.shutdown_timeout;
-
-        shutdownProcesses({}, stopTime, filterFn, actionCompleteFn, alreadySentShutdownMessage);
-    });
 
     messaging.register({
         event: 'cluster:execution:stop',
@@ -229,10 +209,6 @@ module.exports = function module(context) {
                 }
                 logger.error(`Error while loading assets, error: ${ipcMessage.error}`);
             } else {
-                if (!ipcMessage.payload.ex_id) {
-                    logger.error('Error while loading assets, no ex_id in response from assets_loader');
-                }
-
                 const exId = ipcMessage.payload.ex_id;
 
                 if (!pendingWorkerRequests[exId]) {
@@ -243,40 +219,78 @@ module.exports = function module(context) {
                     // Clear this before processing just in case another request
                     // arrives before all workers allocate.
                     delete pendingWorkerRequests[exId];
-                    pending.forEach(_allocateWorkers);
-
-                    // need to update cluster_master immediately so it can balance workers correctly
-                    // and prevent wrong allocations
-                    const state = getNodeState();
-                    messaging.send({ to: 'cluster_master', message: 'node:state', node_id: state.node_id, payload: state });
+                    pending.forEach((pendingContext) => {
+                        _provisionProcesses(pendingContext.request, pendingContext.originalMessage);
+                    });
                 }
             }
         }
     });
 
-    function _allocateWorkers(request) {
-        const numOfCurrentWorkers = Object.keys(context.cluster.workers).length;
-
-        let workerCount = request.originalMessage.payload.workers;
-        const type = request.config.assignment === 'worker' ? 'workers' : request.config.assignment;
-        logger.info(`Attempting to allocate ${workerCount} ${type}.`);
-
-        // if there is an over allocation, send back rest to be enqueued
-        // TODO: confirm this check won't break things if triggered by execution_controller
-        if (configWorkerLimit < numOfCurrentWorkers + workerCount) {
-            workerCount = configWorkerLimit - numOfCurrentWorkers;
-
-            // mutative
-            request.workers -= workerCount;
-            messaging.send({ to: 'cluster_master', message: 'node:workers:over_allocated', payload: request.config });
-            logger.warn(`Worker allocation request would exceed maximum number of workers - ${configWorkerLimit}`);
-            logger.warn(`Reducing allocation to ${workerCount} workers.`);
+    // this fires when entire server will be shutdown
+    events.once('terafoundation:shutdown', () => {
+        const filterFn = () => context.cluster.workers;
+        const alreadySentShutdownMessage = true;
+        function actionCompleteFn() {
+            return getNodeState().active.length === 0;
         }
-        logger.trace(`starting ${workerCount} ${type}`, request.config.ex_id);
+        const stopTime = config.shutdown_timeout;
 
-        context.foundation.startWorkers(workerCount, request.config);
+        shutdownProcesses({}, stopTime, filterFn, actionCompleteFn, alreadySentShutdownMessage);
+    });
 
-        if (request.originalMessage) messaging.respond(request.originalMessage);
+    function _assetsExistForJob(jobStr) {
+        const job = typeof jobStr === 'string' ? JSON.parse(jobStr) : jobStr;
+
+        if (job.assets && job.assets.length > 0) {
+            // if not all assets are loaded, return false
+            if (!_.every(job.assets, assetId => existsSync(`${assetsDir}/${assetId}`))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function _provisionProcesses(request, originalMessage) {
+        if (request.assignment === 'execution_controller') {
+            context.foundation.startWorkers(1, request);
+            // need to update cluster_master immediately so it can balance workers correctly
+            // and prevent wrong allocations
+            const state = getNodeState();
+            messaging.send({ to: 'cluster_master', message: 'node:state', node_id: state.node_id, payload: state });
+        } else {
+            const numOfCurrentWorkers = Object.keys(context.cluster.workers).length;
+            let workerCount = originalMessage.payload.workers;
+            const type = request.assignment === 'worker' ? 'workers' : request.assignment;
+            logger.info(`Attempting to allocate ${workerCount} ${type}.`);
+
+            // if there is an over allocation, send back rest to be enqueued
+            if (configWorkerLimit < numOfCurrentWorkers + workerCount) {
+                workerCount = configWorkerLimit - numOfCurrentWorkers;
+
+                // mutative
+                originalMessage.workers = workerCount;
+                messaging.send({ to: 'cluster_master', message: 'node:workers:over_allocated', payload: originalMessage });
+                logger.warn(`Worker allocation request would exceed maximum number of workers - ${configWorkerLimit}`);
+                logger.warn(`Reducing allocation to ${workerCount} workers.`);
+            }
+
+            context.foundation.startWorkers(workerCount, request);
+        }
+        // respond that child processes where made
+        messaging.respond(originalMessage);
+    }
+
+    function _setupExecutionProcesses(request, originalMessage) {
+        // assets already exist, provision workers/execution_controllers
+        if (_assetsExistForJob(request.job)) {
+            _provisionProcesses(request, originalMessage);
+        } else {
+            // Queue the worker request until after assets have completed loading.
+            const sourceMsg = originalMessage.payload;
+            _queueWorkerRequest(originalMessage, request);
+            _loadAssets(sourceMsg.job, sourceMsg.ex_id);
+        }
     }
 
     function _queueWorkerRequest(originalMessage, request) {
@@ -286,7 +300,7 @@ module.exports = function module(context) {
         }
 
         pendingWorkerRequests[request.ex_id].pending.push({
-            config: request,
+            request,
             originalMessage
         });
     }

--- a/lib/cluster/runners/execution.js
+++ b/lib/cluster/runners/execution.js
@@ -34,19 +34,14 @@ module.exports = function module(context) {
 
     function _instantiateJob() {
         let slicer = null;
-        const reporter = null;
         let queue = [];
 
-        if (context.sysconfig.teraslice.reporter) {
-            throw new Error('reporters are not functional at this time, please do not set one in the configuration');
-        }
         // TODO fix released api
         function executionApi() {
             return {
                 reader: queue[0],
                 queue,
                 config: execution,
-                reporter,
                 slicer
             };
         }
@@ -78,53 +73,8 @@ module.exports = function module(context) {
             });
     }
 
-    function initialize(events, logger) {
-        return new Promise(((resolve, reject) => {
-            let gettingJob = true;
-            let gettingJobInterval;
-
-            events.on('execution:assets_loaded', (ipcMessage) => {
-                if (ipcMessage.error) {
-                    logger.error(`Error while loading assets, error: ${ipcMessage.error}`);
-                    events.removeAllListeners('execution:assets_loaded');
-                    reject(ipcMessage.error);
-                } else {
-                    gettingJobInterval = setInterval(() => {
-                        if (!gettingJob) {
-                            gettingJob = true;
-                            Promise.resolve(_instantiateJob())
-                                .then((jobInstance) => {
-                                    clearInterval(gettingJobInterval);
-                                    events.removeAllListeners('execution:assets_loaded');
-                                    resolve(jobInstance);
-                                })
-                                .catch((err) => {
-                                    clearInterval(gettingJobInterval);
-                                    events.removeAllListeners('execution:assets_loaded');
-                                    logger.error('error initializing execution after loading assets', err.message);
-                                    reject(err.message);
-                                });
-                        }
-                    }, 100);
-                }
-            });
-
-            Promise.resolve(_instantiateJob())
-                .then((jobInstance) => {
-                    events.removeAllListeners('execution:assets_loaded');
-                    clearInterval(gettingJobInterval);
-                    resolve(jobInstance);
-                })
-                .catch((err) => {
-                    // if this errors, then we will wait for the events to fire to start job
-                    if (!needAssets) {
-                        // error out if there are no assets and job cannot initialize straight away
-                        reject(parseError(err));
-                    } else {
-                        gettingJob = false;
-                    }
-                });
-        }));
+    function initialize() {
+        return _instantiateJob();
     }
 
     function getMemoryUsage() {

--- a/lib/cluster/runners/execution.js
+++ b/lib/cluster/runners/execution.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Promise = require('bluebird');
-const parseError = require('error_parser');
 const moment = require('moment');
 
 /*
@@ -11,7 +10,6 @@ module.exports = function module(context) {
     const opRunner = require('./op')(context);
     let isSlicer = process.env.assignment === 'execution_controller';
     let execution = _parseJob(process.env.job);
-    let needAssets = execution.assets && execution.assets.length > 0;
     let assetPath = execution.assets ? context.sysconfig.teraslice.assets_directory : null;
     let jobAssets = execution.assets ? execution.assets : [];
 
@@ -134,7 +132,7 @@ module.exports = function module(context) {
 
         isSlicer = process.env.assignment === 'execution_controller';
         execution = _parseJob(process.env.job);
-        needAssets = execution.assets && execution.assets.length > 0;
+
         assetPath = execution.assets ? context.sysconfig.teraslice.assets_directory : null;
         jobAssets = execution.assets ? execution.assets : [];
 

--- a/lib/cluster/runners/execution.js
+++ b/lib/cluster/runners/execution.js
@@ -9,6 +9,7 @@ const moment = require('moment');
 module.exports = function module(context) {
     const opRunner = require('./op')(context);
     let isSlicer = process.env.assignment === 'execution_controller';
+
     let execution = _parseJob(process.env.job);
     let assetPath = execution.assets ? context.sysconfig.teraslice.assets_directory : null;
     let jobAssets = execution.assets ? execution.assets : [];

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -100,9 +100,7 @@ const assetServiceMessages = {
 
 // This deals with messages to workers and slicers of a given execution
 const executionMessages = {
-    ipc: {
-        // 'assets:loaded': 'assets:loaded',
-    },
+    ipc: {},
     network: {}
 };
 

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -31,7 +31,8 @@ const clusterMasterMessages = {
 const nodeMasterMessages = {
     ipc: {
         'cluster:error:terminal': 'cluster:error:terminal',
-        'child:exit': 'exit'
+        'child:exit': 'exit',
+        'assets:loaded': 'assets:loaded',
     },
     intraProcess: {
         'network:connect': 'connect',
@@ -100,7 +101,7 @@ const assetServiceMessages = {
 // This deals with messages to workers and slicers of a given execution
 const executionMessages = {
     ipc: {
-        'assets:loaded': 'assets:loaded',
+        // 'assets:loaded': 'assets:loaded',
     },
     network: {}
 };
@@ -138,7 +139,7 @@ const routing = {
     node_master: { cluster_process: 'ipc', cluster_master: 'network', execution_controller: 'ipc', worker: 'ipc', assets_loader: 'ipc', execution: 'ipc' },
     execution_controller: { worker: 'network', cluster_master: 'ipc', node_master: 'ipc' },
     worker: { execution_controller: 'network', cluster_master: 'ipc', node_master: 'ipc' },
-    assets_loader: { execution: 'ipc', cluster_master: 'ipc' },
+    assets_loader: { execution: 'ipc', cluster_master: 'ipc', node_master: 'ipc' },
     assets_service: { cluster_master: 'ipc' }
 };
 

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -37,6 +37,7 @@ const nodeMasterMessages = {
         'network:connect': 'connect',
         'network:disconnect': 'disconnect',
         'network:error': 'error',
+        'worker:online': 'worker:online'
     },
     network: {
         'cluster:execution_controller:create': 'cluster:execution_controller:create',
@@ -101,6 +102,12 @@ const executionMessages = {
     ipc: {
         'assets:loaded': 'assets:loaded',
     },
+    network: {}
+};
+
+// Currently does not receive any messages.
+const assetLoaderMessages = {
+    ipc: {},
     network: {}
 };
 
@@ -451,6 +458,7 @@ module.exports = function messaging(context, logger, childHookFn) {
         if (type === 'execution_controller') return slicerMessages;
         if (type === 'worker') return workerMessages;
         if (type === 'assets_service') return assetServiceMessages;
+        if (type === 'assets_loader') return assetLoaderMessages;
         return new Error(`could not find message model for type: ${type}`);
     }
 

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -141,7 +141,7 @@ const routing = {
     assets_service: { cluster_master: 'ipc' }
 };
 
-module.exports = function messaging(context, logger, childHookFn) {
+module.exports = function messaging(context, logger) {
     const networkConfig = { reconnect: true };
     const functionMapping = {};
     const config = makeConfigurations();
@@ -152,6 +152,7 @@ module.exports = function messaging(context, logger, childHookFn) {
     const self = config.assignment;
     const selfMessages = getMessages(self);
 
+    let childHookFn;
     let processContext;
     let io;
 
@@ -468,6 +469,10 @@ module.exports = function messaging(context, logger, childHookFn) {
         return null;
     }
 
+    function registerChildOnlineHook(fn){
+        childHookFn = fn;
+    }
+
     function getClientCounts() {
         if (io) {
             return io.eio.clientsCount;
@@ -514,6 +519,7 @@ module.exports = function messaging(context, logger, childHookFn) {
         getClientCounts,
         send,
         respond,
-        broadcast
+        broadcast,
+        registerChildOnlineHook
     };
 };

--- a/lib/cluster/worker/executor.js
+++ b/lib/cluster/worker/executor.js
@@ -29,6 +29,9 @@ module.exports = function module(context, messaging, executionRunner, stateStore
     // this will be used to keep track of the previously sent message just in case of a disconnect
     let sentMessage = false;
 
+    // TODO: consider if this message is named correctly. It has kind of morphed
+    // into something more like execution:prepared since it will fire even if
+    // there are no assets on the job.
     messaging.register({
         event: 'assets:loaded',
         callback: (ipcMessage) => {
@@ -259,7 +262,7 @@ module.exports = function module(context, messaging, executionRunner, stateStore
         const recycleWorkerRandomFactor = _.random(75, 100);
         let sliceCount = 0;
 
-        return function (sentMsg) {
+        return function cycle(sentMsg) {
             if (recycleWorker) {
                 sliceCount += 1;
                 // recycle worker between 75% and 100% of executionContext.config.recycle_worker

--- a/lib/cluster/worker/executor.js
+++ b/lib/cluster/worker/executor.js
@@ -29,32 +29,21 @@ module.exports = function module(context, messaging, executionRunner, stateStore
     // this will be used to keep track of the previously sent message just in case of a disconnect
     let sentMessage = false;
 
-    // TODO: consider if this message is named correctly. It has kind of morphed
-    // into something more like execution:prepared since it will fire even if
-    // there are no assets on the job.
-    messaging.register({
-        event: 'assets:loaded',
-        callback: (ipcMessage) => {
-            if (ipcMessage.error) {
-                logger.error(`Error while loading assets, error: ${ipcMessage.error}`);
+    function run() {
+        executionRunner.initialize()
+            .then((exContext) => {
+                executionContext = exContext;
+                recycle = _recycleFn();
+                // Now that we have a valid execution context we can
+                // start listening for work.
+                messaging.listen();
+                logger.info(`worker ${ID} is online, communicating with host: ${messaging.getHostUrl()}`);
+            })
+            .catch((err) => {
+                logger.error('error initializing execution', err.message);
                 shutdown();
-            } else if (!executionContext) {
-                executionRunner.initialize()
-                    .then((exContext) => {
-                        executionContext = exContext;
-                        recycle = _recycleFn();
-                        // Now that we have a valid execution context we can
-                        // start listening for work.
-                        messaging.listen();
-                        logger.info(`worker ${ID} is online, communicating with host: ${messaging.getHostUrl()}`);
-                    })
-                    .catch((err) => {
-                        logger.error('error initializing execution', err.message);
-                        shutdown();
-                    });
-            }
-        }
-    });
+            });
+    }
 
     messaging.register({
         event: 'slicer:slice:new',
@@ -307,6 +296,7 @@ module.exports = function module(context, messaging, executionRunner, stateStore
 
     return {
         shutdown,
+        run,
         __test_context: testContext
     };
 };

--- a/lib/cluster/worker/executor.js
+++ b/lib/cluster/worker/executor.js
@@ -4,17 +4,17 @@ const _ = require('lodash');
 const parseError = require('error_parser');
 const Promise = require('bluebird');
 
-module.exports = function module(context, messaging, executionContext, stateStore, analyticsStore) {
+module.exports = function module(context, messaging, executionRunner, stateStore, analyticsStore) {
     const events = context.apis.foundation.getSystemEvents();
     const config = context.sysconfig.teraslice;
-    const cluster = context.cluster;
+
+    // This will be filled in by the runner.
+    let executionContext;
+    let recycle;
+
     let exId = process.env.ex_id;
     let jobId = process.env.job_id;
-    const ID = `${context.sysconfig.teraslice.hostname}__${cluster.worker.id}`;
-    const queue = executionContext.queue;
-
-    const recycle = _recycleFn();
-    const host = messaging.getHostUrl();
+    const ID = `${context.sysconfig.teraslice.hostname}__${context.cluster.worker.id}`;
 
     const logger = context.apis.foundation.makeLogger({
         ex_id: exId,
@@ -29,10 +29,28 @@ module.exports = function module(context, messaging, executionContext, stateStor
     // this will be used to keep track of the previously sent message just in case of a disconnect
     let sentMessage = false;
 
-
     messaging.register({
         event: 'assets:loaded',
-        callback: ipcMessage => events.emit('execution:assets_loaded', ipcMessage)
+        callback: (ipcMessage) => {
+            if (ipcMessage.error) {
+                logger.error(`Error while loading assets, error: ${ipcMessage.error}`);
+                shutdown();
+            } else if (!executionContext) {
+                executionRunner.initialize()
+                    .then((exContext) => {
+                        executionContext = exContext;
+                        recycle = _recycleFn();
+                        // Now that we have a valid execution context we can
+                        // start listening for work.
+                        messaging.listen();
+                        logger.info(`worker ${ID} is online, communicating with host: ${messaging.getHostUrl()}`);
+                    })
+                    .catch((err) => {
+                        logger.error('error initializing execution', err.message);
+                        shutdown();
+                    });
+            }
+        }
     });
 
     messaging.register({
@@ -99,9 +117,6 @@ module.exports = function module(context, messaging, executionContext, stateStor
         }
     });
 
-    messaging.listen();
-    logger.info(`worker ${ID} is online, communicating with host: ${host}`);
-
     function _sliceCompleted(sliceResults, sliceMetaData, slice, specData, sliceLogger) {
         // resultResponse may need to be checked in later functionality
         return stateStore.updateState(sliceMetaData, 'completed')
@@ -146,12 +161,12 @@ module.exports = function module(context, messaging, executionContext, stateStor
             slice_id: slice.slice_id
         });
 
-        let operations = queue;
+        let operations = executionContext.queue;
         let specData;
 
         if (executionContext.config.analytics) {
             specData = { time: [], size: [], memory: [] };
-            operations = queue.map(fn => fn.bind(null, specData));
+            operations = operations.map(fn => fn.bind(null, specData));
         }
         const retrySliceFn = _retrySliceModule(slice, operations, sliceLogger, specData);
 

--- a/lib/cluster/worker/executor.js
+++ b/lib/cluster/worker/executor.js
@@ -30,7 +30,7 @@ module.exports = function module(context, messaging, executionRunner, stateStore
     let sentMessage = false;
 
     function run() {
-        executionRunner.initialize()
+        return executionRunner.initialize()
             .then((exContext) => {
                 executionContext = exContext;
                 recycle = _recycleFn();
@@ -41,7 +41,7 @@ module.exports = function module(context, messaging, executionRunner, stateStore
             })
             .catch((err) => {
                 logger.error('error initializing execution', err.message);
-                shutdown();
+                return Promise.reject(`error initializing execution: ${err.message}`);
             });
     }
 

--- a/lib/cluster/worker/index.js
+++ b/lib/cluster/worker/index.js
@@ -40,14 +40,18 @@ module.exports = function module(context) {
         // assets store is loaded so it can register under context.apis
         return Promise.resolve(require('../storage/assets')(context))
             .then(() => Promise.all([
-                executionRunner.initialize(events, logger),
                 require('../storage/state')(context),
                 require('../storage/analytics')(context)
             ]))
-            .spread((executionContext, _stateStore, _analyticsStore) => {
+            .spread((_stateStore, _analyticsStore) => {
                 stateStore = _stateStore;
                 analyticsStore = _analyticsStore;
-                executor = require('./executor')(context, messaging, executionContext, stateStore, analyticsStore);
+                executor = require('./executor')(context, messaging,
+                    executionRunner, stateStore, analyticsStore);
+
+console.log("Attempting to send message from worker")
+                // TODO: this may need to be more formally synched with the executor init.
+                messaging.send({ to: 'node_master', message: 'worker:online', ex_id: exId });
             })
             .catch((err) => {
                 const errMsg = `worker: ${ID} could not instantiate for execution: ${exId}, error: ${parseError(err)}`;

--- a/lib/cluster/worker/index.js
+++ b/lib/cluster/worker/index.js
@@ -49,7 +49,7 @@ module.exports = function module(context) {
                 executor = require('./executor')(context, messaging,
                     executionRunner, stateStore, analyticsStore);
                 executor.run();
-                
+
                 // TODO: this may need to be more formally synched with the executor init.
                 messaging.send({ to: 'node_master', message: 'worker:online', ex_id: exId });
             })

--- a/lib/cluster/worker/index.js
+++ b/lib/cluster/worker/index.js
@@ -48,10 +48,10 @@ module.exports = function module(context) {
                 analyticsStore = _analyticsStore;
                 executor = require('./executor')(context, messaging,
                     executionRunner, stateStore, analyticsStore);
-                executor.run();
-
-                // TODO: this may need to be more formally synched with the executor init.
-                messaging.send({ to: 'node_master', message: 'worker:online', ex_id: exId });
+                return executor.run()
+                    .then(() => {
+                        messaging.send({ to: 'node_master', message: 'worker:online', ex_id: exId });
+                    });
             })
             .catch((err) => {
                 const errMsg = `worker: ${ID} could not instantiate for execution: ${exId}, error: ${parseError(err)}`;

--- a/lib/cluster/worker/index.js
+++ b/lib/cluster/worker/index.js
@@ -49,7 +49,6 @@ module.exports = function module(context) {
                 executor = require('./executor')(context, messaging,
                     executionRunner, stateStore, analyticsStore);
 
-console.log("Attempting to send message from worker")
                 // TODO: this may need to be more formally synched with the executor init.
                 messaging.send({ to: 'node_master', message: 'worker:online', ex_id: exId });
             })

--- a/lib/cluster/worker/index.js
+++ b/lib/cluster/worker/index.js
@@ -48,7 +48,8 @@ module.exports = function module(context) {
                 analyticsStore = _analyticsStore;
                 executor = require('./executor')(context, messaging,
                     executionRunner, stateStore, analyticsStore);
-
+                executor.run();
+                
                 // TODO: this may need to be more formally synched with the executor init.
                 messaging.send({ to: 'node_master', message: 'worker:online', ex_id: exId });
             })

--- a/spec/runners/execution-spec.js
+++ b/spec/runners/execution-spec.js
@@ -120,11 +120,13 @@ describe('execution runner', () => {
         executionRunner.initialize(eventEmitter, logger)
             .catch((err) => {
                 expect(err).toBeDefined();
-                expect(typeof err).toEqual('string');
+                expect(err.message).toContain('Could not retrieve code');
             })
             .finally(done);
     });
 
+    /* This capability has been moved to the node_master.
+    TODO: see if these tests can be repurposed there.
     it('execution_controller can wait for an asset while initializing', (done) => {
         const assetjob = {
             assets: [assetId],
@@ -158,6 +160,7 @@ describe('execution runner', () => {
             .finally(done);
     });
 
+
     it('worker can wait for an asset while initializing', (done) => {
         const assetjob = {
             assets: [assetId],
@@ -179,6 +182,7 @@ describe('execution runner', () => {
             .catch(fail)
             .finally(done);
     });
+
 
     it('can fail if downloading asset failed', (done) => {
         const assetjob = {
@@ -204,7 +208,7 @@ describe('execution runner', () => {
             })
             .finally(done);
     });
-
+    */
 
     it('can instantiate an execution', (done) => {
         const exRunnerSlicer = executionCode(context).__test_context(context, tempProcess);
@@ -314,4 +318,3 @@ describe('execution runner', () => {
 
     });
 });
-


### PR DESCRIPTION
Current status
 * Appears to work but needs more testing to verify the benefit
 * Integration tests will pass but have been really flaky.
 * Unit tests do NOT pass yet
 * Still more cleanup of debug messages and commented code required.

The goal of this PR is to explicitly sequence the loading of assets with startup of the slicer and workers. This removes any timers or intervals from the startup sequence for the job. The slicer and worker will not start running until the preliminary setup is complete. 

The availability of the slicer and worker are now tied to the firing of the `asset:loaded` event and that event will fire whether there are assets on the job or not. We should probably consider renaming that event since it's more like `execution:prepared` or something now.

This change was largely prompted by the asset related logic in the execution runner which just didn't make any sense to me. Since we're going to be adding a new runner for streaming seemed a good time to clean this up.

@jsnoble please look this over and let me know if it looks like the approach will break something.