### PR TITLE
v0.44.1 Fix a couple small issues in job-components and teraslice-test-harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     },
     "dependencies": {
         "@types/bluebird": "^3.5.24",
-        "@types/bunyan": "^1.8.5",
         "@types/convict": "^4.2.0",
         "@types/debug": "^0.0.31",
         "@types/fs-extra": "^5.0.4",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/job-components",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "publishConfig": {
         "access": "public"
     },

--- a/packages/job-components/src/interfaces/context.ts
+++ b/packages/job-components/src/interfaces/context.ts
@@ -1,16 +1,7 @@
-// @ts-ignore
-import bunyan from '@types/bunyan';
-import Stream from 'stream';
 import { EventEmitter } from 'events';
 import { OpConfig } from './jobs';
 import { ExecutionContextAPI } from '../execution-context';
-
-export type LoggerStream = Stream|WritableStream|undefined;
-
-export interface Logger extends bunyan {
-    streams: LoggerStream[];
-    flush(): Promise<void>;
-}
+import { Logger } from './logger';
 
 export interface ClusterStateConfig {
     connection: string|'default';
@@ -75,7 +66,7 @@ export interface ConnectionConfig {
     type: string;
 }
 
-export type ClientFactoryFn = (config: object, logger: Logger, options: ConnectionConfig) => any;
+export type ClientFactoryFn = (config: object, logger: Logger, options: ConnectionConfig) => { client: any };
 
 export interface FoundationApis {
     makeLogger(...params: any[]): Logger;

--- a/packages/job-components/src/interfaces/index.ts
+++ b/packages/job-components/src/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from './context';
 export * from './jobs';
+export * from './logger';
 export * from './operation-lifecycle';
 export * from './operations';

--- a/packages/job-components/src/interfaces/logger.ts
+++ b/packages/job-components/src/interfaces/logger.ts
@@ -1,0 +1,308 @@
+import Stream from 'stream';
+import { EventEmitter } from 'events';
+
+// This includes additional properties from terafoundation
+// Type definitions for bunyan 1.8
+// Project: https://github.com/trentm/node-bunyan
+// Definitions by: Alex Mikhalev <https://github.com/amikhalev>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+declare class Logger extends EventEmitter {
+    constructor(options: Logger.LoggerOptions);
+    addStream(stream: Logger.Stream): void;
+    addSerializers(serializers: Logger.Serializers): void;
+    child(options: Object, simple?: boolean): Logger;
+    reopenFileStreams(): void;
+
+    level(): number;
+    level(value: Logger.LogLevel): void;
+    levels(): number[];
+    levels(name: number | string): number;
+    levels(name: number | string, value: Logger.LogLevel): void;
+
+    /**
+     * Terafoundation specific
+    */
+    streams: Stream|WritableStream|undefined[];
+
+    fields: any;
+    src: boolean;
+
+    /**
+     * Returns a boolean: is the `trace` level enabled?
+     *
+     * This is equivalent to `log.isTraceEnabled()` or `log.isEnabledFor(TRACE)` in log4j.
+     */
+    trace(): boolean;
+
+    /**
+     * Special case to log an `Error` instance to the record.
+     * This adds an `err` field with exception details
+     * (including the stack) and sets `msg` to the exception
+     * message or you can specify the `msg`.
+     */
+    trace(error: Error, ...params: any[]): void;
+
+    /**
+     * The first field can optionally be a "fields" object, which
+     * is merged into the log record.
+     *
+     * To pass in an Error *and* other fields, use the `err`
+     * field name for the Error instance.
+     */
+    trace(obj: Object, ...params: any[]): void;
+
+    /**
+     * Uses `util.format` for msg formatting.
+     */
+    trace(format: any, ...params: any[]): void;
+
+    /**
+     * Returns a boolean: is the `debug` level enabled?
+     *
+     * This is equivalent to `log.isDebugEnabled()` or `log.isEnabledFor(DEBUG)` in log4j.
+     */
+    debug(): boolean;
+
+    /**
+     * Special case to log an `Error` instance to the record.
+     * This adds an `err` field with exception details
+     * (including the stack) and sets `msg` to the exception
+     * message or you can specify the `msg`.
+     */
+    debug(error: Error, ...params: any[]): void;
+
+    /**
+     * The first field can optionally be a "fields" object, which
+     * is merged into the log record.
+     *
+     * To pass in an Error *and* other fields, use the `err`
+     * field name for the Error instance.
+     */
+    debug(obj: Object, ...params: any[]): void;
+
+    /**
+     * Uses `util.format` for msg formatting.
+     */
+    debug(format: any, ...params: any[]): void;
+
+    /**
+     * Returns a boolean: is the `info` level enabled?
+     *
+     * This is equivalent to `log.isInfoEnabled()` or `log.isEnabledFor(INFO)` in log4j.
+     */
+    info(): boolean;
+
+    /**
+     * Special case to log an `Error` instance to the record.
+     * This adds an `err` field with exception details
+     * (including the stack) and sets `msg` to the exception
+     * message or you can specify the `msg`.
+     */
+    info(error: Error, ...params: any[]): void;
+
+    /**
+     * The first field can optionally be a "fields" object, which
+     * is merged into the log record.
+     *
+     * To pass in an Error *and* other fields, use the `err`
+     * field name for the Error instance.
+     */
+    info(obj: Object, ...params: any[]): void;
+
+    /**
+     * Uses `util.format` for msg formatting.
+     */
+    info(format: any, ...params: any[]): void;
+
+    /**
+     * Returns a boolean: is the `warn` level enabled?
+     *
+     * This is equivalent to `log.isWarnEnabled()` or `log.isEnabledFor(WARN)` in log4j.
+     */
+    warn(): boolean;
+
+    /**
+     * Special case to log an `Error` instance to the record.
+     * This adds an `err` field with exception details
+     * (including the stack) and sets `msg` to the exception
+     * message or you can specify the `msg`.
+     */
+    warn(error: Error, ...params: any[]): void;
+
+    /**
+     * The first field can optionally be a "fields" object, which
+     * is merged into the log record.
+     *
+     * To pass in an Error *and* other fields, use the `err`
+     * field name for the Error instance.
+     */
+    warn(obj: Object, ...params: any[]): void;
+
+    /**
+     * Uses `util.format` for msg formatting.
+     */
+    warn(format: any, ...params: any[]): void;
+
+    /**
+     * Returns a boolean: is the `error` level enabled?
+     *
+     * This is equivalent to `log.isErrorEnabled()` or `log.isEnabledFor(ERROR)` in log4j.
+     */
+    error(): boolean;
+
+    /**
+     * Special case to log an `Error` instance to the record.
+     * This adds an `err` field with exception details
+     * (including the stack) and sets `msg` to the exception
+     * message or you can specify the `msg`.
+     */
+    error(error: Error, ...params: any[]): void;
+
+    /**
+     * The first field can optionally be a "fields" object, which
+     * is merged into the log record.
+     *
+     * To pass in an Error *and* other fields, use the `err`
+     * field name for the Error instance.
+     */
+    error(obj: Object, ...params: any[]): void;
+
+    /**
+     * Uses `util.format` for msg formatting.
+     */
+    error(format: any, ...params: any[]): void;
+
+    /**
+     * Returns a boolean: is the `fatal` level enabled?
+     *
+     * This is equivalent to `log.isFatalEnabled()` or `log.isEnabledFor(FATAL)` in log4j.
+     */
+    fatal(): boolean;
+
+    /**
+     * Special case to log an `Error` instance to the record.
+     * This adds an `err` field with exception details
+     * (including the stack) and sets `msg` to the exception
+     * message or you can specify the `msg`.
+     */
+    fatal(error: Error, ...params: any[]): void;
+
+    /**
+     * The first field can optionally be a "fields" object, which
+     * is merged into the log record.
+     *
+     * To pass in an Error *and* other fields, use the `err`
+     * field name for the Error instance.
+     */
+    fatal(obj: Object, ...params: any[]): void;
+
+    /**
+     * Uses `util.format` for msg formatting.
+     */
+    fatal(format: any, ...params: any[]): void;
+
+    /**
+     * Terafoundation specific, flush the logs
+    */
+    flush(): Promise<void>;
+}
+
+declare namespace Logger {
+    const TRACE: number;
+    const DEBUG: number;
+    const INFO: number;
+    const WARN: number;
+    const ERROR: number;
+    const FATAL: number;
+
+    type LogLevelString = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+    type LogLevel = LogLevelString | number;
+
+    const levelFromName: { [name in LogLevelString]: number };
+    const nameFromLevel: { [level: number]: string };
+
+    const stdSerializers: StdSerializers;
+
+    function createLogger(options: LoggerOptions): Logger;
+
+    function safeCycles(): (key: string, value: any) => any;
+
+    function resolveLevel(value: LogLevel): number;
+
+    interface Stream {
+        type?: string;
+        level?: LogLevel;
+        path?: string;
+        stream?: NodeJS.WritableStream | Stream;
+        closeOnExit?: boolean;
+        period?: string;
+        count?: number;
+        name?: string;
+        reemitErrorEvents?: boolean;
+    }
+
+    interface LoggerOptions {
+        name: string;
+        streams?: Stream[];
+        level?: LogLevel;
+        stream?: NodeJS.WritableStream;
+        serializers?: Serializers;
+        src?: boolean;
+        [custom: string]: any;
+    }
+
+    type Serializer = (input: any) => any;
+
+    interface Serializers {
+        [key: string]: Serializer;
+    }
+
+    interface StdSerializers extends Serializers {
+        err: Serializer;
+        res: Serializer;
+        req: Serializer;
+    }
+
+    interface RingBufferOptions {
+        limit?: number;
+    }
+
+    class RingBuffer extends EventEmitter implements NodeJS.WritableStream {
+        constructor(options: RingBufferOptions);
+
+        writable: boolean;
+        records: any[];
+
+        write(record: any): boolean;
+        end(record?: any): void;
+        destroy(): void;
+        destroySoon(): void;
+    }
+
+    interface RotatingFileStreamOptions {
+        path: string;
+        count?: number;
+        period?: string;
+    }
+
+    class RotatingFileStream extends EventEmitter implements NodeJS.WritableStream {
+        constructor(options: RotatingFileStreamOptions);
+
+        writable: boolean;
+        periodNum: number;
+        periodScope: string;
+        stream: any;
+        rotQueue: any[];
+        rotating: boolean;
+
+        write(record: any): boolean;
+        end(record?: any): void;
+        destroy(): void;
+        destroySoon(): void;
+        rotate(): void;
+    }
+}
+
+export { Logger };

--- a/packages/job-components/src/interfaces/operations.ts
+++ b/packages/job-components/src/interfaces/operations.ts
@@ -1,6 +1,7 @@
 import { Schema } from 'convict';
 import { ValidatedJobConfig, OpConfig, ExecutionConfig, LegacyExecutionContext } from './jobs';
-import { Context, SysConfig, Logger } from './context';
+import { Context, SysConfig } from './context';
+import { Logger } from './logger';
 
 export type crossValidationFn = (job: ValidatedJobConfig, sysconfig: SysConfig) => void;
 export type selfValidationFn = (config: OpConfig) => void;

--- a/packages/job-components/src/operation-loader.ts
+++ b/packages/job-components/src/operation-loader.ts
@@ -310,7 +310,8 @@ export class OperationLoader {
         const allowedNames = uniq([name, ...codeNames]);
 
         const invalid = [
-            'node_modules'
+            'node_modules',
+            ...ignoreDirectories(),
         ];
 
         const findCode = (rootDir: string): string|null => {
@@ -354,4 +355,10 @@ function availableExtensions(): string[] {
     // populated by teraslice Jest configuration
     // @ts-ignore
     return global.availableExtensions ? global.availableExtensions : ['.js'];
+}
+
+function ignoreDirectories() {
+    // populated by teraslice Jest configuration
+    // @ts-ignore
+    return global.ignoreDirectories || [];
 }

--- a/packages/job-components/src/test-helpers.ts
+++ b/packages/job-components/src/test-helpers.ts
@@ -271,7 +271,7 @@ export class TestContext implements i.Context {
                     const cachedClients = _cachedClients.get(ctx) || {};
                     const key = getKey(options);
                     if (cached && cachedClients[key] != null) {
-                        return { client: cachedClients[key] };
+                        return cachedClients[key];
                     }
 
                     const clientFns = _createClientFns.get(ctx) || {};
@@ -286,10 +286,11 @@ export class TestContext implements i.Context {
                     const config = setConnectorConfig(sysconfig, options, {});
 
                     const client = create(config, logger, options);
+
                     cachedClients[key] = client;
                     _cachedClients.set(ctx, cachedClients);
 
-                    return { client };
+                    return client;
                 },
                 getSystemEvents(): EventEmitter {
                     return events;

--- a/packages/job-components/test/fixtures/failing-reader/fetcher.js
+++ b/packages/job-components/test/fixtures/failing-reader/fetcher.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { Fetcher, DataEntity } = require('../../..');
+
+class FailingFetcher extends Fetcher {
+    async fetch() {
+        return [
+            DataEntity.fromBuffer(JSON.stringify({ hello: true }), this.opConfig),
+            DataEntity.fromBuffer(JSON.stringify({ hi: true }), this.opConfig),
+            DataEntity.fromBuffer('{"thiswill":fail}', this.opConfig),
+        ];
+    }
+}
+
+module.exports = FailingFetcher;

--- a/packages/job-components/test/fixtures/failing-reader/index.js
+++ b/packages/job-components/test/fixtures/failing-reader/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const { legacyReaderShim } = require('../../..');
+const Fetcher = require('./fetcher');
+const Slicer = require('./slicer');
+const Schema = require('./schema');
+const ExampleAPI = require('./api');
+
+// This file for backwards compatibility and functionality will be limited
+// but it should allow you to write processors using the new way today
+module.exports = legacyReaderShim(Slicer, Fetcher, Schema, {
+    'example-reader': ExampleAPI
+});

--- a/packages/job-components/test/fixtures/failing-reader/schema.js
+++ b/packages/job-components/test/fixtures/failing-reader/schema.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { ConvictSchema } = require('../../..');
+
+class Schema extends ConvictSchema {
+    build() {
+        return {
+            example: {
+                default: 'examples are quick and easy',
+                doc: 'A random example schema property',
+                format: 'String',
+            }
+        };
+    }
+}
+
+module.exports = Schema;

--- a/packages/job-components/test/fixtures/failing-reader/slicer.js
+++ b/packages/job-components/test/fixtures/failing-reader/slicer.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const uuidv4 = require('uuid/v4');
+const { Slicer } = require('../../..');
+
+class FailingSlicer extends Slicer {
+    async slice() {
+        return {
+            id: uuidv4(),
+        };
+    }
+}
+
+module.exports = FailingSlicer;

--- a/packages/job-components/test/register-apis-spec.ts
+++ b/packages/job-components/test/register-apis-spec.ts
@@ -47,44 +47,101 @@ describe('registerApis', () => {
             {
                 type: 'elasticsearch',
                 create() {
-                    return { elasticsearch: true };
+                    return {
+                        client: {
+                            elasticsearch: true
+                        }
+                    };
                 }
             },
             {
                 type: 'elasticsearch',
                 endpoint: 'otherConnection',
                 create() {
-                    return { elasticsearch: true, endpoint: 'otherConnection' };
+                    return {
+                        client: {
+                            elasticsearch: true,
+                            endpoint: 'otherConnection'
+                        }
+                    };
                 }
             },
             {
                 type: 'elasticsearch',
                 endpoint: 'thirdConnection',
                 create() {
-                    return { elasticsearch: true, endpoint: 'thirdConnection' };
+                    return {
+                        client: {
+                            elasticsearch: true,
+                            endpoint: 'thirdConnection'
+                        }
+                    };
                 }
             },
             {
                 type: 'kafka',
                 endpoint: 'someConnection',
                 create() {
-                    return { kafka: true };
+                    return {
+                        client: {
+                            kafka: true
+                        }
+                    };
                 }
             },
             {
                 type: 'mongo',
                 create() {
-                    return { mongo: true };
+                    return {
+                        client: {
+                            mongo: true
+                        }
+                    };
                 }
             }
         ];
 
         context.apis.setTestClients(clients);
 
-        it('op_runner.getClient should return a client', () => {
-            expect(getClient({}, 'elasticsearch')).toEqual({ elasticsearch: true });
-            expect(getClient({ connection: 'someConnection' }, 'kafka')).toEqual({ kafka: true });
-            expect(getClient({ connection_cache: false }, 'mongo')).toEqual({ mongo: true });
+        it('getClient should return a client', () => {
+            expect(getClient({}, 'elasticsearch')).toEqual({
+                elasticsearch: true
+            });
+
+            const firstResult = getClient({
+                connection: 'otherConnection',
+                connection_cache: true
+            }, 'elasticsearch');
+
+            expect(firstResult).toEqual({
+                elasticsearch: true,
+                endpoint: 'otherConnection'
+            });
+
+            expect(getClient({
+                connection: 'otherConnection',
+                connection_cache: true
+            }, 'elasticsearch')).toBe(firstResult);
+
+            expect(getClient({
+                connection: 'thirdConnection',
+                connection_cache: false,
+            }, 'elasticsearch')).toEqual({
+                elasticsearch: true,
+                endpoint: 'thirdConnection',
+            });
+
+            expect(getClient({
+                connection: 'someConnection'
+            }, 'kafka')).toEqual({
+                kafka: true
+            });
+
+            expect(getClient({
+                connection_cache: false
+            }, 'mongo')).toEqual({
+                mongo: true
+            });
         });
 
         it('getClient will error properly', done => {
@@ -117,35 +174,6 @@ describe('registerApis', () => {
             });
 
             failingContext.apis.op_runner.getClient();
-        });
-
-        it('getClient returns client with certain defaults', () => {
-            const opConfig1 = {};
-            const opConfig2 = {
-                connection: 'otherConnection'
-            };
-            const opConfig3 = {
-                connection: 'thirdConnection',
-                connection_cache: false,
-            };
-
-            const type = 'elasticsearch';
-
-            const results1 = getClient(opConfig1, type);
-            const results2 = getClient(opConfig2, type);
-            const results3 = getClient(opConfig3, type);
-
-            expect(results1).toEqual({ elasticsearch: true });
-
-            expect(results2).toEqual({
-                elasticsearch: true,
-                endpoint: 'otherConnection',
-            });
-
-            expect(results3).toEqual({
-                elasticsearch: true,
-                endpoint: 'thirdConnection',
-            });
         });
     });
 

--- a/packages/teraslice-op-test-harness/index.js
+++ b/packages/teraslice-op-test-harness/index.js
@@ -53,7 +53,9 @@ class TestHarness {
     setClients(clients = []) {
         const testClients = clients.map((config) => {
             const { client } = config;
-            config.create = _.isFunction(config.create) ? config.create : () => client;
+            if (!_.isFunction(config.create)) {
+                config.create = () => ({ client });
+            }
             return config;
         });
         this.context.apis.setTestClients(testClients);

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "publishConfig": {
         "access": "public"
     },
@@ -23,7 +23,7 @@
         "url": "https://github.com/terascope/teraslice/issues"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.11.0",
+        "@terascope/job-components": "^0.11.1",
         "bluebird": "^3.5.3",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-test-harness/README.md
+++ b/packages/teraslice-test-harness/README.md
@@ -103,12 +103,16 @@ describe('Example Asset', () => {
     const simpleClient = new SimpleClient();
     const clientConfig = {
         type: 'simple-client',
-        create: jest.fn(() => simpleClient),
+        create: jest.fn(() => {
+            return { client: simpleClient };
+        }),
     };
 
     beforeEach(() => {
         jest.restoreAllMocks();
-        clientConfig.create = jest.fn(() => simpleClient);
+        clientConfig.create = jest.fn(() => {
+            return { client: simpleClient };
+        });
     });
 
     describe('using the WorkerTestHarness', () => {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-test-harness",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "publishConfig": {
         "access": "public"
     },
@@ -36,8 +36,8 @@
         "test:debug": "env DEBUG='*teraslice*' jest --detectOpenHandles --coverage=false --runInBand"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.11.0",
-        "@terascope/teraslice-op-test-harness": "^1.4.0",
+        "@terascope/job-components": "^0.11.1",
+        "@terascope/teraslice-op-test-harness": "^1.4.1",
         "@types/lodash": "^4.14.118",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-test-harness/src/slicer-test-harness.ts
+++ b/packages/teraslice-test-harness/src/slicer-test-harness.ts
@@ -64,6 +64,9 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
      *
      * @returns an array of Slices including the metadata or the just the Slice Request.
     */
+    async createSlices(): Promise<SliceRequest[]>;
+    async createSlices(options: { fullResponse: false }): Promise<SliceRequest[]>;
+    async createSlices(options: { fullResponse: true }): Promise<Slice[]>;
     async createSlices({ fullResponse = false } = {}): Promise<SliceRequest[]|Slice[]> {
         const { slicer } = this.executionContext;
         const slicers = slicer.slicers();

--- a/packages/teraslice-test-harness/src/worker-test-harness.ts
+++ b/packages/teraslice-test-harness/src/worker-test-harness.ts
@@ -53,6 +53,9 @@ export default class WorkerTestHarness extends BaseTestHarness<WorkerExecutionCo
      *
      * @returns an Array of DataEntities or a SliceResult
     */
+    async runSlice(input: Slice|SliceRequest): Promise<DataEntity[]>;
+    async runSlice(input: Slice|SliceRequest, options: { fullResponse: false }): Promise<DataEntity[]>;
+    async runSlice(input: Slice|SliceRequest, options: { fullResponse: true }): Promise<RunSliceResult>;
     async runSlice(input: Slice|SliceRequest, { fullResponse = false } = {}): Promise<DataEntity[]|RunSliceResult> {
         const slice: Slice = isSlice(input) ? input : newTestSlice(input);
 

--- a/packages/teraslice-test-harness/test/example-asset-spec.ts
+++ b/packages/teraslice-test-harness/test/example-asset-spec.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { DataEntity, SliceRequest, TestClientConfig } from '@terascope/job-components';
+import { DataEntity, TestClientConfig } from '@terascope/job-components';
 import SimpleClient from './fixtures/asset/simple-connector/client';
 import {
     JobTestHarness,
@@ -77,7 +77,7 @@ describe('Example Asset', () => {
         it('should return a list of records', async () => {
             const testSlice = newTestSlice();
             testSlice.request = { count: 10 };
-            const results = await harness.runSlice(testSlice) as DataEntity[];
+            const results = await harness.runSlice(testSlice);
 
             expect(Array.isArray(results)).toBe(true);
             expect(results.length).toBe(10);
@@ -131,7 +131,7 @@ describe('Example Asset', () => {
         });
 
         it('should return a list of records', async () => {
-            const results = await harness.createSlices() as SliceRequest[];
+            const results = await harness.createSlices();
             expect(Array.isArray(results)).toBe(true);
             expect(results.length).toBe(10);
 

--- a/packages/teraslice-test-harness/test/example-asset-spec.ts
+++ b/packages/teraslice-test-harness/test/example-asset-spec.ts
@@ -16,12 +16,16 @@ describe('Example Asset', () => {
     const simpleClient = new SimpleClient();
     const clientConfig: TestClientConfig = {
         type: 'simple-client',
-        create: jest.fn(() => simpleClient),
+        create: jest.fn(() => {
+            return { client: simpleClient };
+        }),
     };
 
     beforeEach(() => {
         jest.restoreAllMocks();
-        clientConfig.create = jest.fn(() => simpleClient);
+        clientConfig.create = jest.fn(() => {
+            return { client: simpleClient };
+        });
     });
 
     describe('using the WorkerTestHarness', () => {

--- a/packages/teraslice-test-harness/test/job-test-harness-spec.ts
+++ b/packages/teraslice-test-harness/test/job-test-harness-spec.ts
@@ -14,8 +14,10 @@ describe('JobTestHarness', () => {
         {
             type: 'example',
             create: () => ({
-                say() {
-                    return 'hello';
+                client: {
+                    say() {
+                        return 'hello';
+                    }
                 }
             })
         }

--- a/packages/teraslice-test-harness/test/op-test-harness-spec.ts
+++ b/packages/teraslice-test-harness/test/op-test-harness-spec.ts
@@ -8,8 +8,10 @@ describe('OpTestHarness', () => {
         {
             type: 'example',
             create: () => ({
-                say() {
-                    return 'hello';
+                client: {
+                    say() {
+                        return 'hello';
+                    }
                 }
             })
         }

--- a/packages/teraslice-test-harness/test/slicer-test-harness-spec.ts
+++ b/packages/teraslice-test-harness/test/slicer-test-harness-spec.ts
@@ -13,8 +13,10 @@ describe('SlicerTestHarness', () => {
         {
             type: 'example',
             create: () => ({
-                say() {
-                    return 'hello';
+                client: {
+                    say() {
+                        return 'hello';
+                    }
                 }
             })
         }

--- a/packages/teraslice-test-harness/test/slicer-test-harness-spec.ts
+++ b/packages/teraslice-test-harness/test/slicer-test-harness-spec.ts
@@ -2,8 +2,6 @@ import 'jest-extended';
 import path from 'path';
 import {
     newTestJobConfig,
-    SliceRequest,
-    Slice,
     Slicer
 } from '@terascope/job-components';
 import { SlicerTestHarness } from '../src';
@@ -47,7 +45,7 @@ describe('SlicerTestHarness', () => {
         });
 
         it('should be able to call createSlices', async () => {
-            const result = await slicerHarness.createSlices() as SliceRequest[];
+            const result = await slicerHarness.createSlices();
             expect(result).toBeArray();
 
             expect(result[0]).not.toHaveProperty('slice_id');
@@ -56,7 +54,7 @@ describe('SlicerTestHarness', () => {
         });
 
         it('should be able to call createSlices with fullResponse', async () => {
-            const result = await slicerHarness.createSlices({ fullResponse: true }) as Slice[];
+            const result = await slicerHarness.createSlices({ fullResponse: true });
             expect(result).toBeArray();
             expect(result[0]).toHaveProperty('slice_id');
             expect(result[0]).toHaveProperty('slicer_id');

--- a/packages/teraslice-test-harness/test/worker-test-harness-spec.ts
+++ b/packages/teraslice-test-harness/test/worker-test-harness-spec.ts
@@ -15,8 +15,10 @@ describe('WorkerTestHarness', () => {
         {
             type: 'example',
             create: () => ({
-                say() {
-                    return 'hello';
+                client: {
+                    say() {
+                        return 'hello';
+                    }
                 }
             })
         }

--- a/packages/teraslice-test-harness/test/worker-test-harness-spec.ts
+++ b/packages/teraslice-test-harness/test/worker-test-harness-spec.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import {
     newTestJobConfig,
     newTestSlice,
-    RunSliceResult,
     DataEntity,
     Fetcher,
     BatchProcessor,
@@ -55,19 +54,19 @@ describe('WorkerTestHarness', () => {
         });
 
         it('should be able to call runSlice', async () => {
-            const result = await workerHarness.runSlice(newTestSlice()) as DataEntity[];
+            const result = await workerHarness.runSlice(newTestSlice());
             expect(result).toBeArray();
             expect(DataEntity.isDataEntityArray(result)).toBeTrue();
         });
 
         it('should be able to call runSlice with just a request object', async () => {
-            const result = await workerHarness.runSlice({ hello: true }) as DataEntity[];
+            const result = await workerHarness.runSlice({ hello: true });
             expect(result).toBeArray();
             expect(DataEntity.isDataEntityArray(result)).toBeTrue();
         });
 
         it('should be able to call runSlice with fullResponse', async () => {
-            const result = await workerHarness.runSlice(newTestSlice(), { fullResponse: true }) as RunSliceResult;
+            const result = await workerHarness.runSlice(newTestSlice(), { fullResponse: true });
             expect(result.analytics).not.toBeNil();
             expect(result.results).toBeArray();
         });

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.44.0",
+    "version": "0.44.1",
     "description": "Slice and dice your Elasticsearch data",
     "bin": "service.js",
     "main": "index.js",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@terascope/elasticsearch-api": "^1.1.3",
         "@terascope/error-parser": "^1.0.1",
-        "@terascope/job-components": "^0.11.0",
+        "@terascope/job-components": "^0.11.1",
         "@terascope/queue": "^1.1.4",
         "@terascope/teraslice-messaging": "^0.2.5",
         "async-mutex": "^0.1.3",
@@ -66,7 +66,7 @@
         "yargs": "^12.0.2"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.4.0",
+        "@terascope/teraslice-op-test-harness": "^1.4.1",
         "archiver": "^3.0.0",
         "bufferstreams": "^2.0.1",
         "chance": "^1.0.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,14 +49,14 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@lerna/add@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.4.1.tgz#d41068317e30f530df48220d256b5e79690b1877"
-  integrity sha512-Vf54B42jlD6G52qnv/cAGH70cVQIa+LX//lfsbkxHvzkhIqBl5J4KsnTOPkA9uq3R+zP58ayicCHB9ReiEWGJg==
+"@lerna/add@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.5.0.tgz#3518b3d4afc3743b7227b1ee3534114eb9575888"
+  integrity sha512-hoOqtal/ChEEtt9rxR/6xmyvTN7581XF4kWHoWPV9NbfZN9e8uTR8z4mCcJq2DiZhRuY7aA5FEROEbl12soowQ==
   dependencies:
-    "@lerna/bootstrap" "^3.4.1"
-    "@lerna/command" "^3.3.0"
-    "@lerna/filter-options" "^3.3.2"
+    "@lerna/bootstrap" "^3.5.0"
+    "@lerna/command" "^3.5.0"
+    "@lerna/filter-options" "^3.5.0"
     "@lerna/npm-conf" "^3.4.1"
     "@lerna/validation-error" "^3.0.0"
     dedent "^0.7.0"
@@ -74,14 +74,14 @@
     "@lerna/validation-error" "^3.0.0"
     npmlog "^4.1.2"
 
-"@lerna/bootstrap@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@lerna/bootstrap/-/bootstrap-3.4.1.tgz#10635e9b547fb7d685949ac78e0923f73da2f52a"
-  integrity sha512-yZDJgNm/KDoRH2klzmQGmpWMg/XMzWgeWvauXkrfW/mj1wwmufOuh5pN4fBFxVmUUa/RFZdfMeaaJt3+W3PPBw==
+"@lerna/bootstrap@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/bootstrap/-/bootstrap-3.5.0.tgz#4d21ef0d1e648c8121432443a7d80c9442756347"
+  integrity sha512-+z4kVVJFO5EGfC2ob/4C9LetqWwDtbhZgTRllr1+zOi/2clbD+WKcVI0ku+/ckzKjz783SOc83swX7RrmiLwMQ==
   dependencies:
     "@lerna/batch-packages" "^3.1.2"
-    "@lerna/command" "^3.3.0"
-    "@lerna/filter-options" "^3.3.2"
+    "@lerna/command" "^3.5.0"
+    "@lerna/filter-options" "^3.5.0"
     "@lerna/has-npm-version" "^3.3.0"
     "@lerna/npm-conf" "^3.4.1"
     "@lerna/npm-install" "^3.3.0"
@@ -103,23 +103,23 @@
     read-package-tree "^5.1.6"
     semver "^5.5.0"
 
-"@lerna/changed@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@lerna/changed/-/changed-3.4.1.tgz#84a049359a53b8812c3a07a664bd41b1768f5938"
-  integrity sha512-gT7fhl4zQWyGETDO4Yy5wsFnqNlBSsezncS1nkMW1uO6jwnolwYqcr1KbrMR8HdmsZBn/00Y0mRnbtbpPPey8w==
+"@lerna/changed@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/changed/-/changed-3.5.0.tgz#c96c4bde6d78f4b2a7b3b3e2511bf78cb6aabe17"
+  integrity sha512-p9o7/hXwFAoet7UPeHIzIPonYxLHZe9bcNcjxKztZYAne5/OgmZiF4X1UPL2S12wtkT77WQy4Oz8NjRTczcapg==
   dependencies:
-    "@lerna/collect-updates" "^3.3.2"
-    "@lerna/command" "^3.3.0"
+    "@lerna/collect-updates" "^3.5.0"
+    "@lerna/command" "^3.5.0"
     "@lerna/listable" "^3.0.0"
     "@lerna/output" "^3.0.0"
-    "@lerna/version" "^3.4.1"
+    "@lerna/version" "^3.5.0"
 
-"@lerna/check-working-tree@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@lerna/check-working-tree/-/check-working-tree-3.3.0.tgz#2118f301f28ccb530812e5b27a341b1e6b3c84e2"
-  integrity sha512-oeEP1dNhiiKUaO0pmcIi73YXJpaD0n5JczNctvVNZ8fGZmrALZtEnmC28o6Z7JgQaqq5nd2kO7xbnjoitrC51g==
+"@lerna/check-working-tree@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/check-working-tree/-/check-working-tree-3.5.0.tgz#015f90247fa0b44a940eab0dd6a9da2ae5b8f455"
+  integrity sha512-aWeIputHddeZgf7/wA1e5yuv6q9S5si2y7fzO2Ah7m3KyDyl8XHP1M0VSSDzZeiloYCryAYQAoRgcrdH65Vhow==
   dependencies:
-    "@lerna/describe-ref" "^3.3.0"
+    "@lerna/describe-ref" "^3.5.0"
     "@lerna/validation-error" "^3.0.0"
 
 "@lerna/child-process@^3.3.0":
@@ -131,13 +131,13 @@
     execa "^1.0.0"
     strong-log-transformer "^2.0.0"
 
-"@lerna/clean@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@lerna/clean/-/clean-3.3.2.tgz#9a7e8a1e400e580de260fa124945b2939a025069"
-  integrity sha512-mvqusgSp2ou5SGqQgTEoTvGJpGfH4+L6XSeN+Ims+eNFGXuMazmKCf+rz2PZBMFufaHJ/Os+JF0vPCcWI1Fzqg==
+"@lerna/clean@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/clean/-/clean-3.5.0.tgz#38e0e58443fa43c19b3eeffcafa46cf254a328ee"
+  integrity sha512-bHUFF6Wv7ms81Tmwe56xk296oqU74Sg9NSkUCDG4kZLpYZx347Aw+89ZPTlaSmUwqCgEXKYLr65ZVVvKmflpcA==
   dependencies:
-    "@lerna/command" "^3.3.0"
-    "@lerna/filter-options" "^3.3.2"
+    "@lerna/command" "^3.5.0"
+    "@lerna/filter-options" "^3.5.0"
     "@lerna/prompt" "^3.3.1"
     "@lerna/rimraf-dir" "^3.3.0"
     p-map "^1.2.0"
@@ -154,25 +154,25 @@
     npmlog "^4.1.2"
     yargs "^12.0.1"
 
-"@lerna/collect-updates@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@lerna/collect-updates/-/collect-updates-3.3.2.tgz#54df5ce59ca05e8aa04ff8a9299f89cc253a9304"
-  integrity sha512-9WyBJI2S5sYgEZEScu525Lbi6nknNrdBKop35sCDIC9y6AIGvH6Dr5tkTd+Kg3n1dE+kHwW/xjERkx3+h7th3w==
+"@lerna/collect-updates@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/collect-updates/-/collect-updates-3.5.0.tgz#e81c17f89367e71ff59e0f244a523a1dc13891c5"
+  integrity sha512-rFCng14K8vHyrDJSAacj6ABKKT/TxZdpL9uPEtZN7DsoJKlKPzqFeRvRGA2+ed/I6mEm4ltauEjEpKG5O6xqtw==
   dependencies:
     "@lerna/child-process" "^3.3.0"
-    "@lerna/describe-ref" "^3.3.0"
+    "@lerna/describe-ref" "^3.5.0"
     minimatch "^3.0.4"
     npmlog "^4.1.2"
     slash "^1.0.0"
 
-"@lerna/command@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@lerna/command/-/command-3.3.0.tgz#e81c4716a676b02dbe9d3f548d5f45b4ba32c25a"
-  integrity sha512-NTOkLEKlWcBLHSvUr9tzVpV7RJ4GROLeOuZ6RfztGOW/31JPSwVVBD2kPifEXNZunldOx5GVWukR+7+NpAWhsg==
+"@lerna/command@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/command/-/command-3.5.0.tgz#6b5cc530653aaa631061c1c234f3bc4408cb9613"
+  integrity sha512-C/0e7qPbuKZ9vEqzRePksoKDJk4TOWzsU5qaPP/ikqc6vClJbKucsIehk3za6glSjlgLCJpzBTF2lFjHfb+JNw==
   dependencies:
     "@lerna/child-process" "^3.3.0"
     "@lerna/package-graph" "^3.1.2"
-    "@lerna/project" "^3.0.0"
+    "@lerna/project" "^3.5.0"
     "@lerna/validation-error" "^3.0.0"
     "@lerna/write-log-file" "^3.0.0"
     dedent "^0.7.0"
@@ -181,15 +181,15 @@
     lodash "^4.17.5"
     npmlog "^4.1.2"
 
-"@lerna/conventional-commits@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@lerna/conventional-commits/-/conventional-commits-3.4.1.tgz#0b47f9fc0c4a10951883e949d939188da1b527bc"
-  integrity sha512-3NETrA58aUkaEW3RdwdJ766Bg9NVpLzb26mtdlsJQcvB5sQBWH5dJSHIVQH1QsGloBeH2pE/mDUEVY8ZJXuR4w==
+"@lerna/conventional-commits@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/conventional-commits/-/conventional-commits-3.5.0.tgz#1c08013c48acdbdbf6400ccfbe1200a18e1f11ce"
+  integrity sha512-roKPILPYnDWiCDxOeBQ0cObJ2FbDgzJSToxr1ZwIqvJU5hGQ4RmooCf8GHcCW9maBJz7ETeestv8M2mBUgBPbg==
   dependencies:
     "@lerna/validation-error" "^3.0.0"
-    conventional-changelog-angular "^5.0.1"
-    conventional-changelog-core "^3.1.0"
-    conventional-recommended-bump "^4.0.1"
+    conventional-changelog-angular "^5.0.2"
+    conventional-changelog-core "^3.1.5"
+    conventional-recommended-bump "^4.0.4"
     fs-extra "^7.0.0"
     get-stream "^4.0.0"
     npm-package-arg "^6.0.0"
@@ -205,13 +205,13 @@
     fs-extra "^7.0.0"
     npmlog "^4.1.2"
 
-"@lerna/create@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@lerna/create/-/create-3.4.1.tgz#7cad78a5701d7666a0f5d0fe0e325acd8d8f5b63"
-  integrity sha512-l+4t2SRO5nvW0MNYY+EWxbaMHsAN8bkWH3nyt7EzhBjs4+TlRAJRIEqd8o9NWznheE3pzwczFz1Qfl3BWbyM5A==
+"@lerna/create@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/create/-/create-3.5.0.tgz#22f64a7af7a08cfbed4af2a01ff82307ee9e0b2b"
+  integrity sha512-ek4flHRmpMegZp9tP3RmuDhmMb9+/Hhy9B5eaZc5X5KWqDvFKJtn56sw+M9hNjiYehiimCwhaLWgE2WSikPvcQ==
   dependencies:
     "@lerna/child-process" "^3.3.0"
-    "@lerna/command" "^3.3.0"
+    "@lerna/command" "^3.5.0"
     "@lerna/npm-conf" "^3.4.1"
     "@lerna/validation-error" "^3.0.0"
     camelcase "^4.1.0"
@@ -227,42 +227,42 @@
     validate-npm-package-name "^3.0.0"
     whatwg-url "^7.0.0"
 
-"@lerna/describe-ref@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@lerna/describe-ref/-/describe-ref-3.3.0.tgz#d373adb530d5428ab91e303ccbfcf51a98374a3a"
-  integrity sha512-4t7M4OupnYMSPNLrLUau8qkS+dgLEi4w+DkRkV0+A+KNYga1W0jVgNLPIIsxta7OHfodPkCNAqZCzNCw/dmAwA==
+"@lerna/describe-ref@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/describe-ref/-/describe-ref-3.5.0.tgz#d59090d201a0e587798496417373c7fbc1151fc4"
+  integrity sha512-XvecK2PSwUv4z+otib5moWJMI+h3mtAg8nFlfo4KbivVtD/sI11jfKsr3S75HuAwhVAa8tAijoAxmuBJSsTE1g==
   dependencies:
     "@lerna/child-process" "^3.3.0"
     npmlog "^4.1.2"
 
-"@lerna/diff@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@lerna/diff/-/diff-3.3.0.tgz#c8130a5f508b47fad5fec81404498bc3acdf9cb5"
-  integrity sha512-sIoMjsm3NVxvmt6ofx8Uu/2fxgldQqLl0zmC9X1xW00j831o5hBffx1EoKj9CnmaEvoSP6j/KFjxy2RWjebCIg==
+"@lerna/diff@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/diff/-/diff-3.5.0.tgz#4d131a1045321bcea20d743f5cc7f0d0095cf027"
+  integrity sha512-iyZ0ZRPqH5Y5XEhOYoKS8H/8UXC/gZ/idlToMFHhUn1oTSd8v9HVU1c2xq1ge0u36ZH/fx/YydUk0A/KSv+p3Q==
   dependencies:
     "@lerna/child-process" "^3.3.0"
-    "@lerna/command" "^3.3.0"
+    "@lerna/command" "^3.5.0"
     "@lerna/validation-error" "^3.0.0"
     npmlog "^4.1.2"
 
-"@lerna/exec@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@lerna/exec/-/exec-3.3.2.tgz#95ecaca617fd85abdb91e9a378ed06ec1763d665"
-  integrity sha512-mN6vGxNir7JOGvWLwKr3DW3LNy1ecCo2ziZj5rO9Mw5Rew3carUu1XLmhF/4judtsvXViUY+rvGIcqHe0vvb+w==
+"@lerna/exec@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/exec/-/exec-3.5.0.tgz#98f4e8719681c07a739241fadb4cbdbd9d518982"
+  integrity sha512-H5jeIueDiuNsxeuGKaP7HqTcenvMsFfBFeWr0W6knHv9NrOF8il34dBqYgApZEDSQ7+2fA3ghwWbF+jUGTSh/A==
   dependencies:
     "@lerna/batch-packages" "^3.1.2"
     "@lerna/child-process" "^3.3.0"
-    "@lerna/command" "^3.3.0"
-    "@lerna/filter-options" "^3.3.2"
+    "@lerna/command" "^3.5.0"
+    "@lerna/filter-options" "^3.5.0"
     "@lerna/run-parallel-batches" "^3.0.0"
     "@lerna/validation-error" "^3.0.0"
 
-"@lerna/filter-options@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@lerna/filter-options/-/filter-options-3.3.2.tgz#ac90702b7876ff4980dcdeaeac049c433dd01773"
-  integrity sha512-0WHqdDgAnt5WKoByi1q+lFw8HWt5tEKP2DnLlGqWv3YFwVF5DsPRlO7xbzjY9sJgvyJtZcnkMtccdBPFhGGyIQ==
+"@lerna/filter-options@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/filter-options/-/filter-options-3.5.0.tgz#34d1719908edbb52d4963c796df565a716282165"
+  integrity sha512-7pEQy1i5ynYOYjcSeo+Qaps4+Ais55RRdnT6/SLLBgyyHAMziflFLX5TnoyEaaXoU90iKfQ5z/ioEp6dFAXSMg==
   dependencies:
-    "@lerna/collect-updates" "^3.3.2"
+    "@lerna/collect-updates" "^3.5.0"
     "@lerna/filter-packages" "^3.0.0"
     dedent "^0.7.0"
 
@@ -295,48 +295,48 @@
     "@lerna/child-process" "^3.3.0"
     semver "^5.5.0"
 
-"@lerna/import@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@lerna/import/-/import-3.3.1.tgz#deca8c93c9cc03c5844b975c6da9937dd7530440"
-  integrity sha512-2OzTQDkYKbBPpyP2iOI1sWfcvMjNLjjHjmREq/uOWJaSIk5J3Ukt71OPpcOHh4V2CBOlXidCcO+Hyb4FVIy8fw==
+"@lerna/import@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/import/-/import-3.5.0.tgz#b42d368378d53c664a3324c1e2fc656a23819f12"
+  integrity sha512-vgI6lMEzd1ODgi75cmAlfPYylaK37WY3E2fwKyO/lj6UKSGj46dVSK0KwTRHx33tu4PLvPzFi5C6nbY57o5ykQ==
   dependencies:
     "@lerna/child-process" "^3.3.0"
-    "@lerna/command" "^3.3.0"
+    "@lerna/command" "^3.5.0"
     "@lerna/prompt" "^3.3.1"
     "@lerna/validation-error" "^3.0.0"
     dedent "^0.7.0"
     fs-extra "^7.0.0"
     p-map-series "^1.0.0"
 
-"@lerna/init@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@lerna/init/-/init-3.3.0.tgz#998f3497da3d891867c593b808b6db4b8fc4ccb9"
-  integrity sha512-HvgRLkIG6nDIeAO6ix5sUVIVV+W9UMk2rSSmFT66CDOefRi7S028amiyYnFUK1QkIAaUbVUyOnYaErtbJwICuw==
+"@lerna/init@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/init/-/init-3.5.0.tgz#40796d70dc261907e4149df62db8acbda8dc56fc"
+  integrity sha512-V21/UWj34Mph+9NxIGH1kYcuJAp+uFjfG8Ku2nMy62OGL3553+YQ+Izr+R6egY8y/99UMCDpi5gkQni5eGv3MA==
   dependencies:
     "@lerna/child-process" "^3.3.0"
-    "@lerna/command" "^3.3.0"
+    "@lerna/command" "^3.5.0"
     fs-extra "^7.0.0"
     p-map "^1.2.0"
     write-json-file "^2.3.0"
 
-"@lerna/link@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@lerna/link/-/link-3.3.0.tgz#c0c05ff52d0f0c659fcf221627edfcd58e477a5c"
-  integrity sha512-8CeXzGL7okrsVXsy2sHXI2KuBaczw3cblAnA2+FJPUqSKMPNbUTRzeU3bOlCjYtK0LbxC4ngENJTL3jJ8RaYQQ==
+"@lerna/link@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/link/-/link-3.5.0.tgz#ae7fe19df1bb0555dfa5aafcaf45c7fad537d81a"
+  integrity sha512-KSu1mhxwNRmguqMqUTJd4c7QIk9/xmxJxbmMkA71OaJd4fwondob6DyI/B17NIWutdLbvSWQ7pRlFOPxjQVoUw==
   dependencies:
-    "@lerna/command" "^3.3.0"
+    "@lerna/command" "^3.5.0"
     "@lerna/package-graph" "^3.1.2"
     "@lerna/symlink-dependencies" "^3.3.0"
     p-map "^1.2.0"
     slash "^1.0.0"
 
-"@lerna/list@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@lerna/list/-/list-3.3.2.tgz#1412b3cce2a83b1baa4ff6fb962d50b46c28ec98"
-  integrity sha512-XXEVy7w+i/xx8NeJmGirw4upEoEF9OfD6XPLjISNQc24VgQV+frXdVJ02QcP7Y/PkY1rdIVrOjvo3ipKVLUxaQ==
+"@lerna/list@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/list/-/list-3.5.0.tgz#ae38724f1cdc588fde8495385e3b1a9aeac0c80f"
+  integrity sha512-T+NZBQ/l6FmZklgrtFuN7luMs3AC/BoS52APOPrM7ZmxW4nenvov0xMwQW1783w/t365YDkDlYd5gM0nX3D1Hg==
   dependencies:
-    "@lerna/command" "^3.3.0"
-    "@lerna/filter-options" "^3.3.2"
+    "@lerna/command" "^3.5.0"
+    "@lerna/filter-options" "^3.5.0"
     "@lerna/listable" "^3.0.0"
     "@lerna/output" "^3.0.0"
 
@@ -434,10 +434,10 @@
     npm-package-arg "^6.0.0"
     write-pkg "^3.1.0"
 
-"@lerna/project@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@lerna/project/-/project-3.0.0.tgz#4320d2a2b4080cabcf95161d9c48475217d8a545"
-  integrity sha512-XhDFVfqj79jG2Speggd15RpYaE8uiR25UKcQBDmumbmqvTS7xf2cvl2pq2UTvDafaJ0YwFF3xkxQZeZnFMwdkw==
+"@lerna/project@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/project/-/project-3.5.0.tgz#ac5c7b3c49318552b29ccb7a471a657fd57d3091"
+  integrity sha512-uFDzqwrD7a/tTohQoo0voTsRy2cgl9D1ZOU2pHZzHzow9S1M8E0x5q3hJI2HlwsZry9IUugmDUGO6UddTjwm3Q==
   dependencies:
     "@lerna/package" "^3.0.0"
     "@lerna/validation-error" "^3.0.0"
@@ -460,17 +460,17 @@
     inquirer "^6.2.0"
     npmlog "^4.1.2"
 
-"@lerna/publish@^3.4.3":
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/@lerna/publish/-/publish-3.4.3.tgz#fb956ca2a871729982022889f90d0e8eb8528340"
-  integrity sha512-baeRL8xmOR25p86cAaS9mL0jdRzdv4dUo04PlK2Wes+YlL705F55cSXeC9npNie+9rGwFyLzCTQe18WdbZyLuw==
+"@lerna/publish@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/publish/-/publish-3.5.0.tgz#e6543375457846557f3cb803f7795a577333a941"
+  integrity sha512-CoK+wzPP/0xG54Iwf9WEbB3VgwayoiVYsubhYpC072Ue7V6mGXQh97KZMm8NzCoMDg35ZGqa85Kxpeqd5hqQlw==
   dependencies:
     "@lerna/batch-packages" "^3.1.2"
-    "@lerna/check-working-tree" "^3.3.0"
+    "@lerna/check-working-tree" "^3.5.0"
     "@lerna/child-process" "^3.3.0"
-    "@lerna/collect-updates" "^3.3.2"
-    "@lerna/command" "^3.3.0"
-    "@lerna/describe-ref" "^3.3.0"
+    "@lerna/collect-updates" "^3.5.0"
+    "@lerna/command" "^3.5.0"
+    "@lerna/describe-ref" "^3.5.0"
     "@lerna/get-npm-exec-opts" "^3.0.0"
     "@lerna/npm-conf" "^3.4.1"
     "@lerna/npm-dist-tag" "^3.3.0"
@@ -480,7 +480,7 @@
     "@lerna/run-lifecycle" "^3.4.1"
     "@lerna/run-parallel-batches" "^3.0.0"
     "@lerna/validation-error" "^3.0.0"
-    "@lerna/version" "^3.4.1"
+    "@lerna/version" "^3.5.0"
     fs-extra "^7.0.0"
     libnpmaccess "^3.0.0"
     npm-package-arg "^6.0.0"
@@ -528,17 +528,18 @@
     p-map "^1.2.0"
     p-map-series "^1.0.0"
 
-"@lerna/run@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@lerna/run/-/run-3.3.2.tgz#f521f4a22585c90758f34a584cb1871f8bb2a83e"
-  integrity sha512-cruwRGZZWnQ5I0M+AqcoT3Xpq2wj3135iVw4n59/Op6dZu50sMFXZNLiTTTZ15k8rTKjydcccJMdPSpTHbH7/A==
+"@lerna/run@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/run/-/run-3.5.0.tgz#f2bf479d8ef12e6a11be5a6404bb1a83eb56146c"
+  integrity sha512-BnPD52tj794xG2Xsc4FvgksyFX2CLmSR28TZw/xASEuy14NuQYMZkvbaj61SEhyOEsq7pLhHE5PpfbIv2AIFJw==
   dependencies:
     "@lerna/batch-packages" "^3.1.2"
-    "@lerna/command" "^3.3.0"
-    "@lerna/filter-options" "^3.3.2"
+    "@lerna/command" "^3.5.0"
+    "@lerna/filter-options" "^3.5.0"
     "@lerna/npm-run-script" "^3.3.0"
     "@lerna/output" "^3.0.0"
     "@lerna/run-parallel-batches" "^3.0.0"
+    "@lerna/timer" "^3.5.0"
     "@lerna/validation-error" "^3.0.0"
     p-map "^1.2.0"
 
@@ -566,6 +567,11 @@
     p-map "^1.2.0"
     p-map-series "^1.0.0"
 
+"@lerna/timer@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/timer/-/timer-3.5.0.tgz#8dee6acf002c55de64678c66ef37ca52143f1b9b"
+  integrity sha512-TAb99hqQN6E3JBGtG9iyZNPq1/DbmqgBOeNrKtdJsGvIeX/NGLgUDWMrj2h04V4O+jpBFmSf6HIld6triKmxCA==
+
 "@lerna/validation-error@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@lerna/validation-error/-/validation-error-3.0.0.tgz#a27e90051c3ba71995e2a800a43d94ad04b3e3f4"
@@ -573,17 +579,17 @@
   dependencies:
     npmlog "^4.1.2"
 
-"@lerna/version@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@lerna/version/-/version-3.4.1.tgz#029448cccd3ccefb4d5f666933bd13cfb37edab0"
-  integrity sha512-oefNaQLBJSI2WLZXw5XxDXk4NyF5/ct0V9ys/J308NpgZthPgwRPjk9ZR0o1IOxW1ABi6z3E317W/dxHDjvAkg==
+"@lerna/version@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lerna/version/-/version-3.5.0.tgz#df6d4d8ef077b51962126c0f52c800d98c53cc26"
+  integrity sha512-vxuGkUSfjJuvOIgPG7SDXVmk4GPwJF9F+uhDW9T/wJzTk4UaxL37GpBeJDo43eutQ7mwluP+t88Luwf8S3WXlA==
   dependencies:
     "@lerna/batch-packages" "^3.1.2"
-    "@lerna/check-working-tree" "^3.3.0"
+    "@lerna/check-working-tree" "^3.5.0"
     "@lerna/child-process" "^3.3.0"
-    "@lerna/collect-updates" "^3.3.2"
-    "@lerna/command" "^3.3.0"
-    "@lerna/conventional-commits" "^3.4.1"
+    "@lerna/collect-updates" "^3.5.0"
+    "@lerna/command" "^3.5.0"
+    "@lerna/conventional-commits" "^3.5.0"
     "@lerna/output" "^3.0.0"
     "@lerna/prompt" "^3.3.1"
     "@lerna/run-lifecycle" "^3.4.1"
@@ -655,13 +661,6 @@
   version "3.5.24"
   resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.24.tgz#11f76812531c14f793b8ecbf1de96f672905de8a"
   integrity sha512-YeQoDpq4Lm8ppSBqAnAeF/xy1cYp/dMTif2JFcvmAbETMRlvKHT2iLcWu+WyYiJO3b3Ivokwo7EQca/xfLVJmg==
-
-"@types/bunyan@^1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.5.tgz#d992adbce8ed20cde634764bd8f269f29f703647"
-  integrity sha512-7n8ANtxh2c5A/NfCuv8cVtWcgSLdq76MQbtmbInpzXuPw4TSAReUJ+MGHK4m67I4zI3ynCJoABfaeHYJaYSeRg==
-  dependencies:
-    "@types/node" "*"
 
 "@types/convict@^4.2.0":
   version "4.2.0"
@@ -2061,7 +2060,7 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-conventional-changelog-angular@^5.0.1:
+conventional-changelog-angular@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.2.tgz#39d945635e03b6d0c9d4078b1df74e06163dc66a"
   integrity sha512-yx7m7lVrXmt4nKWQgWZqxSALEiAKZhOAcbxdUaU9575mB0CzXVbgrgpfSnSP7OqWDUTYGD0YVJ0MSRdyOPgAwA==
@@ -2069,7 +2068,7 @@ conventional-changelog-angular@^5.0.1:
     compare-func "^1.3.1"
     q "^1.5.1"
 
-conventional-changelog-core@^3.1.0:
+conventional-changelog-core@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-3.1.5.tgz#c2edf928539308b54fe1b90a2fc731abc021852c"
   integrity sha512-iwqAotS4zk0wA4S84YY1JCUG7X3LxaRjJxuUo6GI4dZuIy243j5nOg/Ora35ExT4DOiw5dQbMMQvw2SUjh6moQ==
@@ -2130,7 +2129,7 @@ conventional-commits-parser@^3.0.1:
     through2 "^2.0.0"
     trim-off-newlines "^1.0.0"
 
-conventional-recommended-bump@^4.0.1:
+conventional-recommended-bump@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/conventional-recommended-bump/-/conventional-recommended-bump-4.0.4.tgz#05540584641d3da758c8863c09788fcaeb586872"
   integrity sha512-9mY5Yoblq+ZMqJpBzgS+RpSq+SUfP2miOR3H/NR9drGf08WCrY9B6HAGJZEm6+ThsVP917VHAahSOjM6k1vhPg==
@@ -5313,25 +5312,25 @@ lerna-alias@^3.0.2:
     get-lerna-packages "^0.1.0"
 
 lerna@^3.4.3:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.4.3.tgz#501454efb453c65c305802d370ee337f7298787e"
-  integrity sha512-tWq1LvpHqkyB+FaJCmkEweivr88yShDMmauofPVdh0M5gU1cVucszYnIgWafulKYu2LMQ3IfUMUU5Pp3+MvADQ==
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.5.0.tgz#fd989b8992701e90e10aa5b3970d6f7a3512ba64"
+  integrity sha512-12kZb2yCJtx3rhLycepzHTbR6suqLaqky2hSldGQh9+B7FXFgvbQJXwzoi+Y7+1cstmKHHyockdRYFLiLmiEYA==
   dependencies:
-    "@lerna/add" "^3.4.1"
-    "@lerna/bootstrap" "^3.4.1"
-    "@lerna/changed" "^3.4.1"
-    "@lerna/clean" "^3.3.2"
+    "@lerna/add" "^3.5.0"
+    "@lerna/bootstrap" "^3.5.0"
+    "@lerna/changed" "^3.5.0"
+    "@lerna/clean" "^3.5.0"
     "@lerna/cli" "^3.2.0"
-    "@lerna/create" "^3.4.1"
-    "@lerna/diff" "^3.3.0"
-    "@lerna/exec" "^3.3.2"
-    "@lerna/import" "^3.3.1"
-    "@lerna/init" "^3.3.0"
-    "@lerna/link" "^3.3.0"
-    "@lerna/list" "^3.3.2"
-    "@lerna/publish" "^3.4.3"
-    "@lerna/run" "^3.3.2"
-    "@lerna/version" "^3.4.1"
+    "@lerna/create" "^3.5.0"
+    "@lerna/diff" "^3.5.0"
+    "@lerna/exec" "^3.5.0"
+    "@lerna/import" "^3.5.0"
+    "@lerna/init" "^3.5.0"
+    "@lerna/link" "^3.5.0"
+    "@lerna/list" "^3.5.0"
+    "@lerna/publish" "^3.5.0"
+    "@lerna/run" "^3.5.0"
+    "@lerna/version" "^3.5.0"
     import-local "^1.0.0"
     npmlog "^4.1.2"
 
@@ -5570,13 +5569,21 @@ lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
-lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
+lru-cache@^4.0.1:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   integrity sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+lru-cache@^4.1.2, lru-cache@^4.1.3:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.4.tgz#51cc46e8e6d9530771c857e24ccc720ecdbcc031"
+  integrity sha512-EPstzZ23znHUVLKj+lcXO1KvZkrlw+ZirdwvOmnAnA/1PB4ggyXJ77LRkCqkff+ShQ+cqoxCxLQOh4cKITO5iA==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^3.0.2"
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -9145,9 +9152,9 @@ yallist@^2.1.2:
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
-  integrity sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
 yargs-parser@10.1.0, yargs-parser@10.x:
   version "10.1.0"


### PR DESCRIPTION
I found a couple issues when developing with job-components, and the teraslice-test-harness. This PR fixes the following things:

- Fixes `Logger` type definitions
- Terafoundation test clients are now expected to return `{ client: any }` when `create` is called, in order to behave as close to real life as possible.
- Add failing reader spec
- Add support for ignoring certain directories when testing typescript operations
- Fix typescript definitions for runSlice and createSlices