### PR TITLE
fixes for asset builds

### DIFF
--- a/lib/cluster/cluster_master.js
+++ b/lib/cluster/cluster_master.js
@@ -7,7 +7,7 @@ const _ = require('lodash');
 const http = require('http');
 const express = require('express');
 
-module.exports = function (context) {
+module.exports = (context) => {
     const events = context.apis.foundation.getSystemEvents();
     const logger = context.apis.foundation.makeLogger({ module: 'cluster_master' });
     const clusterConfig = context.sysconfig.teraslice;
@@ -94,6 +94,7 @@ module.exports = function (context) {
             }
         }));
     }
+
     require('./services/execution.js')(context)
         .then((clusterService) => {
             messaging.listen({ server });

--- a/lib/cluster/runners/execution.js
+++ b/lib/cluster/runners/execution.js
@@ -5,13 +5,12 @@ const parseError = require('@terascope/error-parser');
 const moment = require('moment');
 const _ = require('lodash');
 const path = require('path');
-const existsSync = require('../../utils/file_utils').existsSync;
+const { existsSync } = require('../../utils/file_utils');
 
 /*
  * This module defines the job execution context on the worker nodes.
  */
-module.exports = function module(context) {
-    const opRunner = require('./op')(context);
+module.exports = function module(context, justRegisterApi) {
     // used for testing so we dont have to pollute the process env in testing
     const processAssingment = context.__test_assignment || process.env.assignment;
     const isSlicer = processAssingment === 'execution_controller';
@@ -20,21 +19,17 @@ module.exports = function module(context) {
     const assetPath = execution.assets ? context.sysconfig.teraslice.assets_directory : null;
     const jobAssets = execution.assets ? execution.assets : [];
 
-    /*
-     * Returns the first op that matches name.
-     */
-    function getOpConfig(name) {
-        return execution.operations.find(op => op._op === name);
+    function getOpConfig(job, name) {
+        return job.operations.find(op => op._op === name);
     }
-
-    /*
-     * This sets up the APIs intended for use by custom readers / processors.
-     */
 
     context.apis.registerAPI('job_runner', {
         getOpConfig
     });
 
+    // if set then we need to prevent opRunner from calling since it also registers an api
+    if (justRegisterApi) return;
+    const opRunner = require('./op')(context);
 
     function _instantiateJob() {
         let slicer = null;
@@ -175,7 +170,7 @@ module.exports = function module(context) {
     }
 
 
-    function _parseJob(processJob) {
+    function _parseJob(processJob = '{}') {
         return JSON.parse(processJob);
     }
 

--- a/lib/cluster/runners/op.js
+++ b/lib/cluster/runners/op.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const existsSync = require('../../utils/file_utils').existsSync;
+const { existsSync } = require('../../utils/file_utils');
 const fs = require('fs');
 
 /*
@@ -19,9 +19,9 @@ module.exports = function module(context) {
      * This will request a connection based on the 'connection' attribute of
      * an opConfig. Intended as a context API endpoint.
      */
-    function getClient(opConfig, type) {
+    function getClient(_context, opConfig, type) {
         const clientConfig = {};
-        const events = context.apis.foundation.getSystemEvents();
+        const events = _context.apis.foundation.getSystemEvents();
         clientConfig.type = type;
 
         if (opConfig && Object.prototype.hasOwnProperty.call(opConfig, 'connection')) {
@@ -34,10 +34,10 @@ module.exports = function module(context) {
         }
 
         try {
-            return context.apis.foundation.getConnection(clientConfig).client;
+            return _context.apis.foundation.getConnection(clientConfig).client;
         } catch (err) {
             const errMsg = `No configuration for endpoint ${clientConfig.endpoint} was found in the terafoundation connectors config, error: ${err.stack}`;
-            context.logger.error(errMsg);
+            _context.logger.error(errMsg);
             events.emit('client:initialization:error', { error: errMsg });
             return false;
         }
@@ -69,15 +69,7 @@ module.exports = function module(context) {
                 }
             });
         }
-
-        types.forEach((type) => {
-            const pathType = path.resolve(`${__dirname}/../../${type}`);
-            if (!filePath) findCode(pathType);
-        });
-
-        // if found, don't do extra searches
-        if (filePath) return filePath;
-
+        // check assets path first
         if (assetsPath && existsSync(assetsPath)) {
             executionAssets.forEach((assetID) => {
                 const assetOpPath = `${assetsPath}/${assetID}`;
@@ -87,6 +79,14 @@ module.exports = function module(context) {
                 }
             });
         }
+
+        // if found, don't do extra searches
+        if (filePath) return filePath;
+
+        types.forEach((type) => {
+            const pathType = path.resolve(`${__dirname}/../../${type}`);
+            if (!filePath) findCode(pathType);
+        });
 
         // if found, don't do extra searches
         if (filePath) return filePath;

--- a/lib/cluster/services/execution.js
+++ b/lib/cluster/services/execution.js
@@ -15,7 +15,7 @@ const parseError = require('@terascope/error-parser');
  */
 
 module.exports = function module(context) {
-    const messaging = context.messaging;
+    const { messaging } = context;
     const logger = context.apis.foundation.makeLogger({ module: 'execution_service' });
     const masterNodeId = _parseNodeId(context.sysconfig._nodeName);
     const pendingExecutionQueue = new Queue();
@@ -235,7 +235,7 @@ module.exports = function module(context) {
 
     function _executionAllocator() {
         let allocatingExecution = false;
-        const readyForAllocation = clusterService.readyForAllocation;
+        const { readyForAllocation } = clusterService;
         return function allocator() {
             const pendingQueueSize = pendingExecutionQueue.size();
             if (!allocatingExecution && pendingQueueSize > 0 && readyForAllocation()) {

--- a/lib/config/validators/config.js
+++ b/lib/config/validators/config.js
@@ -34,8 +34,4 @@ function validateConfig(inputSchema, inputConfig) {
     return config.getProperties();
 }
 
-module.exports = function () {
-    return {
-        validateConfig
-    };
-};
+module.exports = () => ({ validateConfig });

--- a/lib/config/validators/job.js
+++ b/lib/config/validators/job.js
@@ -6,13 +6,15 @@ const convictFormats = require('../../utils/convict_utils');
 const configValidator = require('./config')();
 
 
-module.exports = function (_context) {
+module.exports = (_context) => {
     let context = _context;
     const commonSchema = require('../schemas/job').commonSchema();
     let opRunner;
     let jobSchema;
 
     if (context) {
+        // We need a better story around registering apis
+        require('../../cluster/runners/execution')(context, true);
         opRunner = require('../../cluster/runners/op')(context);
         jobSchema = require('../schemas/job').jobSchema(context);
     }
@@ -52,7 +54,7 @@ module.exports = function (_context) {
         });
 
         topLevelJobValidators.forEach((fn) => {
-            fn(validJob, context.sysconfig);
+            fn(context, validJob);
         });
 
         return validJob;

--- a/lib/processors/elasticsearch_bulk.js
+++ b/lib/processors/elasticsearch_bulk.js
@@ -3,6 +3,7 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
 const { getClient, getOpConfig } = require('../utils/config');
+const util = require('util');
 
 function newProcessor(context, opConfig) {
     let logger;
@@ -211,9 +212,9 @@ function schema() {
     };
 }
 
-function crossValidation(job, sysconfig) {
+function crossValidation(context, job) {
     const opConfig = getOpConfig(job, 'elasticsearch_bulk');
-    const elasticConnectors = sysconfig.terafoundation.connectors.elasticsearch;
+    const elasticConnectors = context.sysconfig.terafoundation.connectors.elasticsearch;
 
     // check to verify if connection map provided is
     //   consistent with sysconfig.terafoundation.connectors
@@ -226,8 +227,11 @@ function crossValidation(job, sysconfig) {
     }
 }
 
+const depMsg = 'This native processors in teraslice are being deprecated, please use the elasticsearch-assets project with the assets api to use this module';
+const code = 'esReader';
+
 module.exports = {
-    newProcessor,
-    crossValidation,
-    schema
+    newProcessor: util.deprecate(newProcessor, depMsg, code),
+    crossValidation: util.deprecate(crossValidation, depMsg, code),
+    schema: util.deprecate(schema, depMsg, code)
 };

--- a/lib/processors/elasticsearch_index_selector.js
+++ b/lib/processors/elasticsearch_index_selector.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const util = require('util');
 
 function newProcessor(context, opConfig, executionConfig) {
     function formattedDate(record) {
@@ -48,7 +49,7 @@ function newProcessor(context, opConfig, executionConfig) {
      * of the record will be preserved.
      */
 
-    return function (data) {
+    return (data) => {
         let fromElastic = false;
         let dataArray = data;
         const fullResponseData = _.get(dataArray, 'hits.hits');
@@ -286,8 +287,11 @@ function selfValidation(op) {
     }
 }
 
+const depMsg = 'This native processors in teraslice are being deprecated, please use the elasticsearch-assets project with the assets api to use this module';
+const code = 'esReader';
+
 module.exports = {
-    newProcessor,
-    selfValidation,
-    schema
+    newProcessor: util.deprecate(newProcessor, depMsg, code) ,
+    selfValidation: util.deprecate(selfValidation, depMsg, code),
+    schema: util.deprecate(schema, depMsg, code)
 };

--- a/lib/readers/elasticsearch_data_generator.js
+++ b/lib/readers/elasticsearch_data_generator.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const Promise = require('bluebird');
-const getOpConfig = require('../utils/config').getOpConfig;
+const { getOpConfig } = require('../utils/config');
 const mocker = require('mocker-data-generator').default;
 const defaultSchema = require('../utils/data_utils');
-const existsSync = require('../utils/file_utils').existsSync;
+const { existsSync } = require('../utils/file_utils');
 const parseError = require('@terascope/error-parser');
 
 function parsedSchema(opConfig) {
@@ -31,7 +31,7 @@ function parsedSchema(opConfig) {
 
 function newReader(context, opConfig) {
     const dataSchema = parsedSchema(opConfig);
-    return function (msg) {
+    return (msg) => {
         if (opConfig.stress_test) {
             return mocker()
                 .schema('schema', dataSchema, 1)
@@ -60,7 +60,7 @@ function onceGenerator(context, opConfig, executionConfig) {
     const lastOp = executionConfig.operations[executionConfig.operations.length - 1];
     const interval = lastOp.size ? lastOp.size : 5000;
 
-    return function () {
+    return () => {
         if (numOfRecords <= 0) {
             return null;
         }
@@ -77,9 +77,7 @@ function onceGenerator(context, opConfig, executionConfig) {
 }
 
 function persistentGenerator(context, opConfig) {
-    return function () {
-        return opConfig.size;
-    };
+    return () => opConfig.size;
 }
 
 function newSlicer(context, executionContext) {
@@ -160,7 +158,7 @@ function selfValidation(op) {
     }
 }
 
-function crossValidation(job) {
+function crossValidation(context, job) {
     const opConfig = getOpConfig(job, 'elasticsearch_data_generator');
 
     if (opConfig.set_id) {

--- a/lib/readers/elasticsearch_reader.js
+++ b/lib/readers/elasticsearch_reader.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const getClient = require('../utils/config').getClient;
-const getOpConfig = require('../utils/config').getOpConfig;
-const dateOptions = require('../utils/date_utils').dateOptions;
+const { getClient, getOpConfig } = require('../utils/config');
+const { dateOptions } = require('../utils/date_utils');
 const dateMath = require('datemath-parser');
 const moment = require('moment');
 const _ = require('lodash');
-
+const util = require('util');
 
 function newSlicer(context, executionContext, retryData, logger) {
     const opConfig = getOpConfig(executionContext.config, 'elasticsearch_reader');
@@ -204,7 +203,7 @@ function _findOperation(opConfig) {
     return _.every(schemaObj, (config, key) => opConfig[key] !== undefined);
 }
 
-function crossValidation(job) {
+function crossValidation(context, job) {
     if (job.lifecycle === 'persistent') {
         const op = job.operations.filter(_findOperation)[0];
         if (op.interval === 'auto') {
@@ -213,10 +212,13 @@ function crossValidation(job) {
     }
 }
 
+const depMsg = 'This native processors in teraslice is being deprecated, please use the elasticsearch-assets project with the assets api to use this module';
+const code = 'esReader';
+
 module.exports = {
-    newReader,
-    newSlicer,
-    schema,
-    selfValidation,
-    crossValidation
+    newReader: util.deprecate(newReader, depMsg, code),
+    newSlicer: util.deprecate(newSlicer, depMsg, code),
+    schema: util.deprecate(schema, depMsg, code),
+    selfValidation: util.deprecate(selfValidation, depMsg, code),
+    crossValidation: util.deprecate(crossValidation, depMsg, code)
 };

--- a/lib/readers/id_reader.js
+++ b/lib/readers/id_reader.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const _ = require('lodash');
-const getClient = require('../utils/config').getClient;
-const getOpConfig = require('../utils/config').getOpConfig;
-
+const { getOpConfig, getClient } = require('../utils/config');
+const util = require('util');
 
 function newSlicer(context, executionContext, retryData, logger) {
     const opConfig = getOpConfig(executionContext.config, 'id_reader');
@@ -16,7 +15,7 @@ function newSlicer(context, executionContext, retryData, logger) {
 function newReader(context, opConfig) {
     const client = getClient(context, opConfig, 'elasticsearch');
 
-    return function (msg, logger) {
+    return (msg, logger) => {
         const elasticsearch = require('@terascope/elasticsearch-api')(client, logger, opConfig);
         const query = elasticsearch.buildQuery(opConfig, msg);
         return elasticsearch.search(query);
@@ -110,7 +109,7 @@ function schema() {
 }
 
 
-function crossValidation(job) {
+function crossValidation(context, job) {
     const opConfig = getOpConfig(job, 'id_reader');
 
     if (opConfig.key_range && job.slicers > opConfig.key_range.length) {
@@ -130,10 +129,12 @@ function crossValidation(job) {
     }
 }
 
+const depMsg = 'This native processors in teraslice are being deprecated, please use the elasticsearch-assets project with the assets api to use this module';
+const code = 'esReader';
 
 module.exports = {
-    newReader,
-    newSlicer,
-    crossValidation,
-    schema
+    newReader: util.deprecate(newReader, depMsg, code),
+    newSlicer: util.deprecate(newSlicer, depMsg, code),
+    crossValidation: util.deprecate(crossValidation, depMsg, code),
+    schema: util.deprecate(schema, depMsg, code)
 };

--- a/spec/processors/elastic_bulk-spec.js
+++ b/spec/processors/elastic_bulk-spec.js
@@ -210,12 +210,14 @@ describe('elasticsearch_bulk', () => {
             }]
         };
 
-        const sysconfig = {
-            terafoundation: {
-                connectors: {
-                    elasticsearch: {
-                        connectionA: 'connection Config',
-                        connectionB: 'otherConnection Config'
+        const contextConfig = {
+            sysconfig: {
+                terafoundation: {
+                    connectors: {
+                        elasticsearch: {
+                            connectionA: 'connection Config',
+                            connectionB: 'otherConnection Config'
+                        }
                     }
                 }
             }
@@ -223,11 +225,11 @@ describe('elasticsearch_bulk', () => {
         const errorString = 'elasticsearch_bulk connection_map specifies a connection for [connectionZ] but is not found in the system configuration [terafoundation.connectors.elasticsearch]';
 
         expect(() => {
-            esSender.crossValidation(badJob, sysconfig);
+            esSender.crossValidation(contextConfig, badJob);
         }).toThrowError(errorString);
 
         expect(() => {
-            esSender.crossValidation(goodJob, sysconfig);
+            esSender.crossValidation(contextConfig, goodJob);
         }).not.toThrow();
     });
 });

--- a/spec/readers/id_slicer-spec.js
+++ b/spec/readers/id_slicer-spec.js
@@ -91,26 +91,28 @@ describe('id_reader', () => {
         const job5 = { slicers: 20, operations: [{ _op: 'id_reader', key_type: 'base64url' }] };
         const job6 = { slicers: 70, operations: [{ _op: 'id_reader', key_type: 'base64url' }] };
 
-
+        const contextConfig = {
+            sysconfig
+        };
         expect(() => {
-            idReader.crossValidation(job1, sysconfig);
+            idReader.crossValidation(contextConfig, job1);
         }).not.toThrow();
         expect(() => {
-            idReader.crossValidation(job2, sysconfig);
+            idReader.crossValidation(contextConfig, job2);
         }).toThrowError(errorStr1);
 
         expect(() => {
-            idReader.crossValidation(job3, sysconfig);
+            idReader.crossValidation(contextConfig, job3);
         }).not.toThrow();
         expect(() => {
-            idReader.crossValidation(job4, sysconfig);
+            idReader.crossValidation(contextConfig, job4);
         }).toThrowError(errorStr2);
 
         expect(() => {
-            idReader.crossValidation(job5, sysconfig);
+            idReader.crossValidation(contextConfig, job5);
         }).not.toThrow();
         expect(() => {
-            idReader.crossValidation(job6, sysconfig);
+            idReader.crossValidation(contextConfig, job6);
         }).toThrowError(errorStr3);
     });
 

--- a/spec/runners/execution-spec.js
+++ b/spec/runners/execution-spec.js
@@ -306,8 +306,8 @@ describe('execution runner', () => {
         expect(typeof testRegisterApi.job_runner).toEqual('object');
         expect(typeof testRegisterApi.job_runner.getOpConfig).toEqual('function');
 
-        expect(testRegisterApi.job_runner.getOpConfig('elasticsearch_data_generator')).toEqual(op1);
-        expect(testRegisterApi.job_runner.getOpConfig('noop')).toEqual(op2);
-        expect(testRegisterApi.job_runner.getOpConfig('somethingElse')).toEqual(undefined);
+        expect(testRegisterApi.job_runner.getOpConfig(assetjob, 'elasticsearch_data_generator')).toEqual(op1);
+        expect(testRegisterApi.job_runner.getOpConfig(assetjob, 'noop')).toEqual(op2);
+        expect(testRegisterApi.job_runner.getOpConfig(assetjob, 'somethingElse')).toEqual(undefined);
     });
 });

--- a/spec/runners/op-spec.js
+++ b/spec/runners/op-spec.js
@@ -130,9 +130,9 @@ describe('op runner', () => {
         opCode(context);
         const { getClient } = testRegisterApi.op_runner;
 
-        expect(getClient({}, 'elasticsearch')).toEqual({ type: 'elasticsearch', endpoint: 'default', cached: true });
-        expect(getClient({ connection: 'someConnection' }, 'kafka')).toEqual({ type: 'kafka', endpoint: 'someConnection', cached: true });
-        expect(getClient({ connection_cache: false }, 'mongo')).toEqual({ type: 'mongo', endpoint: 'default', cached: true });
+        expect(getClient(context, {}, 'elasticsearch')).toEqual({ type: 'elasticsearch', endpoint: 'default', cached: true });
+        expect(getClient(context, { connection: 'someConnection' }, 'kafka')).toEqual({ type: 'kafka', endpoint: 'someConnection', cached: true });
+        expect(getClient(context, { connection_cache: false }, 'mongo')).toEqual({ type: 'mongo', endpoint: 'default', cached: true });
     });
 
     it('getClient will error properly', (done) => {
@@ -147,6 +147,6 @@ describe('op runner', () => {
             expect(errMsg.error.includes(errStr)).toEqual(true);
             done();
         });
-        getClient();
+        getClient(context, {}, 'elasticsearch');
     });
 });


### PR DESCRIPTION
There are some issues to be talked about before this is brought in. Moving out processors from teraslice and into assets brought to light some inconsistencies we have with how we use the context.apis functionality. Also, since we are having the cluster_master do validation checks on the submitted jobs, it was having to load modules that supposed certain things existed which where not true. Different context.apis where available to different parts of a processor file which is not good. We need to better evaluate the proper api signature of these functions have have a discussion on how to load these apis more independently and to every process.