### PR TITLE
add missing tmp dependency

### DIFF
--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-cli",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "Teraslice command line interface",
     "bin": {
         "teraslice-cli": "./index.js",
@@ -43,6 +43,7 @@
         "syncprompt": "^2.0.0",
         "teraslice-client-js": "^0.7.0",
         "terminal-kit": "^1.26.10",
+        "tmp": "^0.0.33",
         "tty-table": "^2.6.14",
         "yargs": "^12.0.2"
     },


### PR DESCRIPTION
Our subpackage setup results in a weird scenario where if we add a dependency to `teraslice-cli` without adding it to `package.json` but its in the top level json it will never be noticed missing in development or in test.