### PR TITLE
Improvements for teraslice-test-op-harness and parallel-slicer

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     networks:
       - cluster
     volumes:
-      - teraslice-assets:/app/assets:delegated
+      - teraslice-assets:/app/assets
       - ./autoload:/app/autoload:delegated
       - ./config:/app/config:delegated
   elasticsearch:
@@ -56,7 +56,7 @@ services:
       - "discovery.type=single-node"
       - "xpack.security.enabled=false"
     volumes:
-      - elasticsearch-data:/usr/share/elasticsearch/data:delegated
+      - elasticsearch-data:/usr/share/elasticsearch/data
     networks:
       - cluster
     ulimits:

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
         "@types/lodash": "^4.14.117",
         "@types/lodash.clonedeep": "^4.5.4",
         "@types/nanoid": "^1.2.0",
-        "@types/node": "^10.12.0",
+        "@types/node": "^10.12.2",
         "@types/p-event": "^1.3.0",
         "@types/socket.io": "^1.4.38",
         "@types/socket.io-client": "^1.4.32",
         "@types/uuid": "^3.4.4",
         "lerna": "^3.4.3",
-        "typescript": "^3.1.3"
+        "typescript": "^3.1.6"
     },
     "devDependencies": {
         "@types/jest": "^23.3.8",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -46,7 +46,7 @@
     },
     "devDependencies": {
         "@types/jest": "^23.3.8",
-        "@types/node": "^10.12.0",
+        "@types/node": "^10.12.2",
         "babel-core": "^6.0.0",
         "babel-jest": "^23.6.0",
         "benchmark": "^2.1.4",
@@ -56,7 +56,7 @@
         "ts-jest": "^23.10.4",
         "tslint": "^5.0.0",
         "tslint-config-airbnb": "^5.11.0",
-        "typescript": "^3.1.3"
+        "typescript": "^3.1.6"
     },
     "engines": {
         "node": ">=8.0.0"

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/job-components",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "publishConfig": {
         "access": "public"
     },

--- a/packages/job-components/src/operations/parallel-slicer.ts
+++ b/packages/job-components/src/operations/parallel-slicer.ts
@@ -59,7 +59,7 @@ export default abstract class ParallelSlicer extends SlicerCore {
                 return !slicer.processing && !slicer.done;
             }).map((slicer) => this.processSlicer(slicer));
 
-        await Promise.all(promises);
+        await Promise.race(promises);
         return this.isFinished;
     }
 

--- a/packages/job-components/src/operations/shims/legacy-processor-shim.ts
+++ b/packages/job-components/src/operations/shims/legacy-processor-shim.ts
@@ -16,6 +16,9 @@ import {
 // tslint:disable-next-line:variable-name
 export default function legacyProcessorShim(Processor: ProcessorConstructor, Schema: SchemaConstructor, apis?: APIs): LegacyProcessor {
     return {
+        // @ts-ignore
+        Processor,
+        Schema,
         schema: (context) => {
             if (Schema.type() !== 'convict') {
                 throw new Error('Backwards compatibility only works for "convict" schemas');

--- a/packages/job-components/src/operations/shims/legacy-reader-shim.ts
+++ b/packages/job-components/src/operations/shims/legacy-reader-shim.ts
@@ -28,6 +28,10 @@ type SchemaType = SchemaConstructor;
 // tslint:disable-next-line:variable-name
 export default function legacyReaderShim(Slicer: SlicerType, Fetcher: FetcherType, Schema: SchemaType, apis?: APIs): LegacyReader {
     return {
+        // @ts-ignore
+        Slicer,
+        Fetcher,
+        Schema,
         schema: (context) => {
             if (Schema.type() !== 'convict') {
                 throw new Error('Backwards compatibility only works for "convict" schemas');

--- a/packages/job-components/src/operations/shims/reader-shim.ts
+++ b/packages/job-components/src/operations/shims/reader-shim.ts
@@ -13,6 +13,7 @@ export default function readerShim<S = any>(legacy: LegacyReader): ReaderModule 
             private _maxQueueLength = 10000;
             private _dynamicQueueLength = false;
             private slicerFns: SlicerFns|undefined;
+            private _slicerCount = 0;
 
             /** legacy slicers should recoverable by default */
             isRecoverable() {
@@ -36,6 +37,7 @@ export default function readerShim<S = any>(legacy: LegacyReader): ReaderModule 
                 }
 
                 this.slicerFns = await legacy.newSlicer(this.context, executionContext, recoveryData, this.logger);
+                this._slicerCount = this.slicerFns.length;
 
                 await super.initialize(recoveryData);
             }
@@ -49,6 +51,10 @@ export default function readerShim<S = any>(legacy: LegacyReader): ReaderModule 
                     return async () => null;
                 }
                 return fn;
+            }
+
+            slicers() {
+                return this._slicerCount;
             }
 
             maxQueueLength() {

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -47,7 +47,7 @@
     },
     "devDependencies": {
         "@types/jest": "^23.3.8",
-        "@types/node": "^10.12.0",
+        "@types/node": "^10.12.2",
         "babel-core": "^6.0.0",
         "babel-jest": "^23.6.0",
         "jest": "^23.6.0",
@@ -55,7 +55,7 @@
         "ts-jest": "^23.10.4",
         "tslint": "^5.0.0",
         "tslint-config-airbnb": "^5.11.0",
-        "typescript": "^3.1.3"
+        "typescript": "^3.1.6"
     },
     "engines": {
         "node": ">=8.0.0"

--- a/packages/teraslice-op-test-harness/README.md
+++ b/packages/teraslice-op-test-harness/README.md
@@ -21,9 +21,13 @@ Now, you can access functionality using the `harness` object.
 ## Processor Execution Function - `init()`
 
 The manner to instanciate a new instance of your operation is by using init
-You make pass in optional clients under the `clients` key but they must follow the format listed in the setClients definition
+You make pass in optional clients under the `clients` key but they must follow the format listed in the setClients definition. This will work with both the new and old Job APIs.
 
 ```javascript
+const { DataEntity } = require('@terascope/job-components');
+const processor = require('../asset/example-op');
+const reader = require('../asset/example-reader');
+
 describe('setting up an operation', () => {
     const processorOpTest = opHarness(processor);
     const readerOpTest = opHarness(reader);
@@ -43,8 +47,10 @@ describe('setting up an operation', () => {
         const data = { some: 'data' };
         const pTest = await processorOpTest.init({ opConfig });
 
-        const results = await pTest.run(data)
-        expect(results).toBeDefined();
+        const results = await pTest.run(data);
+
+        expect(Array.isArray(results)).toBe(true);
+        expect(DataEntity.isDataEntity(results[0])).toBe(true);
     });
 
     it('can make a reader instance', async () => {
@@ -56,8 +62,10 @@ describe('setting up an operation', () => {
         const type = 'reader';
         const rTest = await readerOpTest.init({ executionConfig, type });
 
-        const results = await rTest.run(data)
-        expect(results).toBeDefined();
+        const results = await rTest.run(data);
+
+        expect(Array.isArray(results)).toBe(true);
+        expect(results[0] instanceof DataEntity).toBe(true);
     });
 
     it('can make a slicer instance', async () => {
@@ -68,8 +76,10 @@ describe('setting up an operation', () => {
         // type defaults to slicer
         const sTest = await readerOpTest.init({ executionConfig });
 
-        const results = await sTest.run()
-        expect(results).toBeDefined();
+        const results = await sTest.run();
+
+        expect(Array.isArray(results)).toBe(true);
+        expect(results[0]).toEqual({ foo: 'bar' });
     });
 
     it('can make a multiple slicer instances', async () => {
@@ -82,8 +92,10 @@ describe('setting up an operation', () => {
         // type defaults to slicer
         const sTest = await readerOpTest.init({ executionConfig });
 
-        const results = await sTest.run()
-        expect(results).toBeDefined();
+        const results = await sTest.run();
+
+        expect(Array.isArray(results)).toBe(true);
+        expect(results[0]).toEqual({ foo: 'bar' });
     });
 
     it('can return the full metadata of slice', async () => {
@@ -96,8 +108,15 @@ describe('setting up an operation', () => {
         // type defaults to slicer
         const sTest = await readerOpTest.init({ executionConfig });
 
-        const results = await sTest.run({ fullSlice: true })
-        expect(results).toBeDefined();
+        const results = await sTest.run({ fullSlice: true });
+
+        expect(Array.isArray(results)).toBe(true);
+        expect(results[0]).toEqual({
+            slice_id: 'd994d423-f3a3-411d-8973-4a4ccccd1afd',
+            slicer_id: 0,
+            slicer_order: 10,
+            request: { foo: 'bar' }
+        });
     });
 })
 ```
@@ -106,6 +125,9 @@ This takes an array of client configurations that will be used internally.
 The obejct must have a client key and a type key set.
 
 ```javascript
+const { DataEntity } = require('@terascope/job-components');
+const reader = require('../asset/example-reader');
+
 describe('setting up an operation', () => {
     const opTest = opHarness(reader);
     let client;
@@ -141,7 +163,9 @@ describe('setting up an operation', () => {
         const test = await opTest.init({ executionConfig, type });
 
         const results = await test.run(data)
-        expect(results).toBeDefined();
+
+        expect(Array.isArray(results)).toBe(true);
+        expect(DataEntity.isDataEntity(results[0])).toBe(true);
     });
 
     it('can make a slicer instance', async () => {
@@ -157,21 +181,30 @@ describe('setting up an operation', () => {
 
         const [results1, results2 ] = await Promise.all([ test1.run(), test2.run()]);
 
-        expect(results1).toBeDefined();
-        expect(results2).toBeDefined();
+        expect(Array.isArray(results1)).toBe(true);
+        expect(results1[0]).toEqual({ foo: 'bar' });
+
+        expect(Array.isArray(results2)).toBe(true);
+        expect(results2[0]).toEqual({ foo: 'bar' });
     });
 })
 ```
 ## Processor Execution Function `processData()`
-This provides a short hand for processors to instantiate a new operation, run some data with it and return the results
+This provides a short hand for processors to instantiate a new operation, run some data with it and return the results.
 
 ```javascript
+const processor = require('../asset/example-op');
+
 describe('processor operation test', () => {
+    const opTest = opHarness(processor);
+
     it('has a shorthand method', async () => {
         const opConfig = { _op: 'foo', some: 'config' };
         const data = [{ some: 'data' }];
         const results = await processorOpTest.processData(opConfig, data);
-        expect(results).toBeDefined();
+
+        expect(Array.isArray(results)).toBe(true);
+        expect(DataEntity.isDataEntity(results[0])).toBe(true);
     })
 })
 

--- a/packages/teraslice-op-test-harness/README.md
+++ b/packages/teraslice-op-test-harness/README.md
@@ -50,7 +50,7 @@ describe('setting up an operation', () => {
     it('can make a reader instance', async () => {
         const executionConfig = {
             lifecycle: 'once',
-            operations: [{ _op: 'foo', some: 'config' }
+            operations: [{ _op: 'foo', some: 'config' }]
         };
         const data = { some: 'data' };
         const type = 'reader';
@@ -63,7 +63,7 @@ describe('setting up an operation', () => {
     it('can make a slicer instance', async () => {
         const executionConfig = {
             lifecycle: 'once',
-            operations: [{ _op: 'foo', some: 'config' }
+            operations: [{ _op: 'foo', some: 'config' }]
         };
         // type defaults to slicer
         const sTest = await readerOpTest.init({ executionConfig });
@@ -72,6 +72,33 @@ describe('setting up an operation', () => {
         expect(results).toBeDefined();
     });
 
+    it('can make a multiple slicer instances', async () => {
+        const executionConfig = {
+            lifecycle: 'once',
+            slicers: 3,
+            operations: [{ _op: 'foo', some: 'config' }]
+        };
+
+        // type defaults to slicer
+        const sTest = await readerOpTest.init({ executionConfig });
+
+        const results = await sTest.run()
+        expect(results).toBeDefined();
+    });
+
+    it('can return the full metadata of slice', async () => {
+        const executionConfig = {
+            lifecycle: 'once',
+            slicers: 3,
+            operations: [{ _op: 'foo', some: 'config' }]
+        };
+
+        // type defaults to slicer
+        const sTest = await readerOpTest.init({ executionConfig });
+
+        const results = await sTest.run({ fullSlice: true })
+        expect(results).toBeDefined();
+    });
 })
 ```
 ## Processor Execution Function - `setClients()`
@@ -107,7 +134,7 @@ describe('setting up an operation', () => {
     it('can make a reader instance', async () => {
         const executionConfig = {
             lifecycle: 'once',
-            operations: [{ _op: 'foo', some: 'config' }
+            operations: [{ _op: 'foo', some: 'config' }]
         };
         const data = { some: 'data' };
         const type = 'reader';
@@ -120,7 +147,7 @@ describe('setting up an operation', () => {
     it('can make a slicer instance', async () => {
         const executionConfig = {
             lifecycle: 'once',
-            operations: [{ _op: 'foo', some: 'config' }
+            operations: [{ _op: 'foo', some: 'config' }]
         };
         // you can override the clients at init time
         const clients = [{ client: new OtherClient(), type: 'elasticsearch', endpoint: 'default'}]

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "publishConfig": {
         "access": "public"
     },
@@ -22,7 +22,7 @@
         "url": "https://github.com/terascope/teraslice/issues"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.8.1",
+        "@terascope/job-components": "^0.8.2",
         "bluebird": "^3.5.2",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-op-test-harness/test/harness-spec.js
+++ b/packages/teraslice-op-test-harness/test/harness-spec.js
@@ -135,11 +135,16 @@ describe('tests for new op harness', () => {
         opTest.setClients([{ client, type: 'elasticsearch' }]);
 
         const test = await opTest.init({ executionConfig });
-        const [results] = await test.run();
+        const [results] = await test.run({ fullSlice: true });
 
         expect(results).toBeDefined();
         expect(results.request.count).toEqual(5);
         expect(results.request.now instanceof Date).toEqual(true);
+
+        const [request] = await test.run();
+
+        expect(request.count).toEqual(5);
+        expect(request.now instanceof Date).toEqual(true);
     });
 });
 
@@ -175,11 +180,15 @@ describe('op harness can handle new style procossors/readers/slicers', () => {
         const opConfig = { _op: 'example-reader', some: 'config' };
         const test = await opTest.init({ opConfig });
 
-        const [results] = await test.run();
+        const [results] = await test.run({ fullSlice: true });
 
         expect(results).toBeDefined();
         expect(results.slicer_id).toEqual(0);
         expect(results.slicer_order).toEqual(1);
         expect(results.request.fetchFrom).toEqual('https://httpstat.us/200');
+
+        const [request] = await test.run();
+
+        expect(request.fetchFrom).toEqual('https://httpstat.us/200');
     });
 });

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@terascope/elasticsearch-api": "^1.1.2",
         "@terascope/error-parser": "^1.0.1",
-        "@terascope/job-components": "^0.8.1",
+        "@terascope/job-components": "^0.8.2",
         "@terascope/queue": "^1.1.4",
         "@terascope/teraslice-messaging": "^0.2.4",
         "async-mutex": "^0.1.3",
@@ -66,7 +66,7 @@
         "yargs": "^12.0.2"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.3.1",
+        "@terascope/teraslice-op-test-harness": "^1.3.2",
         "archiver": "^3.0.0",
         "bufferstreams": "^2.0.1",
         "chance": "^1.0.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8399,17 +8399,6 @@ terafoundation@^0.5.0:
     redis "^2.8.0"
     yargs "^12.0.2"
 
-teraslice-client-js@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/teraslice-client-js/-/teraslice-client-js-0.3.0.tgz#fffcc46612a8e857b6a6fc523f2377c45312e380"
-  integrity sha512-nndHXhfqSG2Ta94HmWxv6BdgOICfB/mr4Nxk3ybJC+5bd/d/bLSVYV7ee6x9/gPkr7/9QYbVgUN1qiIpGGRzWA==
-  dependencies:
-    auto-bind "^1.2.1"
-    bluebird "^3.5.2"
-    lodash "^4.17.11"
-    request "^2.88.0"
-    request-promise "^4.2.2"
-
 terminal-kit@^1.26.0:
   version "1.26.4"
   resolved "https://registry.yarnpkg.com/terminal-kit/-/terminal-kit-1.26.4.tgz#4d44c237d9ba68294cfcc67f91157336bf9db76f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,10 +690,15 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^10.12.0":
+"@types/node@*":
   version "10.12.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.1.tgz#da61b64a2930a80fa708e57c45cd5441eb379d5b"
   integrity sha512-i1sl+WCX2OCHeUi9oi7PiCNUtYFrpWhpcx878vpeq/tlZTKzcFdHePlyFHVbWqeuKN0SRPl/9ZFDSTsfv9h7VQ==
+
+"@types/node@^10.12.2":
+  version "10.12.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.2.tgz#d77f9faa027cadad9c912cd47f4f8b07b0fb0864"
+  integrity sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ==
 
 "@types/p-event@^1.3.0":
   version "1.3.0"
@@ -8703,10 +8708,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.1.3:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.4.tgz#c74ef7b3c2da65beff548b903022cb8c3cd997ed"
-  integrity sha512-JZHJtA6ZL15+Q3Dqkbh8iCUmvxD3iJ7ujXS+fVkKnwIVAdHc5BJTDNM0aTrnr2luKulFjU7W+SRhDZvi66Ru7Q==
+typescript@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
 
 typpy@^2.3.1:
   version "2.3.10"


### PR DESCRIPTION
* Easier use in tests
* Fix parallel slicer to handle slicers race to finish
* Return the new Constructors on the legacy shims to make it more compatible with test-op-harness
