### PR TITLE
better job stopping and no assumptions with asset replace

### DIFF
--- a/packages/teraslice-cli/cmds/assets/deploy.js
+++ b/packages/teraslice-cli/cmds/assets/deploy.js
@@ -117,16 +117,15 @@ exports.handler = async (argv) => {
             reply.yellow('*** Warning ***\n'
                 + 'The --replace option is intended for asset development only.\n'
                 + 'Using it for production asset management is a bad idea.');
+
             const clusterAssetData = await terasliceClient.assets.get(asset.name);
 
-            // NOTE: We assume the 0th element of the list is the one that needs
-            // to be deleted.  This probably only works due to the order that
-            // assets are typically posted to a server is by increasing version.
-            // Basically, this assumes the asset currently being deployed has
-            // the same version of the last asset posted to the cluster.
-            if (clusterAssetData.length >= 1) {
-                const response = await terasliceClient.assets
-                    .delete(clusterAssetData[0].id);
+            const assetToReplace = clusterAssetData
+                .filter(clusterAsset => clusterAsset.version === asset.version)[0];
+
+            if (assetToReplace && assetToReplace.id !== undefined) {
+                const response = await terasliceClient.assets.delete(assetToReplace.id);
+
                 if (!cliConfig.args.quiet) {
                     // Support different teraslice api/client versions
                     const assetId = response._id || response.assetId;

--- a/packages/teraslice-cli/cmds/assets/deploy.js
+++ b/packages/teraslice-cli/cmds/assets/deploy.js
@@ -4,8 +4,8 @@
 // TODO: Let's rework all of the IO that the `reply` module provides and ensure
 //       our commands are as Unix like as possible.
 const path = require('path');
-
 const fs = require('fs-extra');
+const _ = require('lodash');
 
 const AssetSrc = require('../../lib/asset-src');
 const GithubAsset = require('../../lib/github-asset');
@@ -123,7 +123,7 @@ exports.handler = async (argv) => {
             const assetToReplace = clusterAssetData
                 .filter(clusterAsset => clusterAsset.version === asset.version)[0];
 
-            if (assetToReplace && assetToReplace.id !== undefined) {
+            if (_.has(assetToReplace, 'id')) {
                 const response = await terasliceClient.assets.delete(assetToReplace.id);
 
                 if (!cliConfig.args.quiet) {
@@ -133,6 +133,8 @@ exports.handler = async (argv) => {
                         `Asset ${assetId} deleted from ${cliConfig.args.clusterAlias}`
                     );
                 }
+            } else {
+                reply.green(`Asset: ${asset.name}, version: ${asset.version}, was not found on ${cliConfig.args.clusterAlias}`);
             }
         }
     } else {

--- a/packages/teraslice-cli/lib/tjm-util.js
+++ b/packages/teraslice-cli/lib/tjm-util.js
@@ -23,23 +23,39 @@ class TjmUtil {
     }
 
     async stop() {
+        const terminalStatuses = [
+            'stopped',
+            'completed',
+            'terminated',
+            'failed',
+            'rejected',
+            'aborted'
+        ];
+
         try {
-            const response = await this.client.jobs.wrap(this.job.jobId).stop();
-            const jobStatus = response.status.status || response.status;
+            const status = await this.client.jobs.wrap(this.job.jobId).status();
 
-            if (jobStatus !== 'stopped') {
-                reply.fatal(`Could not stop ${this.job.name} on ${this.job.clusterUrl}`);
-            }
-
-            reply.green(`Stopped job ${this.job.name} on ${this.job.clusterUrl}`);
-        } catch (e) {
-            if (e.message.includes('no execution context was found') || e.message.includes('Cannot update terminal job status of "stopped" to "stopping"')) {
-                const logMessage = `Job ${this.job.name} is not currently running on ${this.job.clusterUrl}`;
-
-                reply.yellow(logMessage);
+            if (status === 'stopping') {
+                reply.green(`job: ${this.job.name} is stopping, wait for job to stop`);
+                await this.client.jobs.wrap(this.job.jobId).waitForStatus('stopped');
+                reply.green(`Stopped job ${this.job.name} on ${this.job.clusterUrl}`);
                 return;
             }
 
+            if (terminalStatuses.includes(status)) {
+                reply.green(`job: ${this.job.name}, job id: ${this.job.jobId}, is not running.  Current status is ${status} on cluster: ${this.job.clusterUrl}`);
+            } else {
+                reply.green(`attempting to stop job: ${this.job.name}, job id: ${this.job.jobId}, on cluster ${this.job.clusterUrl}`);
+                const response = await this.client.jobs.wrap(this.job.jobId).stop();
+                const jobStatus = response.status.status || response.status;
+
+                if (jobStatus !== 'stopped') {
+                    reply.fatal(`Could not stop ${this.job.name} on ${this.job.clusterUrl}`);
+                }
+
+                reply.green(`Stopped job ${this.job.name} on ${this.job.clusterUrl}`);
+            }
+        } catch (e) {
             reply.fatal(e);
         }
     }

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-cli",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "bin": {
         "teraslice-cli": "./index.js",
@@ -53,6 +53,8 @@
     },
     "pkg": {
         "scripts": "cmds/**/*.js",
-        "assets": ["generators/**/templates/*"]
+        "assets": [
+            "generators/**/templates/*"
+        ]
     }
 }


### PR DESCRIPTION
2 fixes to the cli
* tjm stop checks status before calling stop on a job
* asset --replace doesn't assume the latest asset is the one that needs replacing and checks for the asset version