### PR TITLE
Extraction defaults

### DIFF
--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-transforms",
-    "version": "0.14.0",
+    "version": "0.15.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "publishConfig": {
         "access": "public"

--- a/packages/ts-transforms/src/operations/lib/transforms/extraction.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/extraction.ts
@@ -4,6 +4,13 @@ import { DataEntity } from '@terascope/utils';
 import { OperationConfig } from '../../../interfaces';
 import TransformOpBase from './base';
 
+function isMutation(config: OperationConfig): boolean {
+    let bool = false;
+    if (config.post_process === 'extraction') bool = true;
+    if (config.mutate !== undefined) bool = config.mutate;
+    return bool;
+}
+
 export default class Extraction extends TransformOpBase {
     private isMutation: Boolean;
     private mutltiFieldParams: object;
@@ -11,7 +18,7 @@ export default class Extraction extends TransformOpBase {
 
     constructor(config: OperationConfig) {
         super(config);
-        this.isMutation = config.mutate === true;
+        this.isMutation = isMutation(config);
         const mutltiFieldParams = {};
         if (config.multivalue) {
             const targetSource = {};

--- a/packages/ts-transforms/test/fixtures/transformRules6.txt
+++ b/packages/ts-transforms/test/fixtures/transformRules6.txt
@@ -2,4 +2,4 @@
 {"selector": "hello:world", "source_field": "last", "target_field": "last_name"}
 {"selector": "hello:world", "post_process": "join", "fields": ["first_name", "last_name"], "delimiter": " ", "target_field": "full_name", "tag": "myId"}
 {"follow": "myId", "post_process": "selector", "selector": "full_name:\"Jane Doe\"", "tag": "second_id" }
-{"follow": "second_id", "post_process": "extraction", "target_field": "name"}
+{"follow": "second_id", "post_process": "extraction", "target_field": "transfered_name"}

--- a/packages/ts-transforms/test/operations/transforms/extraction-spec.ts
+++ b/packages/ts-transforms/test/operations/transforms/extraction-spec.ts
@@ -178,6 +178,35 @@ describe('transform operator', () => {
         });
     });
 
+    it('can mutate existing doc by default for post_processing', () => {
+        const opConfig = { post_process: 'extraction', source_field: 'someField', target_field: 'otherField' };
+        const test = new Extraction(opConfig);
+
+        const dataArray = DataEntity.makeArray([
+            { someField: '56.234,95.234' },
+            {},
+            { someField: 'data' },
+            { someField: { some: 'data' } },
+            { someField: false },
+            { someField: 'other' },
+            { otherField: 'data' }
+        ]);
+
+        const finalArray = dataArray.map((doc) => {
+            if (doc.someField !== undefined) {
+                doc['otherField'] = doc.someField;
+            }
+            if (Object.keys(doc).length === 0) return null;
+            return doc;
+        });
+        const resultsArray = dataArray.map(data => test.run(data));
+
+        resultsArray.forEach((result, ind) => {
+            if (result) expect(DataEntity.isDataEntity(result)).toEqual(true);
+            expect(result).toEqual(finalArray[ind]);
+        });
+    });
+
     it('can preserve metadata when transforming documents', () => {
         const opConfig = {
             source_field: 'someField',

--- a/packages/ts-transforms/test/transform-spec.ts
+++ b/packages/ts-transforms/test/transform-spec.ts
@@ -282,7 +282,12 @@ describe('can transform matches', () => {
         const results =  await test.run(data);
 
         expect(results.length).toEqual(1);
-        expect(results[0]).toEqual({ name: 'Jane Doe' });
+        expect(results[0]).toEqual({
+            first_name: 'Jane',
+            full_name: 'Jane Doe',
+            last_name: 'Doe',
+            transfered_name: 'Jane Doe'
+        });
 
         const metaData = results[0].getMetadata();
         expect(metaData.selectors).toEqual({ 'hello:world': true, 'full_name:"Jane Doe"': true });


### PR DESCRIPTION
`post_process: extraction` now defaults to `mutate:true`. You can still set mutate:false if desired.