### PR TITLE
Better Job / Operation Error Handling

### DIFF
--- a/docs/ops-reference.md
+++ b/docs/ops-reference.md
@@ -59,7 +59,6 @@ Note that the job configuration is divided into top level job configuration, and
 
 #### Job level configuration options ####
 
-
 | Configuration | Description | Type |  Notes |
 | --------- | -------- | ------ | ------ |
 | name | Name for the given job | String | optional |
@@ -72,6 +71,16 @@ Note that the job configuration is divided into top level job configuration, and
 | recycle_worker | The number of slices a worker processes before it exits and restarts, only use if you have leaky workers | Null/Number | optional, defaults to null, if specified it must be a number. |
 | operations | An array containing all the operations as well as their configurations. Typically the first is the reader/slicer. | Array | required |
 | probation_window | time in ms that the execution controller checks for failed slices, if there are none then it updates the state of the execution to running (this is only when lifecycle is set to persistent) | Number | optional |
+
+#### Operation level configuration options ####
+
+Here is a list of configuration options that all operations have available to them.
+
+| Configuration | Description | Type |  Notes |
+| --------- | -------- | ------ | ------ |
+| `_op` | Name of operation, it must reflect the exact name of the file | `String` | required |
+| `_encoding` | Used for specifying the data encoding type when using `DataEntity.fromBuffer`. Defaults to `json`. | `String` | optional |
+| `_dead_letter_action` | This action will specify what to do when failing to parse or transform a record. ​​​​​The following builtin actions are supported, "throw", "log", or "none". If none of the actions are specified it will try and use a registered Dead Letter Queue API under that name.The API must be already be created by a operation before it can used.​ | `String` | required |
 
 ## Readers ##
 

--- a/docs/ops-reference.md
+++ b/docs/ops-reference.md
@@ -86,7 +86,7 @@ Here is a list of configuration options that all APIs have available to them.
 
 | Configuration | Description | Type |  Notes |
 | --------- | -------- | ------ | ------ |
-| `_name` | Name of API, it must reflect the exact name of the file | `String` | required |
+| `_name` | The _name property is required, and it is required to be unqiue but can be suffixed with a identifier by using the format "example:0", anything after the ":" is stripped out when searching for the file or folder. | `String` | required |
 
 ## Processors ##
 
@@ -195,7 +195,7 @@ Example configuration
 
 | Configuration | Description | Type |  Notes   |
 | --------- | -------- | ------ | ------ |
-| `ms` | Milliseconds to delay before passing data through | `Number` | required |
+| `ms` | Milliseconds to delay before passing data through | `Number` | optional, defaults to `100` |
 
 ## Bundles ##
 

--- a/docs/ops-reference.md
+++ b/docs/ops-reference.md
@@ -1,30 +1,27 @@
-# Job configurations
+# Configuration
 
-A job configuration is the main way a Teraslice user describes the processing they want done.  This page provides a
-detailed description of the configurations available for a job.
+A job configuration is the main way a Teraslice user describes the processing they want done. This page provides a detailed description of the configurations available for a job.
 
- * [Job configurations](#job-configurations)
-    * [Job level configuration options](#job-level-configuration-options)
-    * [Readers](#readers)
-      * [elasticsearch_reader](#elasticsearch_reader)
-        * [persistent mode](#persistent-mode)
-          * [Differences](#differences)
-          * [Note on common errors](#note-on-common-errors)
-      * [elasticsearch_data_generator](#elasticsearch_data_generator)
-        * [Description of formats available](#description-of-formats-available)
-        * [persistent mode](#persistent-mode-1)
-      * [id_reader](#id_reader)
-    * [Processors](#processors)
-      * [elasticsearch_index_selector](#elasticsearch_index_selector)
-      * [script](#script)
-      * [elasticsearch_bulk](#elasticsearch_bulk)
-      * [stdout](#stdout)
-      * [noop](#noop)
+- [Job Configuration](#job-configuration)
+  - [Job level configuration options](#job-level-configuration-options)
+  - [Operation level configuration options](#operation-level-configuration-options)
+  - [API level configuration options](#api-level-configuration-options)
+- [Processors](#processors)
+  - [script](#script)
+  - [stdout](#stdout)
+  - [noop](#noop)
+  - [delay](#delay)
+- [Bundles](#bundles)
+  - [elasticsearch](#elasticsearch)
+  - [kafka](#kafka)
+  - [file](#file)
+  - [hdfs](#hdfs)
 
+## Job Configuration
 **The schema for jobs can be found at lib/config/schemas/job, and the schema's for each operation can be found in their respective file located in either lib/readers or lib/processors**
 
 Example Job
-```
+```js
 {
     "name": "Reindex Events",
     "lifecycle": "once",
@@ -57,22 +54,23 @@ Example Job
 ```
 Note that the job configuration is divided into top level job configuration, and configuration per each individual operation withing the operations array.
 
-#### Job level configuration options ####
+### Job level configuration options ###
 
 | Configuration | Description | Type |  Notes |
 | --------- | -------- | ------ | ------ |
-| name | Name for the given job | String | optional |
-| lifecycle | Determines system exiting behaviour. Set to either **"once"** which will run the job to completion then the process will exit or **"persistent"** in which the process will continue until it is shutdown manually.  | String | required |
-| analytics | Determines if analytics should be ran for each slice | Boolean | optional, defaults to true
-| max_retries | Number of times a given slice of data will attempt to process before continuing on | Number | optional |
-| slicers | Number of slicer functions that will chunk and prep the data for worker | Number | optional, defaults to 1 |
-| workers | Number of worker instances that will process data, depending on the nature of the operations you may choose to over subscribe the number of workers compared to the number of cpu's | Number | optional, defaults to 5, if the number of workers for the job is set above workers specified in system configuration, a warning is passed and the workers set in the system configuration will be used. |
-| assets | An array of strings that are the id's for the corresponding assets zip files. | Array | optional |
-| recycle_worker | The number of slices a worker processes before it exits and restarts, only use if you have leaky workers | Null/Number | optional, defaults to null, if specified it must be a number. |
-| operations | An array containing all the operations as well as their configurations. Typically the first is the reader/slicer. | Array | required |
-| probation_window | time in ms that the execution controller checks for failed slices, if there are none then it updates the state of the execution to running (this is only when lifecycle is set to persistent) | Number | optional |
+| `name` | Name for the given job | `String` | optional |
+| `lifecycle` | Determines system exiting behaviour. Set to either **"once"** which will run the job to completion then the process will exit or **"persistent"** in which the process will continue until it is shutdown manually.  | `String` | required |
+| `analytics` | Determines if analytics should be ran for each slice | `Boolean` | optional, defaults to true
+| `max_retries` | Number of times a given slice of data will attempt to process before continuing on | `Number` | optional |
+| `slicers` | Number of slicer functions that will chunk and prep the data for worker | `Number` | optional, defaults to 1 |
+| `workers` | Number of worker instances that will process data, depending on the nature of the operations you may choose to over subscribe the number of workers compared to the number of cpu's | Number | optional, defaults to 5, if the number of workers for the job is set above workers specified in system configuration, a warning is passed and the workers set in the system configuration will be used. |
+| `assets` | An array of strings that are the id's for the corresponding assets zip files. | `Array` | optional |
+| `recycle_worker` | The number of slices a worker processes before it exits and restarts, only use if you have leaky workers | `Null`/`Number` | optional, defaults to null, if specified it must be a number. |
+| `operations` | An array containing all the operations as well as their configurations. Typically the first is the reader/slicer. | `Array` | required |
+| `apis` | An array containing all the apis as well as their configurations. | `Array` | required |
+| `probation_window` | time in ms that the execution controller checks for failed slices, if there are none then it updates the state of the execution to running (this is only when lifecycle is set to persistent) | `Number` | optional |
 
-#### Operation level configuration options ####
+### Operation level configuration options ###
 
 Here is a list of configuration options that all operations have available to them.
 
@@ -82,229 +80,21 @@ Here is a list of configuration options that all operations have available to th
 | `_encoding` | Used for specifying the data encoding type when using `DataEntity.fromBuffer`. Defaults to `json`. | `String` | optional |
 | `_dead_letter_action` | This action will specify what to do when failing to parse or transform a record. ​​​​​The following builtin actions are supported, "throw", "log", or "none". If none of the actions are specified it will try and use a registered Dead Letter Queue API under that name.The API must be already be created by a operation before it can used.​ | `String` | required |
 
-## Readers ##
+### API level configuration options ###
 
-### elasticsearch_reader ###
-Used to retrieve elasticsearch data based on dates. This reader has different behaviour if lifecycle is set to "once" or "persistent"
-
-Example configuration if lifecycle is set to "once"
-
-```
-//simplified using defaults
-{
-    "_op": "elasticsearch_reader",
-    "index": "events-*",
-    "type": "event",
-    "size": 5000,
-    "date_field_name": "created"
-}
-
-//expanded
-{
-    "_op": "elasticsearch_reader",
-    "index": "events-*",
-    "type": "event",
-    "size": 5000,
-    "start": "2015-10-26T21:33:27.190-07:00",
-    "end": ""2015-10-27T21:33:27.190-07:00",
-    "interval": "10min",
-    "date_field_name": "created",
-    "query": "someLucene: query",
-    "full_response": true,
-    "time_resolution": "ms",
-    "subslice_key_threshold": 100000,
-    "key_type": base64url
-}
-```
-In this mode, there is a definite start (inclusive) and end time (exclusive). Each slice will be based off of the interval and size configurations.
-If the number of documents exceed the size within a given interval, it will recurse and and split the interval in half continually until the number of documents is less than or equal to size. If this cannot be achieved then the size of the chunk will be calculated against a threshold , and if it passes the threshold it further subdivides the range by the documents \_id's, else the slicer will ignore the size limit and process the chunk as is.
-
+Here is a list of configuration options that all APIs have available to them.
 
 | Configuration | Description | Type |  Notes |
 | --------- | -------- | ------ | ------ |
-| \_op| Name of operation, it must reflect the exact name of the file | String | required |
-| index | Which index to read from | String | required |
-| type | The type of the document that you are reading, used when a chuck is so large that it must be divided up by the documents \_id|String | required |
-| size | The limit to the number of docs pulled in a chunk, if the number of docs retrieved by the slicer exceeds this number, it will cause the slicer to recurse to provide a smaller batch | Number | optional, defaults to 5000 |
-| start | The start date to which it will read from | String/Number/ elasticsearch date math syntax | optional, inclusive , if not provided the index will be queried for earliest date, this date will be reflected in the opConfig saved in the execution context |
-| end | The end date to which it will read to| String/Number/ elasticsearch date math syntax | optional, exclusive, if not provided the index will be queried for latest date, this date will be reflected in the opConfig saved in the execution context |
-| interval | The time interval in which the reader will increment by. The unit of time may be months, weeks, days, hours, minutes, seconds, millesconds or their appropriate abbreviations | String | optional, defaults to auto which tries to calculate the interval by dividing date_range / (numOfRecords / size) |
-| full_response | If set to true, it will return the native response from elasticsearch with all meta-data included. If set to false it will return an array of the actual documents, no meta data included | Boolean | optional, defaults to false |
-| date_field_name | document field name where the date used for searching resides | String | required |
-| query | specify any valid lucene query for elasticsearch to use in filtering| String | optional |
-| subslice_key_threshold |used in determining when to slice a chunk by thier \_ids | Number | optional, defaults to 50000 |
-| time_resolution | Not all dates have millisecond resolutions, specify 's' if you need second level date slicing | String | optional, defaults to milliseconds 'ms' |
-| key_type | Used to specify the key type of the \_ids of the documents being queryed | String | optional, defaults to elasticsearch id generator (base64url) |
-| connection | Name of the elasticsearch connection to use when sending data | String | optional, defaults to the 'default' connection created for elasticsearch |
-| fields | Used to restrict what is returned from elasticsearch. If used, only these fields on the documents are returned | Array | optional |
-
-start and end may be specified in elasticsearch's [date math syntax](https://www.elastic.co/guide/en/elasticsearch/reference/2.x/common-options.html#date-math)
-
-#### persistent mode ####
-
-Example configuration if lifecycle is set to "persistent"
-
-```
-{
-    "_op": "elasticsearch_reader",
-    "index": "someIndex",
-    "size": 5000,
-    "interval": "5s",
-    "delay": "1m",
-    "date_field_name": "created",
-    "full_response": true
-}
-```
-
-The persistent mode expects that there is a continuous stream of data coming into elasticsearch and that it has a date field when it was uploaded. On initializing this job, it will begin reading at the current date (new Date()) minus the delay. The reader will then begin processing at the interval chunk you specify, and will read the next interval after the interval time has passed.
-
- E.g. using the job listed above and current time is "2016-01-27T13:48:05-07:00", it will attempt to start reading at start:"2016-01-27T13:47:00-07:00", end: "2016-01-27T13:47:05-07:00". After 5s has passed it will read start:"2016-01-27T13:47:05-07:00", end: "2016-01-27T13:47:10-07:00" thus keeping the 1m delay.
-
- The delay mechanism allows you to adjust for your elasticsearch refresh rate, network latency so that it can provide ample time to ensure that your data has been flushed.
-
-##### Differences #####
-No start or end keys
-
-| Configuration | Description | Type |  Notes |
-| --------- | -------- | ------ | ------ |
-| delay | Offset applied to reader of when to begin reading, must be in interval syntax e.g "5s" | String | required |
-
-##### Note on common errors #####
-- You must be aware of how your dates are saved in elasticsearch in a given index. If you specify your start or end dates as common '2016-01-23' dates, it is likely the reader will not reach data that have dates set in utc as the time zone difference may set it in the next day. If you would like to go through the entire index, then leave start and end empty, the job will find the dates for you and later be reflected in the execution context (ex) configuration for this operation
-
-- If you are using elasticsearch >= 2.1.0 they introduced a default query limit of 10000 docs for each index which will throw an error if you query anything above that. This will pose an issue if you set the size to big or if you have more than 10000 docs within 1 millisecond, which is the shortest interval the slicer will attempt to make before overriding your size setting for that slice. Your best option is to raise the max_result_window setting for that given index.
-
-- this reader assumes linear date times, and this slicer will stop at the end date specified or the end date determined at the starting point of the job. This means that if an index continually grows while this is running, this will not reach the new data, you would to start another job with the end date from the other job listed as the start date for the new job
-
-### elasticsearch_data_generator ###
-Used to generate sample data for your elasticsearch cluster. You may use the default data generator which creates randomized data fitting the format listed below or you may create your own custom schema using the [mocker-data-generator](https://github.com/danibram/mocker-data-generator) package to create data to whatever schema you desire.
-
-Default generated data :
-```
-{
-    "ip": "1.12.146.136",
-    "userAgent": "Mozilla/5.0 (Windows NT 5.2; WOW64; rv:8.9) Gecko/20100101 Firefox/8.9.9",
-    "url": "https://gabrielle.org",
-    "uuid": "408433ff-9495-4d1c-b066-7f9668b168f0",
-    "ipv6": "8188:b9ad:d02d:d69e:5ca4:05e2:9aa5:23b0",
-    "location": "-25.40587, 56.56418",
-    "created": "2016-01-19T13:33:09.356-07:00",
-    "bytes": 4850020
-}
-
-```
-
-Example configuration
-```
-{
-    "_op": "elasticsearch_data_generator",
-    "size": 25000000,
-    "json_schema": "some/path/to/file.js",
-    "format": "isoBetween",
-    "start": "2015-08-01",
-    "end": "2015-12-30"
-}
-```
-In once mode, this will created a total of 25 million docs with dates ranging from 2015-08-01 to 2015-12-30. The dates will appear in "2015-11-19T13:48:08.426-07:00" format.
-
-| Configuration | Description | Type |  Notes |
-| --------- | -------- | ------ | ------ |
-| _op | Name of operation, it must reflect the exact name of the file | String | required |
-| size | If lifecycle is set to "once", then size is the total number of documents that the generator will make. If lifecycle is set to "persistent", then this generator will will constantly stream  data to elasticsearch in chunks as big as the size indicated | Number | required |
-| json_schema | File path to where custom schema is located | String | optional, the schema must be exported Node style "module.exports = schema" |
-| format | specify any provided formats listed in /lib/utils/data_utils for the generator| String | optional, defaults to "dateNow" |
-| start | start of date range | String | optional, only used with format isoBetween or utcBetween, defaults to Thu Jan 01 1970 00:00:00 GMT-0700 (MST) |
-| end | end of date range | String | optional, only used with format isoBetween or utcBetween, defaults to new Date() |
-| stress_test | If set to true, it will attempt to send non unique documents following your schema as fast as it can, originally used to help determine cluster write performance| Boolean | optional, defaults to false |
-| date_key | Use this to indicate which key of your schema you would like to use a format listed below, just in case you don't want to set your own | String | optional, defaults to created |
-| set_id | used to make an id on the data that will be used for the doc \_id for elasticsearch, values: base64url, hexadecimal, HEXADECIMAL | String | optional, if used, then index selector needs to have id_field set to "id" |
-| id_start_key | set if you would like to force the first part of the ID to a certain character, adds a regex to the front | Sting | optional, must be used in tandem with set_id id_start_key is essentially regex, if you set it to "a", then the first character of the id will be "a", can also set ranges [a-f] or randomly alternate betweeen b and a if its set to "[ab]" |
-
-#### Description of formats available ####
-There are two categories of formats, ones that return the current date at which the function runs, or one that returns a date within a given range. Note for the non-range category, technically if the job takes 5 minutes to run, you will have dates ranging from the time you started the job up until the time it finished, so its still a range but not as one that spans hours, days weeks etc.
-
-
-| Format | Description |
-| --------- | -------- |
-| dateNow | will create a new date in "2016-01-19T13:48:08.426-07:00" format, preserving local time |
-| utcDate | will create a new utc date e.g "2016-01-19T20:48:08.426Z" |
-| utcBetween | similar to utcDate, but uses start and end keys in the job config to specify range |
-| isoBetween | similar to dateNow, but uses start and end keys in the job config to specify range |
-
-
-#### persistent mode ####
- The data generator will continually stream data into elasticsearch, the "size" key" switches from the total number of documents created to how big each slice is when sent to elasticsearch
-
-### id_reader ###
-This will slice and read documents based off of their specific \_ids. Underneath the hood it does a wildcard query on \_uid
-
-Example configuration
-```
-{
-    "_op": "id_reader",
-    "index": "events-2016.05.06",
-    "type": "events",
-    "size": 10000,
-    "key_type": "hexadecimal",
-    "key_range": ["a", "b", "c", "1"]
-}
-
-```
-Currently the id_reader and makes keys for base64url (elasticsearch native id generator) and hexidecimal. However at this point the hexidecimal only works if the keys are lowercase, future update will fix this
-
-| Configuration | Description | Type |  Notes |
-| --------- | -------- | ------ | ------ |
-| \_op | Name of operation, it must reflect the exact name of the file | String | required |
-| index | Which index to read from | String | required
-| type | The type of the document that you are reading, used when a chuck is so large that it must be divided up by the documents \_id | String | required
-| size | The limit to the number of docs pulled in a chunk, if the number of docs retrieved by the slicer exceeds this number, it will cause the slicer to recurse to provide a smaller batch | Number | optional, defaults to 5000
-| full_response | If set to true, it will return the native response from elasticsearch with all meta-data included. If set to false it will return an array of the actual documents, no meta data included | Boolean | optional, defaults to false |
-| key_type | Used to specify the key type of the \_ids of the documents being queryed | String | optional, defaults to elasticsearch id generator (base64url) |
-| key_range | if provided, slicer will only recurse on these given keys | Array | optional |
-| starting_key_depth | if provided, slicer will only produce keys with minimum length determined by this setting | Number | optional |
-| fields | Used to restrict what is returned from elasticsearch. If used, only these fields on the documents are returned | Array | optional |
-| query | specify any valid lucene query for elasticsearch to use in filtering| String | optional |
+| `_name` | Name of API, it must reflect the exact name of the file | `String` | required |
 
 ## Processors ##
-
-### elasticsearch_index_selector ###
-This processor formats the incoming data to prepare it for the elasticsearch bulk request. It accepts either an array of data or a full elasticsearch response with all associated meta-data. It should be noted that the resulting formatted array required for the bulk request will always double the length of the incoming array.
-
-Example configuration
-```
-{
-    "_op": "elasticsearch_index_selector",
-    "type": "events",
-    "indexPrefix": "events",
-    "timeseries": "daily",
-    "date_field": "created"
-}
-```
-
-| Configuration | Description | Type |  Notes
-| --------- | -------- | ------ | ------ |
-| \_op | Name of operation, it must reflect the exact name of the file | String | required |
-| index | Index to where the data will be sent to, if you wish the index to be based on a timeseries use the timeseries option instead | String | optional |
-| type | Set the type of the data for elasticsearch. If incoming data is from elasticsearch it will default to the type on the metadata if this field is not set. This field must be set for all other incoming data | String | optional |
-| preserve_id | If incoming data if from elasticsearch, set this to true if you wish to keep the previous id else elasticsearch will generate one for you (upload performance is faster if you let it auto-generate) | Boolean | optional, defaults to false |
-| id_field | If you wish to set the id based off another field in the doc, set the name of the field here | String | optional |
-| timeseries | Set to either "daily", "monthly" or "yearly" if you want the index to be based off it, must be used in tandem with index_prefix and date_field | String | optional |
-| index_prefix | Used with timeseries, adds a prefix to the date ie (index_prefix: "events-" ,timeseries: "daily => events-2015.08.20 | String | optional, required if timeseries is used |
-| date_field | Used with timeseries, specify what field of the data should be used to calculate the timeseries | String | optional, but required if using timeseries defaults to @timestamp |
-| delete| Use the id_field from the incoming records to bulk delete documents | Boolean | optional, defaults to false |
-| upsert| Specify if the incoming records should be used to perform an upsert. If update_fields is also specified then existing records will be updated with those fields otherwise the full incoming  record will be inserted | Boolean | optional, defaults to false |
-| create| Specify if the incoming records should be used to perform an create event ("put-if-absent" behavior)| Boolean | optional, defaults to false |
-| update | Specify if the data should update existing records, if false it will index them | Boolean | optional, defaults to false |
-| update_fields | if you are updating the documents, you can specify fields to update here (it should be an array containing all the field names you want), it defaults to sending the entire document | Array | optional, defaults to [] |
-| script_file | Name of the script file to run as part of an update request | String | optional |
-| script_params | key -> value parameter mappings. The value will be extracted from the incoming data and passed to the script as param based on the key | Object | optional |
-
 
 ### script
 This is used to allow other languages other than javascript to process data. Note that this is not meant to be highly efficient as it creates a child process that runs the specified script in the job.  Communication between teraslice and the script is done stdin and stdout with the data format expected to be JSON. If another language is needed, it might be a better idea to use C++ or rust to add a module that Node can create native bindings so that you can require the code like a regular javascript module.
 
 Example configuration
-```
+```js
 {
     "_op": "script",
     "command": "someFile.py",
@@ -315,7 +105,7 @@ Example configuration
 ```
 
 Example Job: `examples/jobs/script/test_script_job.json`
-```
+```js
 {
     "name": "ES DataGen test script",
     "lifecycle": "persistent",
@@ -342,65 +132,32 @@ Example Job: `examples/jobs/script/test_script_job.json`
 
 | Configuration | Description | Type |  Notes   |
 | --------- | -------- | ------ | ------ |
-| \_op | Name of operation, it must reflect the exact name of the file | String | required |
-| command | what command to run | String | required |
-| args | arguments to pass along with the command | Array | optional |
-| options | Obj containing options to pass into the process env | Object | optional  |
-| asset | Name of asset containing command to run | String | optional |
+| `_op` | Name of operation, it must reflect the exact name of the file | `String` | required |
+| `command` | what command to run | String | required |
+| `args` | arguments to pass along with the command | `Array` | optional |
+| `options` | Obj containing options to pass into the process env | `Object` | optional  |
+| `asset` | Name of asset containing command to run | `String` | optional |
 
-Note: [ nodejs 4.x spawn documentation ](https://nodejs.org/dist/latest-v4.x/docs/api/child_process.html#child_process_child_process_spawn_command_args_options)
+Note: [ nodejs 8.x spawn documentation ](https://nodejs.org/dist/latest-v8.x/docs/api/child_process.html#child_process_child_process_spawn_command_args_options)
 
-#### script usage example
+**script usage example:**
+
 Create and upload asset
-```
+```bash
 cd examples/jobs/script
 zip -r test_script.zip test_script
 curl -XPOST -H "Content-Type: application/octet-stream" localhost:5678/assets --data-binary @test_script.zip
 ```
 Submit Job
-```
+```bash
 curl -XPOST localhost:5678/jobs -d@test_script_job.json
 ```
-
-### elasticsearch_bulk ###
-This sends a bulk request to elasticsearch
-
-Example configuration
-```
-{
-    "_op": "elasticsearch_bulk",
-    "size": 10000,
-    "multisend": true,
-    "multisend_index_append": true,
-    "connection_map": {
-        "a,2": "es_d1",
-        "b,3": "es_d2",
-        "c,4": "es_d3",
-        "d,5": "es_d4",
-        "e,6": "es_d5",
-        "f,7": "es_d6",
-        "0,8": "es_d7",
-        "1,9": "es_d8"
-    }
-}
-```
-The keys used were hexidecimal based
-
-| Configuration | Description | Type |  Notes |
-| --------- | -------- | ------ | ------ |
-| \_op | Name of operation, it must reflect the exact name of the file | String | required |
-| size | the maximum number of docs it will send in a given request, anything past it will be split up and sent | Number | required, typically the index selector returns up to double the length of the original documents due to the metadata involved with bulk requests. This number is essentially doubled to to maintain the notion that we split by actual documents and not the metadata |
-| connection_map | | Object | optional |
-| multisend | When set to true the connection_map will be used allocate the data stream across multiple connections based on the keys of the incoming documents | Boolean | optional, defaults to false |
-| multisend_index_append | When set to true will append the connection_map prefixes to the name of the index before data is submitted | Boolean | optional, defaults to false |
-| connection | Name of the elasticsearch connection to use when sending data | String | optional, defaults to the 'default' connection created for elasticsearch |
-
 
 ### stdout
 This is primarily used for develop purposes, it console logs the incoming data, it's meant to inspect in between operations or end of outputs
 
 Example configuration
-```
+```js
 {
     "_op": "stdout"
 }
@@ -408,7 +165,7 @@ Example configuration
 
 | Configuration | Description | Type |  Notes   |
 | --------- | -------- | ------ | ------ |
-| limit | Specify a number > 0 to limit the number of results printed to the console log.  Default is to print all results. | Number | optional |
+| `limit` | Specify a number > 0 to limit the number of results printed to the console log.  Default is to print all results. | `Number` | optional |
 
 ### noop
 
@@ -416,10 +173,46 @@ This processor simply passes the data through, unmodified.  It is primarily used
 for develop purposes.
 
 Example configuration
-```
+```js
 {
     "_op": "noop"
 }
 ```
 
 There is no configuration for this processor.
+
+### delay
+
+Wait a specific amount of time, and passes the data through.
+
+Example configuration
+```js
+{
+    "_op": "delay",
+    "ms": 1000
+}
+```
+
+| Configuration | Description | Type |  Notes   |
+| --------- | -------- | ------ | ------ |
+| `ms` | Milliseconds to delay before passing data through | `Number` | required |
+
+## Bundles ##
+
+We support a few asset bundles for dealing with different data sources and operations.
+
+### elasticsearch ##
+
+[Documentation](https://github.com/terascope/elasticsearch-assets/blob/master/README.md)
+
+### kafka ##
+
+[Documentation](https://github.com/terascope/kafka-assets/blob/master/README.md)
+
+### file ##
+
+[Documentation](https://github.com/terascope/file-assets/blob/master/README.md)
+
+### hdfs ##
+
+[Documentation](https://github.com/terascope/hdfs-assets/blob/master/README.md)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "start": "node service.js",
         "setup": "yarn bootstrap && yarn build",
         "bootstrap:prod": "lerna bootstrap -- --production=true --link-duplicates --ignore-optional",
-        "bootstrap": "lerna bootstrap --force-local",
+        "bootstrap": "lerna bootstrap --force-local && lerna link --force-local",
         "build": "lerna run build",
         "build:prod": "lerna run build:prod",
         "build:watch": "lerna run build:watch --stream --prefix",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/job-components",
-    "version": "0.13.1",
+    "version": "0.14.0",
     "publishConfig": {
         "access": "public"
     },

--- a/packages/job-components/src/config-validators.ts
+++ b/packages/job-components/src/config-validators.ts
@@ -1,6 +1,6 @@
-import { ValidatedJobConfig, OpConfig } from './interfaces';
 import convict from 'convict';
-import { opSchema } from './job-schemas';
+import { ValidatedJobConfig, OpConfig, APIConfig } from './interfaces';
+import { opSchema, apiSchema } from './job-schemas';
 
 // @ts-ignore
 const validateOptions: convict.ValidateOptions = { allowed: true };
@@ -18,6 +18,24 @@ export function validateOpConfig<T>(inputSchema: convict.Schema<any>, inputConfi
         config.validate(validateOptions);
     } catch (err) {
         throw new Error(`Validation failed for opConfig: ${inputConfig._op} - ${err.message}`);
+    }
+
+    return config.getProperties();
+}
+
+/**
+ * Merges the provided inputSchema with commonSchema and then validates the
+ * provided apiConfig against the resulting schema.
+ */
+export function validateAPIConfig<T>(inputSchema: convict.Schema<any>, inputConfig: any) {
+    const schema = Object.assign({}, apiSchema, inputSchema) as convict.Schema<APIConfig & T>;
+    const config = convict(schema);
+
+    try {
+        config.load(inputConfig);
+        config.validate(validateOptions);
+    } catch (err) {
+        throw new Error(`Validation failed for apiConfig: ${inputConfig._name} - ${err.message}`);
     }
 
     return config.getProperties();

--- a/packages/job-components/src/execution-context/api.ts
+++ b/packages/job-components/src/execution-context/api.ts
@@ -44,6 +44,12 @@ export class ExecutionContextAPI {
         return _apis.get(this);
     }
 
+    /** Set an api to be used */
+    addAPI(name: string, opAPI: OpAPI) {
+        const apis = _apis.get(this);
+        apis[name] = opAPI;
+    }
+
     /**
      * Get a reference to a specific API,
      * the must be initialized.
@@ -82,7 +88,7 @@ export class ExecutionContextAPI {
 
         config.events.emit('execution:add-to-lifecycle', api);
 
-        this.apis[name] = await api.createAPI(...params);
+        this.addAPI(name, await api.createAPI(...params));
         return this.apis[name];
     }
 }

--- a/packages/job-components/src/execution-context/api.ts
+++ b/packages/job-components/src/execution-context/api.ts
@@ -1,6 +1,5 @@
-import { OpAPI, Context, ExecutionConfig } from '../interfaces';
+import { OpAPI, Context, ExecutionConfig, APIConfig } from '../interfaces';
 import { OperationAPIConstructor } from '../operations';
-import legacySliceEventsShim from '../operations/shims/legacy-slice-events-shim';
 
 // WeakMaps are used as a memory efficient reference to private data
 const _registry = new WeakMap();
@@ -72,12 +71,16 @@ export class ExecutionContextAPI {
 
         const API = this.registry[name];
 
-        const api = new API(config.context, config.executionConfig);
+        const { apis = [] } = config.executionConfig;
+
+        const apiConfig = apis.find((a: APIConfig) => a._name === name) || {
+            _name: name,
+        };
+
+        const api = new API(config.context, apiConfig, config.executionConfig);
         await api.initialize();
 
         config.events.emit('execution:add-to-lifecycle', api);
-
-        legacySliceEventsShim(api);
 
         this.apis[name] = await api.createAPI(...params);
         return this.apis[name];

--- a/packages/job-components/src/execution-context/base.ts
+++ b/packages/job-components/src/execution-context/base.ts
@@ -1,0 +1,163 @@
+import { EventEmitter } from 'events';
+import { isFunction, cloneDeep } from '../utils';
+import { OperationLoader } from '../operation-loader';
+import { OperationAPIConstructor } from '../operations';
+import { registerApis } from '../register-apis';
+import { ExecutionConfig, WorkerContext, OperationLifeCycle } from '../interfaces';
+import {
+    EventHandlers,
+    ExecutionContextConfig,
+} from './interfaces';
+
+/**
+ * A base class for an Execution Context
+*/
+export default class BaseExecutionContext<T extends OperationLifeCycle> {
+    readonly config: ExecutionConfig;
+    readonly context: WorkerContext;
+
+    readonly assetIds: string[] = [];
+
+    readonly exId: string;
+    readonly jobId: string;
+
+    /** The terafoundation EventEmitter */
+    readonly events: EventEmitter;
+
+    protected readonly _loader: OperationLoader;
+    protected readonly _operations = new Set() as Set<T>;
+    protected _methodRegistry = new Map<keyof T, Set<number>>();
+
+    private readonly _handlers: EventHandlers = {};
+
+    constructor(config: ExecutionContextConfig) {
+        this.events = config.context.apis.foundation.getSystemEvents();
+
+        this._handlers['execution:add-to-lifecycle'] = (op: T) => {
+            this.addOperation(op);
+        };
+
+        this.events.on('execution:add-to-lifecycle', this._handlers['execution:add-to-lifecycle']);
+
+        const executionConfig = cloneDeep(config.executionConfig);
+        this._loader = new OperationLoader({
+            terasliceOpPath: config.terasliceOpPath,
+            assetPath: config.context.sysconfig.teraslice.assets_directory,
+        });
+
+        registerApis(config.context, executionConfig, config.assetIds);
+        this.context = config.context as WorkerContext;
+
+        this.assetIds = config.assetIds || [];
+
+        this.config = executionConfig;
+        this.exId = executionConfig.ex_id;
+        this.jobId = executionConfig.job_id;
+    }
+
+    /**
+     * Called to initialize all of the registered operations
+    */
+    async initialize() {
+        const promises = [];
+        for (const op of this.getOperations()) {
+            promises.push(op.initialize());
+        }
+
+        await Promise.all(promises);
+    }
+
+    /**
+     * Called to cleanup all of the registered operations
+    */
+    async shutdown() {
+        const promises = [];
+        for (const op of this.getOperations()) {
+            promises.push(op.shutdown());
+        }
+
+        await Promise.all(promises);
+
+        Object.keys(this._handlers)
+            .forEach((event) => {
+                const listener = this._handlers[event];
+                this.events.removeListener(event, listener);
+            });
+    }
+
+    /**
+     * Returns a list of any registered Operation that has been
+     * initialized.
+    */
+    getOperations() {
+        return this._operations.values();
+    }
+
+    /** Add an operation to the lifecycle queue */
+    protected addOperation(op: T) {
+        this._operations.add(op);
+
+        this._resetMethodRegistry();
+    }
+
+    /** Add an API to the executionContext api registry */
+    protected registerAPI(name: string, API?: OperationAPIConstructor) {
+        if (API == null) return;
+
+        this.context.apis.executionContext.addToRegistry(name, API);
+    }
+
+    /** Run an async method on the operation lifecycle */
+    protected _runMethodAsync(method: keyof T, ...args: any[]) {
+        const set = this._getMethodSet(method);
+        if (set.size === 0) return;
+
+        let i = 0;
+        const promises = [];
+        for (const operation of this.getOperations()) {
+            const index = i++;
+            if (set.has(index)) {
+                // @ts-ignore because I can't get the typedefinitions to work right
+                promises.push(operation[method](...args));
+            }
+        }
+
+        return Promise.all(promises);
+    }
+
+    /** Run an method */
+    protected _runMethod(method: keyof T, ...args: any[]) {
+        const set = this._getMethodSet(method);
+        if (set.size === 0) return;
+
+        let index = 0;
+        for (const operation of this.getOperations()) {
+            if (set.has(index)) {
+                // @ts-ignore because I can't get the typedefinitions to work right
+                operation[method](...args);
+            }
+            index++;
+        }
+    }
+
+    protected _resetMethodRegistry() {
+        for (const set of this._methodRegistry.values()) {
+            set.clear();
+        }
+
+        let index = 0;
+        for (const op of this.getOperations()) {
+            for (const [method, set] of this._methodRegistry.entries()) {
+                if (isFunction(op[method])) {
+                    set.add(index);
+                }
+            }
+
+            index++;
+        }
+    }
+
+    private _getMethodSet(method: keyof T): Set<number> {
+        return this._methodRegistry.get(method) || new Set();
+    }
+}

--- a/packages/job-components/src/execution-context/base.ts
+++ b/packages/job-components/src/execution-context/base.ts
@@ -1,9 +1,8 @@
 import { EventEmitter } from 'events';
 import { isFunction, cloneDeep } from '../utils';
 import { OperationLoader } from '../operation-loader';
-import { OperationAPIConstructor } from '../operations';
 import { registerApis } from '../register-apis';
-import { ExecutionConfig, WorkerContext, OperationLifeCycle, OpAPI } from '../interfaces';
+import { ExecutionConfig, WorkerContext, OperationLifeCycle } from '../interfaces';
 import {
     EventHandlers,
     ExecutionContextConfig,
@@ -98,18 +97,6 @@ export default class BaseExecutionContext<T extends OperationLifeCycle> {
         this._operations.add(op);
 
         this._resetMethodRegistry();
-    }
-
-    /** Add an API to the executionContext api registry */
-    protected registerAPI(name: string, API?: OperationAPIConstructor) {
-        if (API == null) return;
-
-        this.context.apis.executionContext.addToRegistry(name, API);
-    }
-
-    /** Add an API to the executionContext api */
-    protected addAPI(name: string, opAPI: OpAPI) {
-        this.context.apis.executionContext.addAPI(name, opAPI);
     }
 
     /** Run an async method on the operation lifecycle */

--- a/packages/job-components/src/execution-context/base.ts
+++ b/packages/job-components/src/execution-context/base.ts
@@ -3,7 +3,7 @@ import { isFunction, cloneDeep } from '../utils';
 import { OperationLoader } from '../operation-loader';
 import { OperationAPIConstructor } from '../operations';
 import { registerApis } from '../register-apis';
-import { ExecutionConfig, WorkerContext, OperationLifeCycle } from '../interfaces';
+import { ExecutionConfig, WorkerContext, OperationLifeCycle, OpAPI } from '../interfaces';
 import {
     EventHandlers,
     ExecutionContextConfig,
@@ -105,6 +105,11 @@ export default class BaseExecutionContext<T extends OperationLifeCycle> {
         if (API == null) return;
 
         this.context.apis.executionContext.addToRegistry(name, API);
+    }
+
+    /** Add an API to the executionContext api */
+    protected addAPI(name: string, opAPI: OpAPI) {
+        this.context.apis.executionContext.addAPI(name, opAPI);
     }
 
     /** Run an async method on the operation lifecycle */

--- a/packages/job-components/src/execution-context/base.ts
+++ b/packages/job-components/src/execution-context/base.ts
@@ -58,10 +58,10 @@ export default class BaseExecutionContext<T extends OperationLifeCycle> {
     /**
      * Called to initialize all of the registered operations
     */
-    async initialize() {
+    async initialize(initConfig?: any) {
         const promises = [];
         for (const op of this.getOperations()) {
-            promises.push(op.initialize());
+            promises.push(op.initialize(initConfig));
         }
 
         await Promise.all(promises);

--- a/packages/job-components/src/execution-context/interfaces.ts
+++ b/packages/job-components/src/execution-context/interfaces.ts
@@ -3,7 +3,7 @@ import {
     ExecutionConfig,
     SlicerOperationLifeCycle,
     WorkerOperationLifeCycle,
-    SliceAnalyticsData
+    SliceAnalyticsData,
 } from '../interfaces';
 import { DataEntity } from '../operations';
 
@@ -26,22 +26,4 @@ export interface RunSliceResult {
 /** event handlers that should be cleaned up */
 export interface EventHandlers {
     [eventName: string]: (...args: any[]) => void;
-}
-
-export interface SlicerMethodRegistry {
-    readonly onSliceComplete: Set<number>;
-    readonly onSliceDispatch: Set<number>;
-    readonly onSliceEnqueued: Set<number>;
-    readonly onExecutionStats: Set<number>;
-}
-
-export interface WorkerMethodRegistry {
-    readonly onSliceInitialized: Set<number>;
-    readonly onSliceStarted: Set<number>;
-    readonly onSliceFinalizing: Set<number>;
-    readonly onSliceFinished: Set<number>;
-    readonly onSliceFailed: Set<number>;
-    readonly onSliceRetry: Set<number>;
-    readonly onOperationStart: Set<number>;
-    readonly onOperationComplete: Set<number>;
 }

--- a/packages/job-components/src/execution-context/interfaces.ts
+++ b/packages/job-components/src/execution-context/interfaces.ts
@@ -4,8 +4,9 @@ import {
     SlicerOperationLifeCycle,
     WorkerOperationLifeCycle,
     SliceAnalyticsData,
+    OpAPI,
 } from '../interfaces';
-import { DataEntity } from '../operations';
+import { DataEntity, APICore } from '../operations';
 
 export interface ExecutionContextConfig {
     context: Context;
@@ -26,4 +27,14 @@ export interface RunSliceResult {
 /** event handlers that should be cleaned up */
 export interface EventHandlers {
     [eventName: string]: (...args: any[]) => void;
+}
+
+export interface JobAPIInstance {
+    instance: APICore;
+    opAPI?: OpAPI;
+    type: 'api'|'observer';
+}
+
+export interface JobAPIInstances {
+    [name: string]: JobAPIInstance;
 }

--- a/packages/job-components/src/execution-context/slicer.ts
+++ b/packages/job-components/src/execution-context/slicer.ts
@@ -37,6 +37,14 @@ export class SlicerExecutionContext  extends BaseExecutionContext<SlicerOperatio
         this._resetMethodRegistry();
     }
 
+    /**
+     * Called during execution initialization
+     * @param recoveryData is the data to recover from
+    */
+    async initialize(recoveryData?: object[]) {
+        return super.initialize(recoveryData);
+    }
+
     /** The instance of a "Slicer" */
     slicer<T extends SlicerCore = SlicerCore>(): T {
         return this._slicer as T;

--- a/packages/job-components/src/execution-context/slicer.ts
+++ b/packages/job-components/src/execution-context/slicer.ts
@@ -1,95 +1,40 @@
-import { EventEmitter } from 'events';
-import { isFunction, cloneDeep } from '../utils';
+import { cloneDeep } from '../utils';
 import {
     SlicerOperationLifeCycle,
-    ExecutionConfig,
     ExecutionStats,
     Slice,
     SliceResult,
-    WorkerContext
 } from '../interfaces';
-import { OperationLoader } from '../operation-loader';
 import SlicerCore from '../operations/core/slicer-core';
-import { registerApis } from '../register-apis';
 import {
-    EventHandlers,
-    SlicerOperations,
     ExecutionContextConfig,
-    SlicerMethodRegistry,
 } from './interfaces';
-
-// WeakMaps are used as a memory efficient reference to private data
-const _loaders = new WeakMap<SlicerExecutionContext, OperationLoader>();
-const _operations = new WeakMap<SlicerExecutionContext, SlicerOperations>();
+import BaseExecutionContext from './base';
 
 /**
  * SlicerExecutionContext is designed to add more
  * functionality to interface with the
  * Execution Configuration and any Operation.
 */
-export class SlicerExecutionContext implements SlicerOperationLifeCycle {
-    readonly config: ExecutionConfig;
-    readonly context: WorkerContext;
-
-    /**
-     * A list of assetIds available to the job.
-     * This will be replaced by `resolvedAssets`
-    */
-    readonly assetIds: string[] = [];
-
-    readonly exId: string;
-    readonly jobId: string;
-
-    /** The terafoundation EventEmitter */
-    readonly events: EventEmitter;
-
-    private _handlers: EventHandlers = {};
-
-    private _methodRegistry: SlicerMethodRegistry = {
-        onSliceComplete: new Set(),
-        onSliceDispatch: new Set(),
-        onSliceEnqueued: new Set(),
-        onExecutionStats: new Set(),
-    };
-
+export class SlicerExecutionContext  extends BaseExecutionContext<SlicerOperationLifeCycle> implements SlicerOperationLifeCycle {
     private readonly _slicer: SlicerCore;
 
     constructor(config: ExecutionContextConfig) {
-        this.events = config.context.apis.foundation.getSystemEvents();
+        super(config);
 
-        this._handlers['execution:add-to-lifecycle'] = (op: SlicerOperationLifeCycle) => {
-            this.addOperation(op);
-        };
-
-        this.events.on('execution:add-to-lifecycle', this._handlers['execution:add-to-lifecycle']);
-
-        const executionConfig = cloneDeep(config.executionConfig);
-        const loader = new OperationLoader({
-            terasliceOpPath: config.terasliceOpPath,
-            assetPath: config.context.sysconfig.teraslice.assets_directory,
-        });
-
-        registerApis(config.context, executionConfig, config.assetIds);
-        this.context = config.context as WorkerContext;
-
-        this.assetIds = config.assetIds || [];
-
-        this.config = executionConfig;
-        this.exId = executionConfig.ex_id;
-        this.jobId = executionConfig.job_id;
-
-        _loaders.set(this, loader);
-
-        _operations.set(this, new Set());
+        this._methodRegistry.set('onSliceComplete', new Set());
+        this._methodRegistry.set('onSliceDispatch', new Set());
+        this._methodRegistry.set('onSliceEnqueued', new Set());
+        this._methodRegistry.set('onExecutionStats', new Set());
 
         const readerConfig = this.config.operations[0];
-        const mod = loader.loadReader(readerConfig._op, this.assetIds);
+        const mod = this._loader.loadReader(readerConfig._op, this.assetIds);
 
         const op = new mod.Slicer(this.context, cloneDeep(readerConfig), this.config);
         this._slicer = op;
         this.addOperation(op);
 
-        this.resetMethodRegistry();
+        this._resetMethodRegistry();
     }
 
     /** The instance of a "Slicer" */
@@ -97,93 +42,19 @@ export class SlicerExecutionContext implements SlicerOperationLifeCycle {
         return this._slicer as T;
     }
 
-    /**
-     * Called to initialize all of the registered operations available to the Execution Controller
-    */
-    async initialize(recoveryData: object[] = []) {
-        const promises = [];
-        for (const op of this.getOperations()) {
-            promises.push(op.initialize(recoveryData));
-        }
-
-        await Promise.all(promises);
-    }
-
-    /**
-     * Called to cleanup all of the registered operations available to the Execution Controller
-    */
-    async shutdown() {
-        const promises = [];
-        for (const op of this.getOperations()) {
-            promises.push(op.shutdown());
-        }
-
-        await Promise.all(promises);
-
-        Object.keys(this._handlers)
-            .forEach((event) => {
-                const listener = this._handlers[event];
-                this.events.removeListener(event, listener);
-            });
-    }
-
     onExecutionStats(stats: ExecutionStats) {
-        this.runMethod('onExecutionStats', stats);
+        this._runMethod('onExecutionStats', stats);
     }
 
     onSliceEnqueued(slice: Slice) {
-        this.runMethod('onSliceEnqueued', slice);
+        this._runMethod('onSliceEnqueued', slice);
     }
 
     onSliceDispatch(slice: Slice) {
-        this.runMethod('onSliceDispatch', slice);
+        this._runMethod('onSliceDispatch', slice);
     }
 
-    onSliceComplete(result: SliceResult): void {
-        this.runMethod('onSliceComplete', result);
-    }
-
-    getOperations() {
-        const ops = _operations.get(this) as SlicerOperations;
-        return ops.values();
-    }
-
-    private addOperation(op: SlicerOperationLifeCycle) {
-        const ops = _operations.get(this) as SlicerOperations;
-        ops.add(op);
-
-        this.resetMethodRegistry();
-    }
-
-    private runMethod<T>(method: string, arg: T) {
-        const set = this._methodRegistry[method] as Set<number>;
-        if (set.size === 0) return;
-
-        let index = 0;
-        for (const operation of this.getOperations()) {
-            if (set.has(index)) {
-                operation[method](arg);
-            }
-            index++;
-        }
-    }
-
-    private resetMethodRegistry() {
-        for (const method of Object.keys(this._methodRegistry)) {
-            this._methodRegistry[method].clear();
-        }
-
-        const methods = Object.keys(this._methodRegistry);
-
-        let index = 0;
-        for (const op of this.getOperations()) {
-            for (const method of methods) {
-                if (isFunction(op[method])) {
-                    this._methodRegistry[method].add(index);
-                }
-            }
-
-            index++;
-        }
+    onSliceComplete(result: SliceResult) {
+        this._runMethod('onSliceComplete', result);
     }
 }

--- a/packages/job-components/src/execution-context/worker.ts
+++ b/packages/job-components/src/execution-context/worker.ts
@@ -108,11 +108,14 @@ export class WorkerExecutionContext implements WorkerOperationLifeCycle {
                 cloneDeep(opConfig),
                 this.config
             );
+
             this.addOperation(op);
             this.processors.push(op);
         }
 
-        const jobObserver = new JobObserver(this.context, this.config);
+        const apiConfig = { _name: 'job-observer' };
+        const jobObserver = new JobObserver(this.context, apiConfig, this.config);
+
         this.addOperation(jobObserver);
         this.jobObserver = jobObserver;
     }

--- a/packages/job-components/src/execution-context/worker.ts
+++ b/packages/job-components/src/execution-context/worker.ts
@@ -87,8 +87,9 @@ export class WorkerExecutionContext extends BaseExecutionContext<WorkerOperation
         const promises = this.apis
             .filter(isOperationAPI)
             .map(async (api) => {
-                await api.createAPI();
-                this.addAPI(api.apiConfig._name, api);
+                await api.initialize();
+                const opAPI = await api.createAPI();
+                this.addAPI(api.apiConfig._name, opAPI);
             });
 
         await Promise.all(promises);

--- a/packages/job-components/src/execution-context/worker.ts
+++ b/packages/job-components/src/execution-context/worker.ts
@@ -1,95 +1,42 @@
-import { EventEmitter } from 'events';
-import { isFunction, waterfall, isString, isInteger, cloneDeep } from '../utils';
-import { OperationLoader } from '../operation-loader';
+import { waterfall, isString, isInteger, cloneDeep } from '../utils';
 import FetcherCore from '../operations/core/fetcher-core';
 import ProcessorCore from '../operations/core/processor-core';
 import OperationCore from '../operations/core/operation-core';
-import { OperationAPIConstructor, DataEntity } from '../operations';
-import { registerApis } from '../register-apis';
-import { WorkerOperationLifeCycle, ExecutionConfig, Slice, WorkerContext } from '../interfaces';
+import { DataEntity } from '../operations';
+import { WorkerOperationLifeCycle, Slice } from '../interfaces';
 import {
-    EventHandlers,
-    WorkerOperations,
     ExecutionContextConfig,
-    WorkerMethodRegistry,
     RunSliceResult,
 } from './interfaces';
 import JobObserver from '../operations/job-observer';
-
-// WeakMaps are used as a memory efficient reference to private data
-const _loaders = new WeakMap<WorkerExecutionContext, OperationLoader>();
-const _operations = new WeakMap<WorkerExecutionContext, WorkerOperations>();
+import BaseExecutionContext from './base';
 
 /**
  * WorkerExecutionContext is designed to add more
  * functionality to interface with the
  * Execution Configuration and any Operation.
 */
-export class WorkerExecutionContext implements WorkerOperationLifeCycle {
-    readonly config: ExecutionConfig;
-    readonly context: WorkerContext;
-
-    /**
-     * A list of assetIds available to the job.
-     * This will be replaced by `resolvedAssets`
-    */
-    readonly assetIds: string[] = [];
-
-    readonly exId: string;
-    readonly jobId: string;
-
-    /** The terafoundation EventEmitter */
-    readonly events: EventEmitter;
-
+export class WorkerExecutionContext extends BaseExecutionContext<WorkerOperationLifeCycle> implements WorkerOperationLifeCycle {
     readonly processors: ProcessorCore[];
 
     private readonly jobObserver: JobObserver;
 
-    private _handlers: EventHandlers = {};
-
-    private _methodRegistry: WorkerMethodRegistry = {
-        onSliceInitialized: new Set(),
-        onSliceStarted: new Set(),
-        onSliceFinalizing: new Set(),
-        onSliceFinished: new Set(),
-        onSliceFailed: new Set(),
-        onSliceRetry: new Set(),
-        onOperationStart: new Set(),
-        onOperationComplete: new Set(),
-    };
-
     private readonly _fetcher: FetcherCore;
 
     constructor(config: ExecutionContextConfig) {
-        this.events = config.context.apis.foundation.getSystemEvents();
+        super(config);
 
-        this._handlers['execution:add-to-lifecycle'] = (op: WorkerOperationLifeCycle) => {
-            this.addOperation(op);
-        };
-
-        this.events.on('execution:add-to-lifecycle', this._handlers['execution:add-to-lifecycle']);
-
-        const executionConfig = cloneDeep(config.executionConfig);
-        const loader = new OperationLoader({
-            terasliceOpPath: config.terasliceOpPath,
-            assetPath: config.context.sysconfig.teraslice.assets_directory,
-        });
-
-        registerApis(config.context, executionConfig, config.assetIds);
-        this.context = config.context as WorkerContext;
-
-        this.assetIds = config.assetIds || [];
-
-        this.config = executionConfig;
-        this.exId = executionConfig.ex_id;
-        this.jobId = executionConfig.job_id;
-
-        _loaders.set(this, loader);
-
-        _operations.set(this, new Set());
+        this._methodRegistry.set('onSliceInitialized', new Set());
+        this._methodRegistry.set('onSliceStarted', new Set());
+        this._methodRegistry.set('onSliceFinalizing', new Set());
+        this._methodRegistry.set('onSliceFinished', new Set());
+        this._methodRegistry.set('onSliceFailed', new Set());
+        this._methodRegistry.set('onSliceRetry', new Set());
+        this._methodRegistry.set('onOperationStart', new Set());
+        this._methodRegistry.set('onOperationComplete', new Set());
 
         const readerConfig = this.config.operations[0];
-        const mod = loader.loadReader(readerConfig._op, this.assetIds);
+        const mod = this._loader.loadReader(readerConfig._op, this.assetIds);
         this.registerAPI(readerConfig._op, mod.API);
 
         const op = new mod.Fetcher(this.context, cloneDeep(readerConfig), this.config);
@@ -100,7 +47,7 @@ export class WorkerExecutionContext implements WorkerOperationLifeCycle {
 
         for (const opConfig of this.config.operations.slice(1)) {
             const name = opConfig._op;
-            const mod = loader.loadProcessor(name, this.assetIds);
+            const mod = this._loader.loadProcessor(name, this.assetIds);
             this.registerAPI(name, mod.API);
 
             const op = new mod.Processor(
@@ -113,8 +60,9 @@ export class WorkerExecutionContext implements WorkerOperationLifeCycle {
             this.processors.push(op);
         }
 
-        const apiConfig = { _name: 'job-observer' };
-        const jobObserver = new JobObserver(this.context, apiConfig, this.config);
+        const jobObserver = new JobObserver(this.context, {
+            _name: 'job-observer'
+        }, this.config);
 
         this.addOperation(jobObserver);
         this.jobObserver = jobObserver;
@@ -151,36 +99,6 @@ export class WorkerExecutionContext implements WorkerOperationLifeCycle {
      /** The instance of a "Fetcher" */
     fetcher<T extends FetcherCore = FetcherCore>(): T {
         return this._fetcher as T;
-    }
-
-    /**
-     * Called to initialize all of the registered operations available to the Worker
-    */
-    async initialize() {
-        const promises = [];
-        for (const op of this.getOperations()) {
-            promises.push(op.initialize());
-        }
-
-        await Promise.all(promises);
-    }
-
-    /**
-     * Called to cleanup all of the registered operations available to the Worker
-    */
-    async shutdown() {
-        const promises = [];
-        for (const op of this.getOperations()) {
-            promises.push(op.shutdown());
-        }
-
-        await Promise.all(promises);
-
-        Object.keys(this._handlers)
-            .forEach((event) => {
-                const listener = this._handlers[event];
-                this.events.removeListener(event, listener);
-            });
     }
 
     /**
@@ -224,104 +142,34 @@ export class WorkerExecutionContext implements WorkerOperationLifeCycle {
     }
 
     async onSliceInitialized(sliceId: string) {
-        await this.runMethodAsync('onSliceInitialized', sliceId);
+        await this._runMethodAsync('onSliceInitialized', sliceId);
     }
 
     async onSliceStarted(sliceId: string) {
-        await this.runMethodAsync('onSliceStarted', sliceId);
+        await this._runMethodAsync('onSliceStarted', sliceId);
     }
 
     async onSliceFinalizing(sliceId: string) {
-        await this.runMethodAsync('onSliceFinalizing', sliceId);
+        await this._runMethodAsync('onSliceFinalizing', sliceId);
     }
 
     async onSliceFinished(sliceId: string) {
-        await this.runMethodAsync('onSliceFinished', sliceId);
+        await this._runMethodAsync('onSliceFinished', sliceId);
     }
 
     async onSliceFailed(sliceId: string) {
-        await this.runMethodAsync('onSliceFailed', sliceId);
+        await this._runMethodAsync('onSliceFailed', sliceId);
     }
 
     async onSliceRetry(sliceId: string) {
-        await this.runMethodAsync('onSliceRetry', sliceId);
+        await this._runMethodAsync('onSliceRetry', sliceId);
     }
 
     onOperationComplete(sliceId: string, index: number, processed: number) {
-        this.runMethod('onOperationComplete', sliceId, index, processed);
+        this._runMethod('onOperationComplete', sliceId, index, processed);
     }
 
     onOperationStart(sliceId: string, index: number) {
-        this.runMethod('onOperationStart', sliceId, index);
-    }
-
-    /**
-     * Returns a list of any registered Operation that has been
-     * initialized.
-    */
-    getOperations() {
-        const ops = _operations.get(this) as WorkerOperations;
-        return ops.values();
-    }
-
-    private addOperation(op: WorkerOperationLifeCycle) {
-        const ops = _operations.get(this) as WorkerOperations;
-        ops.add(op);
-
-        this.resetMethodRegistry();
-    }
-
-    private registerAPI(name: string, API?: OperationAPIConstructor) {
-        if (API == null) return;
-
-        this.context.apis.executionContext.addToRegistry(name, API);
-    }
-
-    private runMethodAsync(method: string, sliceId: string) {
-        const set = this._methodRegistry[method] as Set<number>;
-        if (set.size === 0) return;
-
-        let i = 0;
-        const promises = [];
-        for (const operation of this.getOperations()) {
-            const index = i++;
-            if (set.has(index)) {
-                promises.push(operation[method](sliceId));
-            }
-        }
-
-        return Promise.all(promises);
-    }
-
-    private runMethod(method: string, ...args: any[]) {
-        const set = this._methodRegistry[method] as Set<number>;
-        if (set.size === 0) return;
-
-        let index = 0;
-        for (const operation of this.getOperations()) {
-            if (set.has(index)) {
-                operation[method](...args);
-            }
-            index++;
-        }
-    }
-
-    private resetMethodRegistry() {
-        for (const method of Object.keys(this._methodRegistry)) {
-            this._methodRegistry[method].clear();
-        }
-
-        const methods = Object.keys(this._methodRegistry);
-
-        let index = 0;
-        for (const op of this.getOperations()) {
-            for (const method of methods) {
-                if (isFunction(op[method])) {
-                    this._methodRegistry[method].add(index);
-                }
-            }
-
-            index++;
-        }
+        this._runMethod('onOperationStart', sliceId, index);
     }
 }

--- a/packages/job-components/src/execution-context/worker.ts
+++ b/packages/job-components/src/execution-context/worker.ts
@@ -1,7 +1,7 @@
 import { waterfall, isString, isInteger, cloneDeep, isFunction } from '../utils';
 import { APICore, FetcherCore, ProcessorCore, OperationCore } from '../operations/core';
-import { DataEntity, OperationAPI } from '../operations';
-import { WorkerOperationLifeCycle, Slice } from '../interfaces';
+import { DataEntity, OperationAPI, OperationAPIConstructor } from '../operations';
+import { WorkerOperationLifeCycle, Slice, OpAPI } from '../interfaces';
 import {
     ExecutionContextConfig,
     RunSliceResult,
@@ -200,6 +200,23 @@ export class WorkerExecutionContext extends BaseExecutionContext<WorkerOperation
 
     onOperationStart(sliceId: string, index: number) {
         this._runMethod('onOperationStart', sliceId, index);
+    }
+
+    /** Add an API to the executionContext api registry */
+    protected registerAPI(name: string, API?: OperationAPIConstructor) {
+        if (API == null) return;
+        const { apis = [] } = this.config;
+        const hasName = apis.some(({ _name }) => _name === name);
+        if (hasName) {
+            throw new Error(`Cannot register API ${name} due to conflict`);
+        }
+
+        this.context.apis.executionContext.addToRegistry(name, API);
+    }
+
+    /** Add an API to the executionContext api */
+    protected addAPI(name: string, opAPI: OpAPI) {
+        this.context.apis.executionContext.addAPI(name, opAPI);
     }
 }
 

--- a/packages/job-components/src/interfaces/jobs.ts
+++ b/packages/job-components/src/interfaces/jobs.ts
@@ -23,10 +23,10 @@ export const dataEncodings: DataEncoding[] = ['json'];
 /**
  * available dead letter queue actions
 */
-export type DeadLetterAction = 'throw'|'log'|'custom'|'none';
+export type DeadLetterAction = 'throw'|'log'|'none'|string;
 
-/** A list of supported dead letter actions */
-export const deadLetterActions = ['throw', 'log', 'custom', 'none'];
+/** A supported DeadLetterAPIFn */
+export type DeadLetterAPIFn = (input: any, err: Error) => void;
 
 export type LifeCycle = 'once'|'persistent';
 

--- a/packages/job-components/src/interfaces/jobs.ts
+++ b/packages/job-components/src/interfaces/jobs.ts
@@ -45,7 +45,10 @@ export type DeadLetterAPIFn = (input: any, err: Error) => void;
  * into a ExecutionContext.
 */
 export interface APIConfig {
-    /** The name of the api, this must be unique among any loaded APIs */
+    /**
+     * The name of the api, this must be unique among any loaded APIs
+     * but can be namespaced by using the format "example:0"
+     */
     _name: string;
     [prop: string]: any;
 }

--- a/packages/job-components/src/interfaces/jobs.ts
+++ b/packages/job-components/src/interfaces/jobs.ts
@@ -39,30 +39,25 @@ export type DeadLetterAction = 'throw'|'log'|'none'|string;
 /** A supported DeadLetterAPIFn */
 export type DeadLetterAPIFn = (input: any, err: Error) => void;
 
+/**
+ * APIConfig is the configuration for loading APIs and Observers
+ * into a ExecutionContext.
+*/
+export interface APIConfig {
+    /** The name of the operation */
+    _name: string;
+    [prop: string]: any;
+}
+
 export type LifeCycle = 'once'|'persistent';
 
 /**
  * JobConfig is the configuration that user specifies
  * for a Job
 */
-export interface JobConfig {
-    analytics?: boolean;
-    assets?: string[];
-    lifecycle?: LifeCycle;
-    max_retries?: number;
-    name: string;
-    operations: OpConfig[];
-    probation_window?: number;
-    recycle_worker?: number;
-    slicers?: number;
-    workers?: number;
-    targets?: Targets[];
-    cpu?: number;
-    memory?: number;
-    volumes?: Volume[];
-}
+export type JobConfig = Partial<ValidatedJobConfig>;
 
-export interface NativeJobConfig {
+export interface ValidatedJobConfig {
     analytics: boolean;
     assets: string[];
     assetIds?: string[];
@@ -74,6 +69,14 @@ export interface NativeJobConfig {
     recycle_worker: number;
     slicers: number;
     workers: number;
+    /** This will only be available in the context of k8s */
+    targets?: Targets[];
+    /** This will only be available in the context of k8s */
+    cpu?: number;
+    /** This will only be available in the context of k8s */
+    memory?: number;
+    /** This will only be available in the context of k8s */
+    volumes?: Volume[];
 }
 
 export interface Targets {
@@ -86,33 +89,12 @@ export interface Volume {
     path: string;
 }
 
-export interface K8sJobConfig extends NativeJobConfig {
-    targets: Targets[];
-    cpu: number;
-    memory: number;
-    volumes: Volume[];
-}
-
-export type ValidatedJobConfig = NativeJobConfig|K8sJobConfig;
-
-export interface NativeExecutionConfig extends NativeJobConfig {
+export interface ExecutionConfig extends ValidatedJobConfig {
     ex_id: string;
     job_id: string;
     slicer_hostname: string;
     slicer_port: number;
 }
-
-export interface K8sExecutionConfig extends K8sJobConfig {
-    ex_id: string;
-    job_id: string;
-    slicer_hostname: string;
-    slicer_port: number;
-}
-
-/**
- * ExecutionConfig a unique configuration instance for a running Job
-*/
-export type ExecutionConfig = NativeExecutionConfig|K8sExecutionConfig;
 
 /**
  * LegacyExecutionContext is the old ExecutionContext available

--- a/packages/job-components/src/interfaces/jobs.ts
+++ b/packages/job-components/src/interfaces/jobs.ts
@@ -45,7 +45,7 @@ export type DeadLetterAPIFn = (input: any, err: Error) => void;
  * into a ExecutionContext.
 */
 export interface APIConfig {
-    /** The name of the operation */
+    /** The name of the api, this must be unique among any loaded APIs */
     _name: string;
     [prop: string]: any;
 }

--- a/packages/job-components/src/interfaces/jobs.ts
+++ b/packages/job-components/src/interfaces/jobs.ts
@@ -8,16 +8,25 @@
 export interface OpConfig {
     _op: string;
     _encoding?: DataEncoding;
+    _dead_letter_action?: DeadLetterAction;
     [prop: string]: any;
 }
 
 /**
- * An enum of available encoding formats
+ * available data encoding types
 */
 export type DataEncoding = 'json';
 
 /** A list of supported encoding formats */
 export const dataEncodings: DataEncoding[] = ['json'];
+
+/**
+ * available dead letter queue actions
+*/
+export type DeadLetterAction = 'throw'|'log'|'custom'|'none';
+
+/** A list of supported dead letter actions */
+export const deadLetterActions = ['throw', 'log', 'custom', 'none'];
 
 export type LifeCycle = 'once'|'persistent';
 

--- a/packages/job-components/src/interfaces/jobs.ts
+++ b/packages/job-components/src/interfaces/jobs.ts
@@ -7,6 +7,7 @@
 export interface OpConfig {
     /** The name of the operation */
     _op: string;
+
     /** Used for specifying the data encoding type when using `DataEntity.fromBuffer`. Defaults to `json`. */
     _encoding?: DataEncoding;
     /**
@@ -64,6 +65,7 @@ export interface ValidatedJobConfig {
     lifecycle: LifeCycle;
     max_retries: number;
     name: string;
+    apis: APIConfig[];
     operations: OpConfig[];
     probation_window: number;
     recycle_worker: number;

--- a/packages/job-components/src/interfaces/jobs.ts
+++ b/packages/job-components/src/interfaces/jobs.ts
@@ -3,11 +3,22 @@
  * for a Operation.
  * The only required property is `_op` since that is used
  * to find the operation.
- * Encoding defaults to "JSON" when DataEntity.fromBuffer() is called
 */
 export interface OpConfig {
+    /** The name of the operation */
     _op: string;
+    /** Used for specifying the data encoding type when using `DataEntity.fromBuffer`. Defaults to `json`. */
     _encoding?: DataEncoding;
+    /**
+     * This action will specify what to do when failing to parse or transform a record. ​​​​​
+​​​​​     * The following builtin actions are supported: ​​​
+​​​​​     *  - "throw": throw the original error ​​​​​
+​​​​​     *  - "log": log the error and the data ​​​​​
+​​​​​     *  - "none": (default) skip the error entirely
+     *
+​​     * If none of the actions are specified it will try and use a registered Dead Letter Queue API under that name.
+     * The API must be already be created by a operation before it can used.​
+    */
     _dead_letter_action?: DeadLetterAction;
     [prop: string]: any;
 }

--- a/packages/job-components/src/interfaces/operation-lifecycle.ts
+++ b/packages/job-components/src/interfaces/operation-lifecycle.ts
@@ -42,7 +42,8 @@ export interface WorkerOperationLifeCycle extends OperationLifeCycle {
     /**
      * Called after the operation failed to process the slice
      * but before the slice is retried.
-     * [DEPRECATION NOTICE]: this will be deprecated in near future
+     *
+     * NOTE: A retry can be stopped by throw an error inside this function
     */
     onSliceRetry?(sliceId: string): Promise <void>;
 

--- a/packages/job-components/src/interfaces/operation-lifecycle.ts
+++ b/packages/job-components/src/interfaces/operation-lifecycle.ts
@@ -66,6 +66,12 @@ export interface WorkerOperationLifeCycle extends OperationLifeCycle {
 
 export interface SlicerOperationLifeCycle extends OperationLifeCycle {
     /**
+     * Called during execution initialization
+     * @param recoveryData is the data to recover from
+    */
+    initialize(recoveryData?: object[]): Promise<void>;
+
+    /**
      * A method called by the "Execution Controller" to give a "Slicer"
      * the opportunity to track the slices enqueued by the execution controller
     */

--- a/packages/job-components/src/job-schemas.ts
+++ b/packages/job-components/src/job-schemas.ts
@@ -86,7 +86,10 @@ export function jobSchema(context: Context): convict.Schema<any> {
         apis: {
             default: [],
             doc: `An array of apis to load and any configurations they require.
-            Validated similar to operations, with the exception of no apis are required and the _name must be unqiue.`,
+            Validated similar to operations, with the exception of no apis are required.
+            The _name property is required, and it is required to be unqiue
+            but can be suffixed with a identifier by using the format "example:0",
+            anything after the ":" is stripped out when searching for the file or folder.`,
             format(arr: any[]) {
                 if (!Array.isArray(arr)) {
                     throw new Error('APIs is required to be an array');
@@ -249,7 +252,9 @@ The API must be already be created by a operation before it can used.​`.trim()
 export const apiSchema: convict.Schema<any> = {
     _name: {
         default: '',
-        doc: 'Name of api, it must reflect the name of the file or folder, and it must unqiue among the other APIs',
+        doc: `The _name property is required, and it is required to be unqiue
+        but can be suffixed with a identifier by using the format "example:0",
+        anything after the ":" is stripped out when searching for the file or folder.`,
         format: 'required_String',
     }
 };

--- a/packages/job-components/src/job-schemas.ts
+++ b/packages/job-components/src/job-schemas.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { Context, dataEncodings } from './interfaces';
+import { Context, dataEncodings, deadLetterActions } from './interfaces';
 import convict from 'convict';
 import { flatten } from './utils';
 import os from 'os';
@@ -196,5 +196,10 @@ export const opSchema: convict.Schema<any> = {
         doc: 'Used to specify the encoding type of the data',
         default: 'json',
         format: dataEncodings,
+    },
+    _dead_letter_action: {
+        doc: 'This action will specify what to do when failing to parse or transform a record. Defaults to doing nothing.',
+        default: 'none',
+        format: deadLetterActions,
     }
 };

--- a/packages/job-components/src/job-schemas.ts
+++ b/packages/job-components/src/job-schemas.ts
@@ -1,9 +1,9 @@
 'use strict';
 
-import { Context, dataEncodings } from './interfaces';
-import convict from 'convict';
-import { flatten } from './utils';
 import os from 'os';
+import convict from 'convict';
+import { Context, dataEncodings } from './interfaces';
+import { flatten, getTypeOf, isPlainObject } from './utils';
 
 const cpuCount = os.cpus().length;
 const workers = cpuCount < 5 ? cpuCount : 5;
@@ -64,23 +64,49 @@ export function jobSchema(context: Context): convict.Schema<any> {
             doc: 'An array of actions to execute, typically the first is a reader ' +
                 'and the last is a sender with '
                 + 'any number of processing function in-between',
-            format: function checkJobProcess(arr: any) {
+            format(arr: any) {
                 if (!(Array.isArray(arr) && arr.length >= 2)) {
-                    throw new Error('operations need to be of type array ' +
-                        'with at least two operations in it');
+                    throw new Error('Operations need to be of type array with at least two operations in it');
                 }
 
                 const connectorsObject = context.sysconfig.terafoundation && context.sysconfig.terafoundation.connectors || {};
                 const connectors = Object.values(connectorsObject);
 
                 const connections = flatten(connectors.map((conn) => Object.keys(conn)));
-                arr.forEach((op) => {
-                    if (!op.connection) { return; }
-
-                    if (!connections.includes(op.connection)) {
-                        throw new Error(`operation ${op._op} refers to an undefined connection`);
+                for (const op of arr) {
+                    if (!op || !isPlainObject(op)) {
+                        throw new Error(`Invalid Operation config in operations, got ${getTypeOf(op)}`);
                     }
-                });
+                    if (op.connection && !connections.includes(op.connection)) {
+                        throw new Error(`Operation ${op._op} refers to connection "${op.connection}" which is unavailable`);
+                    }
+                }
+            },
+        },
+        apis: {
+            default: [],
+            doc: 'An array of apis to load and any configurations they require. Constructed similar to operations.',
+            format(arr: any[]) {
+                if (!Array.isArray(arr)) {
+                    throw new Error('APIs is required to be an array');
+                }
+
+                const connectorsObject = context.sysconfig.terafoundation && context.sysconfig.terafoundation.connectors || {};
+                const connectors = Object.values(connectorsObject);
+
+                const connections = flatten(connectors.map((conn) => Object.keys(conn)));
+
+                for (const api of arr) {
+                    if (!api || !isPlainObject(api)) {
+                        throw new Error(`Invalid API config in apis, got ${getTypeOf(api)}`);
+                    }
+                    if (!api._name) {
+                        throw new Error('API requires an _name');
+                    }
+                    if (api.connection && !connections.includes(api.connection)) {
+                        throw new Error(`API ${api._name} refers to connection "${api.connection}" which is unavailable`);
+                    }
+                }
             },
         },
         probation_window: {
@@ -189,7 +215,7 @@ export const makeJobSchema = jobSchema;
 export const opSchema: convict.Schema<any> = {
     _op: {
         default: '',
-        doc: 'Name of operation, it must reflect the name of the file',
+        doc: 'Name of operation, , it must reflect the name of the file or folder',
         format: 'required_String',
     },
     _encoding: {
@@ -208,5 +234,13 @@ export const opSchema: convict.Schema<any> = {
 The API must be already be created by a operation before it can used.​`.trim(),
         default: 'none',
         format: 'optional_String',
+    }
+};
+
+export const apiSchema: convict.Schema<any> = {
+    _name: {
+        default: '',
+        doc: 'Name of api, it must reflect the name of the file or folder',
+        format: 'required_String',
     }
 };

--- a/packages/job-components/src/job-schemas.ts
+++ b/packages/job-components/src/job-schemas.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { Context, dataEncodings, deadLetterActions } from './interfaces';
+import { Context, dataEncodings } from './interfaces';
 import convict from 'convict';
 import { flatten } from './utils';
 import os from 'os';
@@ -193,13 +193,20 @@ export const opSchema: convict.Schema<any> = {
         format: 'required_String',
     },
     _encoding: {
-        doc: 'Used to specify the encoding type of the data',
+        doc: 'Used for specifying the data encoding type when using `DataEntity.fromBuffer`. Defaults to `json`.',
         default: 'json',
         format: dataEncodings,
     },
     _dead_letter_action: {
-        doc: 'This action will specify what to do when failing to parse or transform a record. Defaults to doing nothing.',
+        doc: `This action will specify what to do when failing to parse or transform a record. ​​​​​
+​​​​​The following builtin actions are supported: ​​​
+​​​​​  - "throw": throw the original error ​​​​​
+​​​​​  - "log": log the error and the data ​​​​​
+​​​​​  - "none": (default) skip the error entirely
+
+​​​​​If none of the actions are specified it will try and use a registered Dead Letter Queue API under that name.
+The API must be already be created by a operation before it can used.​`.trim(),
         default: 'none',
-        format: deadLetterActions,
+        format: 'optional_String',
     }
 };

--- a/packages/job-components/src/job-validator.ts
+++ b/packages/job-components/src/job-validator.ts
@@ -23,9 +23,10 @@ export class JobValidator {
         this.schema = jobSchema(context);
     }
 
-    validateConfig(_jobConfig: JobConfig): ValidatedJobConfig {
+    /** Validate the job configuration, including the Operations and APIs configuration */
+    validateConfig(jobSpec: JobConfig): ValidatedJobConfig {
         // top level job validation occurs, but not operations
-        const jobConfig = validateJobConfig(this.schema, cloneDeep(_jobConfig));
+        const jobConfig = validateJobConfig(this.schema, cloneDeep(jobSpec));
         const assetIds = jobConfig.assets || [];
         const apis = {};
 

--- a/packages/job-components/src/job-validator.ts
+++ b/packages/job-components/src/job-validator.ts
@@ -1,9 +1,9 @@
 'use strict';
 
-import { Context, crossValidationFn, OpConfig, JobConfig, ValidatedJobConfig } from './interfaces';
+import { Context, OpConfig, JobConfig, ValidatedJobConfig } from './interfaces';
 import convict from 'convict';
 import { cloneDeep } from './utils';
-import { validateJobConfig, validateOpConfig } from './config-validators';
+import { validateJobConfig } from './config-validators';
 import { jobSchema } from './job-schemas';
 import { OperationLoader } from './operation-loader';
 import { registerApis } from './register-apis';
@@ -57,6 +57,18 @@ export class JobValidator {
             return handleModule(opConfig, this.opLoader.loadProcessor(opConfig._op, assetIds));
         });
 
+        jobConfig.apis = jobConfig.apis.map((apiConfig) => {
+            const { Schema } = this.opLoader.loadAPI(apiConfig._name, assetIds);
+            const schema = new Schema(this.context, 'api');
+
+            validateJobFns.push((job) => {
+                if (!schema.validateJob) return;
+                schema.validateJob(job);
+            });
+
+            return schema.validate(apiConfig);
+        });
+
         registerApis(this.context, jobConfig);
 
         validateJobFns.forEach((fn) => { fn(jobConfig); });
@@ -66,49 +78,7 @@ export class JobValidator {
             this.context.apis.executionContext.addToRegistry(name, api);
         });
 
-        // @ts-ignore
         return jobConfig;
-    }
-
-    /**
-     * Validate Legacy Jobs
-     * DEPRECATED to accommadate for new Job APIs,
-     * use validateConfig
-    */
-    validate(job: any) {
-        let validJob = cloneDeep(job);
-
-        // this is used if an operation needs to provide additional validation beyond its own scope
-        const topLevelJobValidators : crossValidationFn[] = [];
-
-        // top level job validation occurs, but not operations
-        validJob = validateJobConfig(this.schema, validJob);
-
-        validJob.operations = job.operations.map((opConfig: OpConfig) => {
-            const operation = this.opLoader.load(opConfig._op, job.assets);
-
-            this.hasSchema(operation, opConfig._op);
-
-            const validOP = validateOpConfig(operation.schema(), opConfig);
-
-            if (operation.selfValidation) {
-                operation.selfValidation(validOP);
-            }
-
-            if (operation.crossValidation) {
-                topLevelJobValidators.push(operation.crossValidation);
-            }
-
-            return validOP;
-        });
-
-        registerApis(this.context, job);
-
-        topLevelJobValidators.forEach((fn) => {
-            fn(validJob, this.context.sysconfig);
-        });
-
-        return validJob;
     }
 
     hasSchema(obj: any, name: string) {

--- a/packages/job-components/src/operation-loader.ts
+++ b/packages/job-components/src/operation-loader.ts
@@ -1,5 +1,4 @@
-'use strict';
-
+/* tslint:disable:variable-name */
 import fs from 'fs';
 import path from 'path';
 import { LegacyOperation } from './interfaces';
@@ -10,7 +9,6 @@ import {
     ProcessorConstructor,
     ObserverConstructor,
     SchemaConstructor,
-    ObserverModule,
     ProcessorModule,
     APIModule,
     ReaderModule,
@@ -90,9 +88,7 @@ export class OperationLoader {
             return this.shimLegacyProcessor(name, codePath);
         }
 
-        /* tslint:disable-next-line:variable-name */
         let Processor: ProcessorConstructor|undefined;
-        /* tslint:disable-next-line:variable-name */
         let Schema: SchemaConstructor|undefined;
         let API: OperationAPIConstructor|undefined;
 
@@ -129,11 +125,8 @@ export class OperationLoader {
             return this.shimLegacyReader(name, codePath);
         }
 
-        /* tslint:disable-next-line:variable-name */
         let Fetcher: FetcherConstructor|undefined;
-        /* tslint:disable-next-line:variable-name */
         let Slicer: SlicerConstructor|undefined;
-        /* tslint:disable-next-line:variable-name */
         let Schema: SchemaConstructor|undefined;
         let API: OperationAPIConstructor|undefined;
 
@@ -171,39 +164,42 @@ export class OperationLoader {
         };
     }
 
-    loadObserver(name: string, assetIds?: string[]): ObserverModule {
-        const codePath = this.findOrThrow(name, assetIds);
-
-        /* tslint:disable-next-line:variable-name */
-        let Observer: ObserverConstructor|undefined;
-
-        try {
-            Observer = this.require(codePath, 'observer');
-        } catch (err) {
-            throw new Error(`Failure loading observer from module: ${name}, error: ${parseError(err, true)}`);
-        }
-
-        return {
-            // @ts-ignore
-            Observer,
-        };
-    }
-
     loadAPI(name: string, assetIds?: string[]): APIModule {
         const codePath = this.findOrThrow(name, assetIds);
 
-        /* tslint:disable-next-line:variable-name */
         let API: OperationAPIConstructor|undefined;
 
         try {
             API = this.require(codePath, 'api');
         } catch (err) {
-            throw new Error(`Failure loading api from module: ${name}, error: ${parseError(err, true)}`);
+        }
+
+        let Observer: ObserverConstructor|undefined;
+
+        try {
+            Observer = this.require(codePath, 'observer');
+        } catch (err) {
+        }
+
+        let Schema: SchemaConstructor|undefined;
+
+        try {
+            Schema = this.require(codePath, 'schema');
+        } catch (err) {
+            throw new Error(`Failure loading schema from module: ${name}, error: ${parseError(err, true)}`);
+        }
+
+        if (Observer == null && API == null) {
+            throw new Error(`Failure to load api module: ${name}, requires at least an api.js or observer.js`);
         }
 
         return {
             // @ts-ignore
             API,
+            // @ts-ignore
+            Observer,
+            // @ts-ignore
+            Schema,
         };
     }
 

--- a/packages/job-components/src/operation-loader.ts
+++ b/packages/job-components/src/operation-loader.ts
@@ -165,7 +165,8 @@ export class OperationLoader {
     }
 
     loadAPI(name: string, assetIds?: string[]): APIModule {
-        const codePath = this.findOrThrow(name, assetIds);
+        const [apiName] = name.split(':');
+        const codePath = this.findOrThrow(apiName, assetIds);
 
         let API: OperationAPIConstructor|undefined;
 
@@ -186,13 +187,13 @@ export class OperationLoader {
         try {
             Schema = this.require(codePath, 'schema');
         } catch (err) {
-            throw new Error(`Failure loading schema from module: ${name}, error: ${parseError(err, true)}`);
+            throw new Error(`Failure loading schema from module: ${apiName}, error: ${parseError(err, true)}`);
         }
 
         if (Observer == null && API == null) {
-            throw new Error(`Failure to load api module: ${name}, requires at least an api.js or observer.js`);
+            throw new Error(`Failure to load api module: ${apiName}, requires at least an api.js or observer.js`);
         } else if (Observer != null && API != null) {
-            throw new Error(`Failure to load api module: ${name}, required only one api.js or observer.js`);
+            throw new Error(`Failure to load api module: ${apiName}, required only one api.js or observer.js`);
         }
 
         const type = API != null ? 'api' : 'observer';

--- a/packages/job-components/src/operation-loader.ts
+++ b/packages/job-components/src/operation-loader.ts
@@ -191,15 +191,18 @@ export class OperationLoader {
 
         if (Observer == null && API == null) {
             throw new Error(`Failure to load api module: ${name}, requires at least an api.js or observer.js`);
+        } else if (Observer != null && API != null) {
+            throw new Error(`Failure to load api module: ${name}, required only one api.js or observer.js`);
         }
+
+        const type = API != null ? 'api' : 'observer';
 
         return {
             // @ts-ignore
-            API,
-            // @ts-ignore
-            Observer,
+            API: API || Observer,
             // @ts-ignore
             Schema,
+            type,
         };
     }
 

--- a/packages/job-components/src/operations/convict-schema.ts
+++ b/packages/job-components/src/operations/convict-schema.ts
@@ -1,21 +1,26 @@
 import convict from 'convict';
-import { Context, OpConfig } from '../interfaces';
-import SchemaCore from './core/schema-core';
-import { validateOpConfig } from '../config-validators';
+import SchemaCore, { OpType } from './core/schema-core';
+import { Context, OpConfig, APIConfig } from '../interfaces';
+import { validateOpConfig, validateAPIConfig } from '../config-validators';
 
 /**
  * A base class for supporting convict "Schema" definitions
  */
-
 export default abstract class ConvictSchema<T extends Object, S = any> extends SchemaCore<T> {
     schema: convict.Schema<S>;
 
-    constructor(context: Context) {
-        super(context);
+    constructor(context: Context, opType: OpType = 'operation') {
+        super(context, opType);
         this.schema = this.build(context);
     }
 
-    validate(inputConfig: any): OpConfig & T {
+    validate(inputConfig: any): APIConfig & T;
+    validate(inputConfig: any): OpConfig & T;
+    validate(inputConfig: any): OpConfig|APIConfig & T {
+        if (this.opType === 'api') {
+            return validateAPIConfig(this.schema, inputConfig);
+        }
+
         return validateOpConfig(this.schema, inputConfig);
     }
 

--- a/packages/job-components/src/operations/core/api-core.ts
+++ b/packages/job-components/src/operations/core/api-core.ts
@@ -1,25 +1,35 @@
 import Core from './core';
-import { ExecutionConfig, WorkerOperationLifeCycle, WorkerContext } from '../../interfaces';
+import {
+    ExecutionConfig,
+    WorkerOperationLifeCycle,
+    WorkerContext,
+    APIConfig
+} from '../../interfaces';
 
 /**
  * A base class for supporting APIs that run within an Execution Context.
  */
-export default abstract class APICore extends Core<WorkerContext> implements WorkerOperationLifeCycle {
-    constructor(context: WorkerContext, executionConfig: ExecutionConfig) {
+export default abstract class APICore<T = APIConfig> extends Core<WorkerContext> implements WorkerOperationLifeCycle {
+    readonly apiConfig: Readonly<APIConfig & T>;
+
+    constructor(context: WorkerContext, apiConfig: APIConfig & T, executionConfig: ExecutionConfig) {
         const logger = context.apis.foundation.makeLogger({
             module: 'operation-api',
+            apiName: apiConfig._name,
             jobName: executionConfig.name,
             jobId: executionConfig.job_id,
             exId: executionConfig.ex_id,
         });
+
         super(context, executionConfig, logger);
+        this.apiConfig = apiConfig;
     }
 
     async initialize(): Promise<void> {
-        this.context.logger.trace(`${this.executionConfig.name}->api is initializing...`);
+        this.context.logger.trace(`${this.apiConfig._name}->api is initializing...`);
     }
 
     async shutdown(): Promise<void> {
-        this.context.logger.trace(`${this.executionConfig.name}->api is shutting down...`);
+        this.context.logger.trace(`${this.apiConfig._name}->api is shutting down...`);
     }
 }

--- a/packages/job-components/src/operations/core/core.ts
+++ b/packages/job-components/src/operations/core/core.ts
@@ -6,9 +6,9 @@ import { Context, ExecutionConfig, Logger, OperationLifeCycle } from '../../inte
  */
 
 export default abstract class Core<T extends Context> implements OperationLifeCycle {
-    protected readonly context: Readonly<T>;
-    protected readonly executionConfig: Readonly<ExecutionConfig>;
-    protected readonly logger: Logger;
+    readonly context: Readonly<T>;
+    readonly executionConfig: Readonly<ExecutionConfig>;
+    readonly logger: Logger;
     readonly events: EventEmitter;
 
     constructor(context: T, executionConfig: ExecutionConfig, logger: Logger) {

--- a/packages/job-components/src/operations/core/operation-core.ts
+++ b/packages/job-components/src/operations/core/operation-core.ts
@@ -56,17 +56,18 @@ export default class OperationCore<T = OpConfig> extends Core<WorkerContext> imp
      *
      * See {@link #rejectRecord} for handling
      *
-     * @param data the data to transform
      * @param fn a function to transform the data with
-     * @returns the transformed record or null if it failed
+     * @returns a curried a function that will be called with the data and handle the dead letter action
     */
-    tryRecord<I, R>(input: I, fn: (input: I) => R): R|null {
-        try {
-            return fn(input);
-        } catch (err) {
-            this.rejectRecord(input, err);
-            return null;
-        }
+    tryRecord<I, R>(fn: (input: I) => R): (input: I) => R|null {
+        return (input) => {
+            try {
+                return fn(input);
+            } catch (err) {
+                this.rejectRecord(input, err);
+                return null;
+            }
+        };
     }
 
     /**

--- a/packages/job-components/src/operations/core/operation-core.ts
+++ b/packages/job-components/src/operations/core/operation-core.ts
@@ -19,7 +19,7 @@ import {
  */
 
 export default class OperationCore<T = OpConfig> extends Core<WorkerContext> implements WorkerOperationLifeCycle {
-    protected readonly opConfig: Readonly<OpConfig & T>;
+    readonly opConfig: Readonly<OpConfig & T>;
     deadLetterAction: DeadLetterAction;
 
     constructor(context: WorkerContext, opConfig: OpConfig & T, executionConfig: ExecutionConfig) {

--- a/packages/job-components/src/operations/core/schema-core.ts
+++ b/packages/job-components/src/operations/core/schema-core.ts
@@ -8,7 +8,7 @@ export default abstract class SchemaCore<T> {
     protected context: Context;
     readonly opType: OpType;
 
-    constructor(context: Context, opType: OpType = 'operation') {
+    constructor(context: Context, opType: OpType) {
         this.context = context;
         this.opType = opType;
     }

--- a/packages/job-components/src/operations/core/schema-core.ts
+++ b/packages/job-components/src/operations/core/schema-core.ts
@@ -6,12 +6,16 @@ import { Context, OpConfig, ValidatedJobConfig } from '../../interfaces';
 
 export default abstract class SchemaCore<T> {
     protected context: Context;
+    readonly opType: OpType;
 
-    constructor(context: Context) {
+    constructor(context: Context, opType: OpType = 'operation') {
         this.context = context;
+        this.opType = opType;
     }
 
     abstract build(context?: Context): any;
     abstract validate(inputConfig: any): OpConfig & T;
     abstract validateJob?(job: ValidatedJobConfig): void;
 }
+
+export type OpType = 'operation'|'api';

--- a/packages/job-components/src/operations/core/slicer-core.ts
+++ b/packages/job-components/src/operations/core/slicer-core.ts
@@ -51,6 +51,10 @@ export default abstract class SlicerCore<T = OpConfig> extends Core<WorkerContex
         };
     }
 
+    /**
+     * Called during execution initialization
+     * @param recoveryData is the data to recover from
+    */
     async initialize(recoveryData: object[]): Promise<void> {
         this.recoveryData = recoveryData;
         this.context.logger.trace(`${this.executionConfig.name}->${this.opConfig._op} is initializing...`, recoveryData);

--- a/packages/job-components/src/operations/interfaces.ts
+++ b/packages/job-components/src/operations/interfaces.ts
@@ -1,6 +1,6 @@
-import { ExecutionConfig, Context, OpConfig, WorkerContext } from '../interfaces';
+import { ExecutionConfig, Context, OpConfig, APIConfig, WorkerContext } from '../interfaces';
 import FetcherCore from './core/fetcher-core';
-import SchemaCore from './core/schema-core';
+import SchemaCore, { OpType } from './core/schema-core';
 import SlicerCore from './core/slicer-core';
 import APICore from './core/api-core';
 import ProcessorCore from './core/processor-core';
@@ -9,7 +9,7 @@ import ParallelSlicer from './parallel-slicer';
 import OperationAPI from './operation-api';
 
 export type APICoreConstructor<U> = {
-    new(context: WorkerContext, executionConfig: ExecutionConfig): U;
+    new(context: WorkerContext, apiConfig: APIConfig, executionConfig: ExecutionConfig): U;
 };
 
 export type OperationCoreConstructor<U> = {
@@ -22,7 +22,7 @@ export type SlicerCoreConstructor<U> = {
 
 export type SchemaConstructor<T = any> = {
     type(): string;
-    new(context: Context): SchemaCore<T>;
+    new(context: Context, opType?: OpType): SchemaCore<T>;
 };
 
 export type OperationAPIConstructor = APICoreConstructor<OperationAPI>;
@@ -45,12 +45,9 @@ export interface SchemaModule {
     Schema: SchemaConstructor;
 }
 
-export interface APIModule {
-    API: OperationAPIConstructor;
-}
-
-export interface ObserverModule {
-    Observer: ObserverConstructor;
+export interface APIModule extends SchemaModule {
+    API?: OperationAPIConstructor;
+    Observer?: ObserverConstructor;
 }
 
 export interface ReaderModule extends OperationModule {

--- a/packages/job-components/src/operations/interfaces.ts
+++ b/packages/job-components/src/operations/interfaces.ts
@@ -46,8 +46,8 @@ export interface SchemaModule {
 }
 
 export interface APIModule extends SchemaModule {
-    API?: OperationAPIConstructor;
-    Observer?: ObserverConstructor;
+    API: OperationAPIConstructor|ObserverConstructor;
+    type: 'api'|'observer';
 }
 
 export interface ReaderModule extends OperationModule {

--- a/packages/job-components/src/operations/job-observer.ts
+++ b/packages/job-components/src/operations/job-observer.ts
@@ -1,4 +1,4 @@
-import { ExecutionConfig, SliceAnalyticsData, WorkerContext } from '../interfaces';
+import { ExecutionConfig, APIConfig, SliceAnalyticsData, WorkerContext } from '../interfaces';
 import APICore from './core/api-core';
 import { times } from '../utils';
 
@@ -20,8 +20,8 @@ export default class JobObserver extends APICore {
     // in-flight analytics
     private _initialized: OpAnalytics|null;
 
-    constructor(context: WorkerContext, executionConfig: ExecutionConfig) {
-        super(context, executionConfig);
+    constructor(context: WorkerContext, apiConfig: APIConfig, executionConfig: ExecutionConfig) {
+        super(context, apiConfig, executionConfig);
 
         this._opLength = executionConfig.operations.length;
 

--- a/packages/job-components/src/operations/job-observer.ts
+++ b/packages/job-components/src/operations/job-observer.ts
@@ -1,11 +1,11 @@
 import { ExecutionConfig, APIConfig, SliceAnalyticsData, WorkerContext } from '../interfaces';
-import APICore from './core/api-core';
+import Observer from './observer';
 import { times } from '../utils';
 
 /**
  * An Observer for monitoring the Slice Analyitcs
  */
-export default class JobObserver extends APICore {
+export default class JobObserver extends Observer {
     collectAnalytics: boolean;
     analyticsData: SliceAnalyticsData|undefined;
 

--- a/packages/job-components/src/operations/observer.ts
+++ b/packages/job-components/src/operations/observer.ts
@@ -1,7 +1,8 @@
 import APICore from './core/api-core';
+import { APIConfig } from '../interfaces';
 
 /**
  * An Observer factory class for operations
  */
-export default abstract class Observer extends APICore {
+export default abstract class Observer<T = APIConfig> extends APICore<T> {
 }

--- a/packages/job-components/src/operations/operation-api.ts
+++ b/packages/job-components/src/operations/operation-api.ts
@@ -1,10 +1,10 @@
-import { OpAPI } from '../interfaces';
+import { OpAPI, APIConfig } from '../interfaces';
 import APICore from './core/api-core';
 
 /**
  * An API factory class for operations
  */
-export default abstract class OperationAPI extends APICore {
+export default abstract class OperationAPI<T = APIConfig> extends APICore<T> {
      /**
      * Called when the API is created with in another Operation.
      * This will only be called once during an operation

--- a/packages/job-components/src/operations/shims/processor-shim.ts
+++ b/packages/job-components/src/operations/shims/processor-shim.ts
@@ -30,9 +30,11 @@ export default function processorShim<S = any>(legacy: LegacyProcessor): Process
             }
         },
         Schema: class LegacySchemaShim extends ConvictSchema<S> {
+            // @ts-ignore
             validate(inputConfig: any) {
                 const opConfig = super.validate(inputConfig);
                 if (legacy.selfValidation) {
+                    // @ts-ignore
                     legacy.selfValidation(opConfig);
                 }
                 return opConfig;

--- a/packages/job-components/src/operations/shims/reader-shim.ts
+++ b/packages/job-components/src/operations/shims/reader-shim.ts
@@ -76,9 +76,11 @@ export default function readerShim<S = any>(legacy: LegacyReader): ReaderModule 
             }
         },
         Schema: class LegacySchemaShim extends ConvictSchema<S> {
+            // @ts-ignore
             validate(inputConfig: any) {
                 const opConfig = super.validate(inputConfig);
                 if (legacy.selfValidation) {
+                    // @ts-ignore
                     legacy.selfValidation(opConfig);
                 }
                 return opConfig;

--- a/packages/job-components/src/operations/shims/schema-shim.ts
+++ b/packages/job-components/src/operations/shims/schema-shim.ts
@@ -5,9 +5,11 @@ import { SchemaModule } from '../interfaces';
 export default function schemaShim<S = any>(legacy: LegacyProcessor): SchemaModule {
     return {
         Schema: class LegacySchemaShim extends ConvictSchema<S> {
+            // @ts-ignore
             validate(inputConfig: any) {
                 const opConfig = super.validate(inputConfig);
                 if (legacy.selfValidation) {
+                    // @ts-ignore
                     legacy.selfValidation(opConfig);
                 }
                 return opConfig;

--- a/packages/job-components/src/test-helpers.ts
+++ b/packages/job-components/src/test-helpers.ts
@@ -91,6 +91,7 @@ export function newTestSlice(request: i.SliceRequest = {}): i.Slice {
 export function newTestJobConfig(defaults: Partial<i.JobConfig> = {}) {
     return Object.assign({
         name: 'test-job',
+        apis: [],
         operations: [],
         analytics: false,
         assets: [],

--- a/packages/job-components/test/config-validators-spec.ts
+++ b/packages/job-components/test/config-validators-spec.ts
@@ -8,9 +8,9 @@ import {
     K8sJobConfig,
 } from '../src';
 
-describe('When using native clustering', () => {
-    describe('When passed a valid jobSchema and jobConfig', () => {
-        it('returns a completed and valid jobConfig', () => {
+describe('when using native clustering', () => {
+    describe('when passed a valid jobSchema and jobConfig', () => {
+        it('should return a completed and valid jobConfig', () => {
             const context = new TestContext('teraslice-operations');
 
             const schema = jobSchema(context);
@@ -42,8 +42,8 @@ describe('When using native clustering', () => {
         });
     });
 
-    describe('When passed a job without a known connector', () => {
-        it('raises an exception', () => {
+    describe('when passed a job without a known connector', () => {
+        it('should raises an exception', () => {
             const context = new TestContext('teraslice-operations');
             context.sysconfig.terafoundation = {
                 connectors: {
@@ -73,7 +73,7 @@ describe('When using native clustering', () => {
         });
     });
 
-    describe('When validating opConfig', () => {
+    describe('when validating opConfig', () => {
         const schema: Schema<any> = {
             example: {
                 default: '',
@@ -107,10 +107,12 @@ describe('When using native clustering', () => {
                 example: 'example',
                 formatted_value: 'hi',
             };
+
             const config = validateOpConfig(schema, op);
             expect(config as object).toEqual({
                 _op: 'some-op',
                 _encoding: 'json',
+                _dead_letter_action: 'none',
                 example: 'example',
                 formatted_value: 'hi',
                 test: true,
@@ -129,6 +131,7 @@ describe('When using native clustering', () => {
             expect(config as object).toEqual({
                 _op: 'some-op',
                 _encoding: 'json',
+                _dead_letter_action: 'none',
                 example: 'example',
                 formatted_value: 'hi',
                 test: true,
@@ -161,6 +164,52 @@ describe('When using native clustering', () => {
             }).toThrow();
         });
 
+        it('should handle a custom dead letter action', () => {
+            const op = {
+                _op: 'some-op',
+                _encoding: 'json',
+                _dead_letter_action: 'log',
+                example: 'example',
+                formatted_value: 'hi',
+            };
+
+            const config = validateOpConfig(schema, op);
+            expect(config as object).toEqual({
+                _op: 'some-op',
+                _encoding: 'json',
+                _dead_letter_action: 'log',
+                example: 'example',
+                formatted_value: 'hi',
+                test: true,
+            });
+        });
+
+        it('should handle a non-string dead letter action', () => {
+            const op = {
+                _op: 'some-op',
+                _dead_letter_action: 'this-wont-work',
+                example: 'example',
+                formatted_value: 'hi',
+            };
+
+            expect(() => {
+                validateOpConfig(schema, op);
+            }).toThrow();
+        });
+
+        it('should handle an invalid dead letter action', () => {
+            const op = {
+                _op: 'some-op',
+                _dead_letter_action: 123,
+                example: 'example',
+                formatted_value: 'hi',
+            };
+
+            expect(() => {
+                validateOpConfig(schema, op);
+            }).toThrow();
+        });
+
         it('should fail when given invalid input', () => {
             const op = {
                 _op: 'some-op',
@@ -176,12 +225,12 @@ describe('When using native clustering', () => {
 
 });
 
-describe('When validating k8s clustering', () => {
+describe('when validating k8s clustering', () => {
     const context = new TestContext('teraslice-operations');
     context.sysconfig.teraslice.cluster_manager_type = 'kubernetes';
 
-    describe('When passed a jobConfig with resources', () => {
-        it('returns a completed and valid jobConfig', () => {
+    describe('when passed a jobConfig with resources', () => {
+        it('should return a completed and valid jobConfig', () => {
 
             const schema = jobSchema(context);
             const job = {
@@ -203,8 +252,8 @@ describe('When validating k8s clustering', () => {
         });
     });
 
-    describe('When passed a jobConfig with targets', () => {
-        it('returns a completed and valid jobConfig', () => {
+    describe('when passed a jobConfig with targets', () => {
+        it('should return a completed and valid jobConfig', () => {
             const schema = jobSchema(context);
             const job = {
                 targets: [
@@ -250,8 +299,8 @@ describe('When validating k8s clustering', () => {
         });
     });
 
-    describe('When passed a jobConfig with volumes', () => {
-        it('returns a completed and valid jobConfig', () => {
+    describe('when passed a jobConfig with volumes', () => {
+        it('should return a completed and valid jobConfig', () => {
             const schema = jobSchema(context);
             const job = {
                 volumes: [

--- a/packages/job-components/test/config-validators-spec.ts
+++ b/packages/job-components/test/config-validators-spec.ts
@@ -187,19 +187,6 @@ describe('when using native clustering', () => {
         it('should handle a non-string dead letter action', () => {
             const op = {
                 _op: 'some-op',
-                _dead_letter_action: 'this-wont-work',
-                example: 'example',
-                formatted_value: 'hi',
-            };
-
-            expect(() => {
-                validateOpConfig(schema, op);
-            }).toThrow();
-        });
-
-        it('should handle an invalid dead letter action', () => {
-            const op = {
-                _op: 'some-op',
                 _dead_letter_action: 123,
                 example: 'example',
                 formatted_value: 'hi',

--- a/packages/job-components/test/config-validators-spec.ts
+++ b/packages/job-components/test/config-validators-spec.ts
@@ -44,7 +44,7 @@ describe('when using native clustering', () => {
     });
 
     describe('when passed a job with an invalid op', () => {
-        it('should raises an exception', () => {
+        it('should raise an exception', () => {
             const context = new TestContext('teraslice-operations');
             context.sysconfig.terafoundation = {
                 connectors: {
@@ -73,7 +73,7 @@ describe('when using native clustering', () => {
     });
 
     describe('when passed a job with an invalid operations', () => {
-        it('should raises an exception', () => {
+        it('should raise an exception', () => {
             const context = new TestContext('teraslice-operations');
             context.sysconfig.terafoundation = {
                 connectors: {
@@ -97,7 +97,7 @@ describe('when using native clustering', () => {
     });
 
     describe('when passed a job without a known operation connector', () => {
-        it('should raises an exception', () => {
+        it('should raise an exception', () => {
             const context = new TestContext('teraslice-operations');
             context.sysconfig.terafoundation = {
                 connectors: {
@@ -129,7 +129,7 @@ describe('when using native clustering', () => {
     });
 
     describe('when passed a job with an invalid api', () => {
-        it('should raises an exception', () => {
+        it('should raise an exception', () => {
             const context = new TestContext('teraslice-operations');
             context.sysconfig.terafoundation = {
                 connectors: {
@@ -163,7 +163,7 @@ describe('when using native clustering', () => {
     });
 
     describe('when passed a job without api _name', () => {
-        it('should raises an exception', () => {
+        it('should raise an exception', () => {
             const context = new TestContext('teraslice-operations');
             context.sysconfig.terafoundation = {
                 connectors: {
@@ -195,8 +195,46 @@ describe('when using native clustering', () => {
         });
     });
 
+    describe('when passed a job with duplicate api names', () => {
+        it('should raise an exception', () => {
+            const context = new TestContext('teraslice-operations');
+            context.sysconfig.terafoundation = {
+                connectors: {
+                    elasticsearch: {
+                        t1: {
+                            host: ['1.1.1.1:9200'],
+                        },
+                    },
+                },
+            };
+
+            const schema = jobSchema(context);
+            const job = {
+                apis: [
+                    {
+                        _name: 'hello'
+                    },
+                    {
+                        _name: 'hello'
+                    }
+                ],
+                operations: [
+                    {
+                        _op: 'test-reader',
+                    },
+                    {
+                        _op: 'noop',
+                    },
+                ],
+            };
+            expect(() => {
+                validateJobConfig(schema, job);
+            }).toThrowError(/Duplicate API configurations for/);
+        });
+    });
+
     describe('when passed a job without a known api connector', () => {
-        it('should raises an exception', () => {
+        it('should raise an exception', () => {
             const context = new TestContext('teraslice-operations');
             context.sysconfig.terafoundation = {
                 connectors: {

--- a/packages/job-components/test/execution-context/worker-spec.ts
+++ b/packages/job-components/test/execution-context/worker-spec.ts
@@ -85,8 +85,11 @@ describe('WorkerExecutionContext', () => {
             }
         });
 
-        it('should have the APIs', async () => {
-            expect(executionContext.apis).toBeArrayOfSize(2);
+        it('should have the APIs', () => {
+            expect(Object.keys(executionContext.apis)).toEqual([
+                'example-observer',
+                'example-api',
+            ]);
         });
 
         it('should be able to an operation instance by index', async () => {

--- a/packages/job-components/test/execution-context/worker-spec.ts
+++ b/packages/job-components/test/execution-context/worker-spec.ts
@@ -113,7 +113,6 @@ describe('WorkerExecutionContext', () => {
             const registry = Object.keys(context.apis.executionContext.registry);
             expect(registry).toEqual([
                 'example-reader',
-                'example-api'
             ]);
         });
 

--- a/packages/job-components/test/execution-context/worker-spec.ts
+++ b/packages/job-components/test/execution-context/worker-spec.ts
@@ -23,6 +23,15 @@ describe('WorkerExecutionContext', () => {
     describe('when constructed', () => {
         const executionConfig = newTestExecutionConfig();
 
+        executionConfig.apis = [
+            {
+                _name: 'example-observer'
+            },
+            {
+                _name: 'example-api'
+            }
+        ];
+
         executionConfig.operations = [
             {
                 _op: 'example-reader'
@@ -76,6 +85,10 @@ describe('WorkerExecutionContext', () => {
             }
         });
 
+        it('should have the APIs', async () => {
+            expect(executionContext.apis).toBeArrayOfSize(2);
+        });
+
         it('should be able to an operation instance by index', async () => {
             const fetcher = executionContext.getOperation<FetcherCore>(0);
             // @ts-ignore
@@ -99,7 +112,8 @@ describe('WorkerExecutionContext', () => {
         it('should have the registered apis', () => {
             const registry = Object.keys(context.apis.executionContext.registry);
             expect(registry).toEqual([
-                'example-reader'
+                'example-reader',
+                'example-api'
             ]);
         });
 

--- a/packages/job-components/test/fixtures/empty-api/schema.js
+++ b/packages/job-components/test/fixtures/empty-api/schema.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { ConvictSchema } = require('../../..');
+
+class Schema extends ConvictSchema {
+    build() {
+        return {
+            example: {
+                default: 'examples are quick and easy',
+                doc: 'A random example schema property',
+                format: 'String',
+            }
+        };
+    }
+}
+
+module.exports = Schema;

--- a/packages/job-components/test/fixtures/example-api/schema.js
+++ b/packages/job-components/test/fixtures/example-api/schema.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { ConvictSchema } = require('../../..');
+
+class Schema extends ConvictSchema {
+    build() {
+        return {
+            example: {
+                default: 'examples are quick and easy',
+                doc: 'A random example schema property',
+                format: 'String',
+            }
+        };
+    }
+}
+
+module.exports = Schema;

--- a/packages/job-components/test/fixtures/example-observer/schema.js
+++ b/packages/job-components/test/fixtures/example-observer/schema.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { ConvictSchema } = require('../../..');
+
+class Schema extends ConvictSchema {
+    build() {
+        return {
+            example: {
+                default: 'examples are quick and easy',
+                doc: 'A random example schema property',
+                format: 'String',
+            }
+        };
+    }
+}
+
+module.exports = Schema;

--- a/packages/job-components/test/fixtures/invalid-api-observer/api.js
+++ b/packages/job-components/test/fixtures/invalid-api-observer/api.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { OperationAPI } = require('../../../dist');
+
+class ExampleAPI extends OperationAPI {
+    async initialize() {
+        this.initialized = true;
+        return super.initialize();
+    }
+
+    async shutdown() {
+        this.shutdown = true;
+        return super.shutdown();
+    }
+}
+
+module.exports = ExampleAPI;

--- a/packages/job-components/test/fixtures/invalid-api-observer/observer.js
+++ b/packages/job-components/test/fixtures/invalid-api-observer/observer.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { Observer } = require('../../../dist');
+
+class ExampleObserver extends Observer {
+    async initialize() {
+        this.initialized = true;
+        return super.initialize();
+    }
+
+    async shutdown() {
+        this.shutdown = true;
+        return super.shutdown();
+    }
+}
+
+module.exports = ExampleObserver;

--- a/packages/job-components/test/fixtures/invalid-api-observer/schema.js
+++ b/packages/job-components/test/fixtures/invalid-api-observer/schema.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { ConvictSchema } = require('../../..');
+
+class Schema extends ConvictSchema {
+    build() {
+        return {
+            example: {
+                default: 'examples are quick and easy',
+                doc: 'A random example schema property',
+                format: 'String',
+            }
+        };
+    }
+}
+
+module.exports = Schema;

--- a/packages/job-components/test/job-validator-spec.ts
+++ b/packages/job-components/test/job-validator-spec.ts
@@ -4,15 +4,23 @@ import { JobValidator, TestContext, JobConfig } from '../src';
 
 describe('JobValidator', () => {
     const context = new TestContext('teraslice-operations');
+    context.sysconfig.teraslice.assets_directory = __dirname;
+
     const terasliceOpPath = path.join(__dirname, '../../teraslice/lib');
     const api = new JobValidator(context, {
         terasliceOpPath,
     });
 
-    describe('->validate', () => {
+    describe('->validateConfig', () => {
         it('returns a completed and valid jobConfig', () => {
             const jobSpec: JobConfig = {
                 name: 'noop',
+                assets: ['fixtures'],
+                apis: [
+                    {
+                        _name: 'example-api'
+                    }
+                ],
                 operations: [
                     {
                         _op: 'test-reader',
@@ -35,114 +43,6 @@ describe('JobValidator', () => {
                 name: 'test',
                 // @ts-ignore
                 operations: [
-                    {
-                        something: 'else',
-                    },
-                    {
-                        _op: 'noop',
-                    },
-                ],
-            };
-
-            expect(() => {
-                api.validateConfig(jobSpec);
-            }).toThrowError();
-        });
-
-        it('will properly read an operation', () => {
-            const jobSpec: JobConfig = {
-                name: 'test',
-                operations: [
-                    {
-                        _op: 'elasticsearch_reader',
-                    // @ts-ignore
-                        date_field_name: 'created',
-                        index: 'some_index',
-                    },
-                    {
-                        _op: 'noop',
-                    },
-                ],
-            };
-
-            expect(() => {
-                api.validateConfig(jobSpec);
-            }).not.toThrowError();
-        });
-
-        it('will throw based off opValition errors', () => {
-            // if subslice_by_key, then it needs type specified or it will error
-            const jobSpec: JobConfig = {
-                name: 'test',
-                operations: [
-                    {
-                        _op: 'elasticsearch_reader',
-                    // @ts-ignore
-                        date_field_name: 'created',
-                        index: 'some_index',
-                        subslice_by_key: true,
-                    },
-                    {
-                        _op: 'noop',
-                    },
-                ],
-            };
-
-            expect(() => {
-                api.validateConfig(jobSpec);
-            }).toThrowError();
-        });
-
-        it('will throw based off crossValidation errors', () => {
-            // if persistent, then interval cannot be auto
-            const jobSpec: JobConfig = {
-                lifecycle: 'persistent',
-                operations: [
-                    {
-                        _op: 'elasticsearch_reader',
-                        date_field_name: 'created',
-                        index: 'some_index',
-                        interval: 'auto',
-                        subslice_by_key: true,
-                    },
-                    {
-                        _op: 'noop',
-                    },
-                ],
-            };
-
-            expect(() => {
-                api.validateConfig(jobSpec);
-            }).toThrowError();
-        });
-    });
-
-    describe('->validateConfig', () => {
-        it('returns a completed and valid jobConfig', () => {
-            const jobSpec: JobConfig = {
-                name: 'noop',
-                operations: [
-                    {
-                        _op: 'test-reader',
-                    },
-                    {
-                        _op: 'noop',
-                    },
-                ],
-            };
-
-            const validJob = api.validateConfig(jobSpec);
-            expect(validJob.max_retries).toBeDefined();
-            expect(validJob.lifecycle).toBeDefined();
-            expect(validJob.operations).toBeDefined();
-            expect(validJob.assets).toBeDefined();
-        });
-
-        it('throws an error with faulty operation configuration', () => {
-            const jobSpec: JobConfig = {
-                name: 'test',
-                operations: [
-                    // @ts-ignore
                     {
                         something: 'else',
                     },

--- a/packages/job-components/test/job-validator-spec.ts
+++ b/packages/job-components/test/job-validator-spec.ts
@@ -23,7 +23,7 @@ describe('JobValidator', () => {
                 ],
             };
 
-            const validJob = api.validate(jobSpec);
+            const validJob = api.validateConfig(jobSpec);
             expect(validJob.max_retries).toBeDefined();
             expect(validJob.lifecycle).toBeDefined();
             expect(validJob.operations).toBeDefined();
@@ -33,8 +33,8 @@ describe('JobValidator', () => {
         it('throws an error with faulty operation configuration', () => {
             const jobSpec: JobConfig = {
                 name: 'test',
+                // @ts-ignore
                 operations: [
-                    // @ts-ignore
                     {
                         something: 'else',
                     },
@@ -45,7 +45,7 @@ describe('JobValidator', () => {
             };
 
             expect(() => {
-                api.validate(jobSpec);
+                api.validateConfig(jobSpec);
             }).toThrowError();
         });
 
@@ -66,12 +66,12 @@ describe('JobValidator', () => {
             };
 
             expect(() => {
-                api.validate(jobSpec);
+                api.validateConfig(jobSpec);
             }).not.toThrowError();
         });
 
         it('will throw based off opValition errors', () => {
-        // if subslice_by_key, then it needs type specified or it will error
+            // if subslice_by_key, then it needs type specified or it will error
             const jobSpec: JobConfig = {
                 name: 'test',
                 operations: [
@@ -89,13 +89,13 @@ describe('JobValidator', () => {
             };
 
             expect(() => {
-                api.validate(jobSpec);
+                api.validateConfig(jobSpec);
             }).toThrowError();
         });
 
         it('will throw based off crossValidation errors', () => {
             // if persistent, then interval cannot be auto
-            const jobSpec = {
+            const jobSpec: JobConfig = {
                 lifecycle: 'persistent',
                 operations: [
                     {
@@ -112,7 +112,7 @@ describe('JobValidator', () => {
             };
 
             expect(() => {
-                api.validate(jobSpec);
+                api.validateConfig(jobSpec);
             }).toThrowError();
         });
     });

--- a/packages/job-components/test/operation-loader-spec.ts
+++ b/packages/job-components/test/operation-loader-spec.ts
@@ -25,7 +25,7 @@ describe('OperationLoader', () => {
         await fse.copy(processorPath, path.join(assetPath, 'example-filter-op'));
     });
 
-    it('can instantiate', () => {
+    it('should instantiate', () => {
         const opLoader = new OperationLoader({
             terasliceOpPath,
         });
@@ -35,7 +35,7 @@ describe('OperationLoader', () => {
         expect(opLoader.load).toBeFunction();
     });
 
-    it('can load an operation', async () => {
+    it('should load an operation', async () => {
         const opLoader = new OperationLoader({
             terasliceOpPath,
         });
@@ -63,7 +63,7 @@ describe('OperationLoader', () => {
         expect(processorResults).toEqual(someData);
     });
 
-    it('can load by file path', () => {
+    it('should load by file path', () => {
         const opLoader = new OperationLoader({
             terasliceOpPath,
         });
@@ -86,7 +86,7 @@ describe('OperationLoader', () => {
         expect(reader.schema).toBeFunction();
     });
 
-    it('can throw proper errors if op code does not exits', () => {
+    it('should throw proper errors if op code does not exits', () => {
         const opLoader = new OperationLoader({
             terasliceOpPath,
         });
@@ -96,7 +96,7 @@ describe('OperationLoader', () => {
         }).toThrowError();
     });
 
-    it('can load asset ops', async () => {
+    it('should load asset ops', async () => {
         const opLoader = new OperationLoader({
             terasliceOpPath,
             assetPath: tmpDir,
@@ -126,7 +126,7 @@ describe('OperationLoader', () => {
         expect(processorResults).toEqual([]);
     });
 
-    it('can load the new processor', async () => {
+    it('should load the new processor', () => {
         const exConfig = newTestExecutionConfig();
         const opConfig = {
             _op: 'example-op'
@@ -161,7 +161,7 @@ describe('OperationLoader', () => {
         expect(op.API).toBeNil();
     });
 
-    it('can load a shimmed processor', async () => {
+    it('should load a shimmed processor', () => {
         const exConfig = newTestExecutionConfig();
         const opConfig = {
             _op: 'example-op'
@@ -192,7 +192,7 @@ describe('OperationLoader', () => {
         expect(op.API).toBeNil();
     });
 
-    it('can load the new reader', async () => {
+    it('should load the new reader', () => {
         const exConfig = newTestExecutionConfig();
         const opConfig = {
             _op: 'example-reader'
@@ -233,7 +233,7 @@ describe('OperationLoader', () => {
         }).not.toThrow();
     });
 
-    it('can load a shimmed reader', async () => {
+    it('should load a shimmed reader', () => {
         const exConfig = newTestExecutionConfig();
         const opConfig = {
             _op: 'test-reader'
@@ -266,13 +266,8 @@ describe('OperationLoader', () => {
         expect(op.API).toBeNil();
     });
 
-    it('can load an api', async () => {
+    it('should load an api', () => {
         const exConfig = newTestExecutionConfig();
-        const opConfig = {
-            _op: 'test-reader'
-        };
-
-        exConfig.operations.push(opConfig);
 
         const opLoader = new OperationLoader({
             terasliceOpPath,
@@ -290,14 +285,8 @@ describe('OperationLoader', () => {
         }).not.toThrow();
     });
 
-    it('can load an observer', async () => {
+    it('should load an observer', () => {
         const exConfig = newTestExecutionConfig();
-        const opConfig = {
-            _op: 'test-reader'
-        };
-
-        exConfig.operations.push(opConfig);
-
         const opLoader = new OperationLoader({
             terasliceOpPath,
             assetPath: path.join(__dirname),
@@ -307,10 +296,36 @@ describe('OperationLoader', () => {
             'fixtures'
         ]);
 
-        expect(op.Observer).not.toBeNil();
+        expect(op.API).not.toBeNil();
         expect(() => {
             // @ts-ignore
-            new op.Observer(context, { _name: 'example-observer' }, exConfig);
+            new op.API(context, { _name: 'example-observer' }, exConfig);
         }).not.toThrow();
+    });
+
+    it('should fail if given an api without the required files', () => {
+        const opLoader = new OperationLoader({
+            terasliceOpPath,
+            assetPath: path.join(__dirname),
+        });
+
+        expect(() => {
+            opLoader.loadAPI('empty-api', [
+                'fixtures'
+            ]);
+        }).toThrowError(/requires at least an api\.js or observer\.js/);
+    });
+
+    it('should fail if given an api with both an observer and api', () => {
+        const opLoader = new OperationLoader({
+            terasliceOpPath,
+            assetPath: path.join(__dirname),
+        });
+
+        expect(() => {
+            opLoader.loadAPI('invalid-api-observer', [
+                'fixtures'
+            ]);
+        }).toThrowError(/required only one api\.js or observer\.js/);
     });
 });

--- a/packages/job-components/test/operation-loader-spec.ts
+++ b/packages/job-components/test/operation-loader-spec.ts
@@ -285,6 +285,25 @@ describe('OperationLoader', () => {
         }).not.toThrow();
     });
 
+    it('should load an api with a namespace', () => {
+        const exConfig = newTestExecutionConfig();
+
+        const opLoader = new OperationLoader({
+            terasliceOpPath,
+            assetPath: path.join(__dirname),
+        });
+
+        const op = opLoader.loadAPI('example-api:hello', [
+            'fixtures'
+        ]);
+
+        expect(op.API).not.toBeNil();
+        expect(() => {
+            // @ts-ignore
+            new op.API(context as WorkerContext, { _name: 'example-api' }, exConfig);
+        }).not.toThrow();
+    });
+
     it('should load an observer', () => {
         const exConfig = newTestExecutionConfig();
         const opLoader = new OperationLoader({

--- a/packages/job-components/test/operation-loader-spec.ts
+++ b/packages/job-components/test/operation-loader-spec.ts
@@ -229,7 +229,7 @@ describe('OperationLoader', () => {
         expect(op.API).not.toBeNil();
         expect(() => {
             // @ts-ignore
-            new op.API(context, exConfig);
+            new op.API(context, { _name: 'test' }, exConfig);
         }).not.toThrow();
     });
 
@@ -279,11 +279,14 @@ describe('OperationLoader', () => {
             assetPath: path.join(__dirname),
         });
 
-        const op = opLoader.loadAPI('example-api', ['fixtures']);
+        const op = opLoader.loadAPI('example-api', [
+            'fixtures'
+        ]);
 
         expect(op.API).not.toBeNil();
         expect(() => {
-            new op.API(context as WorkerContext, exConfig);
+            // @ts-ignore
+            new op.API(context as WorkerContext, { _name: 'example-api' }, exConfig);
         }).not.toThrow();
     });
 
@@ -300,11 +303,14 @@ describe('OperationLoader', () => {
             assetPath: path.join(__dirname),
         });
 
-        const op = opLoader.loadObserver('example-observer', ['fixtures']);
+        const op = opLoader.loadAPI('example-observer', [
+            'fixtures'
+        ]);
 
         expect(op.Observer).not.toBeNil();
         expect(() => {
-            new op.Observer(context as WorkerContext, exConfig);
+            // @ts-ignore
+            new op.Observer(context, { _name: 'example-observer' }, exConfig);
         }).not.toThrow();
     });
 });

--- a/packages/job-components/test/operations/convict-schema-spec.ts
+++ b/packages/job-components/test/operations/convict-schema-spec.ts
@@ -41,6 +41,7 @@ describe('Convict Schema', () => {
             })).toEqual({
                 _op: 'hello',
                 _encoding: 'json',
+                _dead_letter_action: 'none',
                 example: 'hi',
             });
         });

--- a/packages/job-components/test/operations/core/api-core-spec.ts
+++ b/packages/job-components/test/operations/core/api-core-spec.ts
@@ -8,9 +8,9 @@ describe('APICore', () => {
     let api: ExampleAPI;
 
     beforeAll(() => {
-        const context = new TestContext('teraslice-operations');
+        const context = new TestContext('teraslice-operations') as WorkerContext;
         const exConfig = newTestExecutionConfig();
-        api = new ExampleAPI(context as WorkerContext, exConfig);
+        api = new ExampleAPI(context, { _name: 'example' }, exConfig);
     });
 
     describe('->initialize', () => {

--- a/packages/job-components/test/operations/core/operation-core-spec.ts
+++ b/packages/job-components/test/operations/core/operation-core-spec.ts
@@ -170,9 +170,11 @@ describe('OperationCore', () => {
 
         describe('when the fn fails', () => {
             it('should call operation.rejectRecord', () => {
-                const result = operation.tryRecord(record, () => {
+                const fn = operation.tryRecord(() => {
                     throw err;
                 });
+
+                const result = fn(record);
                 expect(operation.rejectRecord).toHaveBeenCalledWith(record, err);
                 expect(result).toBeNull();
             });
@@ -180,9 +182,11 @@ describe('OperationCore', () => {
 
         describe('when the fn succceds', () => {
             it('should not call operation.rejectRecord', () => {
-                const result = operation.tryRecord(record, () => {
+                const fn = operation.tryRecord(() => {
                     return { hello: true };
                 });
+
+                const result = fn(record);
                 expect(operation.rejectRecord).not.toHaveBeenCalled();
                 expect(result).toEqual({ hello: true });
             });

--- a/packages/job-components/test/operations/job-observer-spec.ts
+++ b/packages/job-components/test/operations/job-observer-spec.ts
@@ -5,7 +5,7 @@ import { TestContext, newTestExecutionConfig, WorkerContext, JobObserver, SliceA
 describe('JobObserver', () => {
     let observer: JobObserver;
 
-    const context = new TestContext('teraslice-operations');
+    const context = new TestContext('teraslice-operations') as WorkerContext;
     const exConfig = newTestExecutionConfig();
     exConfig.operations = [
         {
@@ -27,7 +27,7 @@ describe('JobObserver', () => {
         beforeAll(() => {
             exConfig.analytics = true;
 
-            observer = new JobObserver(context as WorkerContext, exConfig);
+            observer = new JobObserver(context, { _name: 'example' }, exConfig);
             return observer.initialize();
         });
 
@@ -66,7 +66,7 @@ describe('JobObserver', () => {
         beforeAll(() => {
             exConfig.analytics = false;
 
-            observer = new JobObserver(context as WorkerContext, exConfig);
+            observer = new JobObserver(context, { _name: 'job-observer' }, exConfig);
             return observer.initialize();
         });
 

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
-    "version": "1.4.5",
+    "version": "1.5.0",
     "publishConfig": {
         "access": "public"
     },
@@ -23,7 +23,7 @@
         "url": "https://github.com/terascope/teraslice/issues"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.13.1",
+        "@terascope/job-components": "^0.14.0",
         "bluebird": "^3.5.3",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-test-harness",
-    "version": "0.4.1",
+    "version": "0.5.0",
     "publishConfig": {
         "access": "public"
     },
@@ -36,8 +36,8 @@
         "test:debug": "env DEBUG='*teraslice*' jest --detectOpenHandles --coverage=false --runInBand"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.13.1",
-        "@terascope/teraslice-op-test-harness": "^1.4.5",
+        "@terascope/job-components": "^0.14.0",
+        "@terascope/teraslice-op-test-harness": "^1.5.0",
         "@types/lodash": "^4.14.119",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-test-harness/src/job-test-harness.ts
+++ b/packages/teraslice-test-harness/src/job-test-harness.ts
@@ -41,6 +41,10 @@ export default class JobTestHarness {
         return this.workerHarness.processors;
     }
 
+    get apis() {
+        return this.workerHarness.apis;
+    }
+
     /**
      * Set the Terafoundation Clients on both
      * the Slicer and Worker contexts

--- a/packages/teraslice-test-harness/src/worker-test-harness.ts
+++ b/packages/teraslice-test-harness/src/worker-test-harness.ts
@@ -33,6 +33,10 @@ export default class WorkerTestHarness extends BaseTestHarness<WorkerExecutionCo
         return this.executionContext.processors;
     }
 
+    get apis() {
+        return this.executionContext.apis;
+    }
+
     getOperation<T extends OperationCore = OperationCore>(findBy: string|number): T {
         return this.executionContext.getOperation<T>(findBy);
     }

--- a/packages/teraslice-test-harness/test/example-asset-spec.ts
+++ b/packages/teraslice-test-harness/test/example-asset-spec.ts
@@ -8,7 +8,7 @@ import {
     SlicerTestHarness,
     WorkerTestHarness,
 } from '../src';
-import Transformer from './fixtures/asset/transformer/processor';
+import { SimpleAPI } from './fixtures/asset/simple-api/interfaces';
 
 jest.mock('./fixtures/asset/simple-connector/client');
 
@@ -100,9 +100,11 @@ describe('Example Asset', () => {
         });
 
         it('should have use the simple api', async () => {
-            expect(harness.apis).toBeArrayOfSize(1);
-            const transformer: Transformer = harness.getOperation('transformer');
-            const api = transformer.simpleAPI();
+            expect(Object.keys(harness.apis)).toEqual([
+                'simple-api'
+            ]);
+
+            const api = harness.apis['simple-api'].opAPI as SimpleAPI;
 
             expect(api).toHaveProperty('count', 0);
         });
@@ -220,7 +222,9 @@ describe('Example Asset', () => {
         });
 
         it('should have one api', async () => {
-            expect(harness.apis).toBeArrayOfSize(1);
+            expect(Object.keys(harness.apis)).toEqual([
+                'simple-api'
+            ]);
         });
 
         it('should be finished for the second batch of slices', async () => {

--- a/packages/teraslice-test-harness/test/example-asset-spec.ts
+++ b/packages/teraslice-test-harness/test/example-asset-spec.ts
@@ -8,6 +8,7 @@ import {
     SlicerTestHarness,
     WorkerTestHarness,
 } from '../src';
+import Transformer from './fixtures/asset/transformer/processor';
 
 jest.mock('./fixtures/asset/simple-connector/client');
 
@@ -31,6 +32,11 @@ describe('Example Asset', () => {
     describe('using the WorkerTestHarness', () => {
         const job = newTestJobConfig();
         job.analytics = true;
+        job.apis = [
+            {
+                _name: 'simple-api',
+            }
+        ];
         job.operations = [
             {
                 _op: 'simple-reader'
@@ -92,6 +98,14 @@ describe('Example Asset', () => {
                 });
             }
         });
+
+        it('should have use the simple api', async () => {
+            expect(harness.apis).toBeArrayOfSize(1);
+            const transformer: Transformer = harness.getOperation('transformer');
+            const api = transformer.simpleAPI();
+
+            expect(api).toHaveProperty('count', 0);
+        });
     });
 
     describe('using the SlicerTestHarness', () => {
@@ -146,6 +160,11 @@ describe('Example Asset', () => {
     describe('using the JobTestHarness', () => {
         const job = newTestJobConfig();
         job.analytics = true;
+        job.apis = [
+            {
+                _name: 'simple-api',
+            }
+        ];
         job.operations = [
             {
                 _op: 'simple-reader'
@@ -198,6 +217,10 @@ describe('Example Asset', () => {
                     expect(result.scale).toBe(6);
                 }
             }
+        });
+
+        it('should have one api', async () => {
+            expect(harness.apis).toBeArrayOfSize(1);
         });
 
         it('should be finished for the second batch of slices', async () => {

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-api/api.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-api/api.ts
@@ -1,0 +1,16 @@
+import { OperationAPI } from '@terascope/job-components';
+import { SimpleAPIConfig, SimpleAPI } from './interfaces';
+
+export default class SimpleOperationAPI extends OperationAPI<SimpleAPIConfig> {
+    async createAPI() {
+        return {
+            count: 0,
+            add(n: number = 1) {
+                this.count += n;
+            },
+            sub(n: number = 1) {
+                this.count += n;
+            },
+        } as SimpleAPI;
+    }
+}

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-api/interfaces.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-api/interfaces.ts
@@ -1,0 +1,9 @@
+export interface SimpleAPIConfig {
+
+}
+
+export interface SimpleAPI {
+    count: number;
+    add(n?: number): void;
+    sub(n?: number): void;
+}

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-api/schema.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-api/schema.ts
@@ -1,0 +1,8 @@
+import { SimpleAPIConfig } from './interfaces';
+import { ConvictSchema } from '@terascope/job-components';
+
+export default class Schema extends ConvictSchema<SimpleAPIConfig> {
+    build() {
+        return {};
+    }
+}

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-reader/fetcher.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-reader/fetcher.ts
@@ -2,6 +2,7 @@ import { SimpleReaderConfig } from './interfaces';
 import times from 'lodash/times';
 import { Fetcher, SliceRequest } from '@terascope/job-components';
 import SimpleClient from '../simple-connector/client';
+import { SimpleAPI } from '../simple-api/interfaces';
 
 export default class TestFetcher extends Fetcher<SimpleReaderConfig> {
     client: SimpleClient;
@@ -15,7 +16,9 @@ export default class TestFetcher extends Fetcher<SimpleReaderConfig> {
     }
 
     async fetch(request: SliceRequest) {
+        const api = this.getAPI('simple-api') as SimpleAPI;
         return times(request.count, (id) => {
+            api.add(2);
             return this.client.fetchRecord(id);
         });
     }

--- a/packages/teraslice-test-harness/test/fixtures/asset/transformer/processor.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/transformer/processor.ts
@@ -1,8 +1,13 @@
+import { SimpleAPI } from '../simple-api/interfaces';
 import { MapProcessor, DataEntity } from '@terascope/job-components';
 import { TransformerConfig } from './interfaces';
 
 export default class Transformer extends MapProcessor<TransformerConfig> {
     map(data: DataEntity) {
+        const api = this.simpleAPI();
+        if (api != null) {
+            api.sub();
+        }
         const { action, key } = this.opConfig;
         if (action === 'set') {
             const { setValue } = this.opConfig;
@@ -18,5 +23,13 @@ export default class Transformer extends MapProcessor<TransformerConfig> {
             }
         }
         return data;
+    }
+
+    simpleAPI() {
+        try {
+            return this.getAPI('simple-api') as SimpleAPI;
+        } catch (err) {
+            return null;
+        }
     }
 }

--- a/packages/teraslice/lib/workers/worker/slice.js
+++ b/packages/teraslice/lib/workers/worker/slice.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Promise = require('bluebird');
 const retry = require('bluebird-retry');
 const get = require('lodash/get');
 const toString = require('lodash/toString');
@@ -119,33 +118,40 @@ class Slice {
         this.events.emit('slice:failure', slice);
         await this.executionContext.onSliceFailed(slice.slice_id);
 
+        if (err instanceof retry.StopError) {
+            const stopError = new Error(err.message);
+            throw stopError;
+        }
+
         const sliceError = new Error(prependErrorMsg('Slice failed processing', err, true));
         sliceError.alreadyLogged = true;
-        return Promise.reject(sliceError);
+        throw sliceError;
     }
 
-    _runOnce(shouldRetry) {
+    async _runOnce(shouldRetry) {
         if (this._isShutdown) {
             throw new retry.StopError('Slice shutdown during slice execution');
         }
 
-        const { slice } = this;
+        try {
+            const result = await this.executionContext.runSlice(this.slice);
+            return result;
+        } catch (err) {
+            this.logger.error(`An error has occurred: ${toString(err)}, slice:`, this.slice);
 
-        return this.executionContext.runSlice(slice)
-            .catch((err) => {
-                this.logger.error(`An error has occurred: ${toString(err)}, slice:`, slice);
-
-                if (!shouldRetry) {
-                    return Promise.reject(err);
-                }
-
+            if (shouldRetry) {
                 // for backwards compatibility
-                this.events.emit('slice:retry', slice);
-                return this.executionContext
-                    .onSliceRetry(this.slice.slice_id)
-                    .then(() => Promise.reject(err))
-                    .catch(() => Promise.reject(err));
-            });
+                this.events.emit('slice:retry', this.slice);
+
+                try {
+                    await this.executionContext.onSliceRetry(this.slice.slice_id);
+                } catch (retryErr) {
+                    throw new retry.StopError(`Slice failed to retry: ${toString(retryErr)}, caused by: ${toString(err)}`);
+                }
+            }
+
+            throw err;
+        }
     }
 }
 

--- a/packages/teraslice/lib/workers/worker/slice.js
+++ b/packages/teraslice/lib/workers/worker/slice.js
@@ -140,10 +140,10 @@ class Slice {
             this.logger.error(`An error has occurred: ${toString(err)}, slice:`, this.slice);
 
             if (shouldRetry) {
-                // for backwards compatibility
-                this.events.emit('slice:retry', this.slice);
-
                 try {
+                    // for backwards compatibility
+                    this.events.emit('slice:retry', this.slice);
+
                     await this.executionContext.onSliceRetry(this.slice.slice_id);
                 } catch (retryErr) {
                     throw new retry.StopError(`Slice failed to retry: ${toString(retryErr)}, caused by: ${toString(err)}`);

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.44.4",
+    "version": "0.45.0",
     "description": "Slice and dice your Elasticsearch data",
     "bin": "service.js",
     "main": "index.js",
@@ -36,7 +36,7 @@
     "dependencies": {
         "@terascope/elasticsearch-api": "^1.1.3",
         "@terascope/error-parser": "^1.0.1",
-        "@terascope/job-components": "^0.13.1",
+        "@terascope/job-components": "^0.14.0",
         "@terascope/queue": "^1.1.4",
         "@terascope/teraslice-messaging": "^0.2.5",
         "async-mutex": "^0.1.3",
@@ -66,7 +66,7 @@
         "yargs": "^12.0.2"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.4.5",
+        "@terascope/teraslice-op-test-harness": "^1.5.0",
         "archiver": "^3.0.0",
         "bufferstreams": "^2.0.1",
         "chance": "^1.0.18",

--- a/packages/teraslice/test/workers/fixtures/ops/new-op/processor.js
+++ b/packages/teraslice/test/workers/fixtures/ops/new-op/processor.js
@@ -1,10 +1,11 @@
 'use strict';
 
-const { MapProcessor } = require('@terascope/job-components');
+const { BatchProcessor } = require('@terascope/job-components');
 
-class ExampleMap extends MapProcessor {
+class ExampleBatch extends BatchProcessor {
     async initialize() {
         this.initialized = true;
+        this.logger.debug('example map initalized', this.opConfig);
         return super.initialize();
     }
 
@@ -13,10 +14,22 @@ class ExampleMap extends MapProcessor {
         return super.shutdown();
     }
 
-    map(data) {
-        data.touchedAt = new Date().toISOString();
-        return data;
+    async onBatch(batch) {
+        if (this.opConfig.failOnSliceRetry) {
+            throw new Error('Fail slices');
+        }
+
+        return batch.map((data) => {
+            data.touchedAt = new Date().toISOString();
+            return data;
+        });
+    }
+
+    onSliceRetry() {
+        if (this.opConfig.failOnSliceRetry) {
+            throw new Error('I will not allow it');
+        }
     }
 }
 
-module.exports = ExampleMap;
+module.exports = ExampleBatch;

--- a/packages/teraslice/test/workers/fixtures/ops/new-op/schema.js
+++ b/packages/teraslice/test/workers/fixtures/ops/new-op/schema.js
@@ -9,6 +9,11 @@ class Schema extends ConvictSchema {
                 default: 'examples are quick and easy',
                 doc: 'A random example schema property',
                 format: 'String',
+            },
+            failOnSliceRetry: {
+                default: false,
+                doc: 'fail on slice retry',
+                format: Boolean,
             }
         };
     }

--- a/packages/teraslice/test/workers/helpers/configs.js
+++ b/packages/teraslice/test/workers/helpers/configs.js
@@ -32,7 +32,11 @@ const newConfig = (options = {}) => {
                 }),
                 pickBy({
                     _op: path.join(opsPath, 'new-op'),
-                })
+                    failOnSliceRetry: options.failOnSliceRetry || false,
+                }),
+                {
+                    _op: 'noop'
+                }
             ];
         } else {
             operations = [

--- a/packages/teraslice/test/workers/worker/slice-spec.js
+++ b/packages/teraslice/test/workers/worker/slice-spec.js
@@ -163,6 +163,54 @@ describe('Slice', () => {
             });
         });
 
+        describe('when the slice fails to retry', () => {
+            let slice;
+            let err;
+            let testContext;
+            const eventMocks = {};
+
+            beforeEach(async () => {
+                testContext = new TestContext({
+                    maxRetries: 3,
+                    analytics: false,
+                    newOps: true,
+                    failOnSliceRetry: true
+                });
+
+                slice = await setupSlice(testContext, eventMocks);
+
+                try {
+                    await slice.run();
+                } catch (_err) {
+                    err = _err;
+                }
+            });
+
+            afterEach(async () => {
+                await testContext.cleanup();
+            });
+
+            it('should handle the slice correctly', () => {
+                // should have reject with the error
+                expect(err).toBeDefined();
+                expect(err.toString()).toStartWith('Error: Slice failed to retry: Error: I will not allow it, caused by');
+
+                // should emit the events
+                expect(eventMocks['slice:retry']).toHaveBeenCalledTimes(1);
+                expect(eventMocks['slice:retry']).toHaveBeenCalledWith(slice.slice);
+                expect(eventMocks['slice:failure']).toHaveBeenCalledTimes(1);
+                expect(eventMocks['slice:failure']).toHaveBeenCalledWith(slice.slice);
+                expect(eventMocks['slice:success']).not.toHaveBeenCalled();
+                expect(eventMocks['slice:finalize']).toHaveBeenCalledTimes(1);
+                expect(eventMocks['slice:finalize']).toHaveBeenCalledWith(slice.slice);
+
+                // should have the correct state storage
+                const { exId } = slice.executionContext;
+                const query = `ex_id:${exId} AND state:error`;
+                return expect(slice.stateStore.count(query, 0)).resolves.toEqual(1);
+            });
+        });
+
         describe('when the slice fails', () => {
             let slice;
             let testContext;


### PR DESCRIPTION
This PR adds support for a basic Dead Letter Queue API and when a `onSliceRetry` event fails, the processor can throw an error to stop the retry from happening.

This action will specify what to do when failing to parse or transform a record. ​​​
​​​​​The following built-in actions are supported: ​​​
​​​​​  - "throw": throw the original error ​​​​​
​​​​​  - "log": log the error and the data ​​​​​
​​​​​  - "none": (default) skip the error entirely

​​​​​If none of the actions are specified it will try and use a registered Dead Letter Queue API under that name. The API must be already be created by an operation before it can used.​

Using the dead letter queue:

Option 1:

```ts
class CustomProcessor extends BatchProcessor {
    async onBatch(batch: DataEntity[]) {
        return batch.map((data) => {
            try {
                // do transformation here
            } catch(err) {
                this.rejectRecord(data, err);
            }
        })
    }
}
```

Option 2:

```ts
class CustomProcessor extends BatchProcessor {
    async onBatch(batch: DataEntity[]) {
        return batch.map(this._tryRecord(() => {
            // do transformation here
        }));
    }
}
```

To create and use a custom Dead Letter Queue API:

```js
{
    "name": "Example Job",
    "operations": [
        {
            "_op": "example",
            "_dead_letter_action": "example",
            "_encoding": "json"
        },
        {
            "_op": "noop"
        }
    ]
}
```

```ts
class ExampleDeadLetterAPI extends OperationAPI {
    async createAPI() {
        return (record: any, err: Error) => {
            // handle storing the record for later usage
        };
    }
}
```

```ts
class ExampleFetcher extends Fetcher {
    async initialize() {
        await this.createAPI('example', { ...config });
        return super.initialize();
    }

    fetch() {
        return [
            'hello'
        ].map(this._tryRecord((data) => DataEntity.fromBuffer(data, this.opConfig)))
    }
}
```

Resolves: #904
Resolves: #902 
Resolves: #450 
