### PR TITLE
[WIP] Worker and execution overallocation issues, resolves #739

### DIFF
--- a/lib/cluster/assets_loader.js
+++ b/lib/cluster/assets_loader.js
@@ -42,13 +42,11 @@ module.exports = function assetLoader(context) {
                 Promise.resolve()
                     .then(logger.flush)
                     .finally(() => {
-                        setTimeout(() => {
-                            if (shutdownError) {
-                                logger.error(shutdownError);
-                                process.exit(1);
-                            }
-                            process.exit(0);
-                        }, 10);
+                        if (shutdownError) {
+                            logger.error(shutdownError);
+                            process.exit(1);
+                        }
+                        process.exit(0);
                     });
             } else {
                 if (counter % 6000 === 0) {

--- a/lib/cluster/assets_loader.js
+++ b/lib/cluster/assets_loader.js
@@ -14,9 +14,10 @@ module.exports = function assetLoader(context) {
     const config = context.sysconfig.teraslice;
     let isDone = false;
     let shutdownCalled = false;
+    let shutdownError = null;
 
     messaging.register({ event: 'worker:shutdown', callback: shutdown });
-
+    const { preload } = process.env;
     const job = JSON.parse(process.env.job);
     const exId = job.ex_id;
 
@@ -27,14 +28,28 @@ module.exports = function assetLoader(context) {
             if (isDone || counter <= 0) {
                 clearInterval(shutDownInterval);
                 if (counter <= 0) {
-                    logger.error(`shut down time limit has been reached, asset_loader for execution ${exId} will exit while its loading assets ${JSON.stringify(job.assets)}`);
+                    if (preload) {
+                        shutdownError = new Error(`shut down time limit has been reached, asset_loader for execution ${exId} will exit while its loading assets ${JSON.stringify(job.assets)}`);
+                    } else {
+                        shutdownError = new Error(`shut down time limit has been reached, asset_loader during preloading will exit while its loading assets ${JSON.stringify(job.assets)}`);
+                    }
+                } else if (preload) {
+                    logger.info('asset_loader has finished preloading');
                 } else {
                     logger.info(`asset_loader for execution ${exId} has finished loading`);
                 }
 
                 Promise.resolve()
                     .then(logger.flush)
-                    .finally(() => setTimeout(() => process.exit(0), 500));
+                    .finally(() => {
+                        setTimeout(() => {
+                            if (shutdownError) {
+                                logger.error(shutdownError);
+                                process.exit(1);
+                            }
+                            process.exit(0);
+                        }, 10);
+                    });
             } else {
                 if (counter % 6000 === 0) {
                     logger.warn(`shutdown sequence initiated, but is still processing. Will force shutdown in ${counter / 1000} seconds`);
@@ -74,13 +89,20 @@ module.exports = function assetLoader(context) {
     const respondingData = { __source: 'cluster_master', __msgId: msgId };
     Promise.resolve(require('./storage/assets')(context))
         .then(assetStore => loadAssets(assetStore, job.assets))
-        .then((assetArray) => {
-            logger.info(`finished loading assets ${assetArray.join(', ')} for execution: ${exId} on node ${context.sysconfig._nodeName}`);
-            if (process.env.preload) {
-                messaging.respond(respondingData, { message: 'assets:preloaded', meta: assetArray });
+        .then((assetsResponse) => {
+            if (preload) {
+                messaging.respond(respondingData, {
+                    message: 'assets:preloaded',
+                    meta: assetsResponse
+                });
             } else {
+                const assetsMsg = JSON.stringify(assetsResponse);
+                logger.info(`finished loading assets ${assetsMsg} for execution: ${exId} on node ${context.sysconfig._nodeName}`);
                 messaging.send({
-                    to: 'execution', message: 'assets:loaded', ex_id: exId, meta: assetArray
+                    to: 'execution',
+                    message: 'assets:loaded',
+                    ex_id: exId,
+                    meta: assetsResponse
                 });
             }
         })
@@ -89,9 +111,10 @@ module.exports = function assetLoader(context) {
             if (errMsg === 'Not Found') {
                 errMsg = 'One of the assets provided was not found';
             }
-            logger.error(`error loading assets ${JSON.stringify(job.assets)}, error: ${errMsg}`);
+            shutdownError = new Error(`error loading assets ${JSON.stringify(job.assets)}, error: ${errMsg}`);
+            logger.error(shutdownError);
             // error not found first appears when job is submitted
-            if (process.env.preload) {
+            if (preload) {
                 messaging.respond(respondingData, { message: 'assets:preloaded', error: errMsg });
             } else {
                 messaging.send({

--- a/lib/cluster/cluster_master.js
+++ b/lib/cluster/cluster_master.js
@@ -6,15 +6,18 @@ const messageModule = require('./services/messaging');
 const _ = require('lodash');
 const http = require('http');
 const express = require('express');
+const parseError = require('@terascope/error-parser');
 
 module.exports = function clusterMaster(context) {
     const events = context.apis.foundation.getSystemEvents();
     const logger = context.apis.foundation.makeLogger({ module: 'cluster_master' });
     const clusterConfig = context.sysconfig.teraslice;
-    const parseError = require('@terascope/error-parser');
 
     // Initialize the HTTP service for handling incoming requests.
     const app = express();
+
+    logger.debug('creating cluster_master port');
+
     // we do this to override express final response handler
     const server = http.createServer((req, res) => {
         app(req, res, (err) => {
@@ -25,10 +28,17 @@ module.exports = function clusterMaster(context) {
             res.statusCode = 500;
             res.end(JSON.stringify({ error: 'api is not available' }));
         });
-    }).listen(clusterConfig.port);
+    }).listen(clusterConfig.port, (connectError) => {
+        if (connectError) {
+            logger.error(connectError);
+            process.exit(1);
+        }
+
+        logger.info(`listening on port ${clusterConfig.port}`);
+    });
+
     // setting request timeout to 5 minutes
     server.timeout = 300000;
-    logger.info(`listening on port ${clusterConfig.port}`);
 
     const messaging = messageModule(context, logger);
     context.messaging = messaging;
@@ -72,13 +82,15 @@ module.exports = function clusterMaster(context) {
         messaging.register({
             event: 'assets:service:available',
             callback: () => {
+                logger.debug('asset service available');
                 assetsServiceIsReady = true;
             }
         });
 
         messaging.register({
             event: 'assets:service:unavailable',
-            callback: (error) => {
+            callback: ({ error }) => {
+                logger.error('asset service unavailable', error);
                 assetsServiceIsReady = false;
                 assetsServiceError = error;
             }
@@ -95,15 +107,18 @@ module.exports = function clusterMaster(context) {
                     }
                     if (assetsServiceError) {
                         clearInterval(assetReady);
-                        reject('An error occurred while instantiating the assets service');
+                        reject(`An error occurred while instantiating the assets service: ${assetsServiceError}`);
                     }
                 }, 100);
             }
         }));
     }
     require('./services/execution.js')(context)
+        .then(clusterService =>
+            // connect and pass along the cluster service
+            messaging.listen({ server })
+                .then(() => clusterService))
         .then((clusterService) => {
-            messaging.listen({ server });
             logger.trace('cluster_service has instantiated');
             context.services.execution = clusterService;
             return require('./services/jobs')(context);

--- a/lib/cluster/cluster_master.js
+++ b/lib/cluster/cluster_master.js
@@ -7,7 +7,7 @@ const _ = require('lodash');
 const http = require('http');
 const express = require('express');
 
-module.exports = function (context) {
+module.exports = function clusterMaster(context) {
     const events = context.apis.foundation.getSystemEvents();
     const logger = context.apis.foundation.makeLogger({ module: 'cluster_master' });
     const clusterConfig = context.sysconfig.teraslice;
@@ -18,7 +18,9 @@ module.exports = function (context) {
     // we do this to override express final response handler
     const server = http.createServer((req, res) => {
         app(req, res, (err) => {
-            if (err) console.log('what is this at all', err);
+            if (err) {
+                logger.warn('http service middleware error', err);
+            }
             res.setHeader('Content-Type', 'application/json');
             res.statusCode = 500;
             res.end(JSON.stringify({ error: 'api is not available' }));
@@ -57,7 +59,7 @@ module.exports = function (context) {
                     const errMsg = parseError(err);
                     logger.error(`Error while cluster_master shutting down, error: ${errMsg}`);
                     setTimeout(() => {
-                        process.exit(0);
+                        process.exit(1);
                     }, 10);
                 });
         }
@@ -69,14 +71,19 @@ module.exports = function (context) {
 
         messaging.register({
             event: 'assets:service:available',
-            callback: (assetServiceResponse) => {
-                if (assetServiceResponse.error) {
-                    assetsServiceError = true;
-                } else {
-                    assetsServiceIsReady = true;
-                }
+            callback: () => {
+                assetsServiceIsReady = true;
             }
         });
+
+        messaging.register({
+            event: 'assets:service:unavailable',
+            callback: (error) => {
+                assetsServiceIsReady = false;
+                assetsServiceError = error;
+            }
+        });
+
         return () => new Promise(((resolve, reject) => {
             if (assetsServiceIsReady) {
                 resolve(true);

--- a/lib/cluster/cluster_master.js
+++ b/lib/cluster/cluster_master.js
@@ -16,8 +16,6 @@ module.exports = function clusterMaster(context) {
     // Initialize the HTTP service for handling incoming requests.
     const app = express();
 
-    logger.debug('creating cluster_master port');
-
     // we do this to override express final response handler
     const server = http.createServer((req, res) => {
         app(req, res, (err) => {
@@ -63,14 +61,14 @@ module.exports = function clusterMaster(context) {
         callback: () => {
             logger.info('cluster_master is shutting down');
             Promise.all(_.map(context.services, service => service.shutdown()))
-                .then(() => logger.flush())
-                .then(() => process.exit())
+                .then(() => logger.flush().then(() => process.exit(0)))
                 .catch((err) => {
                     const errMsg = parseError(err);
                     logger.error(`Error while cluster_master shutting down, error: ${errMsg}`);
+                    logger.flush();
                     setTimeout(() => {
                         process.exit(1);
-                    }, 10);
+                    }, 100);
                 });
         }
     });

--- a/lib/cluster/execution_controller/engine.js
+++ b/lib/cluster/execution_controller/engine.js
@@ -7,6 +7,9 @@ const parseError = require('@terascope/error-parser');
 const moment = require('moment');
 const _ = require('lodash');
 const Promise = require('bluebird');
+const newExectionAnalytics = require('./execution_analytics');
+const newRecovery = require('./recovery');
+const newSlicerAnalytics = require('./slice_analytics');
 
 module.exports = function module(context, messaging, exStore, stateStore) {
     const start = moment();
@@ -322,15 +325,25 @@ module.exports = function module(context, messaging, exStore, stateStore) {
             engineFnRunning = false;
         };
 
-        // send message that execution is in running state
-        logger.info(`execution: ${exId} has initialized and is listening on port ${executionConfig.slicer_port}`);
-        exStore.setStatus(exId, 'running');
-        if (!executionAnalytics) executionAnalytics = require('./execution_analytics')(context, messaging);
-        if (!slicerAnalytics) slicerAnalytics = require('./slice_analytics')(context, executionContext);
-        _setQueueLength(executionContext);
-        if (!recovery) recovery = require('./recovery')(context, messaging, executionAnalytics, exStore, stateStore, executionContext);
+        return messaging.listen({ port: executionContext.slicer_port }).then(() => {
+            if (!executionAnalytics) executionAnalytics = newExectionAnalytics(context, messaging);
+            if (!slicerAnalytics) slicerAnalytics = newSlicerAnalytics(context, executionContext);
+            if (!recovery) {
+                recovery = newRecovery(
+                    context,
+                    messaging,
+                    executionAnalytics,
+                    exStore,
+                    stateStore,
+                    executionContext
+                );
+            }
 
-        messaging.listen({ port: executionContext.config.slicer_port }).then(() => {
+            // send message that execution is in running state
+            exStore.setStatus(exId, 'running');
+            _setQueueLength(executionContext);
+
+            logger.info(`execution: ${exId} has initialized and is listening on port ${executionConfig.slicer_port}`);
             // start the engine
             if (engineCanRun) {
                 logger.debug('starting the slicer engine');
@@ -338,12 +351,6 @@ module.exports = function module(context, messaging, exStore, stateStore) {
             }
 
             _startWorkerConnectionWatchDog();
-        }).catch((err) => {
-            logger.error(err);
-            logger.flush();
-            setImmediate(() => {
-                process.exit(1);
-            });
         });
     }
 

--- a/lib/cluster/execution_controller/engine.js
+++ b/lib/cluster/execution_controller/engine.js
@@ -330,15 +330,21 @@ module.exports = function module(context, messaging, exStore, stateStore) {
         _setQueueLength(executionContext);
         if (!recovery) recovery = require('./recovery')(context, messaging, executionAnalytics, exStore, stateStore, executionContext);
 
-        messaging.listen({ port: executionContext.config.slicer_port });
+        messaging.listen({ port: executionContext.config.slicer_port }).then(() => {
+            // start the engine
+            if (engineCanRun) {
+                logger.debug('starting the slicer engine');
+                engine = setInterval(engineFn, 1);
+            }
 
-        // start the engine
-        if (engineCanRun) {
-            logger.debug('starting the slicer engine');
-            engine = setInterval(engineFn, 1);
-        }
-
-        _startWorkerConnectionWatchDog();
+            _startWorkerConnectionWatchDog();
+        }).catch((err) => {
+            logger.error(err);
+            logger.flush();
+            setTimeout(() => {
+                process.exit(1);
+            }, 100);
+        });
     }
 
     function _allocateSlice(sliceRequest, slicerId, slicerOrder) {

--- a/lib/cluster/execution_controller/engine.js
+++ b/lib/cluster/execution_controller/engine.js
@@ -341,9 +341,9 @@ module.exports = function module(context, messaging, exStore, stateStore) {
         }).catch((err) => {
             logger.error(err);
             logger.flush();
-            setTimeout(() => {
+            setImmediate(() => {
                 process.exit(1);
-            }, 100);
+            });
         });
     }
 
@@ -361,6 +361,10 @@ module.exports = function module(context, messaging, exStore, stateStore) {
 
             stateStore.createState(exId, slice, 'start');
             logger.trace('enqueuing slice', slice);
+        }
+        if (slicerQueue.exists('slice_id', slice.slice_id)) {
+            logger.warn(`slice has already been enqueued ${slice.slice_id}`);
+            return;
         }
         slicerQueue.enqueue(slice);
     }

--- a/lib/cluster/execution_controller/engine.js
+++ b/lib/cluster/execution_controller/engine.js
@@ -324,8 +324,12 @@ module.exports = function module(context, messaging, exStore, stateStore) {
             }
             engineFnRunning = false;
         };
+        const slicerPort = executionConfig.slicer_port;
+        if (!slicerPort) {
+            return Promise.reject(new Error('Exection controller requires a slicer_port'));
+        }
 
-        return messaging.listen({ port: executionContext.slicer_port }).then(() => {
+        return messaging.listen({ port: slicerPort }).then(() => {
             if (!executionAnalytics) executionAnalytics = newExectionAnalytics(context, messaging);
             if (!slicerAnalytics) slicerAnalytics = newSlicerAnalytics(context, executionContext);
             if (!recovery) {
@@ -343,7 +347,7 @@ module.exports = function module(context, messaging, exStore, stateStore) {
             exStore.setStatus(exId, 'running');
             _setQueueLength(executionContext);
 
-            logger.info(`execution: ${exId} has initialized and is listening on port ${executionConfig.slicer_port}`);
+            logger.info(`execution: ${exId} has initialized and is listening on port ${slicerPort}`);
             // start the engine
             if (engineCanRun) {
                 logger.debug('starting the slicer engine');

--- a/lib/cluster/execution_controller/index.js
+++ b/lib/cluster/execution_controller/index.js
@@ -77,19 +77,16 @@ module.exports = function module(contextConfig) {
         if (engine) shutdownSequence.push(engine.shutdown());
 
         Promise.all(shutdownSequence)
-            .then(() => {
-                logger.flush();
-                setTimeout(() => {
-                    process.exit(0);
-                }, 10);
-            })
+            .then(() => logger.flush().then(() => {
+                process.exit(0);
+            }))
             .catch((err) => {
                 const errMsg = parseError(err);
                 logger.error(`Error while attempting to shutdown execution_controller ex_id: ${exId}, error: ${errMsg}`);
                 logger.flush();
                 setTimeout(() => {
                     process.exit(1);
-                }, 10);
+                }, 100);
             });
     }
 };

--- a/lib/cluster/execution_controller/index.js
+++ b/lib/cluster/execution_controller/index.js
@@ -77,12 +77,19 @@ module.exports = function module(contextConfig) {
         if (engine) shutdownSequence.push(engine.shutdown());
 
         Promise.all(shutdownSequence)
-            .then(logger.flush)
+            .then(() => {
+                logger.flush();
+                setTimeout(() => {
+                    process.exit(0);
+                }, 10);
+            })
             .catch((err) => {
                 const errMsg = parseError(err);
                 logger.error(`Error while attempting to shutdown execution_controller ex_id: ${exId}, error: ${errMsg}`);
-                return logger.flush();
-            })
-            .finally(process.exit);
+                logger.flush();
+                setTimeout(() => {
+                    process.exit(1);
+                }, 10);
+            });
     }
 };

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -143,6 +143,12 @@ module.exports = function module(context) {
                 logger.warn(`Worker allocation request would exceed maximum number of workers - ${configWorkerLimit}`);
                 logger.warn(`Reducing allocation to ${newWorkers} workers.`);
             }
+            if (!newWorkers) {
+                createWorkerRequest.error = `Unable to allocate enough 0 workers for ${createWorkerMsg.ex_id}.`;
+                logger.error(`Unable to allocate enough 0 workers for ${createWorkerMsg.ex_id}.`);
+                messaging.respond(createWorkerRequest);
+                return;
+            }
             logger.trace(`starting ${newWorkers} workers`, createWorkerMsg.ex_id);
 
             context.foundation.startWorkers(newWorkers, {

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -237,7 +237,7 @@ module.exports = function module(context) {
         callback: () => {
             logger.error('terminal error in cluster_master, flushing logs and shutting down');
             logger.flush()
-                .then(() => process.exit(1));
+                .then(() => setImmediate(() => { process.exit(1); }));
         }
     });
 
@@ -370,22 +370,22 @@ module.exports = function module(context) {
         .catch((err) => {
             logger.error(err);
             logger.flush();
-            setTimeout(() => {
+            setImmediate(() => {
                 process.exit(1);
-            }, 100);
+            });
         });
 
     if (context.sysconfig.teraslice.master) {
-        const assetsPort = systemPorts.getPort(true);
+        const assetsPort = systemPorts.getPort();
 
-        logger.debug(`node ${context.sysconfig._nodeName} is creating the cluster_master`);
+        logger.info(`node ${context.sysconfig._nodeName} is creating the cluster_master`);
         context.foundation.startWorkers(1, {
             assignment: 'cluster_master',
             assets_port: assetsPort,
             node_id: context.sysconfig._nodeName
         });
 
-        logger.debug(`node ${context.sysconfig._nodeName} is creating assets endpoint on port ${assetsPort}`);
+        logger.info(`node ${context.sysconfig._nodeName} is creating assets endpoint on port ${assetsPort}`);
         context.foundation.startWorkers(1, {
             assignment: 'assets_service',
             // key needs to be called port to bypass cluster port sharing
@@ -405,8 +405,9 @@ module.exports = function module(context) {
         } catch (err) {
             const errMsg = parseError(err);
             logger.error(`error while loading EX from enviroment, error: ${errMsg}`);
+            logger.flush();
             // give it time to log before exiting
-            setTimeout(() => process.exit(1), 100);
+            setImmediate(() => { process.exit(1); });
         }
 
         const needAssets = jobNeedsAssets(ex);

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -28,7 +28,10 @@ module.exports = function module(context) {
     const sendNodeState = _.debounce(() => {
         const state = getNodeState();
         messaging.send({
-            to: 'cluster_master', message: 'node:state', node_id: state.node_id, payload: state
+            to: 'cluster_master',
+            message: 'node:state',
+            node_id: state.node_id,
+            payload: state
         });
     }, 500, { leading: false, trailing: true });
 
@@ -363,7 +366,14 @@ module.exports = function module(context) {
         return state;
     }
 
-    messaging.listen();
+    messaging.listen()
+        .catch((err) => {
+            logger.error(err);
+            logger.flush();
+            setTimeout(() => {
+                process.exit(1);
+            }, 100);
+        });
 
     if (context.sysconfig.teraslice.master) {
         const assetsPort = systemPorts.getPort(true);

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -234,7 +234,7 @@ module.exports = function module(context) {
         event: 'cluster:node:get_port',
         callback: (msg) => {
             const port = systemPorts.getPort();
-            logger.info(`assigning port ${port} for new job`);
+            logger.info(`assigning port ${port} to worker ${msg.address} for new job`);
             messaging.respond(msg, { port });
         }
     });
@@ -383,7 +383,7 @@ module.exports = function module(context) {
         });
 
     if (context.sysconfig.teraslice.master) {
-        const assetsPort = systemPorts.getPort();
+        const assetsPort = systemPorts.getPort(true);
 
         logger.info(`node ${context.sysconfig._nodeName} is creating the cluster_master`);
         context.foundation.startWorkers(1, {

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -234,7 +234,7 @@ module.exports = function module(context) {
         callback: () => {
             logger.error('terminal error in cluster_master, flushing logs and shutting down');
             logger.flush()
-                .then(() => process.exit());
+                .then(() => process.exit(1));
         }
     });
 
@@ -313,6 +313,7 @@ module.exports = function module(context) {
             if (!preventEnqueing) {
                 portQueue.enqueue(port);
             }
+            logger.info('getting port', port);
             return port;
         }
 
@@ -395,7 +396,7 @@ module.exports = function module(context) {
             const errMsg = parseError(err);
             logger.error(`error while loading EX from enviroment, error: ${errMsg}`);
             // give it time to log before exiting
-            setTimeout(() => process.exit(), 100);
+            setTimeout(() => process.exit(1), 100);
         }
 
         const needAssets = jobNeedsAssets(ex);

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -144,7 +144,7 @@ module.exports = function module(context) {
                 logger.warn(`Reducing allocation to ${newWorkers} workers.`);
             }
             if (!newWorkers) {
-                const error = new Error(`Unable to allocate enough ${newWorkers} workers for ${createWorkerMsg.ex_id}.`);
+                const error = new Error(`Unable to allocate enough ${newWorkers} workers for ex_id: ${createWorkerMsg.ex_id}.`);
                 logger.error(error.message);
                 messaging.respond(createWorkerRequest, { error: error.message });
                 return;

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -144,9 +144,9 @@ module.exports = function module(context) {
                 logger.warn(`Reducing allocation to ${newWorkers} workers.`);
             }
             if (!newWorkers) {
-                createWorkerRequest.error = `Unable to allocate enough 0 workers for ${createWorkerMsg.ex_id}.`;
-                logger.error(`Unable to allocate enough 0 workers for ${createWorkerMsg.ex_id}.`);
-                messaging.respond(createWorkerRequest);
+                const error = new Error(`Unable to allocate enough ${newWorkers} workers for ${createWorkerMsg.ex_id}.`);
+                logger.error(error.message);
+                messaging.respond(createWorkerRequest, { error: error.message });
                 return;
             }
             logger.trace(`starting ${newWorkers} workers`, createWorkerMsg.ex_id);
@@ -233,8 +233,9 @@ module.exports = function module(context) {
     messaging.register({
         event: 'cluster:node:get_port',
         callback: (msg) => {
-            logger.debug(`assigning port ${msg.port} for new job`);
-            messaging.respond(msg, { port: systemPorts.getPort() });
+            const port = systemPorts.getPort();
+            logger.info(`assigning port ${port} for new job`);
+            messaging.respond(msg, { port });
         }
     });
 

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -243,8 +243,8 @@ module.exports = function module(context) {
         event: 'cluster:error:terminal',
         callback: () => {
             logger.error('terminal error in cluster_master, flushing logs and shutting down');
-            logger.flush()
-                .then(() => setImmediate(() => { process.exit(1); }));
+            logger.flush();
+            setTimeout(() => { process.exit(1); }, 100);
         }
     });
 
@@ -323,7 +323,6 @@ module.exports = function module(context) {
             if (!preventEnqueing) {
                 portQueue.enqueue(port);
             }
-            logger.info('getting port', port);
             return port;
         }
 
@@ -376,8 +375,7 @@ module.exports = function module(context) {
     messaging.listen()
         .catch((err) => {
             logger.error(err);
-            logger.flush();
-            setImmediate(() => {
+            logger.flush().then(() => {
                 process.exit(1);
             });
         });
@@ -385,14 +383,14 @@ module.exports = function module(context) {
     if (context.sysconfig.teraslice.master) {
         const assetsPort = systemPorts.getPort(true);
 
-        logger.info(`node ${context.sysconfig._nodeName} is creating the cluster_master`);
+        logger.debug(`node ${context.sysconfig._nodeName} is creating the cluster_master`);
         context.foundation.startWorkers(1, {
             assignment: 'cluster_master',
             assets_port: assetsPort,
             node_id: context.sysconfig._nodeName
         });
 
-        logger.info(`node ${context.sysconfig._nodeName} is creating assets endpoint on port ${assetsPort}`);
+        logger.debug(`node ${context.sysconfig._nodeName} is creating assets endpoint on port ${assetsPort}`);
         context.foundation.startWorkers(1, {
             assignment: 'assets_service',
             // key needs to be called port to bypass cluster port sharing
@@ -414,7 +412,8 @@ module.exports = function module(context) {
             logger.error(`error while loading EX from enviroment, error: ${errMsg}`);
             logger.flush();
             // give it time to log before exiting
-            setImmediate(() => { process.exit(1); });
+            setTimeout(() => { process.exit(1); }, 100);
+            return;
         }
 
         const needAssets = jobNeedsAssets(ex);

--- a/lib/cluster/services/assets.js
+++ b/lib/cluster/services/assets.js
@@ -17,6 +17,7 @@ module.exports = function module(context) {
         event: 'worker:shutdown',
         callback: () => {
             Promise.resolve(assetsStore.shutdown())
+                .then((() => logger.flush().then(() => process.exit(0)))
                 .catch((err) => {
                     const errMsg = parseError(err);
                     logger.error(`error while shutting down asset_service, error: ${errMsg}`);

--- a/lib/cluster/services/assets.js
+++ b/lib/cluster/services/assets.js
@@ -17,11 +17,11 @@ module.exports = function module(context) {
         event: 'worker:shutdown',
         callback: () => {
             Promise.resolve(assetsStore.shutdown())
-                .then(() => process.exit)
+                .then(() => process.exit(0))
                 .catch((err) => {
                     const errMsg = parseError(err);
                     logger.error(`error while shutting down asset_service, error: ${errMsg}`);
-                    setTimeout(() => process.exit(), 100);
+                    setTimeout(() => process.exit(1), 100);
                 });
         }
     });
@@ -99,18 +99,24 @@ module.exports = function module(context) {
     });
 
     Promise.resolve(require('../storage/assets')(context))
-        .then((store) => {
+        .then(store => new Promise((resolve, reject) => {
             assetsStore = store;
             const { port } = process.env;
-            logger.info(`assets_service is listening on port ${port}`);
-            app.listen(port);
-            messaging.send({ to: 'cluster_master', message: 'assets:service:available' });
-        })
+            app.listen(port, (err) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                logger.info(`assets_service is listening on port ${port}`);
+                messaging.send({ to: 'cluster_master', message: 'assets:service:available' });
+            });
+        }))
         .catch((err) => {
             const errMsg = parseError(err);
-            logger.error(`Error while creating assets_service, error: ${errMsg}`);
-            messaging.send({ to: 'cluster_master', message: 'assets:service:available', error: errMsg });
-            setTimeout(() => process.exit(0), 100);
+            const newError = new Error(`Error while creating assets_service, error: ${errMsg}`);
+            logger.error(newError);
+            messaging.send({ to: 'cluster_master', message: 'assets:service:unavailable', error: newError.message });
+            setTimeout(() => process.exit(1), 100);
         });
 
     function createAssetTable(query, req, res) {

--- a/lib/cluster/services/assets.js
+++ b/lib/cluster/services/assets.js
@@ -20,7 +20,10 @@ module.exports = function module(context) {
                 .catch((err) => {
                     const errMsg = parseError(err);
                     logger.error(`error while shutting down asset_service, error: ${errMsg}`);
-                    setImmediate(() => process.exit(1));
+                    logger.flush();
+                    setTimeout(() => {
+                        process.exit(1);
+                    }, 100);
                 });
         }
     });
@@ -116,6 +119,7 @@ module.exports = function module(context) {
             const newError = new Error(`Error while creating assets_service, error: ${errMsg}`);
             logger.error(newError);
             messaging.send({ to: 'cluster_master', message: 'assets:service:unavailable', error: newError.message });
+            logger.flush();
             setTimeout(() => process.exit(1), 100);
         });
 

--- a/lib/cluster/services/assets.js
+++ b/lib/cluster/services/assets.js
@@ -17,11 +17,10 @@ module.exports = function module(context) {
         event: 'worker:shutdown',
         callback: () => {
             Promise.resolve(assetsStore.shutdown())
-                .then(() => process.exit(0))
                 .catch((err) => {
                     const errMsg = parseError(err);
                     logger.error(`error while shutting down asset_service, error: ${errMsg}`);
-                    setTimeout(() => process.exit(1), 100);
+                    setImmediate(() => process.exit(1));
                 });
         }
     });
@@ -109,6 +108,7 @@ module.exports = function module(context) {
                 }
                 logger.info(`assets_service is listening on port ${port}`);
                 messaging.send({ to: 'cluster_master', message: 'assets:service:available' });
+                resolve();
             });
         }))
         .catch((err) => {

--- a/lib/cluster/services/assets.js
+++ b/lib/cluster/services/assets.js
@@ -17,7 +17,7 @@ module.exports = function module(context) {
         event: 'worker:shutdown',
         callback: () => {
             Promise.resolve(assetsStore.shutdown())
-                .then((() => logger.flush().then(() => process.exit(0)))
+                .then((() => logger.flush().then(() => process.exit(0))))
                 .catch((err) => {
                     const errMsg = parseError(err);
                     logger.error(`error while shutting down asset_service, error: ${errMsg}`);

--- a/lib/cluster/services/cluster/backends/native.js
+++ b/lib/cluster/services/cluster/backends/native.js
@@ -70,11 +70,7 @@ module.exports = function module(context, messaging, executionService) {
         event: 'node:workers:over_allocated',
         callback: (requestData) => {
             logger.debug('over-allocated workers, returning them to pending worker request queue');
-
-            // retry in a second to give the system time to handle errors
-            setTimeout(() => {
-                enqueueWork(requestData.payload);
-            }, 1000);
+            enqueueWork(requestData.payload);
         }
     });
 
@@ -311,11 +307,9 @@ module.exports = function module(context, messaging, executionService) {
         const exId = execution.ex_id;
         const jobId = execution.job_id;
         const jobStr = JSON.stringify(execution);
-        const sortedNodes = _.orderBy(clusterState, 'available', 'desc');
+        const sortedNodes = _.orderBy(getClusterState(), 'available', 'desc');
         let workersRequested = numOfWorkersRequested;
         let availWorkers = _availableWorkers(false, true);
-        logger.debug(`Finding ${numOfWorkersRequested} workers for ex_id: ${exId}, job_id: ${jobId}`);
-        logger.debug(`Available workers ${availWorkers} for ex_id: ${exId}, job_id: ${jobId}`);
 
         const dispatch = _makeDispatch();
 
@@ -373,11 +367,7 @@ module.exports = function module(context, messaging, executionService) {
                 .catch((err) => {
                     logger.error(err);
                     logger.error(`An error has occurred in allocating: ${workerCount} workers to node: ${nodeId}, the worker request has been enqueued`);
-
-                    // retry in a second to give the system time to handle errors
-                    setTimeout(() => {
-                        enqueueWork(requestedWorkersData);
-                    }, 1000);
+                    enqueueWork(requestedWorkersData);
                 }));
         });
 

--- a/lib/cluster/services/cluster/backends/native.js
+++ b/lib/cluster/services/cluster/backends/native.js
@@ -70,7 +70,11 @@ module.exports = function module(context, messaging, executionService) {
         event: 'node:workers:over_allocated',
         callback: (requestData) => {
             logger.debug('over-allocated workers, returning them to pending worker request queue');
-            pendingWorkerRequests.enqueue(requestData.payload);
+
+            // retry in a second to give the system time to handle errors
+            setTimeout(() => {
+                enqueueWork(requestData.payload);
+            }, 1000);
         }
     });
 
@@ -341,7 +345,7 @@ module.exports = function module(context, messaging, executionService) {
 
         while (workersRequested > 0) {
             logger.trace(`adding worker to pending queue for ex: ${exId}`);
-            pendingWorkerRequests.enqueue(workerData);
+            enqueueWork(workerData);
             workersRequested -= 1;
         }
         const results = [];
@@ -363,9 +367,14 @@ module.exports = function module(context, messaging, executionService) {
                 payload: requestedWorkersData,
                 response: true
             })
-                .catch(() => {
-                    logger.error(`An error has occurred in allocating : ${workerCount} workers to node : ${nodeId} , the worker request has been enqueued`);
-                    pendingWorkerRequests.enqueue(requestedWorkersData);
+                .catch((err) => {
+                    logger.error(err);
+                    logger.error(`An error has occurred in allocating: ${workerCount} workers to node: ${nodeId}, the worker request has been enqueued`);
+
+                    // retry in a second to give the system time to handle errors
+                    setTimeout(() => {
+                        enqueueWork(requestedWorkersData);
+                    }, 1000);
                 }));
         });
 
@@ -475,10 +484,6 @@ module.exports = function module(context, messaging, executionService) {
             .value();
     }
 
-    function findAllSlicers() {
-        return _iterateState(worker => worker.assignment === 'execution_controller');
-    }
-
     function findWorkersByExecutionID(exId) {
         return _iterateState(worker => worker.assignment === 'worker' && worker.ex_id === exId);
     }
@@ -496,8 +501,22 @@ module.exports = function module(context, messaging, executionService) {
             workers: workerNum,
             assignment: 'worker'
         };
-        pendingWorkerRequests.enqueue(workerData);
+        enqueueWork(workerData);
         return { action: 'enqueued', ex_id: execution.ex_id, workerNum };
+    }
+
+    function enqueueWork(workerData) {
+        if (!workerData) {
+            throw new Error('enqueueWork requires workerData');
+        }
+
+        const { id, ex_id: exId } = workerData;
+        if (pendingWorkerRequests.exists('id', id)) {
+            logger.warn(`Work has already been enqueued for ex_id: ${exId}`);
+            return;
+        }
+
+        pendingWorkerRequests.enqueue(workerData);
     }
 
     function setWorkers(execution, workerNum) {

--- a/lib/cluster/services/cluster/backends/native.js
+++ b/lib/cluster/services/cluster/backends/native.js
@@ -314,6 +314,8 @@ module.exports = function module(context, messaging, executionService) {
         const sortedNodes = _.orderBy(clusterState, 'available', 'desc');
         let workersRequested = numOfWorkersRequested;
         let availWorkers = _availableWorkers(false, true);
+        logger.debug(`Finding ${numOfWorkersRequested} workers for ex_id: ${exId}, job_id: ${jobId}`);
+        logger.debug(`Available workers ${availWorkers} for ex_id: ${exId}, job_id: ${jobId}`);
 
         const dispatch = _makeDispatch();
 
@@ -323,6 +325,7 @@ module.exports = function module(context, messaging, executionService) {
                 if (workersRequested > 0 && availWorkers > 0) {
                     if (sortedNodes[i].available >= 1) {
                         dispatch.set(sortedNodes[i].node_id, 1);
+                        sortedNodes[i].available -= 1;
                         availWorkers -= 1;
                         workersRequested -= 1;
                     }

--- a/lib/cluster/services/cluster/backends/native.js
+++ b/lib/cluster/services/cluster/backends/native.js
@@ -706,4 +706,3 @@ module.exports = function module(context, messaging, executionService) {
 
     return _initialize();
 };
-

--- a/lib/cluster/services/execution.js
+++ b/lib/cluster/services/execution.js
@@ -286,7 +286,7 @@ module.exports = function module(context) {
                 // the limit for retrieving pending jobs is 10000
                 searchExecutionContexts('pending', null, 10000, '_created:asc')
                     .each((executionSpec) => {
-                        logger.debug('enqueuing pending execution:', executionSpec);
+                        logger.info('enqueuing pending execution:', executionSpec);
                         pendingExecutionQueue.enqueue(executionSpec);
                     })
                     .then(() => {

--- a/lib/cluster/services/execution.js
+++ b/lib/cluster/services/execution.js
@@ -15,11 +15,12 @@ const parseError = require('@terascope/error-parser');
  */
 
 module.exports = function module(context) {
-    const messaging = context.messaging;
+    const { messaging } = context;
     const logger = context.apis.foundation.makeLogger({ module: 'execution_service' });
     const masterNodeId = _parseNodeId(context.sysconfig._nodeName);
     const pendingExecutionQueue = new Queue();
 
+    let executionAllocatorInterval = null;
     let exStore;
     let clusterService;
 
@@ -149,6 +150,10 @@ module.exports = function module(context) {
         return exStore.create(job, 'ex')
             .then(ex => setExecutionStatus(ex.ex_id, 'pending')
                 .then(() => {
+                    if (pendingExecutionQueue.exists('ex_id', ex.ex_id)) {
+                        logger.warn('execution is already been marked to be procesed', ex);
+                        return { job_id: ex.job_id };
+                    }
                     logger.debug('enqueueing execution to be processed', ex);
                     pendingExecutionQueue.enqueue(ex);
                     return { job_id: ex.job_id };
@@ -235,7 +240,7 @@ module.exports = function module(context) {
 
     function _executionAllocator() {
         let allocatingExecution = false;
-        const readyForAllocation = clusterService.readyForAllocation;
+        const { readyForAllocation } = clusterService;
         return function allocator() {
             const pendingQueueSize = pendingExecutionQueue.size();
             if (!allocatingExecution && pendingQueueSize > 0 && readyForAllocation()) {
@@ -286,6 +291,11 @@ module.exports = function module(context) {
                 // the limit for retrieving pending jobs is 10000
                 searchExecutionContexts('pending', null, 10000, '_created:asc')
                     .each((executionSpec) => {
+                        const { ex_id: exId } = executionSpec;
+                        if (pendingExecutionQueue.exists('ex_id', exId)) {
+                            logger.warn('execution is already been marked to be procesed', executionSpec);
+                            return;
+                        }
                         logger.info('enqueuing pending execution:', executionSpec);
                         pendingExecutionQueue.enqueue(executionSpec);
                     })
@@ -299,14 +309,15 @@ module.exports = function module(context) {
                         }
 
                         const executionAllocator = _executionAllocator();
-                        setInterval(() => {
+                        executionAllocatorInterval = setInterval(() => {
                             executionAllocator();
                         }, 1000);
 
                         return api;
                     }))
             .error((err) => {
-            // TODO: verify whats coming here
+                clearInterval(executionAllocatorInterval);
+                // TODO: verify whats coming here
                 if (_.get(err, 'body.error.reason') !== 'no such index') {
                     logger.error(`initialization failed loading state from Elasticsearch: ${err}`);
                 }

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -3,7 +3,11 @@
 const _ = require('lodash');
 const shortid = require('shortid');
 const Promise = require('bluebird');
+const SocketIO = require('socket.io');
+const SocketIOClient = require('socket.io-client');
+const http = require('http');
 const Queue = require('@terascope/queue');
+const parseError = require('@terascope/error-parser');
 
 // messages send to cluster_master
 const clusterMasterMessages = {
@@ -26,7 +30,8 @@ const clusterMasterMessages = {
         'execution:error:terminal': 'execution:error:terminal',
         'node:workers:over_allocated': 'node:workers:over_allocated',
         'assets:preloaded': 'assets:preloaded',
-        'assets:service:available': 'assets:service:available'
+        'assets:service:available': 'assets:service:available',
+        'assets:service:unavailable': 'assets:service:unavailable',
     }
 };
 
@@ -118,10 +123,6 @@ const routing = {
 };
 
 module.exports = function messaging(context, logger) {
-    const networkConfig = {
-        // this option isn't used any more
-        reconnect: true
-    };
     const functionMapping = {};
     // processContext is set in _makeConfigurations
     let processContext;
@@ -293,49 +294,75 @@ module.exports = function messaging(context, logger) {
     }
 
     function listen({ port, server } = {}) {
-        messsagingOnline = true;
+        return new Promise((resolve, reject) => {
+            messsagingOnline = true;
 
-        if (config.clients.networkClient) {
-            // node_master, worker
-            io = require('socket.io-client')(hostURL, networkConfig);
-            _registerFns(io);
-            if (self === 'node_master') {
-                io.on('networkMessage', (networkMsg) => {
-                    const { message } = networkMsg;
-                    const func = functionMapping[message];
-                    if (func) {
-                        func(networkMsg);
-                    } else {
-                        // if no function is registered, it is meant to by passed along to child
-                        _sendToProcesses(networkMsg);
+            if (config.clients.networkClient) {
+                // node_master, worker
+                io = SocketIOClient(hostURL);
+                _registerFns(io);
+
+                io.once('connect', () => {
+                    if (self !== 'node_master') {
+                        resolve();
+                        return;
                     }
+
+                    io.on('networkMessage', (networkMsg) => {
+                        const { message } = networkMsg;
+                        const func = functionMapping[message];
+                        if (func) {
+                            func(networkMsg);
+                        } else {
+                            // if no function is registered, it is meant to by passed along to child
+                            _sendToProcesses(networkMsg);
+                        }
+                    });
+                    logger.debug('client network connection is online');
+                    resolve();
                 });
+                return;
             }
-            logger.debug('client network connection is online');
-        } else if (server) {
-            // cluster_master
-            io = require('socket.io')(server);
-            io.on('connection', (socket) => {
-                logger.debug('a connection to cluster_master has been made');
-                _registerFns(socket);
-            });
-        } else {
-            // execution_controller
-            io = require('socket.io')();
-            io.on('connection', (socket) => {
-                logger.debug('a worker has connected');
-                _registerFns(socket);
+
+            if (server) {
+                // cluster_master
+                io = SocketIO(server);
+                io.on('connection', (socket) => {
+                    logger.debug('a connection to cluster_master has been made');
+                    _registerFns(socket);
+                });
+                resolve();
+                return;
+            }
+
+            const srv = http.createServer((req, res) => {
+                res.writeHead(404);
+                res.end();
             });
 
-            io.listen(port);
-            logger.debug(`execution_controller is online and listening on port ${port}`);
-        }
-        // TODO: message queuing will be used until formal process lifecycles are implemented
-        while (messagingQueue.size() > 0) {
-            const cachedMessages = messagingQueue.dequeue();
-            // they are put in as a tuple, [realMsg, ipcMessage]
-            processContext.emit(cachedMessages[0], cachedMessages[1]);
-        }
+            srv.listen(port, (err) => {
+                if (err) {
+                    const connectError = new Error(`${self} cannot listen on ${port}, error: ${parseError(err)}`);
+                    reject(connectError);
+                    return;
+                }
+                logger.debug(`${self} is online and listening on port ${port}`);
+                // execution_controller
+                io = SocketIO(srv);
+                io.on('connection', (socket) => {
+                    logger.debug('a worker has connected');
+                    _registerFns(socket);
+                });
+                resolve();
+            });
+        }).then(() => {
+            // TODO: message queuing will be used until formal process lifecycles are implemented
+            while (messagingQueue.size() > 0) {
+                const cachedMessages = messagingQueue.dequeue();
+                // they are put in as a tuple, [realMsg, ipcMessage]
+                processContext.emit(cachedMessages[0], cachedMessages[1]);
+            }
+        });
     }
 
     function broadcast(eventName, sentData) {

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -391,8 +391,7 @@ module.exports = function messaging(context, logger) {
         }
     }
 
-    function send(_messageSent) {
-        const messageSent = _.cloneDeep(_messageSent);
+    function send(messageSent) {
         if (!messageSent.__source) messageSent.__source = self;
         const needsReply = messageSent.response;
 

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -342,11 +342,12 @@ module.exports = function messaging(context, logger) {
 
             srv.listen(port, (err) => {
                 if (err) {
+                    logger.error(err.stack);
                     const connectError = new Error(`${self} cannot listen on ${port}, error: ${parseError(err)}`);
                     reject(connectError);
                     return;
                 }
-                logger.debug(`${self} is online and listening on port ${port}`);
+                logger.info(`${self} is online and listening on port ${port}`);
                 // execution_controller
                 io = SocketIO(srv);
                 io.on('connection', (socket) => {

--- a/lib/cluster/services/messaging.js
+++ b/lib/cluster/services/messaging.js
@@ -391,7 +391,8 @@ module.exports = function messaging(context, logger) {
         }
     }
 
-    function send(messageSent) {
+    function send(_messageSent) {
+        const messageSent = _.cloneDeep(_messageSent);
         if (!messageSent.__source) messageSent.__source = self;
         const needsReply = messageSent.response;
 

--- a/lib/cluster/worker/index.js
+++ b/lib/cluster/worker/index.js
@@ -67,7 +67,7 @@ module.exports = function module(context) {
                     .catch((flushErr) => {
                         const flushErrMsg = parseError(flushErr);
                         logger.error(flushErrMsg);
-                        process.exit();
+                        process.exit(1);
                     });
             });
     }
@@ -86,13 +86,20 @@ module.exports = function module(context) {
         if (executor) shutdownSequence.push(executor.shutdown());
 
         Promise.all(shutdownSequence)
-            .then(logger.flush)
+            .then(() => {
+                logger.flush();
+                setTimeout(() => {
+                    process.exit(0);
+                }, 10);
+            })
             .catch((err) => {
                 const errMsg = parseError(err);
                 logger.error(`Error while attempting to shutdown worker ${ID}, error: ${errMsg}`);
-                return logger.flush();
-            })
-            .finally(process.exit);
+                logger.flush();
+                setTimeout(() => {
+                    process.exit(1);
+                }, 10);
+            });
     }
 
     initializeWorker();

--- a/lib/cluster/worker/index.js
+++ b/lib/cluster/worker/index.js
@@ -63,11 +63,13 @@ module.exports = function module(context) {
                     error: errMsg
                 })
                     .then(() => logger.flush())
-                    .then(() => process.exit())
+                    .then(() => process.exit(0))
                     .catch((flushErr) => {
                         const flushErrMsg = parseError(flushErr);
                         logger.error(flushErrMsg);
-                        process.exit(1);
+                        logger.flush().then(() => {
+                            process.exit(1);
+                        });
                     });
             });
     }
@@ -86,19 +88,16 @@ module.exports = function module(context) {
         if (executor) shutdownSequence.push(executor.shutdown());
 
         Promise.all(shutdownSequence)
-            .then(() => {
-                logger.flush();
-                setTimeout(() => {
-                    process.exit(0);
-                }, 10);
-            })
+            .then(() => logger.flush().then(() => {
+                process.exit(0);
+            }))
             .catch((err) => {
                 const errMsg = parseError(err);
                 logger.error(`Error while attempting to shutdown worker ${ID}, error: ${errMsg}`);
                 logger.flush();
                 setTimeout(() => {
                     process.exit(1);
-                }, 10);
+                }, 100);
             });
     }
 

--- a/spec/execution_controller/engine-spec.js
+++ b/spec/execution_controller/engine-spec.js
@@ -72,7 +72,7 @@ describe('execution engine', () => {
         register: (obj) => {
             messagingEvents[obj.event] = obj.callback;
         },
-        listen: () => {},
+        listen: () => Promise.resolve(),
         // respond: (msg) => { respondingMsg = msg; }
         respond: () => {}
     };

--- a/spec/execution_controller/execution_analytics-spec.js
+++ b/spec/execution_controller/execution_analytics-spec.js
@@ -44,7 +44,8 @@ describe('execution_analytics', () => {
         },
         send: (obj) => {
             msgSent = obj;
-        }
+        },
+        listen: () => Promise.resolve()
     };
 
     it('can instantiate', () => {

--- a/spec/execution_controller/recovery-spec.js
+++ b/spec/execution_controller/recovery-spec.js
@@ -33,7 +33,9 @@ describe('execution recovery', () => {
             }
         }
     };
-    const messaging = { send: msg => sentMsg = msg };
+    const messaging = {
+        send: (msg) => { sentMsg = msg; }
+    };
     const executionAnalytics = { getAnalytics: () => ({}) };
     const exStore = {
         executionMetaData: () => {},

--- a/spec/worker-spec.js
+++ b/spec/worker-spec.js
@@ -301,6 +301,7 @@ describe('Worker', () => {
 
     it('will emit recycle after so many invocations', (done) => {
         const events = makeEmitter();
+        let interval = null;
 
         const { testContext } = instantiateModule({
             sentMessage: {
@@ -314,6 +315,7 @@ describe('Worker', () => {
         } = testContext;
 
         events.once('worker:recycle', () => {
+            clearInterval(interval);
             expect(_lastMessage()).toEqual({
                 isShuttingDown: true,
                 someMessage: true
@@ -321,11 +323,11 @@ describe('Worker', () => {
             done();
         });
 
-        setTimeout(() => {
+        interval = setInterval(() => {
             _recycleFn(2);
         }, 100);
         expect(_lastMessage()).toEqual({ someMessage: true });
-    }, 1000);
+    });
 
     it('can shutdown', (done) => {
         const events = makeEmitter();

--- a/spec/worker-spec.js
+++ b/spec/worker-spec.js
@@ -75,7 +75,7 @@ describe('Worker', () => {
         respond: (_inc, res) => {
             respondingMsg = Object.assign({}, _inc, { message: 'messaging:response' }, res);
         },
-        listen: () => {}
+        listen: () => Promise.resolve()
     };
 
     const stateStore = {

--- a/spec/worker-spec.js
+++ b/spec/worker-spec.js
@@ -323,7 +323,7 @@ describe('Worker', () => {
 
         _.defer(_recycleFn, 2);
         expect(_lastMessage()).toEqual({ someMessage: true });
-    }, 300);
+    }, 1000);
 
     it('can shutdown', (done) => {
         const events = makeEmitter();

--- a/spec/worker-spec.js
+++ b/spec/worker-spec.js
@@ -321,7 +321,9 @@ describe('Worker', () => {
             done();
         });
 
-        _.defer(_recycleFn, 2);
+        setTimeout(() => {
+            _recycleFn(2);
+        }, 100);
         expect(_lastMessage()).toEqual({ someMessage: true });
     }, 1000);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,7 +82,7 @@
     lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
-"@terascope/elasticsearch-api@^1.0.1", "@terascope/elasticsearch-api@^1.0.1-beta":
+"@terascope/elasticsearch-api@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@terascope/elasticsearch-api/-/elasticsearch-api-1.0.1.tgz#b8696f122338d6a522782c2acf0914271d7ba9e0"
   dependencies:
@@ -3738,11 +3738,12 @@ terafoundation@^0.2.1:
     redis "^2.8.0"
     yargs "^11.0.0"
 
-"teraslice@github:terascope/teraslice":
-  version "0.36.3"
-  resolved "https://codeload.github.com/terascope/teraslice/tar.gz/ccc08bb009042c9715bb4f091964a570465a133b"
+teraslice@terascope/teraslice:
+  version "0.36.5"
+  resolved "https://codeload.github.com/terascope/teraslice/tar.gz/18e443b9c13208795083bf98b47195d4357f926e"
   dependencies:
-    "@terascope/elasticsearch-api" "^1.0.1-beta"
+    "@terascope/elasticsearch-api" "^1.0.1"
+    "@terascope/error-parser" "^1.0.0"
     "@terascope/queue" "^1.1.3"
     bluebird "^3.5.1"
     body-parser "^1.18.2"
@@ -3750,7 +3751,6 @@ terafoundation@^0.2.1:
     datemath-parser "^1.0.6"
     decompress "^4.2.0"
     easy-table "^1.1.1"
-    error_parser terascope/error_parser
     express "^4.16.3"
     fs-extra "^6.0.1"
     lodash "^4.17.5"


### PR DESCRIPTION
I found that workers get into a terminal state if they are overallocated due to race conditions and improper error handling (See #739). I fixed several of the issues, and it behaves more appropriately.

Although, I did change more than I probably should have, which is why I marked this a `WIP`. I plan on going through my changes and ensuring that I didn't introduce more issues.