### PR TITLE
Execution controller can exit when active workers are gone

### DIFF
--- a/packages/teraslice-worker/lib/execution-controller/index.js
+++ b/packages/teraslice-worker/lib/execution-controller/index.js
@@ -694,6 +694,9 @@ class ExecutionController {
             if (this.isExecutionFinished) return null;
             if (this.forceShutdown) return forcedError;
 
+            this.logger.debug(`connected workers: ${this.messenger.connectedWorkers}, active workers: ${this.messenger.activeWorkers}`);
+            if (this.messenger.activeWorkers === 0) return null
+
             const now = Date.now();
             if (now > shutdownAt) {
                 this.forceShutdown = true;


### PR DESCRIPTION
I am not sure if this is actually the right logic, but maybe it's OK
This commit will allow the execution_controller to shutdown when
there are no more active workers connected.  I am pretty sure
we can only get into this loop during shutdown.  But there's no
other functional mechanism to exit this loop.

refs #820