### PR TITLE
executions will be marked as terminated in native cluster master on s…

### DIFF
--- a/lib/cluster/services/execution.js
+++ b/lib/cluster/services/execution.js
@@ -59,20 +59,28 @@ module.exports = function module(context) {
         return clusterService.allocateSlicer(execution, recoverExecution);
     }
 
-    function shutdown() {
-        logger.info('shutting down');
-        const query = exStore.getLivingStatuses().map(str => `_status:${str}`).join(' OR ');
-        return searchExecutionContexts(query)
-            .map((execution) => {
-                if (context.sysconfig.teraslice.cluster_manager_type === 'native') {
+    function terminateExecutions(type, isStartup) {
+        if (context.sysconfig.teraslice.cluster_manager_type === 'native') {
+            const method = type === 'running' ? 'getRunningStatuses' : 'getLivingStatuses';
+            const query = exStore[method]().map(str => `_status:${str}`).join(' OR ');
+            return searchExecutionContexts(query)
+                .map((execution) => {
                     logger.warn(`marking execution ex_id: ${execution.ex_id}, job_id: ${execution.job_id} as terminated`);
+                    if (isStartup) {
+                        return setExecutionStatus(execution.ex_id, 'terminated');
+                    }
                     // need to exclude sending a stop to cluster master host, the shutdown event
                     // has already been propagated this can cause a condition of it waiting for
                     // stop to return but it already has which pauses this service shutdown
                     return stopExecution(execution.ex_id, null, 'terminated', context.sysconfig.teraslice.hostname);
-                }
-                return true;
-            })
+                });
+        }
+        return Promise.resolve(true);
+    }
+
+    function shutdown() {
+        logger.info('shutting down');
+        terminateExecutions('living', false)
             .then(() => exStore.shutdown())
             .catch((err) => {
                 const errMsg = parseError(err);
@@ -270,17 +278,7 @@ module.exports = function module(context) {
     }
 
     function _initialize() {
-        // Reschedule any persistent jobs that were running.
-        // There may be some additional subtlety required here.
-        return searchExecutionContexts('running').each((execution) => {
-            // For this restarting to work correctly we need to check the job on the running
-            // cluster to make sure it's not still running after a cluster_master restart.
-            if (execution.lifecycle === 'persistent') {
-                // pendingExecutionQueue.enqueue(job);
-            } else {
-                // _setExecutionStatus(job.ex_id, 'aborted');
-            }
-        })
+        return terminateExecutions('running', true)
             .then(() =>
                 // Loads the initial pending jobs queue from storage.
                 // the limit for retrieving pending jobs is 10000


### PR DESCRIPTION
…tartup resolves #697 
In native mode cluster master will look for executions that are in an active status (ie 'running', 'failing', 'paused', 'moderator_paused') and then mark them as terminated on startup

- [ ] Need to handle behavior when cluster master crashes and job is till up and functional assuming the shutdown was never called