### PR TITLE
v0.53.3 - Fix unhandledRejection and improved error logging

### DIFF
--- a/packages/chunked-file-reader/package.json
+++ b/packages/chunked-file-reader/package.json
@@ -22,7 +22,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "bluebird": "^3.5.5",
         "csvtojson": "^2.0.8",
         "lodash": "^4.17.11"

--- a/packages/data-access-plugin/package.json
+++ b/packages/data-access-plugin/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "@terascope/data-access": "^0.11.2",
         "@terascope/data-types": "^0.3.1",
-        "@terascope/elasticsearch-api": "^2.0.4",
+        "@terascope/elasticsearch-api": "^2.0.5",
         "@terascope/utils": "^0.12.2",
         "apollo-server-express": "^2.6.5",
         "graphql": "^14.3.1",

--- a/packages/data-access-plugin/package.json
+++ b/packages/data-access-plugin/package.json
@@ -31,7 +31,7 @@
         "@terascope/data-access": "^0.11.2",
         "@terascope/data-types": "^0.3.1",
         "@terascope/elasticsearch-api": "^2.0.5",
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "apollo-server-express": "^2.6.5",
         "graphql": "^14.3.1",
         "graphql-iso-date": "^3.6.1",

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "@terascope/data-types": "^0.3.1",
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "elasticsearch-store": "^0.9.1",
         "xlucene-evaluator": "^0.9.4"
     },

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -28,7 +28,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "graphql": "^14.3.1",
         "yargs": "^13.2.4"
     },

--- a/packages/elasticsearch-api/index.js
+++ b/packages/elasticsearch-api/index.js
@@ -267,7 +267,7 @@ module.exports = function elasticsearchApi(client = {}, logger, _opConfig) {
                             },
                         });
 
-                        return Promise.reject(error);
+                        reject(error);
                     });
             }
 

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -19,7 +19,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "bluebird": "^3.5.5",
         "lodash": "^4.17.11"
     },

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/elasticsearch-api",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -25,7 +25,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "ajv": "^6.10.0",
         "nanoid": "^2.0.3",
         "rambda": "^2.11.1",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.6",
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^3.3.2"

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -23,7 +23,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.0.4",
+        "@terascope/elasticsearch-api": "^2.0.5",
         "@terascope/utils": "^0.12.2",
         "agentkeepalive": "^4.0.2",
         "bluebird": "^3.5.5",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@terascope/elasticsearch-api": "^2.0.5",
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "agentkeepalive": "^4.0.2",
         "bluebird": "^3.5.5",
         "bunyan": "^1.8.12",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.6",
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "nanoid": "^2.0.3",
         "p-event": "^4.1.0",
         "porty": "^3.1.1",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -25,7 +25,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.0.4",
+        "@terascope/elasticsearch-api": "^2.0.5",
         "@terascope/job-components": "^0.20.4",
         "bluebird": "^3.5.5",
         "lru-cache": "^5.1.1"

--- a/packages/teraslice/lib/workers/execution-controller/scheduler.js
+++ b/packages/teraslice/lib/workers/execution-controller/scheduler.js
@@ -171,7 +171,7 @@ class Scheduler {
             try {
                 await this.recover.shutdown();
             } catch (err) {
-                this.logger.error('failed to shutdown recovery', err);
+                this.logger.error(err, 'failed to shutdown recovery');
             }
         }
 
@@ -312,14 +312,14 @@ class Scheduler {
                 })
                 .catch((err) => {
                     _handling = false;
-                    this.logger.error('failure to run slicers', err);
+                    this.logger.error(err, 'failure to run slicers');
                 });
         }, 3);
 
         createInterval = setInterval(() => {
             if (!this.pendingSlicerCount) return;
 
-            this._drainPendingSlices().catch(err => this.logger.error('failure creating slices', err));
+            this._drainPendingSlices().catch(err => this.logger.error(err, 'failure creating slices'));
         }, 5);
 
         this._processCleanup = cleanup;

--- a/packages/teraslice/lib/workers/helpers/worker-shutdown.js
+++ b/packages/teraslice/lib/workers/helpers/worker-shutdown.js
@@ -36,7 +36,7 @@ function shutdownHandler(context, shutdownFn) {
     const restartOnFailure = assignment !== 'exectution_controller';
     const api = {
         exiting: false,
-        exit,
+        exit
     };
 
     const shutdownTimeout = get(context, 'sysconfig.teraslice.shutdown_timeout', 20 * 1000);
@@ -92,7 +92,7 @@ function shutdownHandler(context, shutdownFn) {
             await shutdownWithTimeout(event, err);
             logger.info(`${assignment} shutdown took ${Date.now() - startTime}ms`);
         } catch (error) {
-            logger.error(`${assignment} while shutting down`, error);
+            logger.error(error, `${assignment} while shutting down`);
         } finally {
             await flushLogs();
             process.exit();
@@ -169,5 +169,5 @@ function shutdownHandler(context, shutdownFn) {
 
 module.exports = {
     shutdownHandler,
-    waitForWorkerShutdown,
+    waitForWorkerShutdown
 };

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -34,7 +34,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.0.4",
+        "@terascope/elasticsearch-api": "^2.0.5",
         "@terascope/error-parser": "^1.0.2",
         "@terascope/job-components": "^0.20.4",
         "@terascope/queue": "^1.1.6",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.53.2",
+    "version": "0.53.3",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -39,7 +39,7 @@
         "@terascope/job-components": "^0.20.4",
         "@terascope/queue": "^1.1.6",
         "@terascope/teraslice-messaging": "^0.3.3",
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "async-mutex": "^0.1.3",
         "barbe": "^3.0.15",
         "bluebird": "^3.5.5",

--- a/packages/teraslice/worker-service.js
+++ b/packages/teraslice/worker-service.js
@@ -15,13 +15,20 @@ class Service {
         this.context = context;
 
         this.logger = this.context.logger;
-        this.shutdownTimeout = _.get(this.context, 'sysconfig.teraslice.shutdown_timeout', 60 * 1000);
+        this.shutdownTimeout = _.get(
+            this.context,
+            'sysconfig.teraslice.shutdown_timeout',
+            60 * 1000
+        );
     }
 
     async initialize() {
         const { assignment } = this.context;
         const { ex_id: exId } = this.executionConfig;
-        this.logger.trace(`Initializing ${assignment} for execution ${exId}...`, this.executionConfig);
+        this.logger.trace(
+            `Initializing ${assignment} for execution ${exId}...`,
+            this.executionConfig
+        );
 
         const executionContext = await makeExecutionContext(this.context, this.executionConfig);
 
@@ -42,7 +49,7 @@ class Service {
 
     shutdown(err) {
         if (err) {
-            this.logger.error('Teraslice Worker shutting down due to failure!', err);
+            this.logger.error(err, 'Teraslice Worker shutting down due to failure!');
         }
         this.shutdownHandler.exit('error', err);
     }

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -37,7 +37,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "@types/graphlib": "^2.1.5",
         "@types/shortid": "^0.0.29",
         "awesome-phonenumber": "^2.12.0",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@terascope/data-access": "^0.11.2",
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "apollo-boost": "^0.4.3",
         "apollo-client": "^2.6.3",
         "date-fns": "^1.30.1",

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -44,7 +44,7 @@
     "devDependencies": {
         "@craco/craco": "^5.2.3",
         "@terascope/ui-components": "^0.3.6",
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "@types/jest": "24.0.15",
         "@types/node": "12.6.2",
         "@types/react": "16.8.23",

--- a/packages/ui-data-access/package.json
+++ b/packages/ui-data-access/package.json
@@ -26,7 +26,7 @@
         "@terascope/data-access": "^0.11.2",
         "@terascope/data-types": "^0.3.1",
         "@terascope/ui-components": "^0.3.6",
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "@types/jest": "24.0.15",
         "@types/node": "12.6.2",
         "@types/react": "16.8.23",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/utils",
-    "version": "0.12.2",
+    "version": "0.12.3",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -126,6 +126,21 @@ type ErrorInfo = {
 const DEFAULT_STATUS_CODE = 500;
 const DEFAULT_ERR_MSG = STATUS_CODES[DEFAULT_STATUS_CODE] as string;
 
+/**
+ * Use following the chain of caused by stack of an error.
+ * Don't use this when logging the error, only when sending it
+ * */
+export function getFullErrorStack(err: any): string {
+    return `${parseError(err, true)}${getCauseStack(err)}`;
+}
+
+function getCauseStack(err: any) {
+    if (!err || !utils.isFunction(err.cause)) return '';
+    const cause = err.cause();
+    if (!cause) return '';
+    return `\nCaused by: ${getFullErrorStack(cause)}`;
+}
+
 /** parse error for info */
 export function parseErrorInfo(input: any, config: TSErrorConfig = {}): ErrorInfo {
     const { defaultErrorMsg, defaultStatusCode = DEFAULT_STATUS_CODE } = config;

--- a/packages/utils/src/promises.ts
+++ b/packages/utils/src/promises.ts
@@ -110,10 +110,12 @@ export async function pRetry<T = any>(fn: PromiseFn<T>, options?: Partial<PRetry
             context,
         });
 
-        if (context.lastErr) {
-            err.stack += `, caused by ${context.lastErr.stack}`;
+        if (_err && _err.stack) {
+            err.stack += `\n${_err.stack
+                .split('\n')
+                .slice(1)
+                .join('\n')}`;
         }
-        config._context.lastErr = err;
 
         if (!isFatalError(err) && err.retryable == null) {
             err.retryable = matches;
@@ -163,7 +165,6 @@ export function getBackoffDelay(current: number, factor: number = 2, max = 60000
 }
 
 type PRetryContext = {
-    lastErr?: Error;
     attempts: number;
     startTime: number;
 };

--- a/packages/utils/test/promises-spec.ts
+++ b/packages/utils/test/promises-spec.ts
@@ -4,11 +4,7 @@ import { waterfall, pRetry, TSError, PRetryConfig, getBackoffDelay } from '../sr
 describe('Utils', () => {
     describe('waterfall', () => {
         it('should call all methods and return the correct value', async () => {
-            const queue = [
-                jest.fn().mockResolvedValue('hello'),
-                jest.fn().mockResolvedValue('hi'),
-                jest.fn().mockResolvedValue('howdy'),
-            ];
+            const queue = [jest.fn().mockResolvedValue('hello'), jest.fn().mockResolvedValue('hi'), jest.fn().mockResolvedValue('howdy')];
 
             const result = await waterfall('greetings', queue);
             expect(result).toEqual('howdy');
@@ -102,7 +98,7 @@ describe('Utils', () => {
 
         it('should end early with a StopError', async () => {
             const error = new TSError('Stop Error', {
-                retryable: false
+                retryable: false,
             });
 
             const fn = jest.fn();
@@ -126,7 +122,7 @@ describe('Utils', () => {
             const input = min;
             const result = getBackoffDelay(input, factor, max, min);
 
-            expect(result).toBeWithin((input - jitter), (input * factor) + jitter);
+            expect(result).toBeWithin(input - jitter, input * factor + jitter);
             expect(result).toBeGreaterThanOrEqual(min);
             expect(result).toBeLessThanOrEqual(max);
         });
@@ -145,7 +141,7 @@ describe('Utils', () => {
             const input = 150;
             const result = getBackoffDelay(input, factor, max, min);
 
-            expect(result).toBeWithin((input - jitter), (input * factor) + jitter);
+            expect(result).toBeWithin(input - jitter, input * factor + jitter);
             expect(result).toBeGreaterThanOrEqual(min);
             expect(result).toBeLessThanOrEqual(max);
         });

--- a/packages/xlucene-evaluator/package.json
+++ b/packages/xlucene-evaluator/package.json
@@ -32,7 +32,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/utils": "^0.12.2",
+        "@terascope/utils": "^0.12.3",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-point-in-polygon": "^6.0.1",


### PR DESCRIPTION
- Fix `unhandledRejection` in `bulkSend` in `elasticsearch-api`
- Fix stack trace in `pRetry`
- Keep error logging consistent by logging the err before the message
- Bumps `teraslice`, `@terascope/utils` and `@terascope/elasticsearch-api`

Resolves #1213

