### PR TITLE
Fix test-op-harness and test client usage

### DIFF
--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/job-components",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "publishConfig": {
         "access": "public"
     },

--- a/packages/job-components/src/test-helpers.ts
+++ b/packages/job-components/src/test-helpers.ts
@@ -307,6 +307,7 @@ export class TestContext implements i.Context {
                     const { create, config = {} } = clientConfig;
 
                     const clientFns = _createClientFns.get(ctx) || {};
+
                     const key = getKey(clientConfig);
                     if (!isFunction(create)) {
                         const actual = getTypeOf(create);
@@ -317,6 +318,10 @@ export class TestContext implements i.Context {
 
                     clientFns[key] = create;
                     _createClientFns.set(ctx, clientFns);
+
+                    const cachedClients = _cachedClients.get(ctx) || {};
+                    delete cachedClients[key];
+                    _cachedClients.set(ctx, cachedClients);
 
                     setConnectorConfig(sysconfig, clientConfig, config, true);
                 });

--- a/packages/job-components/test/test-helpers-spec.ts
+++ b/packages/job-components/test/test-helpers-spec.ts
@@ -103,4 +103,56 @@ describe('Test Helpers', () => {
         expect(context.apis.registerAPI('hello', api)).toBeUndefined();
         expect(context.apis.hello.there()).toEqual('peter');
     });
+
+    it('should be able to get and set clients', () => {
+        const context = new TestContext('test-clients', {
+            clients: [
+                {
+                    create() {
+                        return { client: 'hello' };
+                    },
+                    type: 'test'
+                }
+            ]
+        });
+
+        expect(context.apis.getTestClients()).toEqual({});
+
+        expect(context.apis.foundation.getConnection({
+            type: 'test',
+            endpoint: 'default'
+        })).toEqual({ client: 'hello' });
+
+        expect(context.apis.getTestClients()).toEqual({
+            test: {
+                default: {
+                    client: 'hello'
+                }
+            }
+        });
+
+        context.apis.setTestClients([
+            {
+                create() {
+                    return { client: 'howdy' };
+                },
+                type: 'test'
+            }
+        ]);
+
+        expect(context.apis.getTestClients()).toEqual({});
+
+        expect(context.apis.foundation.getConnection({
+            type: 'test',
+            endpoint: 'default'
+        })).toEqual({ client: 'howdy' });
+
+        expect(context.apis.getTestClients()).toEqual({
+            test: {
+                default: {
+                    client: 'howdy'
+                }
+            }
+        });
+    });
 });

--- a/packages/teraslice-op-test-harness/index.js
+++ b/packages/teraslice-op-test-harness/index.js
@@ -58,6 +58,7 @@ class TestHarness {
             }
             return config;
         });
+
         this.context.apis.setTestClients(testClients);
     }
 

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
-    "version": "1.4.4",
+    "version": "1.4.5",
     "publishConfig": {
         "access": "public"
     },
@@ -23,7 +23,7 @@
         "url": "https://github.com/terascope/teraslice/issues"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.13.0",
+        "@terascope/job-components": "^0.13.1",
         "bluebird": "^3.5.3",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-op-test-harness/types/index.d.ts
+++ b/packages/teraslice-op-test-harness/types/index.d.ts
@@ -16,8 +16,10 @@ import {
     DataEntity,
     Slice,
     TestContext,
+    TestClients,
 } from '@terascope/job-components';
 import { EventEmitter } from 'events';
+import { Client } from 'packages/teraslice-messaging/dist/execution-controller';
 
 export = opTestHarness;
 
@@ -96,6 +98,7 @@ export interface TestHarness {
     opConfig: OpConfig;
     executionConfig: ExecutionConfig;
     retryData?: object[];
+    clientList: TestClients;
 
     /**
      * Initialize and run an operation

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,8 +36,8 @@
         "test:debug": "env DEBUG='*teraslice*' jest --detectOpenHandles --coverage=false --runInBand"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.13.0",
-        "@terascope/teraslice-op-test-harness": "^1.4.4",
+        "@terascope/job-components": "^0.13.1",
+        "@terascope/teraslice-op-test-harness": "^1.4.5",
         "@types/lodash": "^4.14.119",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@terascope/elasticsearch-api": "^1.1.3",
         "@terascope/error-parser": "^1.0.1",
-        "@terascope/job-components": "^0.13.0",
+        "@terascope/job-components": "^0.13.1",
         "@terascope/queue": "^1.1.4",
         "@terascope/teraslice-messaging": "^0.2.5",
         "async-mutex": "^0.1.3",
@@ -66,7 +66,7 @@
         "yargs": "^12.0.2"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.4.4",
+        "@terascope/teraslice-op-test-harness": "^1.4.5",
         "archiver": "^3.0.0",
         "bufferstreams": "^2.0.1",
         "chance": "^1.0.18",


### PR DESCRIPTION
When running in elasticsearch-assets there was an issue when changing an existing client between test runs. This is fixed now.