### PR TITLE
Ensure Asset Directory Exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ npm install --global teraslice-job-manager
 
 Teraslice requires a configuration file in order to run. The configuration file defines your service connections and system level configurations.
 
-This configuration example defines a single connection to Elasticsearch on localhost with 8 workers available to Teraslice. The *teraslice.ops_directory* setting tells Teraslice where it can find custom operation implementations.
+This configuration example defines a single connection to Elasticsearch on localhost with 8 workers available to Teraslice.
 
 The cluster configuration defines this node as a master node. The node will still have workers
 available and this configuration is sufficient to do useful work if you don't have multiple
@@ -97,7 +97,6 @@ nodes available. The workers will connect to the master on localhost and do work
 
 ```
 teraslice:
-    ops_directory: '/path/to/ops/'
     workers: 8
     master: true
     master_hostname: "127.0.0.1"
@@ -120,7 +119,6 @@ Configuration for a worker node is very similar. You just set 'master' to false 
 
 ```
 teraslice:
-    ops_directory: '/path/to/ops/'
     workers: 8
     master: false
     master_hostname: "YOUR_MASTER_IP"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,6 @@ Example Config
     "network_timeout": 20000,
     "master_hostname": "SomeIP",
     "name": "teracluster",
-    "ops_directory": "/Some/path/to/ops",
     "assets_directory": "/Some/path/to/assets_ops",
     "workers": 8,
     "shutdown_timeout": 60000
@@ -51,7 +50,6 @@ The configuration file essentially has two main fields, configuration for terasl
 
 | Configuration | Description | Type |  Notes
 |:---------: | :--------: | :------: | :------:
-ops_directory | 'path/to/directory', to look for more readers and processors. Usually this is where you place your custom code not part of core, unless you want to leave your code in place. The directory should have a "readers" and "processors" folder mirroring teraslice| String | optional
 assets_directory | 'path/to/directory', to look for more custom readers and processors. Usually this is where you place your custom code not part of core, unless you want to leave your code in place. | String | optional
 action_timeout | time in milliseconds for waiting for a action ( pause/stop job, etc) to complete before throwing an error | Number | optional, defaults to 300000 ms
 network_latency_buffer | time in milliseconds buffer which is combined with action_timeout to determine how long the cluster master will wait till it throws an error | Number | optional, defaults to 15000 ms

--- a/docs/custom_operations.md
+++ b/docs/custom_operations.md
@@ -5,18 +5,18 @@ and utilize them in your Teraslice jobs.
 
 The first step to utilizing custom operations is to configure your Teraslice
 nodes to point to the directory containing your custom code, this is done by
-setting the `ops_directory` setting in the `teraslice` section of your
+setting the `assets_directory` setting in the `teraslice` section of your
 configuration file as shown below.
 
 ```yaml
 ...
 teraslice:
-    ops_directory: '/app/source/examples/ops/'
+    assets_directory: '/app/source/assets/'
 ...
 ```
 
-This directory must contain a `package.json`, a `processors` directory with your
-custom processor code, and the `node_modules` required by your custom code.  It
+This directory must contain a `package.json`, a `assets` directory with your
+custom operations, and the `node_modules` required by your custom code. It
 will look something like this:
 
 ```
@@ -24,8 +24,21 @@ will look something like this:
 ├── node_modules
 │   └── lodash
 ├── package.json
-└── processors
+└── assets
+    ├── asset.json
     └── count.js
+```
+
+In order to decrease the size of your asset bundle keepy the `devDependencies` and any test files at the top-level of the asset bundle
+and not within the `assets` directory.
+
+An `asset.json` is used to define a bundle of operations, it contains a name and version.
+
+```json
+{
+    "name": "example",
+    "version": "1.0.0"
+}
 ```
 
 A job configuration that makes use of a custom operator would simply call the
@@ -123,5 +136,4 @@ module.exports = {
   post_validation: post_validation,
   slicerQueueLength: slicerQueueLength
 }
-
 ```

--- a/e2e/config/processor-master.yaml
+++ b/e2e/config/processor-master.yaml
@@ -16,7 +16,6 @@ teraslice:
     slicer_timeout: 60000
     shutdown_timeout: 30000
     assets_directory: '/tmp/'
-    ops_directory: '/app/source/examples/ops/'
     workers: 5
     master: true
     master_hostname: "127.0.0.1"

--- a/e2e/config/processor-worker.yaml
+++ b/e2e/config/processor-worker.yaml
@@ -16,7 +16,6 @@ teraslice:
     slicer_timeout: 60000
     shutdown_timeout: 30000
     assets_directory: '/tmp/'
-    ops_directory: '/app/source/examples/ops/'
     workers: 5
     master: false
     master_hostname: "teraslice-master"

--- a/examples/config/processor-master-k8s.yaml
+++ b/examples/config/processor-master-k8s.yaml
@@ -11,7 +11,6 @@ terafoundation:
                     - "127.0.0.1:9200"
 
 teraslice:
-    ops_directory: '/app/source/examples/ops/'
     cluster_manager_type: 'kubernetes'
     master: true
     master_hostname: "127.0.0.1"

--- a/examples/config/processor-master.yaml
+++ b/examples/config/processor-master.yaml
@@ -11,8 +11,6 @@ terafoundation:
                     - "127.0.0.1:9200"
 
 teraslice:
-    ops_directory: '/app/source/examples/ops/'
-
     master: true
     master_hostname: "127.0.0.1"
     name: "teracluster"

--- a/examples/config/processor-worker.yaml
+++ b/examples/config/processor-worker.yaml
@@ -11,9 +11,6 @@ terafoundation:
                     - "127.0.0.1:9200"
 
 teraslice:
-    ops_directory: '/app/source/examples/ops/'
-
     master: false
     master_hostname: "teraslice-master"
     name: "teracluster"
-

--- a/examples/k8s/teraslice-master.yaml
+++ b/examples/k8s/teraslice-master.yaml
@@ -6,7 +6,6 @@ terafoundation:
                 host:
                     - "<ELASTICSEARCH_HOST>:<ELASTICSEARCH_PORT>"
 teraslice:
-    ops_directory: '/app/source/examples/ops/'
     assets_directory: '/app/assets/'
     cluster_manager_type: "kubernetes"
     master: true

--- a/examples/k8s/teraslice-master.yaml.tpl
+++ b/examples/k8s/teraslice-master.yaml.tpl
@@ -11,7 +11,6 @@ teraslice:
     node_disconnect_timeout: 120000
     slicer_timeout: 60000
     shutdown_timeout: 30000
-    ops_directory: '/app/source/examples/ops/'
     assets_directory: '/app/assets/'
     cluster_manager_type: "kubernetes"
     master: true

--- a/examples/k8s/teraslice-worker.yaml
+++ b/examples/k8s/teraslice-worker.yaml
@@ -6,7 +6,6 @@ terafoundation:
                 host:
                     - "<ELASTICSEARCH_HOST>:<ELASTICSEARCH_PORT>"
 teraslice:
-    ops_directory: '/app/source/examples/ops/'
     assets_directory: '/app/assets/'
     cluster_manager_type: "kubernetes"
     master: false

--- a/examples/k8s/teraslice-worker.yaml.tpl
+++ b/examples/k8s/teraslice-worker.yaml.tpl
@@ -11,7 +11,6 @@ teraslice:
     node_disconnect_timeout: 120000
     slicer_timeout: 60000
     shutdown_timeout: 30000
-    ops_directory: '/app/source/examples/ops/'
     assets_directory: '/app/assets/'
     cluster_manager_type: "kubernetes"
     master: false

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terascope/job-components",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },
@@ -39,6 +39,7 @@
     "@types/lodash": "^4.14.116",
     "@types/node": "^10.7.1",
     "fs-extra": "^7.0.0",
+    "lodash": "^4.17.5",
     "rimraf": "^2.0.0",
     "ts-node": "^7.0.1",
     "typescript": "^3.0.1"

--- a/packages/job-components/src/operation-loader.ts
+++ b/packages/job-components/src/operation-loader.ts
@@ -4,10 +4,10 @@ import { LegacyOperation } from '@terascope/teraslice-types';
 import fs from 'fs';
 import { pathExistsSync } from 'fs-extra';
 import path from 'path';
+import { isString } from 'lodash';
 
 export interface LoaderOptions {
     terasliceOpPath: string;
-    opPath: string|null|undefined;
     assetPath?: string;
 }
 
@@ -47,7 +47,7 @@ export class OperationLoader {
             });
         };
 
-        const findCodeByConvention = (basePath: string|null|undefined, subfolders?: string[], resolvePath?: boolean) => {
+        const findCodeByConvention = (basePath?: string, subfolders?: string[], resolvePath?: boolean) => {
             if (!basePath) return;
             if (!pathExistsSync(basePath)) return;
             if (!subfolders || !subfolders.length) return;
@@ -61,14 +61,10 @@ export class OperationLoader {
             });
         };
 
-        findCodeByConvention(this.options.assetPath || null, executionAssets);
+        findCodeByConvention(this.options.assetPath, executionAssets);
 
         if (!filePath) {
             findCodeByConvention(this.options.terasliceOpPath, ['readers', 'processors']);
-        }
-
-        if (!filePath) {
-            findCodeByConvention(this.options.opPath, ['readers', 'processors']);
         }
 
         if (!filePath) {
@@ -105,8 +101,8 @@ export class OperationLoader {
     }
 
     private verifyOpName(name: string): void {
-        if (typeof name !== 'string') {
-            throw new Error('please verify that ops_directory in config and _op for each job operations are strings');
+        if (!isString(name)) {
+            throw new Error('Please verify that the "_op" name exists for each operation');
         }
     }
 }

--- a/packages/job-components/test/job-validator-spec.ts
+++ b/packages/job-components/test/job-validator-spec.ts
@@ -8,7 +8,6 @@ describe('JobValidator', () => {
     const terasliceOpPath = path.join(__dirname, '../../teraslice/lib');
     const api = new JobValidator(context, {
         terasliceOpPath,
-        opPath: '',
     });
 
     it('returns a completed and valid jobConfig', () => {

--- a/packages/job-components/test/operation-loader-spec.ts
+++ b/packages/job-components/test/operation-loader-spec.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { LegacyProcessor, LegacyReader, newTestJobConfig, TestContext } from '@terascope/teraslice-types';
-import fs from 'fs-extra';
+import fse from 'fs-extra';
 import 'jest-extended'; // require for type definitions
 import path from 'path';
 import { OperationLoader } from '../src';
@@ -15,15 +15,14 @@ describe('OperationLoader', () => {
     const context = new TestContext('teraslice-op-loader');
 
     beforeAll(async () => {
-        await fs.ensureDir(testDir);
-        await fs.copy(processorPath, path.join(assetPath, 'noop.js'));
+        await fse.ensureDir(testDir);
+        await fse.copy(processorPath, path.join(assetPath, 'noop.js'));
     });
 
-    afterAll(() => fs.remove(testDir));
+    afterAll(() => fse.remove(testDir));
 
     it('can instantiate', () => {
         const opLoader = new OperationLoader({
-            opPath: '',
             terasliceOpPath,
         });
 
@@ -34,7 +33,6 @@ describe('OperationLoader', () => {
 
     it('can load an operation', () => {
         const opLoader = new OperationLoader({
-            opPath: '',
             terasliceOpPath,
         });
         const results = opLoader.load('noop') as LegacyProcessor;
@@ -63,7 +61,6 @@ describe('OperationLoader', () => {
 
     it('can load by file path', () => {
         const opLoader = new OperationLoader({
-            opPath: '',
             terasliceOpPath,
         });
         const op = opLoader.load(path.join(__dirname, 'fixtures', 'test-op')) as LegacyProcessor;
@@ -87,7 +84,6 @@ describe('OperationLoader', () => {
 
     it('can throw proper errors if op code does not exits', () => {
         const opLoader = new OperationLoader({
-            opPath: '',
             terasliceOpPath,
         });
 
@@ -98,9 +94,8 @@ describe('OperationLoader', () => {
 
     it('can load asset ops', () => {
         const opLoader = new OperationLoader({
-            assetPath: testDir,
-            opPath: '',
             terasliceOpPath,
+            assetPath: testDir,
         });
 
         const results = opLoader.load('noop', [assetId]) as LegacyProcessor;

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/terascope/teraslice/issues"
   },
   "dependencies": {
-    "@terascope/job-components": "^0.3.2",
+    "@terascope/job-components": "^0.4.0",
     "@terascope/teraslice-types": "^0.1.1",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.4"

--- a/packages/teraslice-types/src/context.ts
+++ b/packages/teraslice-types/src/context.ts
@@ -6,7 +6,6 @@ export interface Logger extends bunyan {
 }
 
 export interface TerasliceConfig {
-    ops_directory?: string;
     assets_directory?: string;
     cluster_manager_type?: string;
 }

--- a/packages/teraslice-types/src/test-helpers.ts
+++ b/packages/teraslice-types/src/test-helpers.ts
@@ -86,7 +86,6 @@ export class TestContext implements c.Context {
                 connectors: {},
             },
             teraslice: {
-                ops_directory: '',
             },
         };
 

--- a/packages/teraslice-worker/lib/execution-context/execution-context.js
+++ b/packages/teraslice-worker/lib/execution-context/execution-context.js
@@ -18,7 +18,6 @@ class ExectionContext {
         this._opLoader = new OperationLoader({
             terasliceOpPath,
             assetPath: _.get(context, 'sysconfig.teraslice.assets_directory'),
-            opPath: _.get(context, 'sysconfig.teraslice.ops_directory')
         });
 
         registerApis(context, executionContext.job);

--- a/packages/teraslice-worker/lib/teraslice/index.js
+++ b/packages/teraslice-worker/lib/teraslice/index.js
@@ -8,7 +8,6 @@ async function validateJob(context, jobSpec) {
     const jobValidator = new JobValidator(context, {
         terasliceOpPath,
         assetPath: get(context, 'sysconfig.teraslice.assets_directory'),
-        opPath: get(context, 'sysconfig.teraslice.ops_directory')
     });
 
     try {

--- a/packages/teraslice-worker/package.json
+++ b/packages/teraslice-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teraslice-worker",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Teraslice worker",
   "main": "index.js",
   "scripts": {
@@ -31,7 +31,7 @@
   "dependencies": {
     "@terascope/error-parser": "^1.0.0",
     "@terascope/queue": "^1.1.3",
-    "@terascope/job-components": "^0.3.2",
+    "@terascope/job-components": "^0.4.0",
     "bluebird": "^3.5.1",
     "bluebird-retry": "^0.11.0",
     "fs-extra": "^7.0.0",
@@ -44,7 +44,7 @@
     "socket.io": "~2.1.1",
     "socket.io-client": "~2.1.1",
     "terafoundation": "^0.2.1",
-    "teraslice": "^0.39.2",
+    "teraslice": "^0.40.0",
     "uuid": "^3.3.2",
     "yargs": "^12.0.1"
   }

--- a/packages/teraslice-worker/test/lib/execution-context/execution-context-spec.js
+++ b/packages/teraslice-worker/test/lib/execution-context/execution-context-spec.js
@@ -88,7 +88,7 @@ describe('Execution Context', () => {
             });
 
             it('should reject with an error', () => {
-                const errMsg = 'please verify that ops_directory in config and _op for each job operations are strings';
+                const errMsg = 'Please verify that the "_op" name exists for each operation';
                 return expect(executionContext.initialize()).rejects.toThrow(errMsg);
             });
         });
@@ -346,7 +346,7 @@ describe('Execution Context', () => {
             });
 
             it('should reject with an error', () => {
-                const errMsg = 'please verify that ops_directory in config and _op for each job operations are strings';
+                const errMsg = 'Please verify that the "_op" name exists for each operation';
                 return expect(executionContext.initialize()).rejects.toThrow(errMsg);
             });
         });

--- a/packages/teraslice/index.js
+++ b/packages/teraslice/index.js
@@ -25,10 +25,6 @@ const { saveAsset } = require('./lib/utils/file_utils');
 
 const terasliceOpPath = path.join(__dirname, 'lib');
 
-function opsDirectory(configFile) {
-    return get(configFile, 'teraslice.ops_directory', null);
-}
-
 function clusterName(configFile) {
     return get(configFile, 'teraslice.name', null);
 }
@@ -42,7 +38,6 @@ function getTerasliceConfig(sysconfig) {
         name: 'teraslice',
         config_schema: configSchema,
         schema_formats: formats,
-        ops_directory: opsDirectory,
         cluster_name: clusterName,
         logging_connection: loggingConnection
     }, sysconfig);

--- a/packages/teraslice/lib/cluster/assets_loader.js
+++ b/packages/teraslice/lib/cluster/assets_loader.js
@@ -28,8 +28,10 @@ module.exports = function assetLoader(context) {
                 clearInterval(shutDownInterval);
                 if (counter <= 0) {
                     logger.error(`shut down time limit has been reached, asset_loader for execution ${exId} will exit while its loading assets ${JSON.stringify(job.assets)}`);
-                } else {
+                } else if (exId) {
                     logger.info(`asset_loader for execution ${exId} has finished loading`);
+                } else {
+                    logger.info('asset_loader has finished preloading');
                 }
 
                 Promise.resolve()
@@ -75,10 +77,11 @@ module.exports = function assetLoader(context) {
     Promise.resolve(require('./storage/assets')(context))
         .then(assetStore => loadAssets(assetStore, job.assets))
         .then((assetArray) => {
-            logger.info(`finished loading assets ${assetArray.join(', ')} for execution: ${exId} on node ${context.sysconfig._nodeName}`);
             if (process.env.preload) {
+                logger.info(`finished preloading loading assets ${job.assets.join(', ')} on node ${context.sysconfig._nodeName}`);
                 messaging.respond(respondingData, { message: 'assets:preloaded', meta: assetArray });
             } else {
+                logger.info(`finished loading assets ${job.assets.join(', ')} for execution: ${exId} on node ${context.sysconfig._nodeName}`);
                 messaging.send({
                     to: 'execution', message: 'assets:loaded', ex_id: exId, meta: assetArray
                 });

--- a/packages/teraslice/lib/cluster/runners/execution.js
+++ b/packages/teraslice/lib/cluster/runners/execution.js
@@ -25,7 +25,6 @@ module.exports = function module(context, config = {}) {
     const opLoader = new OperationLoader({
         assetPath,
         terasliceOpPath: path.join(__dirname, '..', '..'),
-        opPath: _.get(context, 'sysconfig.teraslice.ops_directory'),
     });
 
     registerApis(context, execution);

--- a/packages/teraslice/lib/cluster/services/jobs.js
+++ b/packages/teraslice/lib/cluster/services/jobs.js
@@ -14,7 +14,6 @@ module.exports = function module(context) {
     const jobValidator = new JobValidator(context, {
         terasliceOpPath: path.join(__dirname, '..', '..'),
         assetPath: _.get(context, 'sysconfig.teraslice.assets_directory'),
-        opPath: _.get(context, 'sysconfig.teraslice.ops_directory')
     });
 
     let jobStore;

--- a/packages/teraslice/lib/config/schemas/system.js
+++ b/packages/teraslice/lib/config/schemas/system.js
@@ -14,11 +14,6 @@ const ip = _.chain(require('os').networkInterfaces())
 const workerCount = require('os').cpus().length;
 
 const schema = {
-    ops_directory: {
-        doc: 'directory to look for more readers and processors',
-        default: null,
-        format: 'optional_String'
-    },
     assets_directory: {
         doc: 'directory to look for assets',
         default: path.join(process.cwd(), './assets'),

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teraslice",
-  "version": "0.39.2",
+  "version": "0.40.0",
   "description": "Slice and dice your Elasticsearch data",
   "bin": "service.js",
   "main": "index.js",
@@ -38,7 +38,7 @@
     "@terascope/elasticsearch-api": "^1.0.0",
     "@terascope/error-parser": "^1.0.0",
     "@terascope/queue": "^1.1.3",
-    "@terascope/job-components": "^0.3.2",
+    "@terascope/job-components": "^0.4.0",
     "barbe": "^3.0.14",
     "bluebird": "^3.5.1",
     "body-parser": "^1.18.2",

--- a/packages/teraslice/service.js
+++ b/packages/teraslice/service.js
@@ -10,28 +10,7 @@ const assetsLoader = require('./lib/cluster/assets_loader');
 const assetsService = require('./lib/cluster/services/assets');
 const master = require('./lib/master');
 const clusterMaster = require('./lib/cluster/cluster_master');
-
-function opsDirectory(configFile) {
-    if (configFile.teraslice && configFile.teraslice.ops_directory) {
-        return configFile.teraslice.ops_directory;
-    }
-    return null;
-}
-
-function clusterName(configFile) {
-    if (configFile.teraslice && configFile.teraslice.name) {
-        return configFile.teraslice.name;
-    }
-    return null;
-}
-
-function loggingConnection(configFile) {
-    if (configFile.teraslice && configFile.teraslice.state) {
-        return configFile.teraslice.state.connection;
-    }
-
-    return 'default';
-}
+const { clusterName, loggingConnection } = require('.');
 
 require('terafoundation')({
     name: 'teraslice',
@@ -52,7 +31,6 @@ require('terafoundation')({
     start_workers: false,
     config_schema: configSchema,
     schema_formats: formats,
-    ops_directory: opsDirectory,
     cluster_name: clusterName,
     logging_connection: loggingConnection
 });

--- a/packages/teraslice/test/config/schemas/system_schema-spec.js
+++ b/packages/teraslice/test/config/schemas/system_schema-spec.js
@@ -19,7 +19,6 @@ describe('system_schema', () => {
     }
 
     it('schema has defaults', () => {
-        expect(schema.ops_directory).toBeDefined();
         expect(schema.shutdown_timeout).toBeDefined();
         expect(schema.reporter).toBeDefined();
         expect(schema.hostname).toBeDefined();
@@ -29,7 +28,7 @@ describe('system_schema', () => {
         expect(schema.state.default).toEqual({ connection: 'default' });
     });
 
-    it('ops_directory is optional but requires a string', () => {
-        expect(checkValidation({ ops_directory: 234 })).toEqual('ops_directory: This field is optional but if specified it must be of type string: value was 234');
+    it('assets_directory is optional but requires a string', () => {
+        expect(checkValidation({ assets_directory: 234 })).toEqual('assets_directory: This field is optional but if specified it must be of type string: value was 234');
     });
 });

--- a/packages/teraslice/test/runners/execution-spec.js
+++ b/packages/teraslice/test/runners/execution-spec.js
@@ -35,7 +35,6 @@ describe('execution runner', () => {
     const context = {
         sysconfig: {
             teraslice: {
-                ops_directory: null,
                 assets_directory: testDir
             }
         },


### PR DESCRIPTION
* Ensure `assets_directory` exists when using `Assets Storage`, resolves #808 
* Remove `ops_directory` from teraslice because it is no longer needed
* Fix error logging issue in the `Assets Loader`
* Make `Assets Storage` reject with `Error` objects not strings
* Bump `teraslice` to `0.40.0` (because the ops_directory was removed)
* Bump `teraslice-worker` to `0.2.2`
* Bump `job-components` to `0.4.0`
