### PR TITLE
Change get to update so set will work

### DIFF
--- a/packages/teraslice-worker/lib/execution-controller/analytics.js
+++ b/packages/teraslice-worker/lib/execution-controller/analytics.js
@@ -74,7 +74,7 @@ class ExecutionAnalytics {
     }
 
     set(key, value) {
-        _.get(this.executionAnalytics, key, value);
+        _.update(this.executionAnalytics, key, value);
     }
 
     increment(key) {

--- a/packages/teraslice-worker/lib/execution-controller/analytics.js
+++ b/packages/teraslice-worker/lib/execution-controller/analytics.js
@@ -74,7 +74,7 @@ class ExecutionAnalytics {
     }
 
     set(key, value) {
-        _.update(this.executionAnalytics, key, value);
+        _.set(this.executionAnalytics, key, value);
     }
 
     increment(key) {


### PR DESCRIPTION
I think the change here should resolve our missing slice analytics.  This was introduced 6 days ago.  So I think this it the culprit.  I am still confused as to why we had reports that this didn't work on the previous version.  But I updated the other internal cluster to the `v0.40.0` build and it started exhibiting the same issue.  And this code stood out.