### PR TITLE
Be free from ESLint restrictions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,10 @@
         "no-debugger": "error",
         "handle-callback-err": ["error", "error"],
         "import/no-extraneous-dependencies": "off",
-        "class-methods-use-this": "off"
+        "class-methods-use-this": "off",
+        "no-restricted-syntax": "off",
+        "no-await-in-loop": "off",
+        "no-plusplus": "off",
+        "no-continue": "off"
     }
 }

--- a/packages/elasticsearch-api/index.js
+++ b/packages/elasticsearch-api/index.js
@@ -201,7 +201,7 @@ module.exports = function elasticsearchApi(client = {}, logger, _opConfig) {
                 // On a create request if a document exists it's not an error.
                 // are there cases where this is incorrect?
                 if (item.status === DOCUMENT_EXISTS) {
-                    continue; // eslint-disable-line
+                    continue;
                 }
 
                 if (item.error.type === 'es_rejected_execution_exception') {

--- a/packages/teraslice-op-test-harness/index.js
+++ b/packages/teraslice-op-test-harness/index.js
@@ -228,7 +228,6 @@ class TestHarness {
         });
     }
 
-    // eslint-disable-next-line class-methods-use-this
     get data() {
         return {
             simple: simpleData.slice(),

--- a/packages/teraslice-op-test-harness/test/harness-spec.js
+++ b/packages/teraslice-op-test-harness/test/harness-spec.js
@@ -61,13 +61,11 @@ describe('With multiple slices', () => {
 // Any test above this line is for backward compatability
 describe('tests for new op harness', () => {
     class Client {
-        // eslint-disable-next-line class-methods-use-this
         async get(data) {
             data.wasFetched = true;
             return data;
         }
 
-        // eslint-disable-next-line class-methods-use-this
         async count(data) {
             data.count = 5;
             return data;

--- a/packages/teraslice/cluster-service.js
+++ b/packages/teraslice/cluster-service.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* eslint-disable class-methods-use-this, no-console */
-
 const Promise = require('bluebird');
 const get = require('lodash/get');
 const { shutdownHandler } = require('./lib/workers/helpers/worker-shutdown');

--- a/packages/teraslice/lib/readers/id_slicer.js
+++ b/packages/teraslice/lib/readers/id_slicer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* eslint-disable no-restricted-syntax, no-useless-escape, max-len */
+/* eslint-disable no-useless-escape, max-len */
 
 const _ = require('lodash');
 const parseError = require('@terascope/error-parser');

--- a/packages/teraslice/lib/workers/execution-controller/scheduler.js
+++ b/packages/teraslice/lib/workers/execution-controller/scheduler.js
@@ -333,7 +333,6 @@ class Scheduler {
             let processed = 0;
             const promises = [];
 
-            // eslint-disable-next-line no-restricted-syntax
             for (const id of pendingSlicers) {
                 processed += 1;
                 if (processed > count) break;

--- a/packages/teraslice/worker-service.js
+++ b/packages/teraslice/worker-service.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* eslint-disable class-methods-use-this, no-console */
-
 const _ = require('lodash');
 const Promise = require('bluebird');
 const { shutdownHandler } = require('./lib/workers/helpers/worker-shutdown');


### PR DESCRIPTION
I disabled the following rules because they should be up to the developer's discretion, not the linting.

- [class-methods-use-this](https://eslint.org/docs/rules/class-methods-use-this)
- [no-restricted-syntax](https://eslint.org/docs/rules/no-restricted-syntax)
- [no-await-in-loop](https://eslint.org/docs/rules/no-await-in-loop)
- [no-plusplus](https://eslint.org/docs/rules/no-plusplus)
- [no-continue](https://eslint.org/docs/rules/no-continue)