### PR TITLE
fix k8s job start issue

### DIFF
--- a/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/k8sResource.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/k8sResource.js
@@ -37,16 +37,20 @@ class K8sResource {
         this.templateConfig = this._makeConfig();
         this.resource = this.templateGenerator(this.templateConfig);
 
-        // Apply job `targets` setting as k8s nodeAffinity
-        // We assume that multiple targets require both to match ...
-        // NOTE: If you specify multiple `matchExpressions` associated with
-        // `nodeSelectorTerms`, then the pod can be scheduled onto a node
-        // only if *all* `matchExpressions` can be satisfied.
-        this._setAffinity();
-        this._setResources();
-        this._setVolumes();
-        this._setAssetsVolume();
-        this._setImagePullSecret();
+        // services don't have pod templates that need modification by these
+        // methods
+        if (resourceType !== 'services') {
+            // Apply job `targets` setting as k8s nodeAffinity
+            // We assume that multiple targets require both to match ...
+            // NOTE: If you specify multiple `matchExpressions` associated with
+            // `nodeSelectorTerms`, then the pod can be scheduled onto a node
+            // only if *all* `matchExpressions` can be satisfied.
+            this._setAffinity();
+            this._setResources();
+            this._setVolumes();
+            this._setAssetsVolume();
+            this._setImagePullSecret();
+        }
     }
 
     _makeConfig() {

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8sResource-spec.js
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8sResource-spec.js
@@ -397,5 +397,20 @@ describe('k8sResource', () => {
             expect(kr.resource.spec.ports[0].port).toBe(45680);
             expect(kr.resource.spec.ports[0].targetPort).toBe(45680);
         });
+
+        it('should not throw error on init when resources are set', () => {
+            let kr;
+            execution.cpu = 2;
+            execution.memory = 2147483648;
+
+            function initExService() {
+                kr = new K8sResource(
+                    'services', 'execution_controller', terasliceConfig, execution
+                );
+            }
+            expect(initExService).not.toThrow();
+            expect(kr.resource.kind).toBe('Service');
+            expect(kr.resource.metadata.name).toBe('ts-exc-example-data-generator-job-7ba9afb0-417a');
+        });
     });
 });


### PR DESCRIPTION
Not sure how this got by me.  The job start issue raise by @macgyver603 was caused by trying to set properties on the pod `template.spec` property.  There is no `template` on services since they don't create pods.

This PR includes the fix and a test that should hopefully catch a regression.  There may be other `resourceTypes` in the future that need to be excluded, but none that I can anticipate today, so I've just excluded `services` from running the private methods that set up resources.