### PR TITLE
Recovery changes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -202,7 +202,7 @@ issues a resume command, this allows the slicers to continue if they were in a p
 
 #### POST /jobs/{job_id}/_recover
 
-issues a recover command, this can only be run if the job is stopped, the job will attempt to retry failed slices and to resume where it previously left off
+THIS API ENDPOINT IS BEING DEPRECATED: issues a recover command, this can only be run if the job is stopped, the job will attempt to retry failed slices and to resume where it previously left off
 
 
 #### POST /jobs/{job_id}/_workers
@@ -321,6 +321,17 @@ issues a pause command, this will put the slicers on hold to prevent them from g
 #### POST /ex/{ex_id}/_resume
 
 issues a resume command, this allows the slicers to continue if they were in a paused state, marks the job execution context as running
+
+#### POST /ex/{ex_id}/_recover
+
+parameter options:
+
+- cleanup = [String] 'all' or 'errors'
+
+query:
+``` curl -XPOST localhost:5678/v1/ex/{ex_id}/_recover?cleanup=errors```
+
+issues a recover command, this can only be run if the execution is stopped, the job will attempt to retry failed slices and to resume where it previously left off. If cleanup parameter is specified it will NOT resume where it left off and exit after recovery completes. If the cleanup parameter is set to `all`, then it will attempt to reprocess all slices left in error or started status, if it is set to  `errors` then it will only reprocess state records that are marked as error.
 
 #### POST /ex/{ex_id}/_workers
 

--- a/integration-tests/spec/setup.js
+++ b/integration-tests/spec/setup.js
@@ -6,10 +6,12 @@ const _ = require('lodash');
 const signale = require('signale');
 const path = require('path');
 const Promise = require('bluebird');
+const uuid = require('uuid');
 const execFile = Promise.promisify(require('child_process').execFile);
 const { forNodes } = require('./wait');
 const misc = require('./misc');
 
+const jobList = [];
 // require jasmine-expect for more friendly expecations
 require('jasmine-expect');
 
@@ -72,6 +74,72 @@ function waitForTerasliceNodes() {
 function generateTestData() {
     signale.pending('Generating example data...');
 
+    function populateStateForRecoveryTests() {
+        const exId = jobList.shift();
+        if (!exId) return Promise.resolve(true);
+        const client = misc.es();
+        return misc.teraslice().cluster.get(`/ex/${exId}`)
+            .then((exConfig) => {
+                exConfig.ex_id = 'testex';
+                const date = new Date();
+                const iso = date.toISOString();
+                const index = `teracluster__state-${iso.split('-').slice(0, 2).join('.')}`;
+                const time = date.getTime();
+                const pastDate = new Date(time - 600000);
+
+                exConfig.operations[1].index = 'test-recovery-300';
+                exConfig._status = 'failed';
+                exConfig._created = pastDate;
+                exConfig._created = pastDate;
+
+                const errored = {
+                    _created: iso,
+                    _updated: iso,
+                    slice_id: uuid(),
+                    slicer_order: 1,
+                    slicer_id: 0,
+                    request: 100,
+                    state: 'error',
+                    ex_id: 'testex'
+                };
+
+                const notCompleted = {
+                    _created: iso,
+                    _updated: iso,
+                    slice_id: uuid(),
+                    slicer_order: 1,
+                    slicer_id: 0,
+                    request: 100,
+                    state: 'start',
+                    ex_id: 'testex'
+                };
+
+                return Promise.all([
+                    client.index({ index, type: 'state', id: errored.slice_id, body: errored }),
+                    client.index({ index, type: 'state', id: notCompleted.slice_id, body: notCompleted }),
+                    client.index({ index: 'teracluster__ex', type: 'ex', id: exConfig.ex_id, body: exConfig })
+                ])
+                    .catch(err => Promise.reject(err));
+            });
+    }
+
+    function postJob(jobSpec) {
+        return misc.teraslice().jobs.submit(jobSpec)
+            .then((job) => {
+                return job.ex()
+                    .then((exId) => {
+                        jobList.push(exId);
+                        return job;
+                    });
+            });
+    }
+
+    function cleanupIndex(indexName) {
+        return misc.es().indices.delete({ index: indexName })
+            .then(() => true)
+            .catch(() => Promise.resolve(true));
+    }
+
     function generate(count, hex) {
         let indexName = `example-logs-${count}`;
         if (hex) {
@@ -98,25 +166,19 @@ function generateTestData() {
             ]
         };
 
-        return new Promise(((resolve, reject) => {
-            misc.es().indices.delete({ index: indexName }, () => {
-                if (!hex) {
-                    resolve(misc.teraslice().jobs.submit(jobSpec));
-                } else {
-                    jobSpec.operations[0].size = count / hex.length;
-                    jobSpec.operations[0].set_id = 'hexadecimal';
-                    jobSpec.operations[1].id_field = 'id';
-                    const jobs = _.map(hex, (letter) => {
-                        jobSpec.name = `Generate: ${indexName}[${letter}]`;
-                        jobSpec.operations[0].id_start_key = letter;
-                        return misc.teraslice().jobs.submit(jobSpec);
-                    });
-                    Promise.all(jobs)
-                        .then(() => resolve())
-                        .catch(err => reject(err));
-                }
+        return Promise.resolve()
+            .then(() => cleanupIndex(indexName))
+            .then(() => {
+                if (!hex) return postJob(jobSpec);
+                jobSpec.operations[0].size = count / hex.length;
+                jobSpec.operations[0].set_id = 'hexadecimal';
+                jobSpec.operations[1].id_field = 'id';
+                return Promise.map(hex, (letter) => {
+                    jobSpec.name = `Generate: ${indexName}[${letter}]`;
+                    jobSpec.operations[0].id_start_key = letter;
+                    return postJob(jobSpec);
+                });
             });
-        }));
     }
 
     return Promise.all([
@@ -127,11 +189,19 @@ function generateTestData() {
     ])
         .then(_.filter)
         .then(_.flatten)
-        .map(job => job.waitForStatus('completed'))
+        .then((jobs) => {
+            const generatedJobs = jobs.map(job => job.waitForStatus('completed'));
+            // we need fully active jobs so we can get proper meta data for recovery state tests
+            generatedJobs.push(populateStateForRecoveryTests());
+            return Promise.all(generatedJobs);
+        })
         .then(() => {
             signale.success('Data generation is done');
         })
-        .catch(err => Promise.reject(new Error('Data generation failed: ', err)));
+        .catch((err) => {
+            signale.error('Data generation failed');
+            return Promise.reject(err);
+        });
 }
 
 beforeAll((done) => {
@@ -146,7 +216,9 @@ beforeAll((done) => {
             done();
         })
         .catch((err) => {
-            signale.error(new Error('Setup failed: ', err, '- `docker-compose logs` may provide clues'));
+            signale.error('Setup failed, `docker-compose logs` may provide clues');
+            signale.error(err.stack);
+
             return misc.compose.kill().finally(() => {
                 process.exit(1);
             });

--- a/lib/cluster/execution_controller/engine.js
+++ b/lib/cluster/execution_controller/engine.js
@@ -25,6 +25,7 @@ module.exports = function module(context, messaging, exStore, stateStore) {
     let executionContext;
     let executionConfig;
     let slicerModule;
+    let startingPointStateRecords;
     let engineFnRunning = false;
 
     const logger = context.apis.foundation.makeLogger({ module: 'execution_engine', ex_id: exId, job_id: jobId });
@@ -205,7 +206,7 @@ module.exports = function module(context, messaging, exStore, stateStore) {
     }
 
     function _executionRecovery() {
-        const recoverExecution = testRecovery || process.env.recover_execution;
+        const recoverExecution = testRecovery || executionConfig.recovered_execution;
 
         return new Promise((resolve, reject) => {
             if (recoverExecution) {
@@ -213,7 +214,10 @@ module.exports = function module(context, messaging, exStore, stateStore) {
                 recovery.initialize();
                 events.on('execution:recovery:complete', () => {
                     recovery.getSlicerStartingPosition()
-                        .then(executionStartingPoints => resolve(executionStartingPoints))
+                        .then((executionStartingPoints) => {
+                            startingPointStateRecords = executionStartingPoints;
+                            resolve(executionStartingPoints);
+                        })
                         .catch(err => reject(parseError(err)));
                 });
 
@@ -227,8 +231,11 @@ module.exports = function module(context, messaging, exStore, stateStore) {
         });
     }
 
-    function _slicerInit(startingPointStateRecords) {
-        return slicerModule.newSlicer(context, executionContext, startingPointStateRecords, logger);
+    function _slicerInit(startingStateRecords) {
+        const startingPoint = startingStateRecords || startingPointStateRecords;
+        if (_.get(startingPoint, '_exit', null)) return Promise.resolve([() => null]);
+
+        return slicerModule.newSlicer(context, executionContext, startingPoint, logger);
     }
 
     function _slicerInitRetry(slicerError) {
@@ -239,7 +246,7 @@ module.exports = function module(context, messaging, exStore, stateStore) {
         logger.error(`Error on slicer initialization, will attempt to retry ${maxRetries} times: ${errMsg}`);
         return new Promise(((resolve, reject) => {
             function retry() {
-                _slicerInit()
+                _slicerInit(startingPointStateRecords)
                     .then((slicerArray) => {
                         logger.info('slicer initialization was successful');
                         resolve(slicerArray);

--- a/lib/cluster/execution_controller/recovery.js
+++ b/lib/cluster/execution_controller/recovery.js
@@ -10,9 +10,10 @@ module.exports = function module(context, messaging, executionAnalytics, exStore
     const numOfSlicersToRecover = executionContext.config.slicers;
     const recoveryQueue = new Queue();
 
-    let recoverExecution = process.env.recover_execution;
-    let exId = process.env.ex_id;
-    let jobId = process.env.job_id;
+    const cleanupType = executionContext.config.recovered_slice_type;
+    let recoverExecution = executionContext.config.recovered_execution;
+    let exId = executionContext.ex_id;
+    let jobId = executionContext.job_id;
     let recoverComplete = true;
 
     const logger = context.apis.foundation.makeLogger({ module: 'execution_recovery', ex_id: exId, job_id: jobId });
@@ -56,6 +57,8 @@ module.exports = function module(context, messaging, executionAnalytics, exStore
     }
 
     function getSlicerStartingPosition() {
+        // if cleanup is set, it implies that it should not continue after recovery
+        if (cleanupType) return Promise.resolve({ _exit: true });
         const recoveredSlices = [];
         for (let i = 0; i < numOfSlicersToRecover; i += 1) {
             recoveredSlices.push(stateStore.executionStartingSlice(recoverExecution, i));
@@ -68,7 +71,7 @@ module.exports = function module(context, messaging, executionAnalytics, exStore
     }
 
     function _processIncompleteSlices(slicerID) {
-        return stateStore.recoverSlices(recoverExecution, slicerID)
+        return stateStore.recoverSlices(recoverExecution, slicerID, cleanupType)
             .then((slices) => {
                 slices.forEach((slice) => {
                     _setId(slice);
@@ -154,7 +157,7 @@ module.exports = function module(context, messaging, executionAnalytics, exStore
     }
 
     function testContext(config) {
-        recoverExecution = config.recover_execution;
+        recoverExecution = config.recovered_execution;
         exId = config.ex_id;
         jobId = config.job_id;
 

--- a/lib/cluster/node_master.js
+++ b/lib/cluster/node_master.js
@@ -94,10 +94,7 @@ module.exports = function module(context) {
                 job_id: createSlicerMsg.job_id,
                 slicer_port: createSlicerMsg.slicer_port
             };
-            // used to retry a job on startup after a stop command
-            if (createSlicerMsg.recover_execution) {
-                controllerContext.recover_execution = createSlicerMsg.recover_execution;
-            }
+
             logger.trace('starting a execution controller', controllerContext);
             context.foundation.startWorkers(1, controllerContext);
 
@@ -430,11 +427,6 @@ module.exports = function module(context) {
             job_id: ex.job_id,
             slicer_port: ex.slicer_port
         };
-        // TODO need to set recover_execution somehow
-        // used to retry a job on startup after a stop command
-        if (ex.recover_execution && workerType === 'execution_controller') {
-            childContext.recover_execution = ex.recover_execution;
-        }
 
         context.foundation.startWorkers(1, childContext);
 

--- a/lib/cluster/services/api.js
+++ b/lib/cluster/services/api.js
@@ -275,6 +275,22 @@ module.exports = function module(context, app) {
             .catch(handleApiError);
     });
 
+    v1routes.post('/ex/:ex_id/_recover', (req, res) => {
+        const { ex_id: exId } = req.params;
+        const { cleanup } = req.query;
+        const handleApiError = handleError(res, logger, 500, `Could not recover execution: ${exId}`);
+        logger.debug(`POST /ex_id/:id/_recover endpoint has been called, ex_id: ${exId}`);
+
+        if (cleanup && !(cleanup === 'all' || cleanup === 'errors')) {
+            res.status(400).json({ error: 'if cleanup is specified it must be set to "all" or "errors"' });
+            return;
+        }
+
+        executionService.recoverExecution(exId, cleanup)
+            .then(response => res.status(200).json(response))
+            .catch(handleApiError);
+    });
+
     v1routes.post('/ex/:ex_id/_resume', (req, res) => {
         const { ex_id: exId } = req.params;
         logger.debug(`POST /ex/:id/_resume endpoint has been called, ex_id: ${exId}`);

--- a/lib/cluster/services/cluster/backends/native.js
+++ b/lib/cluster/services/cluster/backends/native.js
@@ -374,7 +374,7 @@ module.exports = function module(context, messaging, executionService) {
         return Promise.all(results);
     }
 
-    function _createSlicer(job, recoverExecution, errorNodes) {
+    function _createSlicer(job, errorNodes) {
         const sortedNodes = _.orderBy(clusterState, 'available', 'desc');
         const slicerNodeID = _findNodeForSlicer(sortedNodes, errorNodes);
 
@@ -396,8 +396,7 @@ module.exports = function module(context, messaging, executionService) {
                     workers: 1,
                     slicer_port: portObj.port,
                     node_id: slicerNodeID,
-                    assignment: 'execution_controller',
-                    recover_execution: recoverExecution
+                    assignment: 'execution_controller'
                 };
 
                 return messaging.send({
@@ -417,12 +416,12 @@ module.exports = function module(context, messaging, executionService) {
     }
 
 
-    function allocateSlicer(job, recoverExecution) {
+    function allocateSlicer(job) {
         let retryCount = 0;
         const errorNodes = {};
         return new Promise(((resolve, reject) => {
             function retry() {
-                _createSlicer(job, recoverExecution, errorNodes)
+                _createSlicer(job, errorNodes)
                     .then((results) => {
                         resolve(results);
                     })

--- a/lib/cluster/services/execution.js
+++ b/lib/cluster/services/execution.js
@@ -15,7 +15,7 @@ const parseError = require('@terascope/error-parser');
  */
 
 module.exports = function module(context) {
-    const messaging = context.messaging;
+    const { messaging } = context;
     const logger = context.apis.foundation.makeLogger({ module: 'execution_service' });
     const masterNodeId = _parseNodeId(context.sysconfig._nodeName);
     const pendingExecutionQueue = new Queue();
@@ -55,8 +55,8 @@ module.exports = function module(context) {
         return clusterService.allocateWorkers(execution, numOfWorkersRequested);
     }
 
-    function allocateSlicer(execution, recoverExecution) {
-        return clusterService.allocateSlicer(execution, recoverExecution);
+    function allocateSlicer(execution) {
+        return clusterService.allocateSlicer(execution);
     }
 
     function shutdown() {
@@ -167,7 +167,6 @@ module.exports = function module(context) {
 
     function getExecutionContext(exId) {
         return exStore.get(exId)
-            .then(ex => ex)
             .catch(err => logger.error(`error getting execution context for ex: ${exId}`, err));
     }
 
@@ -209,6 +208,55 @@ module.exports = function module(context) {
         return exStore.executionMetaData(stats, errMsg);
     }
 
+    function _canRecover(ex) {
+        if (ex._status === 'completed') {
+            throw new Error('This job has completed and can not be restarted.');
+        }
+        if (ex._status === 'scheduling' || ex._status === 'pending') {
+            throw new Error('This job is currently being scheduled and can not be restarted.');
+        }
+        if (ex._status === 'running') {
+            throw new Error('This job is currently successfully running and can not be restarted.');
+        }
+        return ex;
+    }
+
+    function _removeMetaData(execution) {
+        // we need a better story about what is meta data
+        delete execution.ex_id;
+        delete execution._created;
+        delete execution._updated;
+        delete execution._status;
+        delete execution.slicer_hostname;
+        delete execution.slicer_port;
+        delete execution._has_errors;
+        delete execution._slicer_stats;
+        delete execution._failureReason;
+        delete execution.recovered_slice_state;
+        delete execution._failureReason;
+
+        execution.operations = execution.operations.map((opConfig) => {
+            if (opConfig._op === 'elasticsearch_reader') {
+                if (Array.isArray(opConfig.interval)) opConfig.interval = opConfig.interval.join('');
+            }
+            return opConfig;
+        });
+
+        return execution;
+    }
+
+    function recoverExecution(exId, cleanup) {
+        return getExecutionContext(exId)
+            .then(execution => _canRecover(execution))
+            .then(execution => _removeMetaData(execution))
+            .then((execution) => {
+                execution.recovered_execution = exId;
+                if (cleanup) execution.recovered_slice_type = cleanup;
+                return createExecutionContext(execution);
+            })
+            .catch(err => Promise.reject(parseError(err)));
+    }
+
     const api = {
         getClusterState,
         getClusterStats,
@@ -221,6 +269,7 @@ module.exports = function module(context) {
         stopExecution,
         pauseExecution,
         resumeExecution,
+        recoverExecution,
         removeWorkers,
         addWorkers,
         setWorkers,
@@ -235,18 +284,17 @@ module.exports = function module(context) {
 
     function _executionAllocator() {
         let allocatingExecution = false;
-        const readyForAllocation = clusterService.readyForAllocation;
+        const { readyForAllocation } = clusterService;
         return function allocator() {
             const pendingQueueSize = pendingExecutionQueue.size();
             if (!allocatingExecution && pendingQueueSize > 0 && readyForAllocation()) {
                 allocatingExecution = true;
                 const execution = pendingExecutionQueue.dequeue();
-                const recoverExecution = execution._recover_execution;
 
                 logger.info(`Scheduling execution: ${execution.ex_id}`);
 
                 setExecutionStatus(execution.ex_id, 'scheduling')
-                    .then(() => allocateSlicer(execution, recoverExecution)
+                    .then(() => allocateSlicer(execution)
                         .then(() => setExecutionStatus(execution.ex_id, 'initializing', {
                             slicer_port: execution.slicer_port,
                             slicer_hostname: execution.slicer_hostname

--- a/lib/cluster/services/jobs.js
+++ b/lib/cluster/services/jobs.js
@@ -3,6 +3,7 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
 const parseError = require('@terascope/error-parser');
+const util = require('util');
 
 
 module.exports = function module(context) {
@@ -227,6 +228,8 @@ module.exports = function module(context) {
         });
     }
 
+    const depMsg = 'endpoint /jobs/:job_id/_recover is being depricated, please use the /ex/:ex_id/_recover endpoint';
+
     const api = {
         submitJob,
         updateJob,
@@ -234,7 +237,7 @@ module.exports = function module(context) {
         stopJob,
         pauseJob,
         resumeJob,
-        recoverJob,
+        recoverJob: util.deprecate(recoverJob, depMsg),
         getJob,
         getJobs,
         addWorkers,

--- a/lib/cluster/storage/backends/elasticsearch_store.js
+++ b/lib/cluster/storage/backends/elasticsearch_store.js
@@ -31,7 +31,6 @@ module.exports = function module(context, indexName, recordType, idField, _bulkS
         if (fields) {
             query._source = fields;
         }
-
         return elasticsearch.get(query);
     }
 

--- a/lib/cluster/storage/backends/mappings/ex.json
+++ b/lib/cluster/storage/backends/mappings/ex.json
@@ -31,6 +31,12 @@
         "slicer_port": {
           "type": "keyword"
         },
+        "recovered_execution": {
+          "type": "keyword"
+        },
+        "recovered_slice_type": {
+          "type": "keyword"
+        },
         "_slicer_stats": {
           "type": "object"
         },

--- a/lib/cluster/storage/state.js
+++ b/lib/cluster/storage/state.js
@@ -2,7 +2,7 @@
 
 const Promise = require('bluebird');
 const parseError = require('@terascope/error-parser');
-const timeseriesIndex = require('../../utils/date_utils').timeseriesIndex;
+const { timeseriesIndex } = require('../../utils/date_utils');
 
 // Module to manager job states in Elasticsearch.
 // All functions in this module return promises that must be resolved to
@@ -18,7 +18,7 @@ module.exports = function module(context) {
     let backend;
 
     function createState(exId, slice, state, error) {
-        const index = timeseriesIndex(timeseriesFormat, _index, slice._created).index;
+        const { index } = timeseriesIndex(timeseriesFormat, _index, slice._created);
         const record = {
             _created: slice._created,
             _updated: slice._created,
@@ -73,8 +73,15 @@ module.exports = function module(context) {
             });
     }
 
-    function recoverSlices(exId, slicerId) {
-        const retryQuery = `ex_id:${exId} AND slicer_id:${slicerId} AND NOT (state:completed OR state:invalid)`;
+    function recoverSlices(exId, slicerId, cleanupType) {
+        let retryQuery = `ex_id:${exId} AND slicer_id:${slicerId}`;
+
+        if (cleanupType && cleanupType === 'errors') {
+            retryQuery = `${retryQuery} AND state:error`;
+        } else {
+            retryQuery = `${retryQuery} AND NOT (state:completed OR state:invalid)`;
+        }
+
         // Look for all slices that haven't been completed so they can be retried.
         return backend.refresh(indexName)
             .then(() => backend.search(retryQuery, 0, 5000))

--- a/lib/readers/elasticsearch_data_generator.js
+++ b/lib/readers/elasticsearch_data_generator.js
@@ -77,9 +77,7 @@ function onceGenerator(context, opConfig, executionConfig) {
 }
 
 function persistentGenerator(context, opConfig) {
-    return function _persistentGenerator() {
-        return opConfig.size;
-    };
+    return () => opConfig.size;
 }
 
 function newSlicer(context, executionContext) {

--- a/spec/execution_controller/recovery-spec.js
+++ b/spec/execution_controller/recovery-spec.js
@@ -33,14 +33,14 @@ describe('execution recovery', () => {
             }
         }
     };
-    const messaging = { send: msg => sentMsg = msg };
+    const messaging = { send: (msg) => { sentMsg = msg; } };
     const executionAnalytics = { getAnalytics: () => ({}) };
     const exStore = {
         executionMetaData: () => {},
         setStatus: () => new Promise(resolve => resolve(true))
     };
     const stateStore = {
-        executionStartingSlice: (exId, ind) => startingPoints[ind] = exId,
+        executionStartingSlice: (exId, ind) => { startingPoints[ind] = exId; },
         recoverSlices: () => {
             const data = testSlices.slice();
             testSlices = [];
@@ -49,7 +49,7 @@ describe('execution recovery', () => {
     };
     const executionContext = { config: { slicers: 2 } };
 
-    const testConfig = { ex_id: '1234', job_id: '5678', recover_execution: '9999' };
+    const testConfig = { ex_id: '1234', job_id: '5678', recovered_execution: '9999' };
     let recoveryModule = recoveryCode(context, messaging, executionAnalytics, exStore, stateStore, executionContext);
     let recovery = recoveryModule.__test_context(testConfig);
 
@@ -150,7 +150,7 @@ describe('execution recovery', () => {
         const sendSucess2 = sendEvent('slice:success', { slice: data2 }, eventEmitter2);
         let allDoneEventFired = false;
 
-        eventEmitter2.on('execution:recovery:complete', () => allDoneEventFired = true);
+        eventEmitter2.on('execution:recovery:complete', () => { allDoneEventFired = true; });
 
         expect(recoveryModule.recoveryComplete()).toEqual(false);
         let slicer;
@@ -160,7 +160,7 @@ describe('execution recovery', () => {
                 expect(Array.isArray(slicerArray)).toEqual(true);
                 expect(slicerArray.length).toEqual(1);
                 expect(typeof slicerArray[0]).toEqual('function');
-                slicer = slicerArray[0];
+                [slicer] = slicerArray;
                 expect(recoveryModule.recoveryComplete()).toEqual(false);
                 return slicer();
             })

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,6 +86,15 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
+"@terascope/elasticsearch-api@^1.0.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@terascope/elasticsearch-api/-/elasticsearch-api-1.1.1.tgz#87de959d443289c77cbd0a2131de3b71b6fc4b8a"
+  dependencies:
+    "@terascope/error-parser" "^1.0.0"
+    bluebird "^3.5.0"
+    lodash "^4.17.4"
+    uuid "^3.0.1"
+
 "@terascope/elasticsearch-api@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@terascope/elasticsearch-api/-/elasticsearch-api-1.0.1.tgz#b8696f122338d6a522782c2acf0914271d7ba9e0"


### PR DESCRIPTION
added  /ex/ex_id/_recovery?cleanup=all endpoints. If you use cleanup, it will stop the execution after recovery finishes and exit. cleanup may be set to `errors` or `all`. This pr needs to coincide with PRs in teraslice-client-js so tests may fail
