### PR TITLE
changed socket.io to version 1.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teraslice",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "Slice and dice your Elasticsearch data",
   "bin": "service.js",
   "main": "service.js",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "moment": "^2.21.0",
     "request": "^2.85.0",
     "shortid": "^2.2.8",
-    "socket.io": "^2.0.4",
-    "socket.io-client": "^2.0.4",
+    "socket.io": "1.4.5",
+    "socket.io-client": "1.4.5",
     "terafoundation": "^0.2.1",
     "uuid": "^3.2.1",
     "yargs": "^11.0.0"


### PR DESCRIPTION
Reverted socket.io to version 1.4.5 because we were seeing issues with workers failing to reconnect after rebalance or adding workers. 