### PR TITLE
Bump version of teraslice to v0.51.0 for release.

### DIFF
--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.50.0",
+    "version": "0.51.0",
     "description": "Distributed computing platform for processing JSON data",
     "bin": "service.js",
     "main": "index.js",


### PR DESCRIPTION
This just bumps the version of teraslice for when we want to do the `v0.51.0` release.