### PR TITLE
Data Access Plugin Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ jobs:
         packages:
           - jq
     before_script: . ./scripts/travis-setup-credentials.sh
-    script: ./scripts/sync-readmes.sh
+    script: yarn docs:update
     deploy:
       - provider: script
         skip_cleanup: true

--- a/docs/packages/data-access-plugin/overview.md
+++ b/docs/packages/data-access-plugin/overview.md
@@ -40,6 +40,106 @@ Since this project is designed to replace the teraserver teranaut plugin, and th
       - `type` since this can be achieved via a `constraint`
       - `date_range`, `date_start`, `date_end`, `geo_box_top_left`, `geo_box_bottom_right`, `geo_point`, `geo_distance`, since this should be achieved via the view constraint and the xclucene queries.
 
+## GraphQL Usage
+
+### List everything
+
+```js
+query {
+  findUsers(query:"*") {
+    id,
+    username,
+    roles,
+  }
+  findRoles(query:"*") {
+    id,
+    name,
+    spaces,
+  }
+  findSpaces(query:"*") {
+    id,
+    name,
+    views,
+    default_view,
+    metadata
+  }
+  findViews(query:"*") {
+    id,
+    name,
+    space,
+    includes,
+    excludes,
+    constraint,
+    prevent_prefix_wildcard,
+  	metadata,
+  }
+}
+```
+
+### Frist create the Role
+
+```js
+mutation {
+  createRole(role:{
+    name:"Example Role",
+    spaces:[]
+  }){
+    id
+  }
+}
+```
+
+### Create user and space
+
+```js
+mutation {
+  createUser(user:{
+    username:"example-user",
+    email:"user@example.com",
+    firstname:"Billy",
+    lastname:"Joe",
+    roles: ["ROLE_ID"]
+  }, password: "password") {
+    id,
+    api_token
+  }
+
+  createSpace(space: {
+    name: "example-space",
+    metadata: {
+      indexConfig:{
+        index:"example-space"
+      },
+      typeConfig: {
+          created: "date",
+          location: "geo"
+      }
+    }
+  }, views: [
+    {
+      name: "ExampleView",
+      includes: ["foo", "moo"],
+      excludes: ["bar"],
+      roles: ["ROLE_ID"],
+      constraint:"moo:cow"
+    }
+  ], defaultView: {
+      metadata:{
+        searchConfig:{
+          require_query:true
+        }
+      }
+  }) {
+    space {
+      id,
+    }
+    views {
+      id,
+    }
+  }
+}
+```
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/docs/packages/data-access-plugin/overview.md
+++ b/docs/packages/data-access-plugin/overview.md
@@ -23,8 +23,8 @@ Since this project is designed to replace the teraserver teranaut plugin, and th
  - Pre/Post process function will need to be written to use express middleware, docs comming soon.
  - The following configuration has been added to the space config:
       - `index` under `metadata.indexConfig.index`
-      - `typesConfig` for `xlucene-evaluator` under `metadata.indexConfig.typesConfig`
-      - `connection` has been added under `metadata.teraserver.connection`
+      - `typesConfig` for `xlucene-evaluator` under `metadata.typesConfig`
+      - `connection` has been added under `metadata.indexConfig.connection`
  - The following configuration has been moved to the view:
       - `allowed_fields` under `includes`
       - `type`, `date_start`, `date_end`, `geo_box_top_left`, `geo_box_bottom_right`, `geo_point`, `geo_distance` should be added to `constraint`.

--- a/docs/packages/data-access-plugin/overview.md
+++ b/docs/packages/data-access-plugin/overview.md
@@ -24,6 +24,7 @@ Since this project is designed to replace the teraserver teranaut plugin, and th
  - The following configuration has been added to the space config:
       - `index` under `metadata.indexConfig.index`
       - `typesConfig` for `xlucene-evaluator` under `metadata.indexConfig.typesConfig`
+      - `connection` has been added under `metadata.teraserver.connection`
  - The following configuration has been moved to the view:
       - `allowed_fields` under `includes`
       - `type`, `date_start`, `date_end`, `geo_box_top_left`, `geo_box_bottom_right`, `geo_point`, `geo_distance` should be added to `constraint`.

--- a/packages/data-access-plugin/package.json
+++ b/packages/data-access-plugin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "data-access-plugin",
     "description": "A teraserver plugin for managing data access and searching spaces",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "publishConfig": {
         "access": "public"
     },
@@ -29,7 +29,7 @@
         "test:debug": "env DEBUG=\"${DEBUG:-*teraslice*}\" jest --detectOpenHandles --coverage=false --runInBand"
     },
     "dependencies": {
-        "@terascope/data-access": "^0.3.0",
+        "@terascope/data-access": "^0.3.1",
         "@terascope/utils": "^0.6.0",
         "apollo-server-express": "^2.4.8",
         "elasticsearch-store": "^0.4.0",

--- a/packages/data-access-plugin/package.json
+++ b/packages/data-access-plugin/package.json
@@ -39,6 +39,7 @@
         "xlucene-evaluator": "^0.5.1"
     },
     "devDependencies": {
+        "@terascope/job-components": "^0.15.0",
         "@types/express": "^4.16.1",
         "@types/graphql-type-json": "^0.1.3",
         "@types/lodash.get": "^4.4.6",

--- a/packages/data-access-plugin/src/index.ts
+++ b/packages/data-access-plugin/src/index.ts
@@ -28,9 +28,20 @@ const adapter: TeraserverPluginAdapter = {
             });
     },
 
+    post() {
+        if (this._search == null) {
+            throw new Error('Plugin has not been configured');
+        }
+
+        if (!this._initialized) {
+            throw new Error('Plugin has not been initialized');
+        }
+
+        this._search.registerRoutes();
+    },
+
     routes() {
         if (this._manager == null
-            || this._search == null
             || this._config == null) {
             throw new Error('Plugin has not been configured');
         }
@@ -40,7 +51,6 @@ const adapter: TeraserverPluginAdapter = {
         }
 
         this._manager.registerRoutes();
-        this._search.registerRoutes();
     },
 };
 
@@ -53,6 +63,7 @@ interface TeraserverPluginAdapter {
     _initialized: boolean;
 
     config(config: PluginConfig): void;
+    post(): void;
     init(): Promise<void>;
     routes(): void;
 }

--- a/packages/data-access-plugin/src/index.ts
+++ b/packages/data-access-plugin/src/index.ts
@@ -8,6 +8,28 @@ const adapter: TeraserverPluginAdapter = {
     _search: undefined,
     _config: undefined,
 
+    config_schema() {
+        return {
+            connection: {
+                doc: 'Elasticsearch cluster where users, roles, spaces and views are stored',
+                default: 'default',
+                format(val: any) {
+                    if (typeof val !== 'string') {
+                        throw new Error('connection parameter must be of type String as the value');
+                    }
+                }
+            },
+            namespace: {
+                doc: 'Elasticsearch index namespace for the data-access models',
+                default: false,
+            },
+            bootstrap_mode: {
+                doc: '[DEVELOPMENT] Remove authentication from setting up the data access models',
+                default: false,
+            }
+        };
+    },
+
     config(config: PluginConfig) {
         this._manager = new ManagerPlugin(config);
         this._search = new SearchPlugin(config);
@@ -62,6 +84,7 @@ interface TeraserverPluginAdapter {
     _search?: SearchPlugin;
     _initialized: boolean;
 
+    config_schema(): any;
     config(config: PluginConfig): void;
     post(): void;
     init(): Promise<void>;

--- a/packages/data-access-plugin/src/interfaces.ts
+++ b/packages/data-access-plugin/src/interfaces.ts
@@ -1,6 +1,7 @@
 import { Express } from 'express';
 import { Client } from 'elasticsearch';
 import { Logger } from '@terascope/utils';
+import { Context } from '@terascope/job-components';
 
 export interface PluginConfig {
     logger: Logger;
@@ -8,6 +9,7 @@ export interface PluginConfig {
     elasticsearch: Client;
     url_base: string;
     server_config: TeraserverConfig;
+    context: Context;
 }
 
 export interface TeraserverConfig {
@@ -21,6 +23,7 @@ export interface TeraserverConfig {
     data_access?: {
         namespace?: string;
         bootstrap_mode?: boolean;
+        connection?: string;
     };
     teraserver: {
         shutdown_timeout: number;

--- a/packages/data-access-plugin/src/manager/index.ts
+++ b/packages/data-access-plugin/src/manager/index.ts
@@ -15,6 +15,7 @@ import schema from './schema';
  *
  * @todo add permission rules to manage the ACL
  * @todo add session support
+ * @todo use `req.query.token` NOT `req.query.api_token`
 */
 export default class ManagerPlugin {
     readonly config: TeraserverConfig;

--- a/packages/data-access-plugin/src/manager/index.ts
+++ b/packages/data-access-plugin/src/manager/index.ts
@@ -127,7 +127,7 @@ export default class ManagerPlugin {
                     space,
                 });
 
-                const connection = get(accessConfig, 'space_metadata.teraserver.connection', 'default');
+                const connection = get(accessConfig, 'space_metadata.indexConfig.connection', 'default');
                 const client = getESClient(this.context, connection);
 
                 const search = makeSearchFn(client, accessConfig, this.logger);

--- a/packages/data-access-plugin/src/manager/index.ts
+++ b/packages/data-access-plugin/src/manager/index.ts
@@ -16,7 +16,6 @@ import schema from './schema';
  *
  * @todo add permission rules to manage the ACL
  * @todo add session support
- * @todo use `req.query.token` NOT `req.query.api_token`
 */
 export default class ManagerPlugin {
     readonly config: TeraserverConfig;
@@ -77,7 +76,7 @@ export default class ManagerPlugin {
             // @ts-ignore
             req.aclManager = this.manager;
 
-            const apiToken = getFromReq(req, 'api_token');
+            const apiToken = getFromReq(req, 'token');
 
             // If we are in bootstrap mode, we want to provide
             // unauthenticated access to the data access management
@@ -128,7 +127,7 @@ export default class ManagerPlugin {
                     space,
                 });
 
-                const connection: string = get(accessConfig.space_metadata, 'default_connection', 'default');
+                const connection = get(accessConfig, 'space_metadata.teraserver.connection', 'default');
                 const client = getESClient(this.context, connection);
 
                 const search = makeSearchFn(client, accessConfig, this.logger);

--- a/packages/data-access-plugin/src/manager/index.ts
+++ b/packages/data-access-plugin/src/manager/index.ts
@@ -3,10 +3,11 @@ import { Express } from 'express';
 import { Client } from 'elasticsearch';
 import { Logger } from '@terascope/utils';
 import * as apollo from 'apollo-server-express';
+import { Context } from '@terascope/job-components';
 import { ACLManager } from '@terascope/data-access';
 import { TeraserverConfig, PluginConfig } from '../interfaces';
 import { makeSearchFn } from '../search/utils';
-import { getFromReq, makeErrorHandler } from '../utils';
+import { getFromReq, makeErrorHandler, getESClient } from '../utils';
 import { formatError } from './utils';
 import schema from './schema';
 
@@ -25,18 +26,23 @@ export default class ManagerPlugin {
     readonly server: apollo.ApolloServer;
     readonly bootstrapMode: boolean;
     readonly client: Client;
+    readonly context: Context;
 
     constructor(pluginConfig: PluginConfig) {
-        const client = pluginConfig.elasticsearch;
         this.config = pluginConfig.server_config;
         this.logger = pluginConfig.logger;
         this.app = pluginConfig.app;
-        this.client = client;
+        this.context = pluginConfig.context;
 
-        const namespace = get(this.config, 'data_access.namespace');
-        this.bootstrapMode = get(this.config, 'data_access.bootstrap_mode', false);
+        const connection: string = get(this.config, 'data_access.connect', 'default');
+        const namespace: string = get(this.config, 'data_access.namespace');
+        const bootstrapMode: boolean = get(this.config, 'data_access.bootstrap_mode', false);
 
-        this.manager = new ACLManager(client, {
+        this.client = getESClient(this.context, connection);
+
+        this.bootstrapMode = bootstrapMode;
+
+        this.manager = new ACLManager(this.client, {
             namespace,
             logger: pluginConfig.logger,
         });
@@ -122,10 +128,14 @@ export default class ManagerPlugin {
                     space,
                 });
 
-                const search = makeSearchFn(this.client, accessConfig, this.logger);
+                const connection: string = get(accessConfig.space_metadata, 'default_connection', 'default');
+                const client = getESClient(this.context, connection);
+
+                const search = makeSearchFn(client, accessConfig, this.logger);
 
                 // @ts-ignore
                 req.space = {
+                    searchErrorHandler: makeErrorHandler('Search failure', this.logger),
                     accessConfig,
                     search
                 };

--- a/packages/data-access-plugin/src/search/index.ts
+++ b/packages/data-access-plugin/src/search/index.ts
@@ -4,7 +4,7 @@ import { Logger } from '@terascope/utils';
 import { DataAccessConfig } from '@terascope/data-access';
 import { TeraserverConfig, PluginConfig } from '../interfaces';
 import { SearchFn } from './interfaces';
-import { makeErrorHandler } from '../utils';
+import { ErrorHandlerFn } from '../utils';
 
 /**
  * @todo add support for the search counter
@@ -31,7 +31,6 @@ export default class SearchPlugin {
         const searchUrl = '/api/v2/:space';
         this.logger.info(`Registering data-access-plugin search endpoint at ${searchUrl}`);
 
-        const searchErrorHandler = makeErrorHandler('Search failure', this.logger);
         this.app.get(searchUrl, (req, res) => {
             // @ts-ignore
             const space: SpaceSearch = req.space;
@@ -40,7 +39,7 @@ export default class SearchPlugin {
                 return;
             }
 
-            searchErrorHandler(req, res, async () => {
+            space.searchErrorHandler(req, res, async () => {
                 const result = await space.search(req.query);
 
                 res
@@ -58,6 +57,7 @@ export default class SearchPlugin {
 }
 
 export interface SpaceSearch {
+    searchErrorHandler: ErrorHandlerFn;
     accessConfig: DataAccessConfig;
     search: SearchFn;
 }

--- a/packages/data-access-plugin/src/search/index.ts
+++ b/packages/data-access-plugin/src/search/index.ts
@@ -8,7 +8,6 @@ import { ErrorHandlerFn } from '../utils';
 
 /**
  * @todo add support for the search counter
- * @todo smarter about pretty (parse the boolean)
  */
 export default class SearchPlugin {
     readonly config: TeraserverConfig;
@@ -46,7 +45,10 @@ export default class SearchPlugin {
                     .status(200)
                     .set('Content-type', 'application/json; charset=utf-8');
 
-                if (req.query.pretty) {
+                const { pretty } = req.query;
+                const boolValues = [1, true, '1', 'true', 'True', 'TRUE', 'yes'];
+
+                if (boolValues.includes(pretty)) {
                     res.send(JSON.stringify(result, null, 2));
                 } else {
                     res.json(result);

--- a/packages/data-access-plugin/src/search/index.ts
+++ b/packages/data-access-plugin/src/search/index.ts
@@ -8,6 +8,7 @@ import { makeErrorHandler } from '../utils';
 
 /**
  * @todo add support for the search counter
+ * @todo smarter about pretty (parse the boolean)
  */
 export default class SearchPlugin {
     readonly config: TeraserverConfig;

--- a/packages/data-access-plugin/src/search/interfaces.ts
+++ b/packages/data-access-plugin/src/search/interfaces.ts
@@ -49,7 +49,7 @@ export interface ViewMetadata {
 
 export interface SearchSpaceConfig {
     index: string;
-    indexConfig: string;
+    connection?: string;
 }
 
 export interface SpaceMetadata {

--- a/packages/data-access-plugin/src/search/interfaces.ts
+++ b/packages/data-access-plugin/src/search/interfaces.ts
@@ -49,6 +49,7 @@ export interface ViewMetadata {
 
 export interface SearchSpaceConfig {
     index: string;
+    indexConfig: string;
 }
 
 export interface SpaceMetadata {

--- a/packages/data-access-plugin/src/search/utils.ts
+++ b/packages/data-access-plugin/src/search/utils.ts
@@ -187,6 +187,7 @@ export function getGeoSort(field: string, point: string, order: i.SortOrder, uni
     return sort;
 }
 
+/** @todo we should add index context to the error */
 export function getSearchResponse(response: SearchResponse<any>, config: i.SearchConfig, query: i.InputQuery, params: SearchParams) {
     // I don't think this property actually exists
     const error = get(response, 'error');

--- a/packages/data-access-plugin/src/utils.ts
+++ b/packages/data-access-plugin/src/utils.ts
@@ -1,6 +1,8 @@
 import get from 'lodash.get';
-import { parseErrorInfo, Logger, stripErrorMessage } from '@terascope/utils';
+import { Client } from 'elasticsearch';
 import { Request, Response } from 'express';
+import { Context } from '@terascope/job-components';
+import { parseErrorInfo, Logger, stripErrorMessage } from '@terascope/utils';
 
 export function getFromReq(req: Request, prop: string, defaultVal?: any): any {
     return get(req, ['query', prop], get(req, ['body', prop], defaultVal));
@@ -10,9 +12,9 @@ export function getFromQuery(req: Request, prop: string, defaultVal?: any): any 
     return get(req, ['query', prop], defaultVal);
 }
 
-export type errorHandlerFn = (req: Request, res: Response, fn: (...args: any[]) => Promise<any>|any) => Promise<void>;
+export type ErrorHandlerFn = (req: Request, res: Response, fn: (...args: any[]) => Promise<any>|any) => Promise<void>;
 
-export function makeErrorHandler(reason: string, logger: Logger): errorHandlerFn {
+export function makeErrorHandler(reason: string, logger: Logger): ErrorHandlerFn {
     return async (req, res, fn) => {
         try {
             await fn();
@@ -31,4 +33,12 @@ export function makeErrorHandler(reason: string, logger: Logger): errorHandlerFn
             });
         }
     };
+}
+
+export function getESClient(context: Context, connection: string): Client {
+    return context.foundation.getConnection({
+        type: 'elasticsearch',
+        endpoint: connection,
+        cached: true
+    }).client;
 }

--- a/packages/data-access-plugin/test/adapter-spec.ts
+++ b/packages/data-access-plugin/test/adapter-spec.ts
@@ -1,5 +1,5 @@
 import 'jest-extended';
-import { debugLogger } from '@terascope/utils';
+import { TestContext } from '@terascope/job-components';
 import { makeClient } from './helpers/elasticsearch';
 import ManagerPlugin from '../src/manager';
 import SearchPlugin from '../src/search';
@@ -8,6 +8,17 @@ import index from '../src';
 
 describe('TeraserverAdapterPlugin', () => {
     const client = makeClient();
+    const context = new TestContext('adapter-plugin', {
+        clients: [
+            {
+                type: 'elasticsearch',
+                create: () => {
+                    return { client };
+                },
+                endpoint: 'default'
+            }
+        ]
+    });
 
     it('should export a valid plugin adapter', () => {
         expect(index._manager).toBeNil();
@@ -16,6 +27,11 @@ describe('TeraserverAdapterPlugin', () => {
         expect(index.init).toBeFunction();
         expect(index.post).toBeFunction();
         expect(index.routes).toBeFunction();
+        expect(index.config_schema).toBeFunction();
+    });
+
+    it('should have a config', () => {
+        expect(index.config_schema()).toBeObject();
     });
 
     it('should not be able to call init if not configured', () => {
@@ -34,7 +50,8 @@ describe('TeraserverAdapterPlugin', () => {
             url_base: '',
             // @ts-ignore
             app: {},
-            logger: debugLogger('manager-plugin'),
+            context,
+            logger: context.logger,
             server_config: {
                 data_access: {
                     namespace: 'test_da_adapter',

--- a/packages/data-access-plugin/test/adapter-spec.ts
+++ b/packages/data-access-plugin/test/adapter-spec.ts
@@ -14,6 +14,7 @@ describe('TeraserverAdapterPlugin', () => {
         expect(index._initialized).toBeFalse();
         expect(index.config).toBeFunction();
         expect(index.init).toBeFunction();
+        expect(index.post).toBeFunction();
         expect(index.routes).toBeFunction();
     });
 
@@ -75,6 +76,12 @@ describe('TeraserverAdapterPlugin', () => {
         }).toThrowError('Plugin has not been initialized');
     });
 
+    it('should not be able to call post if not initialized', () => {
+        expect(() => {
+            index.post();
+        }).toThrowError('Plugin has not been initialized');
+    });
+
     it('should be able to call init', async () => {
         await expect(index.init()).resolves.toBeNil();
         expect(index._initialized).toBeTrue();
@@ -83,6 +90,12 @@ describe('TeraserverAdapterPlugin', () => {
     it('should be able to call routes', () => {
         expect(() => {
             index.routes();
+        }).not.toThrow();
+    });
+
+    it('should be able to call post', () => {
+        expect(() => {
+            index.post();
         }).not.toThrow();
     });
 });

--- a/packages/data-access-plugin/test/plugin-spec.ts
+++ b/packages/data-access-plugin/test/plugin-spec.ts
@@ -3,7 +3,7 @@ import got from 'got';
 import express from 'express';
 import { Server } from 'http';
 import { request } from 'graphql-request';
-import { debugLogger } from '@terascope/utils';
+import { TestContext } from '@terascope/job-components';
 import { makeClient, cleanupIndexes } from './helpers/elasticsearch';
 import { PluginConfig } from '../src/interfaces';
 import ManagerPlugin from '../src/manager';
@@ -15,11 +15,24 @@ describe('Data Access Plugin', () => {
     const app = express();
     let listener: Server;
 
+    const context = new TestContext('plugin-spec', {
+        clients: [
+            {
+                type: 'elasticsearch',
+                endpoint: 'default',
+                create: () => {
+                    return { client };
+                },
+            }
+        ]
+    });
+
     const pluginConfig: PluginConfig = {
         elasticsearch: client,
         url_base: '',
         app,
-        logger: debugLogger('manager-plugin'),
+        context,
+        logger: context.logger,
         server_config: {
             data_access: {
                 namespace: 'test_da_plugin',

--- a/packages/data-access-plugin/test/plugin-spec.ts
+++ b/packages/data-access-plugin/test/plugin-spec.ts
@@ -152,9 +152,7 @@ describe('Data Access Plugin', () => {
                         name: "greetings",
                         metadata: {
                             indexConfig: {
-                                index: "hello-space"
-                            },
-                            teraserver: {
+                                index: "hello-space",
                                 connection: "other"
                             }
                         }

--- a/packages/data-access-plugin/test/plugin-spec.ts
+++ b/packages/data-access-plugin/test/plugin-spec.ts
@@ -23,6 +23,13 @@ describe('Data Access Plugin', () => {
                 create: () => {
                     return { client };
                 },
+            },
+            {
+                type: 'elasticsearch',
+                endpoint: 'other',
+                create: () => {
+                    return { client };
+                },
             }
         ]
     });
@@ -146,6 +153,9 @@ describe('Data Access Plugin', () => {
                         metadata: {
                             indexConfig: {
                                 index: "hello-space"
+                            },
+                            teraserver: {
+                                connection: "other"
                             }
                         }
                     }, views: [
@@ -391,7 +401,7 @@ describe('Data Access Plugin', () => {
 
             const result = await got(uri, {
                 query: {
-                    api_token: apiToken
+                    token: apiToken
                 },
                 json: true,
                 throwHttpErrors: false
@@ -426,7 +436,7 @@ describe('Data Access Plugin', () => {
             const uri = formatBaseUri();
             const result = await got(uri, {
                 query: {
-                    api_token: apiToken
+                    token: apiToken
                 },
                 json: true,
                 throwHttpErrors: false
@@ -527,7 +537,7 @@ describe('Data Access Plugin', () => {
             const uri = formatBaseUri(spaceId);
             const result = await got(uri, {
                 query: {
-                    api_token: apiToken,
+                    token: apiToken,
                     q: 'foo:bar',
                     sort: '_id:asc'
                 },
@@ -591,7 +601,7 @@ describe('Data Access Plugin', () => {
                 const uri = formatBaseUri(spaceId);
                 const result = await got(uri, {
                     query: {
-                        api_token: apiToken,
+                        token: apiToken,
                         q: 'foo:baz',
                         pretty: true
                     },

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-access",
     "description": "A tool designed to limit access to reading and querying data",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "publishConfig": {
         "access": "public"
     },

--- a/packages/data-access/src/acl-manager.ts
+++ b/packages/data-access/src/acl-manager.ts
@@ -8,6 +8,10 @@ import { ManagerConfig } from './interfaces';
  * high level abstraction of Spaces, Users, Roles, and Views
  *
  * @todo add a method to find the views for space, with the applied defaults
+ * @todo auto-create an admin role
+ * @todo an admin should be able to view api_token without knowing the password
+ * @todo only admins can write to the data-access models
+ * @todo authenticated users can query and update their user
 */
 export class ACLManager {
     static GraphQLSchema = `

--- a/packages/data-access/src/models/users.ts
+++ b/packages/data-access/src/models/users.ts
@@ -7,8 +7,6 @@ import * as utils from '../utils';
 
 /**
  * Manager for Users
- *
- * @todo GraphQL CreateUserInput should not require the client_id
 */
 export class Users extends Base<PrivateUserModel, CreatePrivateUserInput, UpdatePrivateUserInput> {
     static PrivateFields: string[] = ['api_token', 'salt', 'hash'];
@@ -42,7 +40,7 @@ export class Users extends Base<PrivateUserModel, CreatePrivateUserInput, Update
         }
 
         input CreateUserInput {
-            client_id: Int!
+            client_id: Int
             username: String!
             firstname: String
             lastname: String

--- a/packages/data-access/src/models/users.ts
+++ b/packages/data-access/src/models/users.ts
@@ -7,6 +7,8 @@ import * as utils from '../utils';
 
 /**
  * Manager for Users
+ *
+ * @todo GraphQL CreateUserInput should not require the client_id
 */
 export class Users extends Base<PrivateUserModel, CreatePrivateUserInput, UpdatePrivateUserInput> {
     static PrivateFields: string[] = ['api_token', 'salt', 'hash'];

--- a/packages/elasticsearch-store/src/index-manager.ts
+++ b/packages/elasticsearch-store/src/index-manager.ts
@@ -5,7 +5,11 @@ import { IndexConfig } from './interfaces';
 
 const _loggers = new WeakMap<IndexConfig, ts.Logger>();
 
-/** Manage Elasticsearch Indicies */
+/**
+ * Manage Elasticsearch Indicies
+ *
+ * @todo when setting up and index with multiple workers at the same it should not fail with an "index_exists"
+ */
 export default class IndexManager {
     readonly client: es.Client;
 


### PR DESCRIPTION
- Add support for configuring the connector for the data-access and for spaces. For spaces set `metadata.teraserver.connection` on the space.
- Fix use of pretty
- Add todos, update docs and fixes
- Fixes to user graphql types