### PR TITLE
Issue 773 config image pull

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN yarn install \
     --no-progress \
     --production=true
 
-COPY entrypoint.js lerna.json examples /app/source/ 
+COPY entrypoint.js lerna.json examples /app/source/
 COPY packages /app/source/packages
 COPY scripts /app/source/scripts
 

--- a/docs/k8s-clustering.md
+++ b/docs/k8s-clustering.md
@@ -33,11 +33,17 @@ This may not be appropriate for production environments.
 
 ### Kubernetes Specific Configuration Settings
 
-|  Configuration   |                    Description                    |  Type  |  Notes   |
-|:----------------:|:-------------------------------------------------:|:------:|:--------:|
-| kubernetes_image | Name of docker image, default: `teraslice:k8sdev` | String | optional |
+|        Configuration         |                                                                         Description                                                                         |  Type  |  Notes   |
+|:----------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------:|:------:|:--------:|
+|       kubernetes_image       |                                                      Name of docker image, default: `teraslice:k8sdev`                                                      | String | optional |
+| kubernetes_image_pull_secret |                                                     Secret used to pull docker images from private repo                                                     | String | optional |
+|  kubernetes_config_map_name  | Name of the configmap used by worker and executcion_controller containers for config.  If this is not provided, the default will be `<CLUSTER_NAME>-worker` | String | optional |
+
 
 ### ConfigMaps
+
+TODO: New configMap names must match the cluster name set in  the config
+followed by `-worker`, e.g.: `teraslice-qa3-worker`
 
 Kubernetes ConfigMaps are used to configure Teraslice, you will need to
 substitute the appropriate Elasticsearch host and port number for the values:

--- a/docs/k8s-clustering.md
+++ b/docs/k8s-clustering.md
@@ -42,9 +42,6 @@ This may not be appropriate for production environments.
 
 ### ConfigMaps
 
-TODO: New configMap names must match the cluster name set in  the config
-followed by `-worker`, e.g.: `teraslice-qa3-worker`
-
 Kubernetes ConfigMaps are used to configure Teraslice, you will need to
 substitute the appropriate Elasticsearch host and port number for the values:
 

--- a/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/deployments/worker.hbs
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/deployments/worker.hbs
@@ -51,15 +51,15 @@
                 "volumes": [{
                     "name": "config",
                     "configMap": {
-                        "name": "teraslice-worker",
+                        "name": "{{configMapName}}",
                         "items": [{
-                            "key": "teraslice-worker.yaml",
+                            "key": "teraslice.yaml",
                             "path": "teraslice.yaml"
                         }]
                     }
                 }],
                 "terminationGracePeriodSeconds": {{shutdownTimeout}},
-                "imagePullSecrets": [{ "name": "docker-tera1-secret" }]
+                "imagePullSecrets": [{ "name": "{{imagePullSecret}}" }]
             }
         },
         "selector": {

--- a/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/index.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/index.js
@@ -32,6 +32,16 @@ module.exports = function kubernetesClusterBackend(context, messaging) {
 
     const kubernetesImage = _.get(context, 'sysconfig.teraslice.kubernetes_image', 'teraslice:k8sdev');
     const kubernetesNamespace = _.get(context, 'sysconfig.teraslice.kubernetes_namespace', 'default');
+    const configMapName = _.get(
+        context,
+        'sysconfig.teraslice.kubernetes_config_map_name',
+        `${context.sysconfig.teraslice.name}-worker`
+    );
+    const imagePullSecret = _.get(
+        context,
+        'sysconfig.teraslice.kubernetes_image_pull_secret',
+        'teraslice-image-pull-secret'
+    );
 
     const clusterState = {};
     let clusterStateInterval = null;
@@ -189,7 +199,11 @@ module.exports = function kubernetesClusterBackend(context, messaging) {
             nodeType: 'execution_controller',
             namespace: kubernetesNamespace,
             shutdownTimeout: shutdownTimeoutSeconds,
+            configMapName,
+            imagePullSecret,
         };
+
+        logger.info(`c: ${JSON.stringify(jobConfig, null, 2)}`);
 
         const exJob = exJobTemplate(jobConfig);
 
@@ -232,6 +246,8 @@ module.exports = function kubernetesClusterBackend(context, messaging) {
             namespace: kubernetesNamespace,
             shutdownTimeout: shutdownTimeoutSeconds,
             replicas: numWorkers,
+            configMapName,
+            imagePullSecret,
         };
 
         const workerDeployment = workerDeploymentTemplate(deploymentConfig);

--- a/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/index.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/index.js
@@ -203,8 +203,6 @@ module.exports = function kubernetesClusterBackend(context, messaging) {
             imagePullSecret,
         };
 
-        logger.info(`c: ${JSON.stringify(jobConfig, null, 2)}`);
-
         const exJob = exJobTemplate(jobConfig);
 
         logger.debug(`exJob:\n\n${JSON.stringify(exJob, null, 2)}`);

--- a/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/jobs/execution_controller.hbs
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/jobs/execution_controller.hbs
@@ -50,16 +50,14 @@
                 "volumes": [{
                     "name": "config",
                     "configMap": {
-                        "name": "teraslice-worker",
+                        "name": "{{configMapName}}",
                         "items": [{
-                            "key": "teraslice-worker.yaml",
+                            "key": "teraslice.yaml",
                             "path": "teraslice.yaml"
                         }]
                     }
                 }],
-                "imagePullSecrets": [
-                    { "name": "docker-tera1-secret" }
-                ],
+                "imagePullSecrets": [{ "name": "{{imagePullSecret}}" }],
                 "terminationGracePeriodSeconds": {{shutdownTimeout}},
                 "restartPolicy": "Never"
             }

--- a/packages/teraslice/lib/config/schemas/system.js
+++ b/packages/teraslice/lib/config/schemas/system.js
@@ -210,6 +210,16 @@ const schema = {
         doc: 'Specify a custom kubernetes namespace, this only applies to kubernetes systems',
         default: 'default',
         format: 'optional_String'
+    },
+    kubernetes_config_map_name: {
+        doc: 'Specify the name of the Kubernetes ConfigMap used to configure worker pods',
+        default: 'teraslice-worker',
+        format: 'optional_String'
+    },
+    kubernetes_image_pull_secret: {
+        doc: 'Name of Kubernetes secret used to pull docker images from private repository',
+        default: 'teraslice-image-pull-secret',
+        format: 'optional_String'
     }
 };
 


### PR DESCRIPTION
This PR adds two new config options

* `kubernetes_config_map_name` - the name of the config map that the teraslice master associates with the workers it launches.  On our internal systems, the name ends up being `<CLUSTERNAME>-worker` but it should be able to be anything.
* `kubernetes_image_pull_secret` - the kubernetes secret used for pulling docker images


