### PR TITLE
Ensure execution_controller pods are remove on job stop

### DIFF
--- a/lib/cluster/services/cluster/backends/kubernetes/k8s.js
+++ b/lib/cluster/services/cluster/backends/kubernetes/k8s.js
@@ -200,8 +200,16 @@ class K8s {
                 response = await this.client.api.apps.v1.namespaces(this.defaultNamespace)
                     .deployments(name).delete();
             } else if (objType === 'jobs') {
+                // To get a Job to remove the associated pods you have to
+                // include a body like the one below with the delete request
                 response = await this.client.api.batch.v1.namespaces(this.defaultNamespace)
-                    .jobs(name).delete();
+                    .jobs(name).delete({
+                        body: {
+                            apiVersion: 'v1',
+                            kind: 'DeleteOptions',
+                            propagationPolicy: 'Background'
+                        }
+                    });
             } else {
                 throw new Error(`Invalid objType: ${objType}`);
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teraslice",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "Slice and dice your Elasticsearch data",
   "bin": "service.js",
   "main": "service.js",


### PR DESCRIPTION
This is called the Cascading Deletion Policy by k8s.  Basically we just
need to pass a body with the request that will ensure pods get deleted
too.  I suppose we might encounter conditions where we don't want the
pods deleted when the job is, but for now, we'll force that.

closes: #777