### PR TITLE
Use kafka 2.0 asset bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM terascope/teraslice-base:v0.1.3
+FROM terascope/teraslice-base:v0.2.0
 
 RUN mkdir -p /app/source/packages/teraslice \
     && mkdir -p /app/source/packages/teraslice-messaging \

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -17,7 +17,6 @@ RUN yarn global add \
 COPY package.json yarn.lock /app/
 
 RUN export WITH_SASL=0 && yarn \
-    --silent \
     --no-progress \
     --no-emoji \
     --no-cache

--- a/docker-base/README.md
+++ b/docker-base/README.md
@@ -3,7 +3,7 @@
 This is used to speed up builds in CI and the e2e tests. It includes the following modules:
 
 - bunyan
-- terascope/terafoundation_kafka_connector
+- terafoundation_kafka_connector
 - terascope/teraslice_kafka_reader
 - terascope/teraslice_kafka_sender
 
@@ -11,13 +11,13 @@ For a list available tags, see: [hub.docker.com/r/terascope/teraslice-base/tags]
 
 ## Making changes
 
-Once you make changes to the Dockerfile, you have to manually publish it. I have created a script to make it easier.
+Once you make changes to the Dockerfile, you have to manually publish it. I have created a script to make it easier. Before building and pushing, change the version in this directories package.json.
 
 **IMPORTANT** Make sure you are logged in to docker hub with permission to push to `terascope/teraslice-base`, i.e. `docker login`
 
 ```sh
 cd ./docker-base
-./build-and-push.sh v[NEW_TAG]
+./build-and-push.sh
 ```
 
 Make sure to update the tereslice Dockerfile in the root of this repo with the new tag.

--- a/docker-base/build-and-push.sh
+++ b/docker-base/build-and-push.sh
@@ -2,15 +2,28 @@
 
 set -e
 
-main() {
-    local tag="$1"
-    if [ -z "$tag" ]; then
-        echo "build-and-push.sh requires a tag as the first arg"
-        exit 1;
-    fi
+build_and_push() {
+    local slug="$1"
+    echo "* building $slug..."
+    docker build --pull --no-cache -t "$slug" .
 
-    docker build -t "terascope/teraslice-base:$tag" .
-    docker push "terascope/teraslice-base:$tag"
+    echo "* pushing $slug..."
+    docker push "$slug"
+}
+
+main() {
+    local tag slug yn
+    tag="$(jq -r '.version' ./package.json)"
+    slug="terascope/teraslice-base:v$tag"
+
+    while true; do
+        read -p "Do you want to build and push \"$slug\"? " -r yn
+        case $yn in
+            [Yy]* ) build_and_push "$slug"; break;;
+            [Nn]* ) echo; echo "OK: Bump the package.json version in this directory"; exit;;
+            * ) echo "Please answer yes or no.";;
+        esac
+    done
 }
 
 main "$@"

--- a/docker-base/package.json
+++ b/docker-base/package.json
@@ -1,10 +1,8 @@
 {
-  "name": "teraslice-docker-base",
-  "version": "0.2.0",
-  "license": "MIT",
-  "dependencies": {
-    "terafoundation_kafka_connector": "^0.3.0",
-    "teraslice_kafka_reader": "terascope/teraslice_kafka_reader",
-    "teraslice_kafka_sender": "terascope/teraslice_kafka_sender"
-  }
+    "name": "teraslice-docker-base",
+    "version": "0.2.0",
+    "license": "MIT",
+    "dependencies": {
+        "terafoundation_kafka_connector": "^0.3.0"
+    }
 }

--- a/docker-base/package.json
+++ b/docker-base/package.json
@@ -1,10 +1,9 @@
 {
   "name": "teraslice-docker-base",
-  "version": "1.0.0",
-  "main": "index.js",
+  "version": "0.2.0",
   "license": "MIT",
   "dependencies": {
-    "terafoundation_kafka_connector": "terascope/terafoundation_kafka_connector",
+    "terafoundation_kafka_connector": "^0.3.0",
     "teraslice_kafka_reader": "terascope/teraslice_kafka_reader",
     "teraslice_kafka_sender": "terascope/teraslice_kafka_sender"
   }

--- a/docker-base/yarn.lock
+++ b/docker-base/yarn.lock
@@ -2,35 +2,40 @@
 # yarn lockfile v1
 
 
-bindings@1.x:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
+bindings@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.1.tgz#21fc7c6d67c18516ec5aaa2815b145ff77b26ea5"
+  integrity sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==
 
 bluebird@^3.5.0:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
+  integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
 
 lodash@^4.17.4:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-nan@2.x:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+nan@^2.11.1:
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
+  integrity sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==
 
-node-rdkafka@^2.2.0:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.3.3.tgz#47536136359af2c101217317936796575486d5a7"
+node-rdkafka@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.5.1.tgz#69830c9ca814e5b553dba8bf0b4fd3db69c62e87"
+  integrity sha512-tC7LeyshdZEds+nx0RicLn9Cam0ahpGIDNY+QAD82K/UpD2rAMIM4K/Z8NUnlnvCaLukA7229agSMogG23XcTA==
   dependencies:
-    bindings "1.x"
-    nan "2.x"
+    bindings "^1.3.1"
+    nan "^2.11.1"
 
-terafoundation_kafka_connector@terascope/terafoundation_kafka_connector:
-  version "0.2.1"
-  resolved "https://codeload.github.com/terascope/terafoundation_kafka_connector/tar.gz/150f8abdcf35d48855ace6e146bb5f60015b3737"
+terafoundation_kafka_connector@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/terafoundation_kafka_connector/-/terafoundation_kafka_connector-0.3.0.tgz#3aa894d25ab43fde3bbdf61ce8a38d54eb15d256"
+  integrity sha512-46hIQrfF+tA4Pq7V8TS/85fwqN/CtP4i1/yBqrLFkRwhEh8ke7aVqBHCdJYbzbph8USzNfunvr0ozdpjo8J81Q==
   dependencies:
-    lodash "^4.17.4"
-    node-rdkafka "^2.2.0"
+    node-rdkafka "^2.5.1"
 
 teraslice_kafka_reader@terascope/teraslice_kafka_reader:
   version "0.1.0"

--- a/docker-base/yarn.lock
+++ b/docker-base/yarn.lock
@@ -7,16 +7,6 @@ bindings@^1.3.1:
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.1.tgz#21fc7c6d67c18516ec5aaa2815b145ff77b26ea5"
   integrity sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==
 
-bluebird@^3.5.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
-  integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
-
-lodash@^4.17.4:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
-
 nan@^2.11.1:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
@@ -36,16 +26,3 @@ terafoundation_kafka_connector@^0.3.0:
   integrity sha512-46hIQrfF+tA4Pq7V8TS/85fwqN/CtP4i1/yBqrLFkRwhEh8ke7aVqBHCdJYbzbph8USzNfunvr0ozdpjo8J81Q==
   dependencies:
     node-rdkafka "^2.5.1"
-
-teraslice_kafka_reader@terascope/teraslice_kafka_reader:
-  version "0.1.0"
-  resolved "https://codeload.github.com/terascope/teraslice_kafka_reader/tar.gz/690fbf0d6dca2aab5c3d4a7f8f5a8dab3c457602"
-  dependencies:
-    bluebird "^3.5.0"
-    lodash "^4.17.4"
-
-teraslice_kafka_sender@terascope/teraslice_kafka_sender:
-  version "0.0.1"
-  resolved "https://codeload.github.com/terascope/teraslice_kafka_sender/tar.gz/d57b64913e72004edcae4984c624801b49372e7c"
-  dependencies:
-    bluebird "^3.5.0"

--- a/e2e/test/download-assets.js
+++ b/e2e/test/download-assets.js
@@ -43,7 +43,7 @@ function hasNewerAsset(assets, assetName) {
 }
 
 function filterRelease(release) {
-    return !release.draft && !release.prerelease;
+    return !release.draft;
 }
 
 function filterAsset(asset) {

--- a/e2e/test/fixtures/jobs/kafka-reader.json
+++ b/e2e/test/fixtures/jobs/kafka-reader.json
@@ -7,7 +7,7 @@
     "max_retries": 0,
     "operations": [
         {
-            "_op": "teraslice_kafka_reader",
+            "_op": "kafka_reader",
             "connection": "default",
             "topic": "example-logs-1000",
             "group": "example-kafka-group",

--- a/e2e/test/fixtures/jobs/kafka-sender.json
+++ b/e2e/test/fixtures/jobs/kafka-sender.json
@@ -15,7 +15,7 @@
             "preserve_id": true
         },
         {
-            "_op": "teraslice_kafka_sender",
+            "_op": "kafka_sender",
             "connection": "default",
             "topic": "example-logs-1000",
             "size": 100,


### PR DESCRIPTION
Use the new Kafka 2.0.0 asset bundle and connector.

Removes kafka processors from base docker image