### PR TITLE
fix job name special character issue in k8s

### DIFF
--- a/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/k8sResource.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/k8sResource.js
@@ -62,7 +62,9 @@ class K8sResource {
             `${this.terasliceConfig.name}-worker`
         );
         const dockerImage = this.execution.kubernetes_image || this.terasliceConfig.kubernetes_image;
-        const jobNameLabel = this.execution.name.replace(/[^a-zA-Z0-9_\-.]/g, '_').substring(0, 63);
+        // name needs to be a valid DNS name since it is used in the svc name,
+        // so we can only permit alphanumeric and - characters.  _ is forbidden.
+        const jobNameLabel = this.execution.name.replace(/[^a-zA-Z0-9\-.]/g, '-').substring(0, 63);
         const name = `ts-${this.nameInfix}-${jobNameLabel.substring(0, 42)}-${this.execution.job_id.substring(0, 13)}`;
         const shutdownTimeoutMs = _.get(this.terasliceConfig, 'shutdown_timeout', 60000);
         const shutdownTimeoutSeconds = Math.round(shutdownTimeoutMs / 1000);

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8sResource-spec.js
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8sResource-spec.js
@@ -412,5 +412,22 @@ describe('k8sResource', () => {
             expect(kr.resource.kind).toBe('Service');
             expect(kr.resource.metadata.name).toBe('ts-exc-example-data-generator-job-7ba9afb0-417a');
         });
+
+        test.each([
+            ['temp#job', 'ts-exc-temp-job-7ba9afb0-417a'],
+            ['temp_job', 'ts-exc-temp-job-7ba9afb0-417a'],
+            ['temp!job', 'ts-exc-temp-job-7ba9afb0-417a']
+        ])(
+            'should sanitize %s to be valid DNS name',
+            (name, expected) => {
+                execution.name = name;
+                const kr = new K8sResource(
+                    'services', 'execution_controller', terasliceConfig, execution
+                );
+
+                expect(kr.resource.kind).toBe('Service');
+                expect(kr.resource.metadata.name).toBe(expected);
+            }
+        );
     });
 });


### PR DESCRIPTION
Fortunately @macgyver603 caught the k8s jobname invalid DNS character problem (# wouldn't work in job names) a couple days ago.  I remembered and fix it here.

This happened because I added job names into the pod names ... which in turn end up being DNS names.

So this should go into `v0.50.0` or Charlie will be sad.