### PR TITLE
DataEntity serialization/deserialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@types/convict": "^4.2.0",
         "@types/debug": "^0.0.31",
         "@types/fs-extra": "^5.0.4",
-        "@types/lodash": "^4.14.117",
+        "@types/lodash": "^4.14.118",
         "@types/lodash.clonedeep": "^4.5.4",
         "@types/nanoid": "^1.2.0",
         "@types/node": "^10.12.2",

--- a/packages/job-components/bench/data-encoding-suite.js
+++ b/packages/job-components/bench/data-encoding-suite.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { Suite } = require('./helpers');
+const { DataEntity } = require('../dist');
+
+const data = JSON.stringify({
+    id: Math.random(),
+    hello: 'sir',
+    hi: 'dude',
+    howdy: 'there'
+});
+
+const dataBuf = Buffer.from(data);
+
+module.exports = () => Suite('DataEncoding')
+    .add('without DataEntities', {
+        fn() {
+            const obj = JSON.parse(dataBuf);
+            Buffer.from(JSON.stringify(Object.assign({}, obj)));
+        }
+    })
+    .add('with DataEntities', {
+        fn() {
+            const dataEntity = DataEntity.fromBuffer(dataBuf);
+            dataEntity.toBuffer();
+        }
+    })
+    .run({
+        async: true,
+        initCount: 2,
+        maxTime: 5,
+    });

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/job-components",
-    "version": "0.8.2",
+    "version": "0.9.0",
     "publishConfig": {
         "access": "public"
     },

--- a/packages/job-components/src/interfaces/jobs.ts
+++ b/packages/job-components/src/interfaces/jobs.ts
@@ -2,11 +2,23 @@
  * OpConfig is the configuration that user specifies
  * for a Operation.
  * The only required property is `_op` since that is used
- * to find the operation
+ * to find the operation.
+ * Encoding defaults to "JSON" when DataEntity.fromBuffer() is called
 */
 export interface OpConfig {
     _op: string;
+    _encoding?: DataEncoding;
 }
+
+/**
+ * An enum of available encoding formats
+*/
+export enum DataEncoding {
+    JSON = 'json',
+}
+
+/** A list of supported encoding formats */
+export const dataEncodings = [DataEncoding.JSON];
 
 export enum LifeCycle {
     Once = 'once',

--- a/packages/job-components/src/job-schemas.ts
+++ b/packages/job-components/src/job-schemas.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { Context } from './interfaces';
+import { Context, DataEncoding, dataEncodings } from './interfaces';
 import convict from 'convict';
 import { flatten } from './utils';
 import os from 'os';
@@ -190,4 +190,9 @@ export const opSchema: convict.Schema<any> = {
         doc: 'Name of operation, it must reflect the name of the file',
         format: 'required_String',
     },
+    _encoding: {
+        doc: 'Used to specify the encoding type of the data',
+        default: DataEncoding.JSON,
+        format: dataEncodings,
+    }
 };

--- a/packages/job-components/src/operations/data-entity.ts
+++ b/packages/job-components/src/operations/data-entity.ts
@@ -1,5 +1,5 @@
 import { fastAssign, fastMap, isFunction, isPlainObject, parseJSON } from '../utils';
-import { OpConfig, DataEncoding } from '../interfaces';
+import { DataEncoding } from '../interfaces';
 
 // WeakMaps are used as a memory efficient reference to private data
 const _metadata = new WeakMap();
@@ -26,11 +26,12 @@ export default class DataEntity {
      * @param opConfig The operation config used to get the encoding type of the buffer, defaults to "json"
      * @param metadata Optionally add any metadata
     */
-    static fromBuffer(input: Buffer, opConfig: OpConfig, metadata?: object): DataEntity {
+    static fromBuffer(input: Buffer, opConfig: EncodingConfig = {}, metadata?: object): DataEntity {
         const { _encoding = DataEncoding.JSON } = opConfig || {};
         if (_encoding === DataEncoding.JSON) {
             return new DataEntity(parseJSON(input), metadata);
         }
+
         throw new Error(`Unsupported encoding type, got "${_encoding}"`);
     }
 
@@ -114,6 +115,25 @@ export default class DataEntity {
         metadata[key] = value;
         _metadata.set(this, metadata);
     }
+
+    /**
+     * Convert the DataEntity to an encoded buffer
+     * @param opConfig The operation config used to get the encoding type of the buffer, defaults to "json"
+    */
+    toBuffer(config: EncodingConfig = {}): Buffer {
+        const { _encoding = DataEncoding.JSON } = config;
+        if (_encoding === DataEncoding.JSON) {
+            return Buffer.from(JSON.stringify(this));
+        }
+
+        throw new Error(`Unsupported encoding type, got "${_encoding}"`);
+    }
+}
+
+/** an encoding focused interfaces */
+export interface EncodingConfig {
+    _op?: string;
+    _encoding?: DataEncoding;
 }
 
 export type DataInput = object|DataEntity;

--- a/packages/job-components/src/operations/data-entity.ts
+++ b/packages/job-components/src/operations/data-entity.ts
@@ -1,4 +1,5 @@
-import { fastAssign, fastMap, isFunction, isPlainObject } from '../utils';
+import { fastAssign, fastMap, isFunction, isPlainObject, parseJSON } from '../utils';
+import { OpConfig, DataEncoding } from '../interfaces';
 
 // WeakMaps are used as a memory efficient reference to private data
 const _metadata = new WeakMap();
@@ -17,6 +18,20 @@ export default class DataEntity {
             return input;
         }
         return new DataEntity(input, metadata);
+    }
+
+    /**
+     * A utility for safely converting an buffer to a DataEntity.
+     * @param input A buffer to parse to JSON
+     * @param opConfig The operation config used to get the encoding type of the buffer, defaults to "json"
+     * @param metadata Optionally add any metadata
+    */
+    static fromBuffer(input: Buffer, opConfig: OpConfig, metadata?: object): DataEntity {
+        const { _encoding = DataEncoding.JSON } = opConfig || {};
+        if (_encoding === DataEncoding.JSON) {
+            return new DataEntity(parseJSON(input), metadata);
+        }
+        throw new Error(`Unsupported encoding type, got "${_encoding}"`);
     }
 
     /**

--- a/packages/job-components/src/utils.ts
+++ b/packages/job-components/src/utils.ts
@@ -3,6 +3,31 @@ export function isString(val: any): val is string {
     return typeof val === 'string' ? true : false;
 }
 
+/** Safely convert any input to a string */
+export function toString(val: any): string {
+    if (val && isFunction(val.toString)) {
+        return val.toString();
+    }
+
+    return JSON.stringify(val);
+}
+
+/**
+ * A utility for serializing a buffer to a json object
+ */
+export function parseJSON<T = object>(buf: Buffer|string): T {
+    if (!Buffer.isBuffer(buf) && !isString(buf)) {
+        throw new TypeError(`Failure to serialize non-buffer, got "${typeof buf}"`);
+    }
+
+    try {
+        // @ts-ignore because it does work with buffers
+        return JSON.parse(buf);
+    } catch (err) {
+        throw new Error(`Failure to parse buffer, ${toString(err)}`);
+    }
+}
+
 /** A simplified implemation of lodash isInteger */
 export function isInteger(val: any): val is number {
     if (typeof val !== 'number') return false;

--- a/packages/job-components/test/config-validators-spec.ts
+++ b/packages/job-components/test/config-validators-spec.ts
@@ -111,10 +111,55 @@ describe('When using native clustering', () => {
             const config = validateOpConfig(schema, op);
             expect(config as object).toEqual({
                 _op: 'some-op',
+                _encoding: 'json',
                 example: 'example',
                 formatted_value: 'hi',
                 test: true,
             });
+        });
+
+        it('should handle a custom encoding', () => {
+            const op = {
+                _op: 'some-op',
+                _encoding: 'json',
+                example: 'example',
+                formatted_value: 'hi',
+            };
+
+            const config = validateOpConfig(schema, op);
+            expect(config as object).toEqual({
+                _op: 'some-op',
+                _encoding: 'json',
+                example: 'example',
+                formatted_value: 'hi',
+                test: true,
+            });
+        });
+
+        it('should handle an invalid encoding', () => {
+            const op = {
+                _op: 'some-op',
+                _encoding: 'uh-oh',
+                example: 'example',
+                formatted_value: 'hi',
+            };
+
+            expect(() => {
+                validateOpConfig(schema, op);
+            }).toThrow();
+        });
+
+        it('should handle a non-string encoding', () => {
+            const op = {
+                _op: 'some-op',
+                _encoding: 123,
+                example: 'example',
+                formatted_value: 'hi',
+            };
+
+            expect(() => {
+                validateOpConfig(schema, op);
+            }).toThrow();
         });
 
         it('should fail when given invalid input', () => {

--- a/packages/job-components/test/operations/convict-schema-spec.ts
+++ b/packages/job-components/test/operations/convict-schema-spec.ts
@@ -40,7 +40,8 @@ describe('Convict Schema', () => {
                 example: 'hi'
             })).toEqual({
                 _op: 'hello',
-                example: 'hi'
+                _encoding: 'json',
+                example: 'hi',
             });
         });
 

--- a/packages/job-components/test/operations/data-entity-spec.ts
+++ b/packages/job-components/test/operations/data-entity-spec.ts
@@ -1,5 +1,5 @@
 import 'jest-extended'; // require for type definitions
-import { DataEntity } from '../../src';
+import { DataEntity, DataEncoding } from '../../src';
 
 describe('DataEntity', () => {
     describe('when constructed with an object', () => {
@@ -226,6 +226,42 @@ describe('DataEntity', () => {
         it('should not be able to get metadata from null', () => {
             // @ts-ignore
             expect(DataEntity.getMetadata(null, 'hi')).toBeNil();
+        });
+    });
+
+    describe('#fromBuffer', () => {
+        it('should be able to create a DataEntity from a buffer', () => {
+            const buf = Buffer.from(JSON.stringify({ foo: 'bar' }));
+            const entity = DataEntity.fromBuffer(buf, {
+                _op: 'baz',
+                _encoding: DataEncoding.JSON,
+            }, {
+                howdy: 'there'
+            });
+
+            expect(entity.foo).toEqual('bar');
+            expect(entity.getMetadata('howdy')).toEqual('there');
+        });
+
+        it('should throw an error if given invalid buffer', () => {
+            const buf = Buffer.from('hello:there');
+            expect(() => {
+                DataEntity.fromBuffer(buf, {
+                    _op: 'test',
+                    _encoding: DataEncoding.JSON,
+                });
+            }).toThrow();
+        });
+
+        it('should throw an error if given an unsupported encoding', () => {
+            const buf = Buffer.from(JSON.stringify({ hi: 'there' }));
+            expect(() => {
+                DataEntity.fromBuffer(buf, {
+                    _op: 'test',
+                    // @ts-ignore
+                    _encoding: 'crazy',
+                });
+            }).toThrowError('Unsupported encoding type, got "crazy"');
         });
     });
 });

--- a/packages/job-components/test/operations/data-entity-spec.ts
+++ b/packages/job-components/test/operations/data-entity-spec.ts
@@ -34,10 +34,12 @@ describe('DataEntity', () => {
             const keys = Object.keys(dataEntity);
             expect(keys).not.toInclude('getMetadata');
             expect(keys).not.toInclude('setMetadata');
+            expect(keys).not.toInclude('toBuffer');
 
             for (const prop in dataEntity) {
                 expect(prop).not.toEqual('getMetadata');
                 expect(prop).not.toEqual('setMetadata');
+                expect(prop).not.toEqual('toBuffer');
             }
         });
 
@@ -45,6 +47,7 @@ describe('DataEntity', () => {
             const object = JSON.parse(JSON.stringify(dataEntity));
             expect(object).not.toHaveProperty('getMetadata');
             expect(object).not.toHaveProperty('setMetadata');
+            expect(object).not.toHaveProperty('toBuffer');
 
             expect(object).toHaveProperty('teal', 'neal');
             expect(object).toHaveProperty('blue', 'green');

--- a/packages/job-components/test/utils-spec.ts
+++ b/packages/job-components/test/utils-spec.ts
@@ -1,5 +1,5 @@
 import 'jest-extended';
-import { waterfall, isPlainObject } from '../src/utils';
+import { waterfall, isPlainObject, parseJSON } from '../src/utils';
 
 describe('Utils', () => {
     describe('waterfall', () => {
@@ -52,6 +52,37 @@ describe('Utils', () => {
             expect(isPlainObject(Buffer.from('some-string'))).toBeFalse();
             expect(isPlainObject(new TestObj())).toBeTrue();
             expect(isPlainObject({})).toBeTrue();
+        });
+    });
+
+    describe('parseJSON', () => {
+        it('should handle a json encoded Buffer', () => {
+            const input = Buffer.from(JSON.stringify({ foo: 'bar' }));
+            expect(parseJSON(input)).toEqual({ foo: 'bar' });
+        });
+
+        // TODO: We may need to add support for this?
+        xit('should handle a json base64 encoded Buffer', () => {
+            const input = Buffer.from(JSON.stringify({ foo: 'bar' }), 'base64');
+            expect(parseJSON(input)).toEqual({ foo: 'bar' });
+        });
+
+        it('should handle a json encoded string', () => {
+            const input = JSON.stringify({ foo: 'bar' });
+            expect(parseJSON(input)).toEqual({ foo: 'bar' });
+        });
+
+        it('should throw a TypeError if given a non-buffer', () => {
+            expect(() => {
+                // @ts-ignore
+                parseJSON(123);
+            }).toThrowError('Failure to serialize non-buffer, got "number"');
+        });
+
+        it('should throw an Error if given invalid json', () => {
+            expect(() => {
+                parseJSON(Buffer.from('foo:bar'));
+            }).toThrowError(/^Failure to parse buffer, SyntaxError:/);
         });
     });
 });

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -39,6 +39,6 @@
         "eslint-plugin-import": "^2.14.0",
         "jest": "^23.6.0",
         "jest-extended": "^0.11.0",
-        "nock": "^10.0.1"
+        "nock": "^10.0.2"
     }
 }

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -39,7 +39,7 @@
         "@terascope/queue": "^1.1.4",
         "bluebird": "^3.5.2",
         "debug": "^4.1.0",
-        "nanoid": "^1.3.3",
+        "nanoid": "^2.0.0",
         "p-event": "^2.1.0",
         "porty": "^3.1.1",
         "socket.io": "^1.7.4",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -22,7 +22,7 @@
         "url": "https://github.com/terascope/teraslice/issues"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.8.2",
+        "@terascope/job-components": "^0.9.0",
         "bluebird": "^3.5.2",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-op-test-harness/test/harness-spec.js
+++ b/packages/teraslice-op-test-harness/test/harness-spec.js
@@ -98,7 +98,7 @@ describe('tests for new op harness', () => {
         const test = await opTest.init({ opConfig });
 
         expect(test).toBeDefined();
-        expect(test.opConfig).toEqual({ _op: 'foo', field: 'foo', some: 'config' });
+        expect(test.opConfig).toMatchObject({ _op: 'foo', field: 'foo', some: 'config' });
         expect(test.operation).toBeDefined();
         expect(test.isProcessor).toEqual(true);
 

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -78,6 +78,6 @@
         "jest-extended": "^0.11.0",
         "jest-fixtures": "^0.6.0",
         "json-schema-faker": "^0.5.0-rc16",
-        "nock": "^10.0.1"
+        "nock": "^10.0.2"
     }
 }

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@terascope/elasticsearch-api": "^1.1.2",
         "@terascope/error-parser": "^1.0.1",
-        "@terascope/job-components": "^0.8.2",
+        "@terascope/job-components": "^0.9.0",
         "@terascope/queue": "^1.1.4",
         "@terascope/teraslice-messaging": "^0.2.4",
         "async-mutex": "^0.1.3",

--- a/packages/teraslice/test/processors/noop-spec.js
+++ b/packages/teraslice/test/processors/noop-spec.js
@@ -24,7 +24,7 @@ describe('Noop Processor', () => {
 
     it('should be able to pass validation', () => {
         const result = schema.validate({ _op: 'delay' });
-        expect(result).toEqual({ _op: 'delay' });
+        expect(result).toMatchObject({ _op: 'delay' });
     });
 
     it('should not mutate the data when given an empty array', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -678,10 +678,15 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash@*", "@types/lodash@^4.14.117":
+"@types/lodash@*":
   version "4.14.117"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.117.tgz#695a7f514182771a1e0f4345d189052ee33c8778"
   integrity sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw==
+
+"@types/lodash@^4.14.118":
+  version "4.14.118"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.118.tgz#247bab39bfcc6d910d4927c6e06cbc70ec376f27"
+  integrity sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw==
 
 "@types/nanoid@^1.2.0":
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,12 +690,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*":
-  version "10.12.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.1.tgz#da61b64a2930a80fa708e57c45cd5441eb379d5b"
-  integrity sha512-i1sl+WCX2OCHeUi9oi7PiCNUtYFrpWhpcx878vpeq/tlZTKzcFdHePlyFHVbWqeuKN0SRPl/9ZFDSTsfv9h7VQ==
-
-"@types/node@^10.12.2":
+"@types/node@*", "@types/node@^10.12.2":
   version "10.12.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.2.tgz#d77f9faa027cadad9c912cd47f4f8b07b0fb0864"
   integrity sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ==
@@ -711,9 +706,9 @@
   integrity sha512-Vs55Kq8F+OWvy1RLA31rT+cAyemzgm0EWNeax6BWF8H7QiiOYMJIdcwSDdm5LVgfEkoepsWkS+40+WNb7BUMbg==
 
 "@types/socket.io@^1.4.38":
-  version "1.4.38"
-  resolved "https://registry.yarnpkg.com/@types/socket.io/-/socket.io-1.4.38.tgz#ee1e16d66242a153e1e27aad5a99e0513c39a0ae"
-  integrity sha512-+f49CywK6w2RNDzcug7iUVZoC0262Wr6XrGg0yunW+wFBG8RXC8hiQm94HV1I3H0/8bEodGSjDOxd4i2yhFbwA==
+  version "1.4.39"
+  resolved "https://registry.yarnpkg.com/@types/socket.io/-/socket.io-1.4.39.tgz#ae1e79f7b7692bee2a370f2aafd9d510452806d6"
+  integrity sha512-uMOtC3QsoApFQxu5ow1zVu40Y0SIb0E6NuybqhIjsAbfhV05EANXZfklM3yp+DmFAeUtRdaEz3x6vWqLhjsy/A==
   dependencies:
     "@types/node" "*"
 
@@ -6021,15 +6016,10 @@ nan@^2.10.0, nan@^2.4.0, nan@^2.9.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
   integrity sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==
 
-nanoid@^1.0.7:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-1.3.1.tgz#4538e1a02822b131da198d8eb17c9e3b3ac5167f"
-  integrity sha512-wSBw7t+JVjQAY8q89BhrTaBTMdoPGbZP8qQqidQHL76oeaFJ9i+c6SKKHP2l/DmzLP43eeV6JkM3f5Mb6saH8Q==
-
-nanoid@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-1.3.3.tgz#23d4130cb3dcb455c742cbf281163d52f0cd51b0"
-  integrity sha512-07OUEbP7fMX/tFLP3oIa3yTt+sUfDQf99JULSKc/ZNERIVG8T87S+Kt9iu6N4efVzmeMvlXjVUUQcEXKEm0OCQ==
+nanoid@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.0.0.tgz#e1ab4a4b024a38d15531ba34a712a201540de639"
+  integrity sha512-SG2qscLE3iM4C0CNzGrsAojJHSVHMS1J8NnvJ31P1lH8P0hGHOiafmniNJz6w6q7vuoDlV7RdySlJgtqkFEVtQ==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -6098,10 +6088,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-nock@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-10.0.1.tgz#71eeb580c2995878e582b3e32420daead9eb44f7"
-  integrity sha512-M0aL9IDbUFURmokoXqejZQybZk8EtlYjUBjaoICVbW62uOlyPRsnEsceyOlUik4spCOt50ptwM4BTPt20ITtcQ==
+nock@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-10.0.2.tgz#9e9a92253808e480a8163c2a21fc12937c02c3b0"
+  integrity sha512-uWrdlRzG28SXM5yqYsUHfYBRqljF8P6aTRDh6Y5kTgs/Q4GB59QWlpiegmDHQouvmX/rDyKkC/nk+k4nA+QPNw==
   dependencies:
     chai "^4.1.2"
     debug "^4.1.0"
@@ -7800,11 +7790,11 @@ shellwords@^0.1.1:
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
 shortid@^2.2.13:
-  version "2.2.13"
-  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.13.tgz#b2441e71c664ace458a341d343959f677910ef5b"
-  integrity sha512-dBuNnQGKrJNfjunmXI2X7bl1gnMO4PwbNxrTzO1JvilODmL7WyyCtA+DYxe9XunLXmxmgzFIvKPQ6XRAQrr46Q==
+  version "2.2.14"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.14.tgz#80db6aafcbc3e3a46850b3c88d39e051b84c8d18"
+  integrity sha512-4UnZgr9gDdA1kaKj/38IiudfC3KHKhDc1zi/HSxd9FQDR0VLwH3/y79tZJLsVYPsJgIjeHjqIWaWVRJUj9qZOQ==
   dependencies:
-    nanoid "^1.0.7"
+    nanoid "^2.0.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
This initial version only supports JSON encoded buffers and strings, but it is designed in a way to support other types in the future, like `cbor` or `protobuf`.

An example usage is:

```ts
const opConfig = {
   _op: 'example',
   _encoding: 'json'
};

const buf = Buffer.from(JSON.stringify({ foo: 'bar' }));
const dataEntity = DataEntity.fromBuffer(buf, opConfig);

console.log('it should have foo: bar', dataEntity.foo === 'bar');
const resultBuf = dataEntity.toBuffer(opConfig);

console.log('it should equal buf', resultBuf === buf);
```

Resolves #855