### PR TITLE
Remove state and analytics store refresh

### DIFF
--- a/e2e/config/teraslice-master.yaml
+++ b/e2e/config/teraslice-master.yaml
@@ -30,3 +30,19 @@ teraslice:
     master_hostname: "127.0.0.1"
     port: 45678
     name: "teracluster"
+    index_settings:
+        analytics:
+            number_of_shards: 1
+            number_of_replicas: 0
+        assets:
+            number_of_shards: 1
+            number_of_replicas: 0
+        jobs:
+            number_of_shards: 1
+            number_of_replicas: 0
+        execution:
+            number_of_shards: 1
+            number_of_replicas: 0
+        state:
+            number_of_shards: 1
+            number_of_replicas: 0

--- a/e2e/config/teraslice-worker.yaml
+++ b/e2e/config/teraslice-worker.yaml
@@ -29,3 +29,19 @@ teraslice:
     master_hostname: "teraslice-master"
     port: 45678
     name: "teracluster"
+    index_settings:
+        analytics:
+            number_of_shards: 1
+            number_of_replicas: 0
+        assets:
+            number_of_shards: 1
+            number_of_replicas: 0
+        jobs:
+            number_of_shards: 1
+            number_of_replicas: 0
+        execution:
+            number_of_shards: 1
+            number_of_replicas: 0
+        state:
+            number_of_shards: 1
+            number_of_replicas: 0

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "jest": "^24.1.0",
         "jest-extended": "^0.11.1",
         "lerna-alias": "^3.0.2",
+        "markdown-table": "^1.1.2",
         "semver": "^5.6.0",
         "ts-jest": "^24.0.0",
         "tslint": "^5.12.1",

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -30,7 +30,7 @@
         "test:debug": "env DEBUG='*teraslice*' jest --detectOpenHandles --coverage=false --runInBand"
     },
     "dependencies": {
-        "@terascope/utils": "^0.4.1",
+        "@terascope/utils": "^0.5.0",
         "elasticsearch-store": "^0.3.0",
         "nanoid": "^2.0.1",
         "xlucene-evaluator": "^0.5.0"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -21,7 +21,7 @@
         "url": "https://github.com/terascope/teraslice/issues"
     },
     "dependencies": {
-        "@terascope/utils": "^0.4.1",
+        "@terascope/utils": "^0.5.0",
         "bluebird": "^3.5.3",
         "lodash": "^4.17.11"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -26,7 +26,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/utils": "^0.4.1",
+        "@terascope/utils": "^0.5.0",
         "ajv": "^6.9.1",
         "rambda": "^2.3.1",
         "xlucene-evaluator": "^0.5.0"

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -38,7 +38,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.6",
-        "@terascope/utils": "^0.4.1",
+        "@terascope/utils": "^0.5.0",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^3.3.2"

--- a/packages/terafoundation/lib/api/getConnection.js
+++ b/packages/terafoundation/lib/api/getConnection.js
@@ -51,7 +51,7 @@ module.exports = function module(context) {
         }
 
         if (Object.prototype.hasOwnProperty.call(connectors, type)) {
-            logger.info(`Creating connection for ${type}`);
+            logger.info(`creating connection for ${type}`);
 
             let moduleConfig = {};
 

--- a/packages/terafoundation/lib/connectors/elasticsearch.js
+++ b/packages/terafoundation/lib/connectors/elasticsearch.js
@@ -25,7 +25,7 @@ function logWrapper(logger) {
 function create(customConfig, logger) {
     const elasticsearch = require('elasticsearch');
 
-    logger.info(`Using elasticsearch hosts: ${customConfig.host}`);
+    logger.info(`using elasticsearch hosts: ${customConfig.host}`);
 
     customConfig.defer = function _defer() {
         return Promise.defer();

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -42,6 +42,6 @@
         "yargs": "^13.2.1"
     },
     "devDependencies": {
-        "@terascope/utils": "^0.4.1"
+        "@terascope/utils": "^0.5.0"
     }
 }

--- a/packages/teraslice/lib/cluster/services/cluster/backends/native/index.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/native/index.js
@@ -584,7 +584,7 @@ module.exports = function module(context, clusterMasterServer, executionService)
     };
 
     function _initialize() {
-        logger.info('Native clustering initializing');
+        logger.info('native clustering initializing');
         const server = clusterMasterServer.httpServer;
         return Promise.resolve()
             .then(() => messaging.listen({ server }))

--- a/packages/teraslice/lib/cluster/services/cluster/backends/native/messaging.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/native/messaging.js
@@ -86,7 +86,7 @@ module.exports = function messaging(context, logger) {
     let childHookFn = null;
     let io;
 
-    logger.debug('messaging service configuration', config);
+    logger.debug(`messaging service configuration for assignment ${config.assignment}`);
 
     // set a default listener the is used for forwarding/completing responses
     functionMapping['messaging:response'] = _handleResponse;
@@ -236,7 +236,7 @@ module.exports = function messaging(context, logger) {
             } = socket.handshake.query;
 
             if (nodeId) {
-                logger.info(`Node ${nodeId} joining room on connect`);
+                logger.info(`node ${nodeId} joining room on connect`);
                 socket.join(nodeId);
             }
 

--- a/packages/teraslice/lib/cluster/services/execution.js
+++ b/packages/teraslice/lib/cluster/services/execution.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const Promise = require('bluebird');
 const Queue = require('@terascope/queue');
 const { TSError, parseError } = require('@terascope/utils');
+const makeExStore = require('../storage/execution');
 
 /*
  Execution Life Cycle for _status
@@ -493,7 +494,7 @@ module.exports = function module(context, { clusterMasterServer }) {
     }
 
 
-    return require('../storage/execution')(context)
+    return makeExStore(context)
         .then((ex) => {
             logger.info('execution service is initializing...');
             exStore = ex;

--- a/packages/teraslice/lib/cluster/services/jobs.js
+++ b/packages/teraslice/lib/cluster/services/jobs.js
@@ -7,6 +7,7 @@ const { TSError } = require('@terascope/utils');
 const { JobValidator } = require('@terascope/job-components');
 const { terasliceOpPath } = require('../../config');
 const spawnAssetsLoader = require('../../workers/assets/spawn');
+const makeJobStore = require('../storage/jobs');
 
 module.exports = function module(context) {
     const executionService = context.services.execution;
@@ -255,7 +256,7 @@ module.exports = function module(context) {
         return Promise.resolve(api);
     }
 
-    return require('../storage/jobs')(context)
+    return makeJobStore(context)
         .then((job) => {
             jobStore = job;
             return _initialize(); // Load the initial pendingJobs state.

--- a/packages/teraslice/lib/cluster/storage/analytics.js
+++ b/packages/teraslice/lib/cluster/storage/analytics.js
@@ -64,13 +64,19 @@ module.exports = function module(context) {
         return backend.shutdown(forceShutdown);
     }
 
+    function refresh() {
+        const { index } = timeseriesIndex(timeseriesFormat, _index);
+        return backend.refresh(index);
+    }
+
     const api = {
         log,
         get: getRecord,
         search,
         update,
         remove,
-        shutdown
+        shutdown,
+        refresh
     };
 
     const backendConfig = {
@@ -79,7 +85,8 @@ module.exports = function module(context) {
         recordType: 'analytics',
         idField: '_id',
         fullResponse: false,
-        logRecord: false
+        logRecord: false,
+        forceRefresh: false,
     };
 
     return elasticsearchBackend(backendConfig)

--- a/packages/teraslice/lib/cluster/storage/analytics.js
+++ b/packages/teraslice/lib/cluster/storage/analytics.js
@@ -87,6 +87,7 @@ module.exports = function module(context) {
         fullResponse: false,
         logRecord: false,
         forceRefresh: false,
+        storageName: 'analytics'
     };
 
     return elasticsearchBackend(backendConfig)

--- a/packages/teraslice/lib/cluster/storage/analytics.js
+++ b/packages/teraslice/lib/cluster/storage/analytics.js
@@ -73,10 +73,19 @@ module.exports = function module(context) {
         shutdown
     };
 
-    return elasticsearchBackend(context, indexName, 'analytics', '_id')
+    const backendConfig = {
+        context,
+        indexName,
+        recordType: 'analytics',
+        idField: '_id',
+        fullResponse: false,
+        logRecord: false
+    };
+
+    return elasticsearchBackend(backendConfig)
         .then((elasticsearch) => {
             backend = elasticsearch;
-            logger.info('AnalyticsStorage: initializing');
+            logger.info('analytics storage initialized');
             return api;
         });
 };

--- a/packages/teraslice/lib/cluster/storage/assets.js
+++ b/packages/teraslice/lib/cluster/storage/assets.js
@@ -248,7 +248,8 @@ module.exports = function module(context) {
         recordType: 'asset',
         idField: '_id',
         fullResponse: true,
-        logRecord: false
+        logRecord: false,
+        storageName: 'assets'
     };
 
     return ensureAssetDir()

--- a/packages/teraslice/lib/cluster/storage/assets.js
+++ b/packages/teraslice/lib/cluster/storage/assets.js
@@ -242,10 +242,20 @@ module.exports = function module(context) {
         shutdown
     };
 
+    const backendConfig = {
+        context,
+        indexName,
+        recordType: 'asset',
+        idField: '_id',
+        fullResponse: true,
+        logRecord: false
+    };
+
     return ensureAssetDir()
-        .then(() => elasticsearchBackend(context, indexName, 'asset', '_id', null, true, false))
+        .then(() => elasticsearchBackend(backendConfig))
         .then((elasticsearch) => {
             backend = elasticsearch;
+            logger.info('assets storage initialized');
             return api;
         });
 };

--- a/packages/teraslice/lib/cluster/storage/backends/elasticsearch_store.js
+++ b/packages/teraslice/lib/cluster/storage/backends/elasticsearch_store.js
@@ -16,7 +16,8 @@ module.exports = function module(backendConfig) {
         idField,
         bulkSize = 500,
         fullResponse = false,
-        logRecord = true
+        logRecord = true,
+        forceRefresh = true
     } = backendConfig;
 
     const logger = context.apis.foundation.makeLogger({
@@ -79,7 +80,7 @@ module.exports = function module(backendConfig) {
             index: indexArg || indexName,
             type: recordType,
             body: record,
-            refresh: true
+            refresh: forceRefresh
         };
 
         return elasticsearch.index(query);
@@ -96,7 +97,7 @@ module.exports = function module(backendConfig) {
             type: recordType,
             id: recordId,
             body: record,
-            refresh: true
+            refresh: forceRefresh
         };
 
         return elasticsearch.indexWithId(query);
@@ -114,7 +115,7 @@ module.exports = function module(backendConfig) {
             type: recordType,
             id: record[idField],
             body: record,
-            refresh: true
+            refresh: forceRefresh
         };
 
         return elasticsearch.create(query);
@@ -146,7 +147,7 @@ module.exports = function module(backendConfig) {
             body: {
                 doc: updateSpec
             },
-            refresh: true,
+            refresh: forceRefresh,
             retryOnConflict: 3
         };
 
@@ -159,7 +160,7 @@ module.exports = function module(backendConfig) {
             index: indexArg || indexName,
             type: recordType,
             id: recordId,
-            refresh: true
+            refresh: forceRefresh
         };
 
         return elasticsearch.remove(query);

--- a/packages/teraslice/lib/cluster/storage/backends/elasticsearch_store.js
+++ b/packages/teraslice/lib/cluster/storage/backends/elasticsearch_store.js
@@ -8,8 +8,22 @@ const { getClient } = require('@terascope/job-components');
 const { timeseriesIndex } = require('../../../utils/date_utils');
 
 // eslint-disable-next-line max-len
-module.exports = function module(context, indexName, recordType, idField, _bulkSize, fullResponse, logRecord = true) {
-    const logger = context.apis.foundation.makeLogger({ module: 'elasticsearch_backend' });
+module.exports = function module(backendConfig) {
+    const {
+        context,
+        indexName,
+        recordType,
+        idField,
+        bulkSize = 500,
+        fullResponse = false,
+        logRecord = true
+    } = backendConfig;
+
+    const logger = context.apis.foundation.makeLogger({
+        module: 'elasticsearch_backend',
+        storageType: recordType,
+    });
+
     const config = context.sysconfig.teraslice;
     let elasticsearch;
     let client;
@@ -19,9 +33,6 @@ module.exports = function module(context, indexName, recordType, idField, _bulkS
     // Buffer to build up bulk requests.
     let bulkQueue = [];
     let savingBulk = false; // serialize save requests.
-
-    let bulkSize = 500;
-    if (_bulkSize) bulkSize = _bulkSize;
 
     function getRecord(recordId, indexArg, fields) {
         logger.trace(`getting record id: ${recordId}`);

--- a/packages/teraslice/lib/cluster/storage/backends/elasticsearch_store.js
+++ b/packages/teraslice/lib/cluster/storage/backends/elasticsearch_store.js
@@ -8,7 +8,6 @@ const elasticsearchApi = require('@terascope/elasticsearch-api');
 const { getClient } = require('@terascope/job-components');
 const { timeseriesIndex } = require('../../../utils/date_utils');
 
-// eslint-disable-next-line max-len
 module.exports = function module(backendConfig) {
     const {
         context,
@@ -364,7 +363,8 @@ module.exports = function module(backendConfig) {
             logger.error(err, 'background flush failure');
             return null;
         });
-    }, 10000);
+    // stager the interval to avoid collisions
+    }, _.random(9000, 11000));
 
     // javascript is having a fit if you use the shorthand get, so we renamed function to getRecord
     const api = {

--- a/packages/teraslice/lib/cluster/storage/backends/mappings/analytics.json
+++ b/packages/teraslice/lib/cluster/storage/backends/mappings/analytics.json
@@ -1,9 +1,5 @@
 {
     "template": "__analytics*",
-    "settings" : {
-        "index.number_of_shards" : 5,
-        "index.number_of_replicas": 1
-    },
     "mappings": {
         "analytics": {
             "_all": {

--- a/packages/teraslice/lib/cluster/storage/backends/mappings/asset.json
+++ b/packages/teraslice/lib/cluster/storage/backends/mappings/asset.json
@@ -1,36 +1,32 @@
 {
-  "settings": {
-    "index.number_of_shards": 5,
-    "index.number_of_replicas": 1
-  },
-  "mappings": {
-    "asset": {
-      "_all": {
-        "enabled": false
-      },
-      "dynamic": false,
-      "properties": {
-        "blob": {
-          "type": "keyword",
-          "index": false,
-          "doc_values": false
-        },
-        "name": {
-          "type": "keyword"
-        },
-        "version": {
-          "type": "keyword"
-        },
-        "id": {
-          "type": "keyword"
-        },
-        "description": {
-          "type": "keyword"
-        },
-        "_created": {
-          "type": "date"
+    "mappings": {
+        "asset": {
+            "_all": {
+                "enabled": false
+            },
+            "dynamic": false,
+            "properties": {
+                "blob": {
+                    "type": "keyword",
+                    "index": false,
+                    "doc_values": false
+                },
+                "name": {
+                    "type": "keyword"
+                },
+                "version": {
+                    "type": "keyword"
+                },
+                "id": {
+                    "type": "keyword"
+                },
+                "description": {
+                    "type": "keyword"
+                },
+                "_created": {
+                    "type": "date"
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/packages/teraslice/lib/cluster/storage/backends/mappings/ex.json
+++ b/packages/teraslice/lib/cluster/storage/backends/mappings/ex.json
@@ -1,52 +1,48 @@
 {
-  "settings": {
-    "index.number_of_shards": 5,
-    "index.number_of_replicas": 1
-  },
-  "mappings": {
-    "ex": {
-      "_all": {
-        "enabled": false
-      },
-      "dynamic": false,
-      "properties": {
-        "job_id": {
-          "type": "keyword"
-        },
-        "ex_id": {
-          "type": "keyword"
-        },
-        "_context": {
-          "type": "keyword"
-        },
-        "_status": {
-          "type": "keyword"
-        },
-        "_has_errors": {
-          "type": "keyword"
-        },
-        "slicer_hostname": {
-          "type": "keyword"
-        },
-        "slicer_port": {
-          "type": "keyword"
-        },
-        "recovered_execution": {
-          "type": "keyword"
-        },
-        "recovered_slice_type": {
-          "type": "keyword"
-        },
-        "_slicer_stats": {
-          "type": "object"
-        },
-        "_created": {
-          "type": "date"
-        },
-        "_updated": {
-          "type": "date"
+    "mappings": {
+        "ex": {
+            "_all": {
+                "enabled": false
+            },
+            "dynamic": false,
+            "properties": {
+                "job_id": {
+                    "type": "keyword"
+                },
+                "ex_id": {
+                    "type": "keyword"
+                },
+                "_context": {
+                    "type": "keyword"
+                },
+                "_status": {
+                    "type": "keyword"
+                },
+                "_has_errors": {
+                    "type": "keyword"
+                },
+                "slicer_hostname": {
+                    "type": "keyword"
+                },
+                "slicer_port": {
+                    "type": "keyword"
+                },
+                "recovered_execution": {
+                    "type": "keyword"
+                },
+                "recovered_slice_type": {
+                    "type": "keyword"
+                },
+                "_slicer_stats": {
+                    "type": "object"
+                },
+                "_created": {
+                    "type": "date"
+                },
+                "_updated": {
+                    "type": "date"
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/packages/teraslice/lib/cluster/storage/backends/mappings/logs.json
+++ b/packages/teraslice/lib/cluster/storage/backends/mappings/logs.json
@@ -1,17 +1,17 @@
 {
-  "template": "__logs*",
-  "mappings": {
-    "_default_": {
-      "dynamic_templates": [
-        {
-          "strings": {
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "keyword"
-            }
-          }
+    "template": "__logs*",
+    "mappings": {
+        "_default_": {
+            "dynamic_templates": [
+                {
+                    "strings": {
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "keyword"
+                        }
+                    }
+                }
+            ]
         }
-      ]
     }
-  }
 }

--- a/packages/teraslice/lib/cluster/storage/backends/mappings/state.json
+++ b/packages/teraslice/lib/cluster/storage/backends/mappings/state.json
@@ -1,9 +1,5 @@
 {
     "template": "__state*",
-    "settings" : {
-        "index.number_of_shards" : 5,
-        "index.number_of_replicas": 1
-    },
     "mappings": {
         "state": {
             "_all": {
@@ -20,7 +16,7 @@
                 "slicer_id": {
                     "type": "keyword"
                 },
-                "slicer_order":{
+                "slicer_order": {
                     "type": "integer"
                 },
                 "state": {

--- a/packages/teraslice/lib/cluster/storage/execution.js
+++ b/packages/teraslice/lib/cluster/storage/execution.js
@@ -179,7 +179,8 @@ module.exports = function module(context) {
         recordType: 'ex',
         idField: 'ex_id',
         fullResponse: false,
-        logRecord: false
+        logRecord: false,
+        storageName: 'execution'
     };
 
     return elasticsearchBackend(backendConfig)

--- a/packages/teraslice/lib/cluster/storage/execution.js
+++ b/packages/teraslice/lib/cluster/storage/execution.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const { TSError } = require('@terascope/utils');
 const uuid = require('uuid');
 const Promise = require('bluebird');
+const elasticsearchBackend = require('./backends/elasticsearch_store');
 
 const INIT_STATUS = ['pending', 'scheduling', 'initializing'];
 const RUNNING_STATUS = ['running', 'failing', 'paused', 'stopping'];
@@ -19,7 +20,7 @@ module.exports = function module(context) {
     const logger = context.apis.foundation.makeLogger({ module: 'ex_storage' });
     const config = context.sysconfig.teraslice;
     const jobType = 'ex';
-    const jobsIndex = `${config.name}__ex`;
+    const indexName = `${config.name}__ex`;
 
     let backend;
 
@@ -172,9 +173,18 @@ module.exports = function module(context) {
         verifyStatusUpdate,
     };
 
-    return require('./backends/elasticsearch_store')(context, jobsIndex, 'ex', 'ex_id')
+    const backendConfig = {
+        context,
+        indexName,
+        recordType: 'ex',
+        idField: 'ex_id',
+        fullResponse: false,
+        logRecord: false
+    };
+
+    return elasticsearchBackend(backendConfig)
         .then((elasticsearch) => {
-            logger.info('Initializing');
+            logger.info('execution storage initialized');
             backend = elasticsearch;
             return api;
         });

--- a/packages/teraslice/lib/cluster/storage/jobs.js
+++ b/packages/teraslice/lib/cluster/storage/jobs.js
@@ -1,15 +1,19 @@
 'use strict';
 
 const uuid = require('uuid');
+const elasticsearchBackend = require('./backends/elasticsearch_store');
 
 // Module to manager job states in Elasticsearch.
 // All functions in this module return promises that must be resolved to
 // get the final result.
 module.exports = function module(context) {
-    const logger = context.apis.foundation.makeLogger({ module: 'job_storage' });
+    const logger = context.apis.foundation.makeLogger({
+        module: 'job_storage'
+    });
+
     const config = context.sysconfig.teraslice;
     const jobType = 'job';
-    const jobsIndex = `${config.name}__jobs`;
+    const indexName = `${config.name}__jobs`;
 
     let backend;
 
@@ -57,9 +61,18 @@ module.exports = function module(context) {
         shutdown
     };
 
-    return require('./backends/elasticsearch_store')(context, jobsIndex, 'job', 'job_id')
+    const backendConfig = {
+        context,
+        indexName,
+        recordType: 'job',
+        idField: 'job_id',
+        fullResponse: false,
+        logRecord: false
+    };
+
+    return elasticsearchBackend(backendConfig)
         .then((elasticsearch) => {
-            logger.info('Initializing');
+            logger.info('job storage initialized');
             backend = elasticsearch;
             return api;
         });

--- a/packages/teraslice/lib/cluster/storage/jobs.js
+++ b/packages/teraslice/lib/cluster/storage/jobs.js
@@ -67,7 +67,8 @@ module.exports = function module(context) {
         recordType: 'job',
         idField: 'job_id',
         fullResponse: false,
-        logRecord: false
+        logRecord: false,
+        storageName: 'jobs'
     };
 
     return elasticsearchBackend(backendConfig)

--- a/packages/teraslice/lib/cluster/storage/logs.js
+++ b/packages/teraslice/lib/cluster/storage/logs.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Promise = require('bluebird');
 const _ = require('lodash');
+const Promise = require('bluebird');
 const { getClient } = require('@terascope/job-components');
 
 module.exports = function module(context) {

--- a/packages/teraslice/lib/cluster/storage/state.js
+++ b/packages/teraslice/lib/cluster/storage/state.js
@@ -134,10 +134,19 @@ module.exports = function module(context) {
         shutdown
     };
 
-    return elasticsearchBackend(context, indexName, 'state', '_id')
+    const backendConfig = {
+        context,
+        indexName,
+        recordType: 'state',
+        idField: '_id',
+        fullResponse: false,
+        logRecord: false
+    };
+
+    return elasticsearchBackend(backendConfig)
         .then((elasticsearch) => {
             backend = elasticsearch;
-            logger.info('initializing');
+            logger.info('state storage initialized');
             return api;
         });
 };

--- a/packages/teraslice/lib/cluster/storage/state.js
+++ b/packages/teraslice/lib/cluster/storage/state.js
@@ -57,6 +57,7 @@ module.exports = function module(context) {
             delay: 1000,
             backoff: 5,
             matches: [
+                'Not Found',
                 'Request Timeout',
             ],
             endWithFatal: true,
@@ -124,6 +125,11 @@ module.exports = function module(context) {
         return backend.shutdown(forceShutdown);
     }
 
+    function refresh() {
+        const { index } = timeseriesIndex(timeseriesFormat, _index);
+        return backend.refresh(index);
+    }
+
     const api = {
         search,
         createState,
@@ -131,7 +137,8 @@ module.exports = function module(context) {
         recoverSlices,
         executionStartingSlice,
         count,
-        shutdown
+        shutdown,
+        refresh,
     };
 
     const backendConfig = {
@@ -140,7 +147,8 @@ module.exports = function module(context) {
         recordType: 'state',
         idField: '_id',
         fullResponse: false,
-        logRecord: false
+        logRecord: false,
+        forceRefresh: false
     };
 
     return elasticsearchBackend(backendConfig)

--- a/packages/teraslice/lib/cluster/storage/state.js
+++ b/packages/teraslice/lib/cluster/storage/state.js
@@ -148,7 +148,8 @@ module.exports = function module(context) {
         idField: '_id',
         fullResponse: false,
         logRecord: false,
-        forceRefresh: false
+        forceRefresh: false,
+        storageName: 'state'
     };
 
     return elasticsearchBackend(backendConfig)

--- a/packages/teraslice/lib/config/schemas/system.js
+++ b/packages/teraslice/lib/config/schemas/system.js
@@ -92,6 +92,58 @@ const schema = {
             }
         }
     },
+    index_settings: {
+        analytics: {
+            number_of_shards: {
+                doc: 'The number of shards for the analytics index',
+                default: 5,
+            },
+            number_of_replicas: {
+                doc: 'The number of replicas for the analytics index',
+                default: 1,
+            },
+        },
+        assets: {
+            number_of_shards: {
+                doc: 'The number of shards for the assets index',
+                default: 5,
+            },
+            number_of_replicas: {
+                doc: 'The number of replicas for the assets index',
+                default: 1,
+            },
+        },
+        jobs: {
+            number_of_shards: {
+                doc: 'The number of shards for the jobs index',
+                default: 5,
+            },
+            number_of_replicas: {
+                doc: 'The number of replicas for the jobs index',
+                default: 1,
+            },
+        },
+        execution: {
+            number_of_shards: {
+                doc: 'The number of shards for the execution index',
+                default: 5,
+            },
+            number_of_replicas: {
+                doc: 'The number of replicas for the execution index',
+                default: 1,
+            },
+        },
+        state: {
+            number_of_shards: {
+                doc: 'The number of shards for the state index',
+                default: 5,
+            },
+            number_of_replicas: {
+                doc: 'The number of replicas for the state index',
+                default: 1,
+            },
+        },
+    },
     action_timeout: {
         doc: 'time in milliseconds for waiting for a action ( pause/stop job, etc) to complete before throwing an error',
         default: 300000,

--- a/packages/teraslice/lib/workers/execution-controller/index.js
+++ b/packages/teraslice/lib/workers/execution-controller/index.js
@@ -567,6 +567,10 @@ class ExecutionController {
 
         this._logFinishedJob();
 
+        // refresh the state store index
+        // to prevent the execution from failing incorrectly
+        await this.stores.stateStore.refresh();
+
         try {
             await this._updateExecutionStatus();
         } catch (err) {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -39,7 +39,7 @@
         "@terascope/job-components": "^0.14.5",
         "@terascope/queue": "^1.1.6",
         "@terascope/teraslice-messaging": "^0.3.1",
-        "@terascope/utils": "^0.4.1",
+        "@terascope/utils": "^0.5.0",
         "async-mutex": "^0.1.3",
         "barbe": "^3.0.15",
         "bluebird": "^3.5.3",

--- a/packages/teraslice/test/workers/helpers/configs.js
+++ b/packages/teraslice/test/workers/helpers/configs.js
@@ -130,6 +130,28 @@ const newSysConfig = (options = {}) => {
             name: clusterName,
             master_hostname: 'localhost',
             port: clusterMasterPort,
+            index_settings: {
+                analytics: {
+                    number_of_shards: 1,
+                    number_of_replicas: 0
+                },
+                assets: {
+                    number_of_shards: 1,
+                    number_of_replicas: 0
+                },
+                jobs: {
+                    number_of_shards: 1,
+                    number_of_replicas: 0
+                },
+                execution: {
+                    number_of_shards: 1,
+                    number_of_replicas: 0
+                },
+                state: {
+                    number_of_shards: 1,
+                    number_of_replicas: 0
+                },
+            }
         }
     };
 };

--- a/packages/teraslice/test/workers/worker/slice-spec.js
+++ b/packages/teraslice/test/workers/worker/slice-spec.js
@@ -47,6 +47,11 @@ describe('Slice', () => {
                 slice = await setupSlice(testContext, eventMocks);
 
                 results = await slice.run();
+
+                await Promise.all([
+                    slice.stateStore.refresh(),
+                    slice.analyticsStore.refresh(),
+                ]);
             });
 
             afterEach(async () => {
@@ -91,6 +96,10 @@ describe('Slice', () => {
                 slice = await setupSlice(testContext, eventMocks);
 
                 results = await slice.run();
+                await Promise.all([
+                    slice.stateStore.refresh(),
+                    slice.analyticsStore.refresh(),
+                ]);
             });
 
             afterEach(async () => {
@@ -135,6 +144,10 @@ describe('Slice', () => {
                 slice = await setupSlice(testContext, eventMocks);
 
                 results = await slice.run();
+                await Promise.all([
+                    slice.stateStore.refresh(),
+                    slice.analyticsStore.refresh(),
+                ]);
             });
 
             afterEach(async () => {
@@ -184,6 +197,11 @@ describe('Slice', () => {
                 } catch (_err) {
                     err = _err;
                 }
+
+                await Promise.all([
+                    slice.stateStore.refresh(),
+                    slice.analyticsStore.refresh(),
+                ]);
             });
 
             afterEach(async () => {
@@ -233,6 +251,11 @@ describe('Slice', () => {
                 } catch (_err) {
                     err = _err;
                 }
+
+                await Promise.all([
+                    slice.stateStore.refresh(),
+                    slice.analyticsStore.refresh(),
+                ]);
             });
 
             afterEach(async () => {
@@ -280,6 +303,11 @@ describe('Slice', () => {
                 } catch (_err) {
                     err = _err;
                 }
+
+                await Promise.all([
+                    slice.stateStore.refresh(),
+                    slice.analyticsStore.refresh(),
+                ]);
             });
 
             afterEach(async () => {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -41,7 +41,7 @@
         "test:debug": "env DEBUG='*teraslice*' jest --detectOpenHandles --coverage=false --runInBand"
     },
     "dependencies": {
-        "@terascope/utils": "^0.4.1",
+        "@terascope/utils": "^0.5.0",
         "@types/got": "^9.4.0",
         "awesome-phonenumber": "^2.4.2",
         "got": "^9.6.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "description": "A collection of Teraslice Utilities",
-    "version": "0.4.1",
+    "version": "0.5.0",
     "publishConfig": {
         "access": "public"
     },

--- a/packages/utils/src/promises.ts
+++ b/packages/utils/src/promises.ts
@@ -88,8 +88,9 @@ export async function pRetry<T = any>(fn: PromiseFn<T>, options?: Partial<PRetry
         attempts: 0,
     };
 
+    config._context.attempts++;
+
     try {
-        config._context.attempts++;
         return await fn();
     } catch (_err) {
         let matches = true;
@@ -102,11 +103,9 @@ export async function pRetry<T = any>(fn: PromiseFn<T>, options?: Partial<PRetry
             });
         }
 
-        const endTime = Date.now();
         const context = {
             ...config._context,
-            endTime,
-            duration: endTime - config._context.startTime
+            duration: Date.now() - config._context.startTime
         };
 
         const err = new TSError(_err, {

--- a/packages/xlucene-evaluator/package.json
+++ b/packages/xlucene-evaluator/package.json
@@ -33,7 +33,7 @@
     },
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-evaluator#readme",
     "dependencies": {
-        "@terascope/utils": "^0.4.1",
+        "@terascope/utils": "^0.5.0",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-point-in-polygon": "^6.0.1",

--- a/scripts/generate-schema-md.js
+++ b/scripts/generate-schema-md.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const path = require('path');
+const os = require('os');
+const { chain } = require('lodash');
+const {
+    toString,
+    isString,
+    getTypeOf,
+    firstToUpper,
+    isEmpty,
+    isFunction,
+} = require('@terascope/utils');
+const table = require('markdown-table');
+
+const homedir = os.homedir();
+const hostname = os.hostname();
+const ip = chain(require('os').networkInterfaces())
+    .values()
+    .flatten()
+    .filter(val => (val.family === 'IPv4' && val.internal === false))
+    .map('address')
+    .head()
+    .value();
+
+const cwd = process.cwd();
+
+const replaceThese = {
+    $PWD: cwd,
+    $HOME: homedir,
+    $HOSTNAME: hostname,
+    $HOST_IP: ip,
+};
+
+const schemaArg = process.argv[2];
+if (!schemaArg || ['h', '-h', 'help', '--help'].includes(schemaArg)) {
+    // eslint-disable-next-line no-console
+    console.error(`
+./scripts/generate-schema-md.js <path/to/schema/file.(js|json)>
+
+Generate a markdown table from a convict schema
+`.trim());
+
+    process.exit(1);
+}
+
+const result = generateConfigDocs(path.resolve(schemaArg));
+// eslint-disable-next-line no-console
+console.log(result);
+
+function generateConfigDocs(schemaPath) {
+    let schema = require(schemaPath);
+    if (schema.default) schema = schema.default;
+    if (isEmpty(schema)) {
+        throw new Error('Schema exported an empty schema');
+    }
+
+    if (schema.schema) ({ schema } = schema);
+
+    if (isEmpty(schema)) {
+        throw new Error('Schema exported an invalid schema');
+    }
+
+    const data = [
+        [
+            'Field',
+            'Type',
+            'Default',
+            'Description'
+        ],
+    ];
+
+    function handleSchemaObj(schemaObj, prefix = '') {
+        Object.keys(schemaObj)
+            .sort()
+            .forEach((field) => {
+                const s = schemaObj[field];
+                if (!s) return;
+
+                const fullField = [prefix, field]
+                    .join('.')
+                    .replace(/^\./, '');
+
+                if (!s.doc) {
+                    handleSchemaObj(s, fullField);
+                    return;
+                }
+
+                data.push([
+                    `**${fullField}**`,
+                    formatType(s),
+                    formatDefaultVal(s),
+                    sanatizeStr(s.doc),
+                ]);
+            });
+    }
+
+    handleSchemaObj(schema);
+
+    return table(data, { align: 'c' });
+}
+
+function formatArr(arr) {
+    return arr.map(v => formatVal(v)).join(', ');
+}
+
+function formatVal(val, isType = false) {
+    if (Array.isArray(val)) return formatArr(val);
+    let str;
+
+    if (isString(val)) {
+        if (isType) {
+            if (val.indexOf('required_') === 0) {
+                str = `${val.replace('required_', '')}`;
+            } else if (val.indexOf('optional_') === 0) {
+                str = `${val.replace('optional_', '')}`;
+            } else {
+                str = `${val}`;
+            }
+        } else {
+            str = `"${val}"`;
+        }
+    } else if (val && val.name) {
+        str = val.name;
+    } else {
+        str = toString(val);
+    }
+
+    if (isString(str)) {
+        for (const [replaceWith, searchFor] of Object.entries(replaceThese)) {
+            str = str.replace(searchFor, replaceWith);
+        }
+    }
+
+    return `\`${str}\``;
+}
+
+function formatDefaultVal(s) {
+    const val = s.default;
+    if (val == null || (isString(val) && !val)) return '-';
+    return formatVal(val);
+}
+
+function formatType(s) {
+    if (s.default != null && (!s.format || isFunction(s.format))) {
+        const typeOf = getTypeOf(s.default);
+        if (/^[`"']/.test(typeOf)) {
+            return typeOf;
+        }
+        return `\`${typeOf}\``;
+    }
+    return firstToUpper(formatVal(s.format, true));
+}
+
+function sanatizeStr(str) {
+    if (!str) return '';
+    return str.replace(/\r?\n|\r/g, '<br>').trim();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5878,6 +5878,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-table@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
+  integrity sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw==
+
 math-random@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"


### PR DESCRIPTION
- Removes state and analytics refreshes when creating and updating records to improve performance and prevent the cluster for being overloaded with large jobs.
- Add the ability to configure the index shards and replicas for analytics, assets, execution, jobs, and state, see the example below.

```yaml
terafoundation:
  connectors:
    elasticsearch:
      default:
        host:
          - "127.0.0.1:9200"

teraslice:
  master: true
  master_hostname: "127.0.0.1"
  name: "teracluster"
  index_settings:
    analytics:
      number_of_shards: 8
      number_of_replicas: 1
    assets:
      number_of_shards: 5
      number_of_replicas: 2
    jobs:
      number_of_shards: 5
      number_of_replicas: 2
    execution:
      number_of_shards: 5
      number_of_replicas: 2
    state:
      number_of_shards: 15
      number_of_replicas: 1
```

Resolves #990 
Resolves #988 