### PR TITLE
k8s cluster master fix

### DIFF
--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -377,7 +377,8 @@ module.exports = function module(context) {
         });
     }
 
-    if (context.sysconfig.teraslice.cluster_manager_type === 'kubernetes') {
+    if (context.sysconfig.teraslice.cluster_manager_type === 'kubernetes'
+        && !context.sysconfig.teraslice.master) {
         const workerType = process.env.node_type;
         const jobStr = process.env.EX;
         let ex;


### PR DESCRIPTION
The k8s cluster_master should be able to start up without requiring an EX.