### PR TITLE
A proposal for eslint changes to catch errors and handle ES6 better

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,10 @@
     "extends": "airbnb",
     "parserOptions": {
         "ecmaVersion": 6,
-        "sourceType": "script"
+        "sourceType": "script",
+        "ecmaFeatures": {
+            "experimentalObjectRestSpread": true
+        }
     },
     "env": {
         "node": true,
@@ -18,6 +21,12 @@
         "strict": ["error", "global"],
         "comma-dangle": "off",
         "prefer-promise-reject-errors": "off",
-        "no-restricted-globals": ["error", "isFinite"]
+        "no-restricted-globals": ["error", "isFinite"],
+        "func-names": ["error", "as-needed"],
+        "semi-spacing": "error",
+        "rest-spread-spacing": ["error"],
+        "no-path-concat": "error",
+        "no-debugger": "error",
+        "handle-callback-err": ["error", "error"]
     }
 }


### PR DESCRIPTION
Since we are slowing updating teraslice and our other projects to follow our eslint rules, I believe now is a good time to add a few rules that improve our ability to catch errors before they happen. I also think it is important that our eslint is upgraded to better support changes in ES6. All of these change are what I would consider a "patch" release to our eslint rules.

I propose adding the following to catch errors before they happen:

- [handle-callback-err](https://eslint.org/docs/rules/handle-callback-err)
    - Ignorance is not bliss when it comes errors
- [no-debugger](https://eslint.org/docs/rules/no-debugger)
    - Debugger statements can decrease performance and should not be left in the code
- [no-path-concat](https://eslint.org/docs/rules/no-path-concat)
    - Using string concatenation for paths can lead to cross-platform issues because of path separators

I propose adding the following rules to have consistent spacing and improve `--fix`:

- [rest-spread-spacing](https://eslint.org/docs/rules/rest-spread-spacing)
    - This rule will help more consistent ES6 styling
- [semi-spacing](https://eslint.org/docs/rules/semi-spacing)
    - This rule is already a practice we use, so let's enforce it

I propose changing the following rules:

- [func-names](https://eslint.org/docs/rules/func-names)
    - This should set `"func-names": ["error", "as-needed"]` in order to better support ES6
    > ECMAScript 6 introduced a name property on all functions. The value of name is determined by evaluating the code around the function to see if a name can be inferred. For example, a function assigned to a variable will automatically have a name property equal to the name of the variable. The value of name is then used in stack traces for easier debugging.

I am also curious about the reasoning behind the `"prefer-promise-reject-errors": "off"` exists?
