### PR TITLE
v0.42.2 update packages and a few minor changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
         "publish:changed": "./scripts/publish.sh"
     },
     "dependencies": {
-        "lerna": "^3.4.0",
+        "lerna": "^3.4.1",
         "typescript": "^3.1.1"
     },
     "devDependencies": {
-        "@types/jest": "^23.3.2",
+        "@types/jest": "^23.3.3",
         "babel-core": "^6.0.0",
         "babel-jest": "^23.6.0",
         "eslint": "^5.6.1",

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -21,7 +21,7 @@
         "url": "https://github.com/terascope/teraslice/issues"
     },
     "dependencies": {
-        "@terascope/error-parser": "^1.0.0",
+        "@terascope/error-parser": "^1.0.1",
         "bluebird": "^3.5.2",
         "lodash": "^4.17.11",
         "uuid": "^3.3.2"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -3,7 +3,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "",
     "main": "index.js",
     "scripts": {

--- a/packages/error-parser/package.json
+++ b/packages/error-parser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/error-parser",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Generic error parser",
     "main": "index.js",
     "publishConfig": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/job-components",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "publishConfig": {
         "access": "public"
     },
@@ -36,11 +36,11 @@
         "test:debug": "env DEBUG='*teraslice*' jest --detectOpenHandles --coverage=false --runInBand"
     },
     "dependencies": {
-        "@terascope/queue": "^1.1.3",
-        "@terascope/teraslice-types": "^0.2.0",
+        "@terascope/queue": "^1.1.4",
+        "@terascope/teraslice-types": "^0.2.1",
         "@types/fs-extra": "^5.0.4",
         "@types/lodash": "^4.14.116",
-        "@types/node": "^10.11.3",
+        "@types/node": "^10.11.4",
         "@types/uuid": "^3.4.4",
         "datemath-parser": "^1.0.6",
         "fs-extra": "^7.0.0",
@@ -50,7 +50,7 @@
         "uuid": "^3.3.2"
     },
     "devDependencies": {
-        "@types/jest": "^23.3.2",
+        "@types/jest": "^23.3.3",
         "babel-core": "^6.0.0",
         "babel-jest": "^23.6.0",
         "jest": "^23.6.0",

--- a/packages/job-components/src/operations/parallel-slicer.ts
+++ b/packages/job-components/src/operations/parallel-slicer.ts
@@ -67,7 +67,7 @@ export default abstract class ParallelSlicer extends SlicerCore {
             slicer.done = true;
         } else {
             if (_.isArray(result)) {
-                this.events.emit('execution:subslice');
+                this.events.emit('slicer:subslice');
                 _.each(result, (item) => {
                     slicer.order += 1;
                     this.createSlice(item, slicer.order, slicer.id);

--- a/packages/job-components/src/operations/slicer.ts
+++ b/packages/job-components/src/operations/slicer.ts
@@ -31,7 +31,7 @@ export default abstract class Slicer extends SlicerCore {
         }
 
         if (_.isArray(result)) {
-            this.events.emit('execution:subslice');
+            this.events.emit('slicer:subslice');
             _.each(result, (item) => {
                 this.order += 1;
                 this.createSlice(item, this.order);

--- a/packages/job-components/test/operations/parallel-slicer-spec.ts
+++ b/packages/job-components/test/operations/parallel-slicer-spec.ts
@@ -64,26 +64,20 @@ describe('ParallelSlicer', () => {
 
                     if (!slice1) {
                         expect(slice1).toBeNil();
-                    } else if (slice1.slice.slicer_id === 0) {
+                    } else if (slice1.slicer_id === 0) {
                         expect(slice1).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 1,
-                                slicer_id: 0,
-                                request: {
-                                    hi: true,
-                                }
+                            slicer_order: 1,
+                            slicer_id: 0,
+                            request: {
+                                hi: true,
                             }
                         });
                     } else {
                         expect(slice1).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 1,
-                                slicer_id: 1,
-                                request: {
-                                    hello: true,
-                                }
+                            slicer_order: 1,
+                            slicer_id: 1,
+                            request: {
+                                hello: true,
                             }
                         });
                     }
@@ -92,26 +86,20 @@ describe('ParallelSlicer', () => {
 
                     if (!slice2) {
                         expect(slice2).toBeNil();
-                    } else if (slice2.slice.slicer_id === 0) {
+                    } else if (slice2.slicer_id === 0) {
                         expect(slice2).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 1,
-                                slicer_id: 0,
-                                request: {
-                                    hi: true,
-                                }
+                            slicer_order: 1,
+                            slicer_id: 0,
+                            request: {
+                                hi: true,
                             }
                         });
                     } else {
                         expect(slice2).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 1,
-                                slicer_id: 1,
-                                request: {
-                                    hello: true,
-                                }
+                            slicer_order: 1,
+                            slicer_id: 1,
+                            request: {
+                                hello: true,
                             }
                         });
                     }
@@ -129,26 +117,20 @@ describe('ParallelSlicer', () => {
 
                     if (!slice1) {
                         expect(slice1).toBeNil();
-                    } else if (slice1.slice.slicer_id === 0) {
+                    } else if (slice1.slicer_id === 0) {
                         expect(slice1).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 2,
-                                slicer_id: 0,
-                                request: {
-                                    hi: true,
-                                }
+                            slicer_order: 2,
+                            slicer_id: 0,
+                            request: {
+                                hi: true,
                             }
                         });
                     } else {
                         expect(slice1).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 2,
-                                slicer_id: 1,
-                                request: {
-                                    hello: true,
-                                }
+                            slicer_order: 2,
+                            slicer_id: 1,
+                            request: {
+                                hello: true,
                             }
                         });
                     }
@@ -157,26 +139,20 @@ describe('ParallelSlicer', () => {
 
                     if (!slice2) {
                         expect(slice2).toBeNil();
-                    } else if (slice2.slice.slicer_id === 0) {
+                    } else if (slice2.slicer_id === 0) {
                         expect(slice2).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 2,
-                                slicer_id: 0,
-                                request: {
-                                    hi: true,
-                                }
+                            slicer_order: 2,
+                            slicer_id: 0,
+                            request: {
+                                hi: true,
                             }
                         });
                     } else {
                         expect(slice2).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 2,
-                                slicer_id: 1,
-                                request: {
-                                    hello: true,
-                                }
+                            slicer_order: 2,
+                            slicer_id: 1,
+                            request: {
+                                hello: true,
                             }
                         });
                     }
@@ -207,13 +183,13 @@ describe('ParallelSlicer', () => {
 
     describe('when returning a sub-slices', () => {
         let slicer: ExampleParallelSlicer;
-        const onExecutionSubslice = jest.fn();
+        const onSlicerSubslice = jest.fn();
 
         beforeAll(async () => {
             const context = new TestContext('teraslice-operations');
             const events = context.apis.foundation.getSystemEvents();
 
-            events.on('execution:subslice', onExecutionSubslice);
+            events.on('slicer:subslice', onSlicerSubslice);
 
             const exConfig = newTestExecutionConfig();
 
@@ -236,8 +212,8 @@ describe('ParallelSlicer', () => {
         });
 
         describe('->handle', () => {
-            it('should not emit execution:subslice yet', () => {
-                expect(onExecutionSubslice).not.toHaveBeenCalled();
+            it('should not emit slicer:subslice yet', () => {
+                expect(onSlicerSubslice).not.toHaveBeenCalled();
             });
 
             describe('on the first call', () => {
@@ -249,26 +225,20 @@ describe('ParallelSlicer', () => {
 
                     if (!slice1) {
                         expect(slice1).toBeNil();
-                    } else if (slice1.slice.slicer_id === 0) {
+                    } else if (slice1.slicer_id === 0) {
                         expect(slice1).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 1,
-                                slicer_id: 0,
-                                request: {
-                                    hi: true,
-                                }
+                            slicer_order: 1,
+                            slicer_id: 0,
+                            request: {
+                                hi: true,
                             }
                         });
                     } else {
                         expect(slice1).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 1,
-                                slicer_id: 1,
-                                request: {
-                                    hello: true,
-                                }
+                            slicer_order: 1,
+                            slicer_id: 1,
+                            request: {
+                                hello: true,
                             }
                         });
                     }
@@ -277,31 +247,25 @@ describe('ParallelSlicer', () => {
 
                     if (!slice2) {
                         expect(slice2).toBeNil();
-                    } else if (slice2.slice.slicer_id === 0) {
+                    } else if (slice2.slicer_id === 0) {
                         expect(slice2).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 1,
-                                slicer_id: 0,
-                                request: {
-                                    hi: true,
-                                }
+                            slicer_order: 1,
+                            slicer_id: 0,
+                            request: {
+                                hi: true,
                             }
                         });
                     } else {
                         expect(slice2).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 1,
-                                slicer_id: 1,
-                                request: {
-                                    hello: true,
-                                }
+                            slicer_order: 1,
+                            slicer_id: 1,
+                            request: {
+                                hello: true,
                             }
                         });
                     }
 
-                    expect(onExecutionSubslice).toHaveBeenCalledTimes(2);
+                    expect(onSlicerSubslice).toHaveBeenCalledTimes(2);
                     expect(slicer.getSlice()).toBeNil();
                 });
             });
@@ -315,26 +279,20 @@ describe('ParallelSlicer', () => {
 
                     if (!slice1) {
                         expect(slice1).toBeNil();
-                    } else if (slice1.slice.slicer_id === 0) {
+                    } else if (slice1.slicer_id === 0) {
                         expect(slice1).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 2,
-                                slicer_id: 0,
-                                request: {
-                                    hi: true,
-                                }
+                            slicer_order: 2,
+                            slicer_id: 0,
+                            request: {
+                                hi: true,
                             }
                         });
                     } else {
                         expect(slice1).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 2,
-                                slicer_id: 1,
-                                request: {
-                                    hello: true,
-                                }
+                            slicer_order: 2,
+                            slicer_id: 1,
+                            request: {
+                                hello: true,
                             }
                         });
                     }
@@ -343,31 +301,25 @@ describe('ParallelSlicer', () => {
 
                     if (!slice2) {
                         expect(slice2).toBeNil();
-                    } else if (slice2.slice.slicer_id === 0) {
+                    } else if (slice2.slicer_id === 0) {
                         expect(slice2).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 2,
-                                slicer_id: 0,
-                                request: {
-                                    hi: true,
-                                }
+                            slicer_order: 2,
+                            slicer_id: 0,
+                            request: {
+                                hi: true,
                             }
                         });
                     } else {
                         expect(slice2).toMatchObject({
-                            needsState: true,
-                            slice: {
-                                slicer_order: 2,
-                                slicer_id: 1,
-                                request: {
-                                    hello: true,
-                                }
+                            slicer_order: 2,
+                            slicer_id: 1,
+                            request: {
+                                hello: true,
                             }
                         });
                     }
 
-                    expect(onExecutionSubslice).toHaveBeenCalledTimes(4);
+                    expect(onSlicerSubslice).toHaveBeenCalledTimes(4);
                     expect(slicer.getSlice()).toBeNil();
                 });
             });
@@ -377,7 +329,7 @@ describe('ParallelSlicer', () => {
                     const done = await slicer.handle();
                     expect(done).toBeTrue();
 
-                    expect(onExecutionSubslice).toHaveBeenCalledTimes(4);
+                    expect(onSlicerSubslice).toHaveBeenCalledTimes(4);
                     expect(slicer.getSlice()).toBeNil();
                 });
             });

--- a/packages/job-components/test/operations/slicer-spec.ts
+++ b/packages/job-components/test/operations/slicer-spec.ts
@@ -41,13 +41,10 @@ describe('Slicer', () => {
                     expect(done).toBeFalse();
 
                     expect(slicer.getSlice()).toMatchObject({
-                        needsState: true,
-                        slice: {
-                            slicer_order: 1,
-                            slicer_id: 0,
-                            request: {
-                                hi: true,
-                            }
+                        slicer_order: 1,
+                        slicer_id: 0,
+                        request: {
+                            hi: true,
                         }
                     });
 
@@ -61,13 +58,10 @@ describe('Slicer', () => {
                     expect(done).toBeFalse();
 
                     expect(slicer.getSlice()).toMatchObject({
-                        needsState: true,
-                        slice: {
-                            slicer_order: 2,
-                            slicer_id: 0,
-                            request: {
-                                hi: true,
-                            }
+                        slicer_order: 2,
+                        slicer_id: 0,
+                        request: {
+                            hi: true,
                         }
                     });
 
@@ -97,14 +91,14 @@ describe('Slicer', () => {
 
     describe('when returning a sub-slices', () => {
         let slicer: ExampleSlicer;
-        const onExecutionSubslice = jest.fn();
+        const onSlicerSubslice = jest.fn();
 
         beforeAll(async () => {
             const context = new TestContext('teraslice-operations');
 
             const events = context.apis.foundation.getSystemEvents();
 
-            events.on('execution:subslice', onExecutionSubslice);
+            events.on('slicer:subslice', onSlicerSubslice);
 
             const exConfig = newTestExecutionConfig();
             exConfig.operations.push({
@@ -120,8 +114,8 @@ describe('Slicer', () => {
         });
 
         describe('->handle', () => {
-            it('should not emit execution:subslice yet', () => {
-                expect(onExecutionSubslice).not.toHaveBeenCalled();
+            it('should not emit slicer:subslice yet', () => {
+                expect(onSlicerSubslice).not.toHaveBeenCalled();
             });
 
             describe('when called the first time', () => {
@@ -130,17 +124,14 @@ describe('Slicer', () => {
                     expect(done).toBeFalse();
 
                     expect(slicer.getSlice()).toMatchObject({
-                        needsState: true,
-                        slice: {
-                            slicer_order: 1,
-                            slicer_id: 0,
-                            request: {
-                                hi: true,
-                            }
+                        slicer_order: 1,
+                        slicer_id: 0,
+                        request: {
+                            hi: true,
                         }
                     });
 
-                    expect(onExecutionSubslice).toHaveBeenCalledTimes(1);
+                    expect(onSlicerSubslice).toHaveBeenCalledTimes(1);
 
                     expect(slicer.getSlice()).toBeNil();
                 });
@@ -152,17 +143,14 @@ describe('Slicer', () => {
                     expect(done).toBeFalse();
 
                     expect(slicer.getSlice()).toMatchObject({
-                        needsState: true,
-                        slice: {
-                            slicer_order: 2,
-                            slicer_id: 0,
-                            request: {
-                                hi: true,
-                            }
+                        slicer_order: 2,
+                        slicer_id: 0,
+                        request: {
+                            hi: true,
                         }
                     });
 
-                    expect(onExecutionSubslice).toHaveBeenCalledTimes(2);
+                    expect(onSlicerSubslice).toHaveBeenCalledTimes(2);
 
                     expect(slicer.getSlice()).toBeNil();
                 });
@@ -174,7 +162,7 @@ describe('Slicer', () => {
                     expect(done).toBeTrue();
 
                     expect(slicer.getSlice()).toBeNil();
-                    expect(onExecutionSubslice).toHaveBeenCalledTimes(2);
+                    expect(onSlicerSubslice).toHaveBeenCalledTimes(2);
                 });
             });
         });

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -1,32 +1,32 @@
 {
-  "name": "@terascope/queue",
-  "version": "1.1.3",
-  "description": "",
-  "main": "index.js",
-  "typings": "dist/index.d.ts",
-  "publishConfig": {
-    "access": "public"
-  },
-  "scripts": {
-    "lint": "eslint *.js test",
-    "lint:fix": "eslint --fix *.js test",
-    "test": "jest",
-    "test:watch": "jest --coverage=false --notify --watch --onlyChanged",
-    "test:debug": "env DEBUG='*teraslice*' jest --detectOpenHandles --coverage=false --runInBand"
-  },
-  "homepage": "https://github.com/terascope/teraslice/tree/master/packages/queue#readme",
-  "repository": "git@github.com:terascope/teraslice.git",
-  "author": "Terascope, LLC <info@terascope.io>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/terascope/teraslice/issues"
-  },
-  "dependencies": {},
-  "devDependencies": {
-    "eslint": "^5.6.1",
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.14.0",
-    "jest": "^23.6.0",
-    "jest-extended": "^0.11.0"
-  }
+    "name": "@terascope/queue",
+    "version": "1.1.4",
+    "description": "",
+    "main": "index.js",
+    "typings": "dist/index.d.ts",
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "lint": "eslint *.js test",
+        "lint:fix": "eslint --fix *.js test",
+        "test": "jest",
+        "test:watch": "jest --coverage=false --notify --watch --onlyChanged",
+        "test:debug": "env DEBUG='*teraslice*' jest --detectOpenHandles --coverage=false --runInBand"
+    },
+    "homepage": "https://github.com/terascope/teraslice/tree/master/packages/queue#readme",
+    "repository": "git@github.com:terascope/teraslice.git",
+    "author": "Terascope, LLC <info@terascope.io>",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/terascope/teraslice/issues"
+    },
+    "dependencies": {},
+    "devDependencies": {
+        "eslint": "^5.6.1",
+        "eslint-config-airbnb-base": "^13.1.0",
+        "eslint-plugin-import": "^2.14.0",
+        "jest": "^23.6.0",
+        "jest-extended": "^0.11.0"
+    }
 }

--- a/packages/queue/types/index.d.ts
+++ b/packages/queue/types/index.d.ts
@@ -3,15 +3,15 @@
 
 export = Queue;
 
-declare class Queue {
-    enqueue(value: any): void;
-    unshift(value: any): void;
+declare class Queue<T> {
+    enqueue(value: T): void;
+    unshift(value: T): void;
     exists(key: string, val: any): boolean;
     size(): number;
-    extract(key: string, val: any): any | null;
+    extract(key: string, val: any): T | null;
     remove(id: string, keyForID?: string): void;
     each(fn: Function): void;
-    dequeue(): any | null;
+    dequeue(): T | null;
 }
 
 declare namespace Queue {

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-messaging",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "publishConfig": {
         "access": "public"
     },
@@ -36,14 +36,14 @@
         "test:debug": "env DEBUG='*teraslice*' jest --detectOpenHandles --coverage=false --runInBand"
     },
     "dependencies": {
-        "@terascope/queue": "^1.1.3",
-        "@terascope/teraslice-types": "^0.2.0",
+        "@terascope/queue": "^1.1.4",
+        "@terascope/teraslice-types": "^0.2.1",
         "@types/bluebird": "^3.5.24",
         "@types/debug": "^0.0.30",
         "@types/fs-extra": "^5.0.4",
         "@types/lodash": "^4.14.116",
         "@types/nanoid": "^1.2.0",
-        "@types/node": "^10.11.3",
+        "@types/node": "^10.11.4",
         "@types/socket.io": "^1.4.38",
         "@types/socket.io-client": "^1.4.32",
         "bluebird": "^3.5.2",
@@ -55,7 +55,7 @@
         "socket.io-client": "^1.7.4"
     },
     "devDependencies": {
-        "@types/jest": "^23.3.2",
+        "@types/jest": "^23.3.3",
         "babel-core": "^6.0.0",
         "babel-jest": "^23.6.0",
         "jest": "^23.6.0",

--- a/packages/teraslice-messaging/src/execution-controller/interfaces.ts
+++ b/packages/teraslice-messaging/src/execution-controller/interfaces.ts
@@ -43,3 +43,7 @@ export interface SliceCompletePayload {
 export interface WaitUntilFn {
     (): boolean;
 }
+
+export interface EnqueuedWorker {
+    workerId: string;
+}

--- a/packages/teraslice-messaging/src/execution-controller/server.ts
+++ b/packages/teraslice-messaging/src/execution-controller/server.ts
@@ -9,7 +9,7 @@ const debug = debugFn('teraslice-messaging:execution-controller:server');
 
 export class Server extends core.Server {
     private _activeWorkers: string[];
-    queue: Queue;
+    queue: Queue<i.EnqueuedWorker>;
 
     constructor(opts: i.ServerOptions) {
         const {

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "publishConfig": {
         "access": "public"
     },
@@ -22,8 +22,8 @@
         "url": "https://github.com/terascope/teraslice/issues"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.5.0",
-        "@terascope/teraslice-types": "^0.2.0",
+        "@terascope/job-components": "^0.5.1",
+        "@terascope/teraslice-types": "^0.2.1",
         "bluebird": "^3.5.2",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-types/package.json
+++ b/packages/teraslice-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-types",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "publishConfig": {
         "access": "public"
     },
@@ -39,14 +39,14 @@
         "@types/bunyan": "^1.8.4",
         "@types/convict": "^4.2.0",
         "@types/lodash": "^4.14.116",
-        "@types/node": "^10.11.3",
+        "@types/node": "^10.11.4",
         "bunyan": "^1.8.12",
         "convict": "^4.4.0",
         "debugnyan": "^2.0.2",
         "lodash": "^4.17.11"
     },
     "devDependencies": {
-        "@types/jest": "^23.3.2",
+        "@types/jest": "^23.3.3",
         "babel-core": "^6.0.0",
         "babel-jest": "^23.6.0",
         "jest": "^23.6.0",

--- a/packages/teraslice/lib/workers/execution-controller/index.js
+++ b/packages/teraslice/lib/workers/execution-controller/index.js
@@ -471,7 +471,7 @@ class ExecutionController {
 
         await pWhilst(isRunning, () => {
             dispatch();
-            return Promise.delay(100);
+            return Promise.delay(500);
         });
 
         unsubscribe();

--- a/packages/teraslice/lib/workers/execution-controller/index.js
+++ b/packages/teraslice/lib/workers/execution-controller/index.js
@@ -471,7 +471,7 @@ class ExecutionController {
 
         await pWhilst(isRunning, () => {
             dispatch();
-            return Promise.delay(500);
+            return Promise.delay(100);
         });
 
         unsubscribe();

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.42.1",
+    "version": "0.42.2",
     "description": "Slice and dice your Elasticsearch data",
     "bin": "service.js",
     "main": "index.js",
@@ -35,10 +35,10 @@
     "homepage": "https://github.com/terascope/teraslice#readme",
     "dependencies": {
         "@terascope/elasticsearch-api": "^1.1.1",
-        "@terascope/error-parser": "^1.0.0",
-        "@terascope/job-components": "^0.5.0",
-        "@terascope/queue": "^1.1.3",
-        "@terascope/teraslice-messaging": "^0.2.1",
+        "@terascope/error-parser": "^1.0.1",
+        "@terascope/job-components": "^0.5.1",
+        "@terascope/queue": "^1.1.4",
+        "@terascope/teraslice-messaging": "^0.2.2",
         "async-mutex": "^0.1.3",
         "auto-bind": "^1.2.1",
         "barbe": "^3.0.14",
@@ -67,7 +67,7 @@
         "yargs": "^12.0.2"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.1.0",
+        "@terascope/teraslice-op-test-harness": "^1.2.1",
         "archiver": "^3.0.0",
         "bufferstreams": "^2.0.1",
         "chance": "^1.0.16",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -34,7 +34,7 @@
     "author": "Terascope, LLC <info@terascope.io>",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "dependencies": {
-        "@terascope/elasticsearch-api": "^1.1.1",
+        "@terascope/elasticsearch-api": "^1.1.2",
         "@terascope/error-parser": "^1.0.1",
         "@terascope/job-components": "^0.5.1",
         "@terascope/queue": "^1.1.4",

--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -95,4 +95,4 @@ fs.readdirSync(packagesPath).forEach(updatePkgVersion);
 
 updatePkgVersion('../e2e');
 
-console.log('DONE! Don\'t forget to run "yarn" to update your yarn.lock');
+console.log('DONE!');

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -23,21 +23,13 @@ publish() {
 
     if [ "$currentVersion" != "$targetVersion" ]; then
         echo "$name@$currentVersion -> $targetVersion"
-        if [ "$dryRun" != "false" ]; then
-            return;
-        elif [ "$name" != "teraslice" ]; then
+        if [ "$dryRun" == "false" ]; then
             yarn publish \
                 --silent \
                 --tag "$tag" \
                 --non-interactive \
                 --new-version "$targetVersion" \
                 --no-git-tag-version
-        elif [ "$name" != "teraslice" ]; then
-            yarn publish \
-                --silent \
-                --tag "$tag" \
-                --non-interactive \
-                --new-version "$targetVersion"
         fi
     fi
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,15 +53,15 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@lerna/add@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.3.2.tgz#767a879ecb117be06414e7e76d4d93bb9934fa57"
-  integrity sha512-nKRRRKb4wt/GAywi8P++NY1TUiyhMs2g2KHSb41I4/qiCFQnTj2zkeshPyNmtBGjKzFXnOqrmc/8Wa2vmHHZVg==
+"@lerna/add@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.4.1.tgz#d41068317e30f530df48220d256b5e79690b1877"
+  integrity sha512-Vf54B42jlD6G52qnv/cAGH70cVQIa+LX//lfsbkxHvzkhIqBl5J4KsnTOPkA9uq3R+zP58ayicCHB9ReiEWGJg==
   dependencies:
-    "@lerna/bootstrap" "^3.3.2"
+    "@lerna/bootstrap" "^3.4.1"
     "@lerna/command" "^3.3.0"
     "@lerna/filter-options" "^3.3.2"
-    "@lerna/npm-conf" "^3.0.0"
+    "@lerna/npm-conf" "^3.4.1"
     "@lerna/validation-error" "^3.0.0"
     dedent "^0.7.0"
     npm-package-arg "^6.0.0"
@@ -78,19 +78,19 @@
     "@lerna/validation-error" "^3.0.0"
     npmlog "^4.1.2"
 
-"@lerna/bootstrap@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@lerna/bootstrap/-/bootstrap-3.3.2.tgz#01e894295dea89dcc0c62ee188f49f78873e08c9"
-  integrity sha512-f0/FZ6iCXHNpHoUiM3wfmiJebHetrquP9mdNT7t//2iTGm1nz8iuKSLhfu9APazDXtqo3aDFx7JvuYKMg+GiXQ==
+"@lerna/bootstrap@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@lerna/bootstrap/-/bootstrap-3.4.1.tgz#10635e9b547fb7d685949ac78e0923f73da2f52a"
+  integrity sha512-yZDJgNm/KDoRH2klzmQGmpWMg/XMzWgeWvauXkrfW/mj1wwmufOuh5pN4fBFxVmUUa/RFZdfMeaaJt3+W3PPBw==
   dependencies:
     "@lerna/batch-packages" "^3.1.2"
     "@lerna/command" "^3.3.0"
     "@lerna/filter-options" "^3.3.2"
     "@lerna/has-npm-version" "^3.3.0"
-    "@lerna/npm-conf" "^3.0.0"
+    "@lerna/npm-conf" "^3.4.1"
     "@lerna/npm-install" "^3.3.0"
     "@lerna/rimraf-dir" "^3.3.0"
-    "@lerna/run-lifecycle" "^3.3.1"
+    "@lerna/run-lifecycle" "^3.4.1"
     "@lerna/run-parallel-batches" "^3.0.0"
     "@lerna/symlink-binary" "^3.3.0"
     "@lerna/symlink-dependencies" "^3.3.0"
@@ -107,16 +107,16 @@
     read-package-tree "^5.1.6"
     semver "^5.5.0"
 
-"@lerna/changed@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@lerna/changed/-/changed-3.3.2.tgz#679c9fd353a82d00e2a27847c79f061d5abdea67"
-  integrity sha512-wLH6RzYPQAryrsJakc9I3k0aFWE/cJyWoUD8dQy186jxwtLgeQdVc0+NegNyab7MIPi7Hsv9A3hx6lM1rPH94A==
+"@lerna/changed@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@lerna/changed/-/changed-3.4.1.tgz#84a049359a53b8812c3a07a664bd41b1768f5938"
+  integrity sha512-gT7fhl4zQWyGETDO4Yy5wsFnqNlBSsezncS1nkMW1uO6jwnolwYqcr1KbrMR8HdmsZBn/00Y0mRnbtbpPPey8w==
   dependencies:
     "@lerna/collect-updates" "^3.3.2"
     "@lerna/command" "^3.3.0"
     "@lerna/listable" "^3.0.0"
     "@lerna/output" "^3.0.0"
-    "@lerna/version" "^3.3.2"
+    "@lerna/version" "^3.4.1"
 
 "@lerna/check-working-tree@^3.3.0":
   version "3.3.0"
@@ -185,16 +185,15 @@
     lodash "^4.17.5"
     npmlog "^4.1.2"
 
-"@lerna/conventional-commits@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@lerna/conventional-commits/-/conventional-commits-3.3.0.tgz#68302b6ca58b3ab7e91807664deeda2eac025ab0"
-  integrity sha512-nUFardc5G4jG5LI/Jlw0kblzlRLJ08ut6uJjHXTnUE/QJuKYaqBZm6goGG8OSxp/WltklndkQUOtThyZpefviA==
+"@lerna/conventional-commits@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@lerna/conventional-commits/-/conventional-commits-3.4.1.tgz#0b47f9fc0c4a10951883e949d939188da1b527bc"
+  integrity sha512-3NETrA58aUkaEW3RdwdJ766Bg9NVpLzb26mtdlsJQcvB5sQBWH5dJSHIVQH1QsGloBeH2pE/mDUEVY8ZJXuR4w==
   dependencies:
     "@lerna/validation-error" "^3.0.0"
-    conventional-changelog-angular "^1.6.6"
-    conventional-changelog-core "^2.0.5"
-    conventional-recommended-bump "^2.0.6"
-    dedent "^0.7.0"
+    conventional-changelog-angular "^5.0.1"
+    conventional-changelog-core "^3.1.0"
+    conventional-recommended-bump "^4.0.1"
     fs-extra "^7.0.0"
     get-stream "^4.0.0"
     npm-package-arg "^6.0.0"
@@ -210,14 +209,14 @@
     fs-extra "^7.0.0"
     npmlog "^4.1.2"
 
-"@lerna/create@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@lerna/create/-/create-3.3.1.tgz#cfd7e0cb30d1f45133691165e103d26318d90ebf"
-  integrity sha512-4VASkTLvN66euTcWMPN2vIzEoP07hgutx7V70CXSOc+DiWV8S22z0PjXATi2yli83TC/Qj4gHYtU2futQrdY1A==
+"@lerna/create@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@lerna/create/-/create-3.4.1.tgz#7cad78a5701d7666a0f5d0fe0e325acd8d8f5b63"
+  integrity sha512-l+4t2SRO5nvW0MNYY+EWxbaMHsAN8bkWH3nyt7EzhBjs4+TlRAJRIEqd8o9NWznheE3pzwczFz1Qfl3BWbyM5A==
   dependencies:
     "@lerna/child-process" "^3.3.0"
     "@lerna/command" "^3.3.0"
-    "@lerna/npm-conf" "^3.0.0"
+    "@lerna/npm-conf" "^3.4.1"
     "@lerna/validation-error" "^3.0.0"
     camelcase "^4.1.0"
     dedent "^0.7.0"
@@ -363,10 +362,10 @@
     has-unicode "^2.0.1"
     npmlog "^4.1.2"
 
-"@lerna/npm-conf@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-conf/-/npm-conf-3.0.0.tgz#7a4b8304a0ecd1e366208f656bd3d7f4dcb3b5e7"
-  integrity sha512-xXG7qt349t+xzaHTQELmIDjbq8Q49HOMR8Nx/gTDBkMl02Fno91LXFnA4A7ErPiyUSGqNSfLw+zgij0hgpeN7w==
+"@lerna/npm-conf@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-conf/-/npm-conf-3.4.1.tgz#859e931b0bc9a5eed86309cc09508810c1e7d121"
+  integrity sha512-i9G6DnbCqiAqxKx2rSXej/n14qxlV/XOebL6QZonxJKzNTB+Q2wglnhTXmfZXTPJfoqimLaY4NfAEtbOXRWOXQ==
   dependencies:
     config-chain "^1.1.11"
     pify "^3.0.0"
@@ -465,10 +464,10 @@
     inquirer "^6.2.0"
     npmlog "^4.1.2"
 
-"@lerna/publish@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@lerna/publish/-/publish-3.4.0.tgz#d2665f7b16eb3b2b8962c47fcf31fe901ff9a288"
-  integrity sha512-wcqWDKbkDjyj6F9Mw4/LL2CtpCN61RazNKxYm+fyJ20P2zfcAwLEwxttA6ZWIO8xUiLXkCTFIhwOulHyAPAq3w==
+"@lerna/publish@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@lerna/publish/-/publish-3.4.1.tgz#abbbc656b3bfafc2289399a46da060b90f6baf32"
+  integrity sha512-Nd5PT2Ksngo1GHqT6ccmGVfMvoA9MplBvqyzPFIjFIJOgODrJ9IGJAMobxgBQ6xXXShflQ/1dHWk8faTOYKLoQ==
   dependencies:
     "@lerna/batch-packages" "^3.1.2"
     "@lerna/check-working-tree" "^3.3.0"
@@ -477,15 +476,15 @@
     "@lerna/command" "^3.3.0"
     "@lerna/describe-ref" "^3.3.0"
     "@lerna/get-npm-exec-opts" "^3.0.0"
-    "@lerna/npm-conf" "^3.0.0"
+    "@lerna/npm-conf" "^3.4.1"
     "@lerna/npm-dist-tag" "^3.3.0"
     "@lerna/npm-publish" "^3.3.1"
     "@lerna/output" "^3.0.0"
     "@lerna/prompt" "^3.3.1"
-    "@lerna/run-lifecycle" "^3.3.1"
+    "@lerna/run-lifecycle" "^3.4.1"
     "@lerna/run-parallel-batches" "^3.0.0"
     "@lerna/validation-error" "^3.0.0"
-    "@lerna/version" "^3.3.2"
+    "@lerna/version" "^3.4.1"
     fs-extra "^7.0.0"
     libnpmaccess "^3.0.0"
     npm-package-arg "^6.0.0"
@@ -516,12 +515,12 @@
     path-exists "^3.0.0"
     rimraf "^2.6.2"
 
-"@lerna/run-lifecycle@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@lerna/run-lifecycle/-/run-lifecycle-3.3.1.tgz#13a03f353aab6c1639bf8953f58f0c45585785ac"
-  integrity sha512-xy4K3amlXk0LjSa5d3VqmrW9SsxMyvI7lw2dHDMb5PqjjcjMQgb6+nFbycwyJMhCP8u7MwQIZ4hFYF9XYbWSzQ==
+"@lerna/run-lifecycle@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@lerna/run-lifecycle/-/run-lifecycle-3.4.1.tgz#6d7e44eada31cb4ec78b18ef050da0d86f6c892b"
+  integrity sha512-N/hi2srM9A4BWEkXccP7vCEbf4MmIuALF00DTBMvc0A/ccItwUpl3XNuM7+ADDRK0mkwE3hDw89lJ3A7f8oUQw==
   dependencies:
-    "@lerna/npm-conf" "^3.0.0"
+    "@lerna/npm-conf" "^3.4.1"
     npm-lifecycle "^2.0.0"
     npmlog "^4.1.2"
 
@@ -578,20 +577,20 @@
   dependencies:
     npmlog "^4.1.2"
 
-"@lerna/version@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@lerna/version/-/version-3.3.2.tgz#b1f4be43f61edf97428efca09dddc47ffd769bb4"
-  integrity sha512-2MHP6mA1f0t3UdzqPpfgAhsT1L64HOedlJxrQUoHrkou/G25Od4wjmKr9OZ0Oc4CLDbXD/sYEmE/9fZi1GGgKg==
+"@lerna/version@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@lerna/version/-/version-3.4.1.tgz#029448cccd3ccefb4d5f666933bd13cfb37edab0"
+  integrity sha512-oefNaQLBJSI2WLZXw5XxDXk4NyF5/ct0V9ys/J308NpgZthPgwRPjk9ZR0o1IOxW1ABi6z3E317W/dxHDjvAkg==
   dependencies:
     "@lerna/batch-packages" "^3.1.2"
     "@lerna/check-working-tree" "^3.3.0"
     "@lerna/child-process" "^3.3.0"
     "@lerna/collect-updates" "^3.3.2"
     "@lerna/command" "^3.3.0"
-    "@lerna/conventional-commits" "^3.3.0"
+    "@lerna/conventional-commits" "^3.4.1"
     "@lerna/output" "^3.0.0"
     "@lerna/prompt" "^3.3.1"
-    "@lerna/run-lifecycle" "^3.3.1"
+    "@lerna/run-lifecycle" "^3.4.1"
     "@lerna/validation-error" "^3.0.0"
     chalk "^2.3.1"
     dedent "^0.7.0"
@@ -666,10 +665,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/jest@^23.3.2":
-  version "23.3.2"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.2.tgz#07b90f6adf75d42c34230c026a2529e56c249dbb"
-  integrity sha512-D1xlXHZpDonVX+VJ28XtcD5xlu8ex6Fc4cQNnrm2wJvlQnbec9RedhCrhQr6kRAE9XWHSec+JPuTmqJ9jC0qsA==
+"@types/jest@^23.3.3":
+  version "23.3.3"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.3.tgz#246ebcc52771d2327bb8e37aa971b412d9dc4237"
+  integrity sha512-G6EBrbjWDfmIpYu8UcRBOhwtDiYaLj5N5jUR5rx0YvbKxRBhXPZVLUmtfShewSUNKiQwpHavpML69a2WMbIlEQ==
 
 "@types/lodash@^4.14.116":
   version "4.14.116"
@@ -688,10 +687,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.8.tgz#6f14ccecad1d19332f063a6a764f8907801fece0"
   integrity sha512-sWSjw+bYW/2W+1V3m8tVsm9PKJcxk3NHN7oRqNUfEdofKg0Imbdu1dQbFvLKjZQXEDXRN6IfSMACjJ7Wv4NGCQ==
 
-"@types/node@^10.11.3":
-  version "10.11.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.3.tgz#c055536ac8a5e871701aa01914be5731539d01ee"
-  integrity sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ==
+"@types/node@^10.11.4":
+  version "10.11.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.4.tgz#e8bd933c3f78795d580ae41d86590bfc1f4f389d"
+  integrity sha512-ojnbBiKkZFYRfQpmtnnWTMw+rzGp/JiystjluW9jgN3VzRwilXddJ6aGQ9V/7iuDG06SBgn7ozW9k3zcAnYjYQ==
 
 "@types/socket.io-client@^1.4.32":
   version "1.4.32"
@@ -2017,26 +2016,26 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-conventional-changelog-angular@^1.6.6:
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz#b27f2b315c16d0a1f23eb181309d0e6a4698ea0f"
-  integrity sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==
+conventional-changelog-angular@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.1.tgz#f96431b76de453333a909decd02b15cb5bd2d364"
+  integrity sha512-q4ylJ68fWZDdrFC9z4zKcf97HW6hp7Mo2YlqD4owfXhecFKy/PJCU/1oVFF4TqochchChqmZ0Vb0e0g8/MKNlA==
   dependencies:
     compare-func "^1.3.1"
     q "^1.5.1"
 
-conventional-changelog-core@^2.0.5:
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz#19b5fbd55a9697773ed6661f4e32030ed7e30287"
-  integrity sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==
+conventional-changelog-core@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-3.1.0.tgz#96a81bb3301b4b2a3dc2851cc54c5fb674ac1942"
+  integrity sha512-bcZkcFXkqVgG2W8m/1wjlp2wn/BKDcrPgw3/mvSEQtzs8Pax8JbAPFpEQReHY92+EKNNXC67wLA8y2xcNx0rDA==
   dependencies:
-    conventional-changelog-writer "^3.0.9"
-    conventional-commits-parser "^2.1.7"
+    conventional-changelog-writer "^4.0.0"
+    conventional-commits-parser "^3.0.0"
     dateformat "^3.0.0"
     get-pkg-repo "^1.0.0"
-    git-raw-commits "^1.3.6"
+    git-raw-commits "^2.0.0"
     git-remote-origin-url "^2.0.0"
-    git-semver-tags "^1.3.6"
+    git-semver-tags "^2.0.0"
     lodash "^4.2.1"
     normalize-package-data "^2.3.5"
     q "^1.5.1"
@@ -2044,18 +2043,18 @@ conventional-changelog-core@^2.0.5:
     read-pkg-up "^1.0.1"
     through2 "^2.0.0"
 
-conventional-changelog-preset-loader@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz#40bb0f142cd27d16839ec6c74ee8db418099b373"
-  integrity sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==
+conventional-changelog-preset-loader@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.0.1.tgz#d134734e0cc1b91b88b30586c5991f31442029f1"
+  integrity sha512-HiSfhXNzAzG9klIqJaA97MMiNBR4js+53g4Px0k7tgKeCNVXmrDrm+CY+nIqcmG5NVngEPf8rAr7iji1TWW7zg==
 
-conventional-changelog-writer@^3.0.9:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz#4aecdfef33ff2a53bb0cf3b8071ce21f0e994634"
-  integrity sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==
+conventional-changelog-writer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-4.0.0.tgz#3ed983c8ef6a3aa51fe44e82c9c75e86f1b5aa42"
+  integrity sha512-hMZPe0AQ6Bi05epeK/7hz80xxk59nPA5z/b63TOHq2wigM0/akreOc8N4Jam5b9nFgKWX1e9PdPv2ewgW6bcfg==
   dependencies:
     compare-func "^1.3.1"
-    conventional-commits-filter "^1.1.6"
+    conventional-commits-filter "^2.0.0"
     dateformat "^3.0.0"
     handlebars "^4.0.2"
     json-stringify-safe "^5.0.1"
@@ -2065,18 +2064,18 @@ conventional-changelog-writer@^3.0.9:
     split "^1.0.0"
     through2 "^2.0.0"
 
-conventional-commits-filter@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz#4389cd8e58fe89750c0b5fb58f1d7f0cc8ad3831"
-  integrity sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==
+conventional-commits-filter@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-2.0.0.tgz#a0ce1d1ff7a1dd7fab36bee8e8256d348d135651"
+  integrity sha512-Cfl0j1/NquB/TMVx7Wrmyq7uRM+/rPQbtVVGwzfkhZ6/yH6fcMmP0Q/9044TBZPTNdGzm46vXFXL14wbET0/Mg==
   dependencies:
     is-subset "^0.1.1"
     modify-values "^1.0.0"
 
-conventional-commits-parser@^2.1.7:
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz#eca45ed6140d72ba9722ee4132674d639e644e8e"
-  integrity sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==
+conventional-commits-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-3.0.0.tgz#7f604549a50bd8f60443fbe515484b1c2f06a5c4"
+  integrity sha512-GWh71U26BLWgMykCp+VghZ4s64wVbtseECcKQ/PvcPZR2cUnz+FUc2J9KjxNl7/ZbCxST8R03c9fc+Vi0umS9Q==
   dependencies:
     JSONStream "^1.0.4"
     is-text-path "^1.0.0"
@@ -2086,17 +2085,17 @@ conventional-commits-parser@^2.1.7:
     through2 "^2.0.0"
     trim-off-newlines "^1.0.0"
 
-conventional-recommended-bump@^2.0.6:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/conventional-recommended-bump/-/conventional-recommended-bump-2.0.9.tgz#7392421e7d0e3515f3df2040572a23cc73a68a93"
-  integrity sha512-YE6/o+648qkX3fTNvfBsvPW3tSnbZ6ec3gF0aBahCPgyoVHU2Mw0nUAZ1h1UN65GazpORngrgRC8QCltNYHPpQ==
+conventional-recommended-bump@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/conventional-recommended-bump/-/conventional-recommended-bump-4.0.1.tgz#304a45a412cfec050a10ea2e7e4a89320eaf3991"
+  integrity sha512-9waJvW01TUs4HQJ3khwGSSlTlKsY+5u7OrxHL+oWEoGNvaNO/0qL6qqnhS3J0Fq9fNKA9bmlf5cOXjCQoW+I4Q==
   dependencies:
     concat-stream "^1.6.0"
-    conventional-changelog-preset-loader "^1.1.8"
-    conventional-commits-filter "^1.1.6"
-    conventional-commits-parser "^2.1.7"
-    git-raw-commits "^1.3.6"
-    git-semver-tags "^1.3.6"
+    conventional-changelog-preset-loader "^2.0.1"
+    conventional-commits-filter "^2.0.0"
+    conventional-commits-parser "^3.0.0"
+    git-raw-commits "^2.0.0"
+    git-semver-tags "^2.0.0"
     meow "^4.0.0"
     q "^1.5.1"
 
@@ -3610,10 +3609,10 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-git-raw-commits@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-1.3.6.tgz#27c35a32a67777c1ecd412a239a6c19d71b95aff"
-  integrity sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==
+git-raw-commits@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-2.0.0.tgz#d92addf74440c14bcc5c83ecce3fb7f8a79118b5"
+  integrity sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==
   dependencies:
     dargs "^4.0.1"
     lodash.template "^4.0.2"
@@ -3629,10 +3628,10 @@ git-remote-origin-url@^2.0.0:
     gitconfiglocal "^1.0.0"
     pify "^2.3.0"
 
-git-semver-tags@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-1.3.6.tgz#357ea01f7280794fe0927f2806bee6414d2caba5"
-  integrity sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==
+git-semver-tags@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-2.0.0.tgz#c218fd895bdf8e8e02f6bde555b2c3893ac73cd7"
+  integrity sha512-lSgFc3zQTul31nFje2Q8XdNcTOI6B4I3mJRPCgFzHQQLfxfqdWTYzdtCaynkK5Xmb2wQlSJoKolhXJ1VhKROnQ==
   dependencies:
     meow "^4.0.0"
     semver "^5.5.0"
@@ -5213,26 +5212,26 @@ lerna-alias@^3.0.2:
   dependencies:
     get-lerna-packages "^0.1.0"
 
-lerna@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.4.0.tgz#c1403852b4b3fa986072de11d7f549604fd41775"
-  integrity sha512-RCLm0gMi8PESEF8PzMxo35foA2NGGC/NKnKiUmJyRrhLybOIUfVPdPStSAWCjW1c+DYCgLZCbxu57/KWt4ZWZA==
+lerna@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.4.1.tgz#4acc5a6b9d843993db7a7bb1350274bcaf20ca80"
+  integrity sha512-00X2mYuwJk/bvxdjJceUxTjUgUg7MIMWllo2zGfDVGPijLadrg8QCtJASZqVE7HDQbBLDxLGPjswk29HF5JS2Q==
   dependencies:
-    "@lerna/add" "^3.3.2"
-    "@lerna/bootstrap" "^3.3.2"
-    "@lerna/changed" "^3.3.2"
+    "@lerna/add" "^3.4.1"
+    "@lerna/bootstrap" "^3.4.1"
+    "@lerna/changed" "^3.4.1"
     "@lerna/clean" "^3.3.2"
     "@lerna/cli" "^3.2.0"
-    "@lerna/create" "^3.3.1"
+    "@lerna/create" "^3.4.1"
     "@lerna/diff" "^3.3.0"
     "@lerna/exec" "^3.3.2"
     "@lerna/import" "^3.3.1"
     "@lerna/init" "^3.3.0"
     "@lerna/link" "^3.3.0"
     "@lerna/list" "^3.3.2"
-    "@lerna/publish" "^3.4.0"
+    "@lerna/publish" "^3.4.1"
     "@lerna/run" "^3.3.2"
-    "@lerna/version" "^3.3.2"
+    "@lerna/version" "^3.4.1"
     import-local "^1.0.0"
     npmlog "^4.1.2"
 


### PR DESCRIPTION
A few of our packages had changed but were never published, which means that that NPM wasn't reflecting the latest changes. I bumped a lot of packages so that they can be updated. This release should decrease the size of the `job-components` library.

In addition to bumping the packages, I made a few fixes the`job-components` library to match the latest teraslice changed, updated the queue type definitions and fixed some of our scripts.