### PR TITLE
set a transition of stopping before its stopped resolves #783

### DIFF
--- a/packages/teraslice/lib/cluster/services/api.js
+++ b/packages/teraslice/lib/cluster/services/api.js
@@ -517,8 +517,8 @@ module.exports = function module(context, app) {
             function checkExecution() {
                 executionService.getExecutionContext(exId)
                     .then((execution) => {
-                        const terminalStatuses = executionService.terminalStatusList();
-                        const isTerminal = terminalStatuses.find(tStatus => tStatus === execution._status);
+                        const terminalList = executionService.terminalStatusList();
+                        const isTerminal = terminalList.find(tStat => tStat === execution._status);
                         if (isTerminal) resolve(true);
                         else setTimeout(checkExecution, 3000);
                     })

--- a/packages/teraslice/lib/cluster/services/api.js
+++ b/packages/teraslice/lib/cluster/services/api.js
@@ -137,11 +137,12 @@ module.exports = function module(context, app) {
     });
 
     v1routes.post('/jobs/:job_id/_stop', (req, res) => {
-        const { query: { timeout }, params: { job_id: jobId } } = req;
+        const { query: { timeout, blocking = true }, params: { job_id: jobId } } = req;
         logger.trace(`POST /jobs/:job_id/_stop endpoint has been called, job_id: ${jobId}, removing any pending workers for the job`);
-        const handleApiError = handleError(res, logger, 500, `Could not stop execution for job: ${jobId}`);
 
-        jobsService.stopJob(jobId, timeout)
+        const handleApiError = handleError(res, logger, 500, `Could not stop execution for job: ${jobId}`);
+        console.log('what is blocking', blocking, typeof blocking)
+        jobsService.stopJob(jobId, timeout, blocking)
             .then(status => res.status(200).json({ status }))
             .catch(handleApiError);
     });
@@ -254,12 +255,12 @@ module.exports = function module(context, app) {
     });
 
     v1routes.post('/ex/:ex_id/_stop', (req, res) => {
-        const { params: { ex_id: exId }, query: { timeout } } = req;
+        const { params: { ex_id: exId }, query: { timeout, blocking = true } } = req;
         logger.trace(`POST /ex/:ex_id/_stop endpoint has been called, ex_id: ${exId}, removing any pending workers for the job`);
         const handleApiError = handleError(res, logger, 500, `Could not stop execution: ${exId}`);
         // for lifecyle events, we need to ensure that the execution is alive first
         executionService.getActiveExecution(exId)
-            .then(() => executionService.stopExecution(exId, timeout))
+            .then(() => executionService.stopExecution(exId, timeout, blocking))
             .then(() => res.status(200).json({ status: 'stopped' }))
             .catch(handleApiError);
     });

--- a/packages/teraslice/lib/cluster/services/api.js
+++ b/packages/teraslice/lib/cluster/services/api.js
@@ -529,16 +529,7 @@ module.exports = function module(context, app) {
             }
 
             checkExecution();
-        })
-            .then(() => executionService.getExecutionContext(exId))
-            .then((execution) => {
-                const terminalStatuses = executionService.terminalStatusList();
-                const isTerminal = terminalStatuses.find(tStatus => tStatus === execution._status);
-                if (!isTerminal) {
-                    return executionService.setExecutionStatus(exId, 'stopped');
-                }
-                return true;
-            });
+        });
     }
 
     return require('../storage/state')(context)

--- a/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/index.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/index.js
@@ -335,25 +335,7 @@ module.exports = function kubernetesClusterBackend(context, messaging) {
      */
 
     async function stopExecution(exId) {
-        await k8s.deleteExecution(exId);
-
-        return new Promise((resolve) => {
-            function checkCluster() {
-                _getClusterState()
-                    .then((state) => {
-                        const results = _.flatten(_.map(
-                            state,
-                            node => _.map(node.active, worker => worker.ex_id)
-                        ));
-                        if (results.find(exId)) {
-                            setTimeout(checkCluster, 3000);
-                        }
-                        resolve(true);
-                    })
-                    .catch(() => setTimeout(checkCluster, 3000));
-            }
-            checkCluster();
-        });
+        return k8s.deleteExecution(exId);
     }
 
     function pauseExecution(exId) {

--- a/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/index.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/index.js
@@ -333,8 +333,27 @@ module.exports = function kubernetesClusterBackend(context, messaging) {
      * @param  {string} exId    The execution ID of the Execution to stop
      * @return {Promise}
      */
+
     async function stopExecution(exId) {
-        return k8s.deleteExecution(exId);
+        await k8s.deleteExecution(exId);
+
+        return new Promise((resolve) => {
+            function checkCluster() {
+                _getClusterState()
+                    .then((state) => {
+                        const results = _.flatten(_.map(
+                            state,
+                            node => _.map(node.active, worker => worker.ex_id)
+                        ));
+                        if (results.find(exId)) {
+                            setTimeout(checkCluster, 3000);
+                        }
+                        resolve(true);
+                    })
+                    .catch(() => setTimeout(checkCluster, 3000));
+            }
+            checkCluster();
+        });
     }
 
     function pauseExecution(exId) {

--- a/packages/teraslice/lib/cluster/services/cluster/backends/native.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/native.js
@@ -543,7 +543,7 @@ module.exports = function module(context, messaging, executionService) {
             });
     }
 
-    function _notifyNodesWithExecution(exId, messageData, slicerOnly, excludeNode) {
+    function _notifyNodesWithExecution(exId, messageData, slicerOnly, excludeNode, response) {
         return new Promise(((resolve, reject) => {
             const destination = slicerOnly ? 'execution_controller' : 'node_master';
             let nodes = _findNodesForExecution(exId, slicerOnly);
@@ -561,7 +561,7 @@ module.exports = function module(context, messaging, executionService) {
                     to: destination,
                     address: node.node_id,
                     ex_id: exId,
-                    response: true
+                    response
                 });
 
                 return messaging.send(sendingMsg);
@@ -584,21 +584,32 @@ module.exports = function module(context, messaging, executionService) {
     function clusterAvailable() {}
 
     function stopExecution(exId, timeout, exclude) {
+        // we are allowing stopExecution to be non blocking, we block at api level
+        const response = false;
+        const slicerOnly = false;
         const excludeNode = exclude || null;
         pendingWorkerRequests.remove(exId);
         const sendingMessage = { message: 'cluster:execution:stop' };
         if (timeout) {
             sendingMessage.timeout = timeout;
         }
-        return _notifyNodesWithExecution(exId, sendingMessage, false, excludeNode);
+        return _notifyNodesWithExecution(exId, sendingMessage, slicerOnly, excludeNode, response);
     }
 
     function pauseExecution(exId) {
-        return _notifyNodesWithExecution(exId, { message: 'cluster:execution:pause' }, true, null);
+        const response = true;
+        const slicerOnly = true;
+        const excludeNode = null;
+        const sendingMessage = { message: 'cluster:execution:pause' };
+        return _notifyNodesWithExecution(exId, sendingMessage, slicerOnly, excludeNode, response);
     }
 
     function resumeExecution(exId) {
-        return _notifyNodesWithExecution(exId, { message: 'cluster:execution:resume' }, true, null);
+        const response = true;
+        const slicerOnly = true;
+        const excludeNode = null;
+        const sendingMessage = { message: 'cluster:execution:resume' };
+        return _notifyNodesWithExecution(exId, sendingMessage, slicerOnly, excludeNode, response);
     }
 
     const getSlicerStats = stateUtils.newGetSlicerStats(clusterState, context, messaging);

--- a/packages/teraslice/lib/cluster/services/jobs.js
+++ b/packages/teraslice/lib/cluster/services/jobs.js
@@ -107,12 +107,6 @@ module.exports = function module(context) {
             .catch(err => Promise.reject(parseError(err)));
     }
 
-    function stopJob(jobId, timeout, blocking) {
-        return getLatestExecutionId(jobId)
-            .then(exId => executionService.stopExecution(exId, timeout, null, null, blocking))
-            .catch(err => Promise.reject(parseError(err)));
-    }
-
     function pauseJob(jobId) {
         return getLatestExecutionId(jobId)
             .then(exId => executionService.pauseExecution(exId))
@@ -239,7 +233,6 @@ module.exports = function module(context) {
         submitJob,
         updateJob,
         startJob,
-        stopJob,
         pauseJob,
         resumeJob,
         recoverJob: util.deprecate(recoverJob, depMsg),

--- a/packages/teraslice/lib/cluster/services/jobs.js
+++ b/packages/teraslice/lib/cluster/services/jobs.js
@@ -127,7 +127,7 @@ module.exports = function module(context) {
         return jobStore.search('job_id:*', from, size, sort);
     }
 
-    function _getLatestExecution(jobId, _query, allowZero) {
+    function getLatestExecution(jobId, _query, allowZero) {
         const allowZeroResults = allowZero || false;
         let query = `job_id: ${jobId}`;
         if (_query) query = _query;
@@ -143,7 +143,7 @@ module.exports = function module(context) {
     function _getActiveExecution(jobId, allowZeroResults) {
         const str = executionService.terminalStatusList().map(state => ` _status:${state} `).join('OR');
         const query = `job_id: ${jobId} AND _context:ex NOT (${str.trim()})`;
-        return _getLatestExecution(jobId, query, allowZeroResults);
+        return getLatestExecution(jobId, query, allowZeroResults);
     }
 
     function _getActiveExecutionId(jobId) {
@@ -152,7 +152,7 @@ module.exports = function module(context) {
     }
 
     function getLatestExecutionId(jobId) {
-        return _getLatestExecution(jobId)
+        return getLatestExecution(jobId)
             .then(ex => ex.ex_id);
     }
 
@@ -242,6 +242,7 @@ module.exports = function module(context) {
         removeWorkers,
         setWorkers,
         getLatestExecutionId,
+        getLatestExecution,
         shutdown
     };
 

--- a/packages/teraslice/lib/cluster/services/jobs.js
+++ b/packages/teraslice/lib/cluster/services/jobs.js
@@ -107,9 +107,9 @@ module.exports = function module(context) {
             .catch(err => Promise.reject(parseError(err)));
     }
 
-    function stopJob(jobId, timeout) {
+    function stopJob(jobId, timeout, blocking) {
         return getLatestExecutionId(jobId)
-            .then(exId => executionService.stopExecution(exId, timeout))
+            .then(exId => executionService.stopExecution(exId, timeout, null, null, blocking))
             .catch(err => Promise.reject(parseError(err)));
     }
 

--- a/packages/teraslice/lib/cluster/storage/execution.js
+++ b/packages/teraslice/lib/cluster/storage/execution.js
@@ -6,7 +6,7 @@ const Promise = require('bluebird');
 const _ = require('lodash');
 
 const INIT_STATUS = ['pending', 'scheduling', 'initializing'];
-const RUNNING_STATUS = ['running', 'failing', 'paused'];
+const RUNNING_STATUS = ['running', 'failing', 'paused', 'stopping'];
 const TERMINAL_STATUS = ['completed', 'stopped', 'rejected', 'failed', 'terminated'];
 
 const VALID_STATUS = INIT_STATUS.concat(RUNNING_STATUS).concat(TERMINAL_STATUS);


### PR DESCRIPTION
simple fix. It changes the status to `stopping`, waits for it to stop, then it checks to see if its already in a terminal status before changing it to `stopped` 