### PR TITLE
Fix for matching xlucene query translations

### DIFF
--- a/packages/data-access-plugin/package.json
+++ b/packages/data-access-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/data-access-plugin",
-    "version": "0.11.1",
+    "version": "0.11.2",
     "description": "A teraserver plugin for managing data access and searching spaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-access-plugin#readme",
     "bugs": {
@@ -28,7 +28,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged --forceExit"
     },
     "dependencies": {
-        "@terascope/data-access": "^0.12.2",
+        "@terascope/data-access": "^0.12.3",
         "@terascope/data-types": "^0.4.1",
         "@terascope/elasticsearch-api": "^2.1.0",
         "@terascope/utils": "^0.12.4",
@@ -38,7 +38,7 @@
         "graphql-tag": "^2.10.1",
         "graphql-type-json": "^0.3.0",
         "terafoundation": "^0.10.0",
-        "xlucene-evaluator": "^0.9.4"
+        "xlucene-evaluator": "^0.9.5"
     },
     "devDependencies": {
         "@terascope/job-components": "^0.20.5",

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/data-access",
-    "version": "0.12.2",
+    "version": "0.12.3",
     "description": "A tool designed to limit access to reading and querying data",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-access#readme",
     "bugs": {
@@ -28,8 +28,8 @@
     "dependencies": {
         "@terascope/data-types": "^0.4.1",
         "@terascope/utils": "^0.12.4",
-        "elasticsearch-store": "^0.10.0",
-        "xlucene-evaluator": "^0.9.4"
+        "elasticsearch-store": "^0.10.1",
+        "xlucene-evaluator": "^0.9.5"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -38,7 +38,7 @@
         "@types/lodash.defaultsdeep": "^4.6.6",
         "@types/lodash.set": "^4.3.6",
         "@types/yargs": "^13.0.0",
-        "xlucene-evaluator": "^0.9.4"
+        "xlucene-evaluator": "^0.9.5"
     },
     "engines": {
         "node": ">=8.0.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "elasticsearch-store",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,7 +30,7 @@
         "ajv": "^6.10.0",
         "nanoid": "^2.0.3",
         "rambda": "^2.11.1",
-        "xlucene-evaluator": "^0.9.4"
+        "xlucene-evaluator": "^0.9.5"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -46,7 +46,7 @@
         "shortid": "^2.2.14",
         "valid-url": "^1.0.9",
         "validator": "^11.0.0",
-        "xlucene-evaluator": "^0.9.4",
+        "xlucene-evaluator": "^0.9.5",
         "yargs": "^13.2.4"
     },
     "devDependencies": {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -23,7 +23,7 @@
         "test": "echo '* tests not supported yet'"
     },
     "dependencies": {
-        "@terascope/data-access": "^0.12.2",
+        "@terascope/data-access": "^0.12.3",
         "@terascope/utils": "^0.12.4",
         "apollo-boost": "^0.4.3",
         "apollo-client": "^2.6.3",

--- a/packages/ui-data-access/package.json
+++ b/packages/ui-data-access/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@terascope/data-access": "^0.12.2",
+        "@terascope/data-access": "^0.12.3",
         "@terascope/data-types": "^0.4.1",
         "@terascope/ui-components": "^0.3.6",
         "@terascope/utils": "^0.12.4",
@@ -48,7 +48,7 @@
         "ts-loader": "^6.0.3",
         "webpack": "^4.34.0",
         "webpack-cli": "^3.3.4",
-        "xlucene-evaluator": "^0.9.4"
+        "xlucene-evaluator": "^0.9.5"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/xlucene-evaluator/package.json
+++ b/packages/xlucene-evaluator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xlucene-evaluator",
-    "version": "0.9.4",
+    "version": "0.9.5",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-evaluator#readme",
     "repository": {

--- a/packages/xlucene-evaluator/peg/lucene.pegjs
+++ b/packages/xlucene-evaluator/peg/lucene.pegjs
@@ -212,12 +212,6 @@ TermExpression
             field: null,
         }
     }
-    / term:WildcardType {
-        return {
-            ...term,
-            field: null,
-        }
-    }
     / term:TermType {
         return {
             ...term,
@@ -335,13 +329,13 @@ RangeTermType
     / RestrictedStringType
 
 TermType
-    = FloatType
+    = QuotedStringType
+    / FloatType
     / IntegerType
     / RegexpType
     / BooleanType
-    / WildcardType
     / ParensStringType
-    / QuotedStringType
+    / WildcardType
     / RestrictedStringType
 
 NegativeInfinityType

--- a/packages/xlucene-evaluator/src/translator/interfaces.ts
+++ b/packages/xlucene-evaluator/src/translator/interfaces.ts
@@ -15,6 +15,7 @@ export type AnyQuery =
     | GeoQuery
     | TermQuery
     | MatchQuery
+    | MatchPhraseQuery
     | WildcardQuery
     | ExistsQuery
     | RegExprQuery
@@ -51,6 +52,14 @@ export interface MatchQuery {
         [field: string]: {
             query: string;
             operator: 'and' | 'or';
+        };
+    };
+}
+
+export interface MatchPhraseQuery {
+    match_phrase: {
+        [field: string]: {
+            query: string;
         };
     };
 }

--- a/packages/xlucene-evaluator/src/translator/interfaces.ts
+++ b/packages/xlucene-evaluator/src/translator/interfaces.ts
@@ -48,6 +48,7 @@ export interface RegExprQuery {
 
 export interface MatchQuery {
     match: {
+        operator: 'or' | 'and';
         [field: string]: string;
     };
 }

--- a/packages/xlucene-evaluator/src/translator/interfaces.ts
+++ b/packages/xlucene-evaluator/src/translator/interfaces.ts
@@ -48,8 +48,10 @@ export interface RegExprQuery {
 
 export interface MatchQuery {
     match: {
-        operator: 'or' | 'and';
-        [field: string]: string;
+        [field: string]: {
+            query: string;
+            operator: 'and' | 'or';
+        };
     };
 }
 

--- a/packages/xlucene-evaluator/src/translator/interfaces.ts
+++ b/packages/xlucene-evaluator/src/translator/interfaces.ts
@@ -10,7 +10,16 @@ export type BoolQuery = {
 
 export type BoolQueryTypes = 'filter' | 'should' | 'must_not';
 
-export type AnyQuery = BoolQuery | GeoQuery | TermQuery | WildcardQuery | ExistsQuery | RegExprQuery | RangeQuery | MultiMatchQuery;
+export type AnyQuery =
+    | BoolQuery
+    | GeoQuery
+    | TermQuery
+    | MatchQuery
+    | WildcardQuery
+    | ExistsQuery
+    | RegExprQuery
+    | RangeQuery
+    | MultiMatchQuery;
 
 export interface ExistsQuery {
     exists: {
@@ -37,9 +46,15 @@ export interface RegExprQuery {
     };
 }
 
+export interface MatchQuery {
+    match: {
+        [field: string]: string;
+    };
+}
+
 export interface TermQuery {
     term: {
-        [field: string]: string | number | boolean;
+        [field: string]: number | boolean;
     };
 }
 

--- a/packages/xlucene-evaluator/src/translator/utils.ts
+++ b/packages/xlucene-evaluator/src/translator/utils.ts
@@ -155,8 +155,10 @@ export function buildTermQuery(node: p.Term): i.TermQuery | i.MatchQuery | i.Mul
     if (isString(node.value)) {
         const matchQuery: i.MatchQuery = {
             match: {
-                operator: 'and',
-                [field]: `${node.value}`,
+                [field]: {
+                    operator: 'and',
+                    query: `${node.value}`,
+                },
             },
         };
 

--- a/packages/xlucene-evaluator/src/translator/utils.ts
+++ b/packages/xlucene-evaluator/src/translator/utils.ts
@@ -155,6 +155,7 @@ export function buildTermQuery(node: p.Term): i.TermQuery | i.MatchQuery | i.Mul
     if (isString(node.value)) {
         const matchQuery: i.MatchQuery = {
             match: {
+                operator: 'and',
                 [field]: `${node.value}`,
             },
         };

--- a/packages/xlucene-evaluator/src/translator/utils.ts
+++ b/packages/xlucene-evaluator/src/translator/utils.ts
@@ -144,7 +144,7 @@ export function buildRangeQuery(node: p.Range): i.RangeQuery | i.MultiMatchQuery
     return rangeQuery;
 }
 
-export function buildTermQuery(node: p.Term): i.TermQuery | i.MatchQuery | i.MultiMatchQuery {
+export function buildTermQuery(node: p.Term): i.TermQuery | i.MatchQuery | i.MatchPhraseQuery | i.MultiMatchQuery {
     if (isMultiMatch(node)) {
         const query = `${node.value}`;
         return buildMultiMatchQuery(node, query);
@@ -153,6 +153,20 @@ export function buildTermQuery(node: p.Term): i.TermQuery | i.MatchQuery | i.Mul
     const field = getTermField(node);
 
     if (isString(node.value)) {
+        // @ts-ignore
+        if (node.quoted) {
+            const matchPhraseQuery: i.MatchPhraseQuery = {
+                match_phrase: {
+                    [field]: {
+                        query: `${node.value}`,
+                    },
+                },
+            };
+
+            logger.trace('built match phrase query', { node, matchPhraseQuery });
+            return matchPhraseQuery;
+        }
+
         const matchQuery: i.MatchQuery = {
             match: {
                 [field]: {

--- a/packages/xlucene-evaluator/src/translator/utils.ts
+++ b/packages/xlucene-evaluator/src/translator/utils.ts
@@ -1,17 +1,17 @@
-import { debugLogger, TSError } from '@terascope/utils';
+import { debugLogger, TSError, isString } from '@terascope/utils';
 import * as p from '../parser';
 import * as i from './interfaces';
 import { parseRange } from '../utils';
 
 const logger = debugLogger('xlucene-translator-utils');
 
-export function buildAnyQuery(node: p.AST, parser: p.Parser): i.AnyQuery|undefined {
+export function buildAnyQuery(node: p.AST, parser: p.Parser): i.AnyQuery | undefined {
     // if no field and is wildcard
     if (p.isWildcard(node) && !node.field && node.value === '*') {
         return {
             bool: {
-                filter: []
-            }
+                filter: [],
+            },
         };
     }
 
@@ -42,7 +42,7 @@ export function buildAnyQuery(node: p.AST, parser: p.Parser): i.AnyQuery|undefin
     return;
 }
 
-export function buildTermLevelQuery(node: p.TermLikeAST): i.AnyQuery|undefined {
+export function buildTermLevelQuery(node: p.TermLikeAST): i.AnyQuery | undefined {
     if (p.isTerm(node)) {
         return buildTermQuery(node);
     }
@@ -78,7 +78,7 @@ export function buildMultiMatchQuery(node: p.TermLikeAST, query: string): i.Mult
     const multiMatchQuery: i.MultiMatchQuery = {
         multi_match: {
             query,
-        }
+        },
     };
 
     logger.trace('built mutli-match query', { node, multiMatchQuery });
@@ -89,7 +89,7 @@ export function getTermField(node: p.TermLikeAST): string {
     return node.field!;
 }
 
-export function buildGeoBoundingBoxQuery(node: p.GeoBoundingBox): i.GeoQuery|undefined {
+export function buildGeoBoundingBoxQuery(node: p.GeoBoundingBox): i.GeoQuery | undefined {
     if (isMultiMatch(node)) return;
 
     const field = getTermField(node);
@@ -97,15 +97,15 @@ export function buildGeoBoundingBoxQuery(node: p.GeoBoundingBox): i.GeoQuery|und
     const geoQuery: i.GeoQuery = {};
     geoQuery['geo_bounding_box'] = {};
     geoQuery['geo_bounding_box'][field] = {
-        top_left:  node.top_left,
-        bottom_right: node.bottom_right
+        top_left: node.top_left,
+        bottom_right: node.bottom_right,
     };
 
     logger.trace('built geo bounding box query', { node, geoQuery });
     return geoQuery;
 }
 
-export function buildGeoDistanceQuery(node: p.GeoDistance): i.GeoQuery|undefined {
+export function buildGeoDistanceQuery(node: p.GeoDistance): i.GeoQuery | undefined {
     if (isMultiMatch(node)) return;
 
     const field = getTermField(node);
@@ -123,7 +123,7 @@ export function buildGeoDistanceQuery(node: p.GeoDistance): i.GeoQuery|undefined
     return geoQuery;
 }
 
-export function buildRangeQuery(node: p.Range): i.RangeQuery|i.MultiMatchQuery|undefined {
+export function buildRangeQuery(node: p.Range): i.RangeQuery | i.MultiMatchQuery | undefined {
     if (isMultiMatch(node)) {
         if (!node.right) {
             return;
@@ -136,15 +136,15 @@ export function buildRangeQuery(node: p.Range): i.RangeQuery|i.MultiMatchQuery|u
 
     const rangeQuery: i.RangeQuery = {
         range: {
-            [field]: parseRange(node, true)
-        }
+            [field]: parseRange(node, true),
+        },
     };
 
     logger.trace('built range query', { node, rangeQuery });
     return rangeQuery;
 }
 
-export function buildTermQuery(node: p.Term): i.TermQuery|i.MultiMatchQuery {
+export function buildTermQuery(node: p.Term): i.TermQuery | i.MatchQuery | i.MultiMatchQuery {
     if (isMultiMatch(node)) {
         const query = `${node.value}`;
         return buildMultiMatchQuery(node, query);
@@ -152,17 +152,28 @@ export function buildTermQuery(node: p.Term): i.TermQuery|i.MultiMatchQuery {
 
     const field = getTermField(node);
 
+    if (isString(node.value)) {
+        const matchQuery: i.MatchQuery = {
+            match: {
+                [field]: `${node.value}`,
+            },
+        };
+
+        logger.trace('built match query', { node, matchQuery });
+        return matchQuery;
+    }
+
     const termQuery: i.TermQuery = {
         term: {
-            [field]: node.value
-        }
+            [field]: node.value,
+        },
     };
 
     logger.trace('built term query', { node, termQuery });
     return termQuery;
 }
 
-export function buildWildcardQuery(node: p.Wildcard): i.WildcardQuery|i.MultiMatchQuery {
+export function buildWildcardQuery(node: p.Wildcard): i.WildcardQuery | i.MultiMatchQuery {
     if (isMultiMatch(node)) {
         const query = `${node.value}`;
         return buildMultiMatchQuery(node, query);
@@ -172,15 +183,15 @@ export function buildWildcardQuery(node: p.Wildcard): i.WildcardQuery|i.MultiMat
 
     const wildcardQuery: i.WildcardQuery = {
         wildcard: {
-            [field]: node.value
-        }
+            [field]: node.value,
+        },
     };
 
     logger.trace('built wildcard query', { node, wildcardQuery });
     return wildcardQuery;
 }
 
-export function buildRegExprQuery(node: p.Regexp): i.RegExprQuery|i.MultiMatchQuery {
+export function buildRegExprQuery(node: p.Regexp): i.RegExprQuery | i.MultiMatchQuery {
     if (isMultiMatch(node)) {
         const query = `${node.value}`;
         return buildMultiMatchQuery(node, query);
@@ -190,8 +201,8 @@ export function buildRegExprQuery(node: p.Regexp): i.RegExprQuery|i.MultiMatchQu
 
     const regexQuery: i.RegExprQuery = {
         regexp: {
-            [field]: node.value
-        }
+            [field]: node.value,
+        },
     };
 
     logger.trace('built regexpr query', { node, regexQuery });
@@ -201,15 +212,15 @@ export function buildRegExprQuery(node: p.Regexp): i.RegExprQuery|i.MultiMatchQu
 export function buildExistsQuery(node: p.Exists): i.ExistsQuery {
     const existsQuery: i.ExistsQuery = {
         exists: {
-            field: node.field
-        }
+            field: node.field,
+        },
     };
 
     logger.trace('built exists query', { node, existsQuery });
     return existsQuery;
 }
 
-export function buildBoolQuery(node: p.GroupLikeAST, parser: p.Parser): i.BoolQuery|undefined {
+export function buildBoolQuery(node: p.GroupLikeAST, parser: p.Parser): i.BoolQuery | undefined {
     const should: i.AnyQuery[] = [];
 
     for (const conj of node.flow) {
@@ -220,8 +231,8 @@ export function buildBoolQuery(node: p.GroupLikeAST, parser: p.Parser): i.BoolQu
 
     const boolQuery: i.BoolQuery = {
         bool: {
-            should
-        }
+            should,
+        },
     };
 
     logger.trace('built bool query', { node, boolQuery });
@@ -238,11 +249,11 @@ export function buildConjunctionQuery(conj: p.Conjunction, parser: p.Parser): i.
     return {
         bool: {
             filter,
-        }
+        },
     };
 }
 
-export function flattenQuery(query: i.AnyQuery|undefined, flattenTo: i.BoolQueryTypes): i.AnyQuery[] {
+export function flattenQuery(query: i.AnyQuery | undefined, flattenTo: i.BoolQueryTypes): i.AnyQuery[] {
     if (!query) return [];
     if (isBoolQuery(query) && canFlattenBoolQuery(query, flattenTo)) {
         return query.bool[flattenTo]!;
@@ -257,7 +268,7 @@ export function canFlattenBoolQuery(query: i.BoolQuery, flattenTo: i.BoolQueryTy
     return types[0] === flattenTo;
 }
 
-export function buildNegationQuery(node: p.Negation, parser: p.Parser): i.BoolQuery|undefined {
+export function buildNegationQuery(node: p.Negation, parser: p.Parser): i.BoolQuery | undefined {
     const query = buildAnyQuery(node.node, parser);
     if (!query) return;
 
@@ -265,8 +276,8 @@ export function buildNegationQuery(node: p.Negation, parser: p.Parser): i.BoolQu
     logger.trace('built negation query', mustNot, node);
     return {
         bool: {
-            must_not: mustNot
-        }
+            must_not: mustNot,
+        },
     };
 }
 
@@ -274,7 +285,7 @@ export function isBoolQuery(query: any): query is i.BoolQuery {
     return query && query.bool != null;
 }
 
-export function compactFinalQuery(query?: i.AnyQuery): i.AnyQuery|i.AnyQuery[] {
+export function compactFinalQuery(query?: i.AnyQuery): i.AnyQuery | i.AnyQuery[] {
     if (!query) return [];
     if (isBoolQuery(query) && canFlattenBoolQuery(query, 'filter')) {
         const filter = query.bool.filter!;

--- a/packages/xlucene-evaluator/test/cases/parser/terms.ts
+++ b/packages/xlucene-evaluator/test/cases/parser/terms.ts
@@ -185,6 +185,17 @@ export default [
         },
     ],
     [
+        'foo:"ba?"',
+        'field with q quoted wildcard',
+        {
+            type: ASTType.Term,
+            data_type: 'string',
+            field: 'foo',
+            quoted: true,
+            value: 'ba?',
+        },
+    ],
+    [
         'val:(155 223)',
         'a field with parens unqouted string',
         {

--- a/packages/xlucene-evaluator/test/cases/translator/field-group.ts
+++ b/packages/xlucene-evaluator/test/cases/translator/field-group.ts
@@ -1,55 +1,20 @@
 import { TestCase } from './interfaces';
 
 export default [
-    ['any_count:(50 OR 40 OR 30)', 'query.constant_score.filter.bool', {
-        should: [
-            {
-                bool: {
-                    filter: [
-                        {
-                            term: {
-                                any_count: 50,
-                            }
-                        },
-                    ]
-                }
-            },
-            {
-                bool: {
-                    filter: [
-                        {
-                            term: {
-                                any_count: 40,
-                            }
-                        },
-                    ]
-                }
-            },
-            {
-                bool: {
-                    filter: [
-                        {
-                            term: {
-                                any_count: 30,
-                            },
-                        }
-                    ]
-                }
-            },
-        ],
-    }],
-    ['id:(hi OR hello OR howdy OR aloha OR hey OR sup)', 'query.constant_score.filter', {
-        bool: {
+    [
+        'any_count:(50 OR 40 OR 30)',
+        'query.constant_score.filter.bool',
+        {
             should: [
                 {
                     bool: {
                         filter: [
                             {
                                 term: {
-                                    id: 'hi',
-                                }
+                                    any_count: 50,
+                                },
                             },
-                        ]
+                        ],
                     },
                 },
                 {
@@ -57,10 +22,10 @@ export default [
                         filter: [
                             {
                                 term: {
-                                    id: 'hello',
-                                }
+                                    any_count: 40,
+                                },
                             },
-                        ]
+                        ],
                     },
                 },
                 {
@@ -68,46 +33,89 @@ export default [
                         filter: [
                             {
                                 term: {
-                                    id: 'howdy',
-                                }
+                                    any_count: 30,
+                                },
                             },
-                        ]
-                    }
-                },
-                {
-                    bool: {
-                        filter: [
-                            {
-                                term: {
-                                    id: 'aloha',
-                                }
-                            },
-                        ]
-                    }
-                },
-                {
-                    bool: {
-                        filter: [
-                            {
-                                term: {
-                                    id: 'hey',
-                                }
-                            },
-                        ]
-                    }
-                },
-                {
-                    bool: {
-                        filter: [
-                            {
-                                term: {
-                                    id: 'sup',
-                                }
-                            }
-                        ]
-                    }
+                        ],
+                    },
                 },
             ],
-        }
-    }],
+        },
+    ],
+    [
+        'id:(hi OR hello OR howdy OR aloha OR hey OR sup)',
+        'query.constant_score.filter',
+        {
+            bool: {
+                should: [
+                    {
+                        bool: {
+                            filter: [
+                                {
+                                    match: {
+                                        id: 'hi',
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    {
+                        bool: {
+                            filter: [
+                                {
+                                    match: {
+                                        id: 'hello',
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    {
+                        bool: {
+                            filter: [
+                                {
+                                    match: {
+                                        id: 'howdy',
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    {
+                        bool: {
+                            filter: [
+                                {
+                                    match: {
+                                        id: 'aloha',
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    {
+                        bool: {
+                            filter: [
+                                {
+                                    match: {
+                                        id: 'hey',
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    {
+                        bool: {
+                            filter: [
+                                {
+                                    match: {
+                                        id: 'sup',
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        },
+    ],
 ] as TestCase[];

--- a/packages/xlucene-evaluator/test/cases/translator/field-group.ts
+++ b/packages/xlucene-evaluator/test/cases/translator/field-group.ts
@@ -53,8 +53,10 @@ export default [
                             filter: [
                                 {
                                     match: {
-                                        operator: 'and',
-                                        id: 'hi',
+                                        id: {
+                                            query: 'hi',
+                                            operator: 'and',
+                                        },
                                     },
                                 },
                             ],
@@ -65,8 +67,10 @@ export default [
                             filter: [
                                 {
                                     match: {
-                                        operator: 'and',
-                                        id: 'hello',
+                                        id: {
+                                            query: 'hello',
+                                            operator: 'and',
+                                        },
                                     },
                                 },
                             ],
@@ -77,8 +81,10 @@ export default [
                             filter: [
                                 {
                                     match: {
-                                        operator: 'and',
-                                        id: 'howdy',
+                                        id: {
+                                            query: 'howdy',
+                                            operator: 'and',
+                                        },
                                     },
                                 },
                             ],
@@ -89,8 +95,10 @@ export default [
                             filter: [
                                 {
                                     match: {
-                                        operator: 'and',
-                                        id: 'aloha',
+                                        id: {
+                                            query: 'aloha',
+                                            operator: 'and',
+                                        },
                                     },
                                 },
                             ],
@@ -101,8 +109,10 @@ export default [
                             filter: [
                                 {
                                     match: {
-                                        operator: 'and',
-                                        id: 'hey',
+                                        id: {
+                                            query: 'hey',
+                                            operator: 'and',
+                                        },
                                     },
                                 },
                             ],
@@ -113,8 +123,10 @@ export default [
                             filter: [
                                 {
                                     match: {
-                                        operator: 'and',
-                                        id: 'sup',
+                                        id: {
+                                            query: 'sup',
+                                            operator: 'and',
+                                        },
                                     },
                                 },
                             ],

--- a/packages/xlucene-evaluator/test/cases/translator/field-group.ts
+++ b/packages/xlucene-evaluator/test/cases/translator/field-group.ts
@@ -53,6 +53,7 @@ export default [
                             filter: [
                                 {
                                     match: {
+                                        operator: 'and',
                                         id: 'hi',
                                     },
                                 },
@@ -64,6 +65,7 @@ export default [
                             filter: [
                                 {
                                     match: {
+                                        operator: 'and',
                                         id: 'hello',
                                     },
                                 },
@@ -75,6 +77,7 @@ export default [
                             filter: [
                                 {
                                     match: {
+                                        operator: 'and',
                                         id: 'howdy',
                                     },
                                 },
@@ -86,6 +89,7 @@ export default [
                             filter: [
                                 {
                                     match: {
+                                        operator: 'and',
                                         id: 'aloha',
                                     },
                                 },
@@ -97,6 +101,7 @@ export default [
                             filter: [
                                 {
                                     match: {
+                                        operator: 'and',
                                         id: 'hey',
                                     },
                                 },
@@ -108,6 +113,7 @@ export default [
                             filter: [
                                 {
                                     match: {
+                                        operator: 'and',
                                         id: 'sup',
                                     },
                                 },

--- a/packages/xlucene-evaluator/test/cases/translator/logical-group.ts
+++ b/packages/xlucene-evaluator/test/cases/translator/logical-group.ts
@@ -9,12 +9,12 @@ export default [
                 bool: {
                     filter: [
                         {
-                            term: {
+                            match: {
                                 some: 'query',
                             },
                         },
                         {
-                            term: {
+                            match: {
                                 other: 'thing',
                             },
                         },
@@ -32,7 +32,7 @@ export default [
                     bool: {
                         must_not: [
                             {
-                                term: {
+                                match: {
                                     value: 'awesome',
                                 },
                             },
@@ -40,7 +40,7 @@ export default [
                     },
                 },
                 {
-                    term: {
+                    match: {
                         other: 'thing',
                     },
                 },
@@ -155,7 +155,7 @@ export default [
                             },
                         },
                         {
-                            term: {
+                            match: {
                                 field: 'value',
                             },
                         },
@@ -246,7 +246,7 @@ export default [
                                                                 },
                                                             },
                                                             {
-                                                                term: {
+                                                                match: {
                                                                     sometype: 'thevalue',
                                                                 },
                                                             },
@@ -263,7 +263,7 @@ export default [
                             bool: {
                                 must_not: [
                                     {
-                                        term: {
+                                        match: {
                                             anotherfield: 'value',
                                         },
                                     },
@@ -301,7 +301,7 @@ export default [
                 bool: {
                     filter: [
                         {
-                            term: {
+                            match: {
                                 foo: 'bar',
                             },
                         },
@@ -309,7 +309,7 @@ export default [
                             bool: {
                                 must_not: [
                                     {
-                                        term: {
+                                        match: {
                                             bar: 'foo',
                                         },
                                     },
@@ -326,7 +326,7 @@ export default [
         'query.constant_score.filter.bool.should[0].bool.filter',
         [
             {
-                term: {
+                match: {
                     some: 'key',
                 },
             },
@@ -386,7 +386,7 @@ export default [
                     bool: {
                         filter: [
                             {
-                                term: {
+                                match: {
                                     some: 'query',
                                 },
                             },
@@ -397,7 +397,7 @@ export default [
                     bool: {
                         filter: [
                             {
-                                term: {
+                                match: {
                                     other: 'thing',
                                 },
                             },
@@ -408,7 +408,7 @@ export default [
                     bool: {
                         filter: [
                             {
-                                term: {
+                                match: {
                                     next: 'value',
                                 },
                             },
@@ -424,7 +424,7 @@ export default [
         {
             filter: [
                 {
-                    term: {
+                    match: {
                         some: 'query',
                     },
                 },
@@ -432,7 +432,7 @@ export default [
                     bool: {
                         must_not: [
                             {
-                                term: {
+                                match: {
                                     other: 'thing',
                                 },
                             },

--- a/packages/xlucene-evaluator/test/cases/translator/logical-group.ts
+++ b/packages/xlucene-evaluator/test/cases/translator/logical-group.ts
@@ -10,14 +10,18 @@ export default [
                     filter: [
                         {
                             match: {
-                                operator: 'and',
-                                some: 'query',
+                                some: {
+                                    query: 'query',
+                                    operator: 'and',
+                                },
                             },
                         },
                         {
                             match: {
-                                operator: 'and',
-                                other: 'thing',
+                                other: {
+                                    query: 'thing',
+                                    operator: 'and',
+                                },
                             },
                         },
                     ],
@@ -35,8 +39,10 @@ export default [
                         must_not: [
                             {
                                 match: {
-                                    operator: 'and',
-                                    value: 'awesome',
+                                    value: {
+                                        operator: 'and',
+                                        query: 'awesome',
+                                    },
                                 },
                             },
                         ],
@@ -44,8 +50,10 @@ export default [
                 },
                 {
                     match: {
-                        operator: 'and',
-                        other: 'thing',
+                        other: {
+                            query: 'thing',
+                            operator: 'and',
+                        },
                     },
                 },
             ],
@@ -160,8 +168,10 @@ export default [
                         },
                         {
                             match: {
-                                operator: 'and',
-                                field: 'value',
+                                field: {
+                                    query: 'value',
+                                    operator: 'and',
+                                },
                             },
                         },
                         {
@@ -252,8 +262,10 @@ export default [
                                                             },
                                                             {
                                                                 match: {
-                                                                    operator: 'and',
-                                                                    sometype: 'thevalue',
+                                                                    sometype: {
+                                                                        operator: 'and',
+                                                                        query: 'thevalue',
+                                                                    },
                                                                 },
                                                             },
                                                         ],
@@ -270,8 +282,10 @@ export default [
                                 must_not: [
                                     {
                                         match: {
-                                            operator: 'and',
-                                            anotherfield: 'value',
+                                            anotherfield: {
+                                                operator: 'and',
+                                                query: 'value',
+                                            },
                                         },
                                     },
                                 ],
@@ -309,8 +323,10 @@ export default [
                     filter: [
                         {
                             match: {
-                                operator: 'and',
-                                foo: 'bar',
+                                foo: {
+                                    operator: 'and',
+                                    query: 'bar',
+                                },
                             },
                         },
                         {
@@ -318,8 +334,10 @@ export default [
                                 must_not: [
                                     {
                                         match: {
-                                            operator: 'and',
-                                            bar: 'foo',
+                                            bar: {
+                                                query: 'foo',
+                                                operator: 'and',
+                                            },
                                         },
                                     },
                                 ],
@@ -336,8 +354,10 @@ export default [
         [
             {
                 match: {
-                    operator: 'and',
-                    some: 'key',
+                    some: {
+                        query: 'key',
+                        operator: 'and',
+                    },
                 },
             },
             {
@@ -397,8 +417,10 @@ export default [
                         filter: [
                             {
                                 match: {
-                                    operator: 'and',
-                                    some: 'query',
+                                    some: {
+                                        operator: 'and',
+                                        query: 'query',
+                                    },
                                 },
                             },
                         ],
@@ -409,8 +431,10 @@ export default [
                         filter: [
                             {
                                 match: {
-                                    operator: 'and',
-                                    other: 'thing',
+                                    other: {
+                                        operator: 'and',
+                                        query: 'thing',
+                                    },
                                 },
                             },
                         ],
@@ -421,8 +445,10 @@ export default [
                         filter: [
                             {
                                 match: {
-                                    operator: 'and',
-                                    next: 'value',
+                                    next: {
+                                        operator: 'and',
+                                        query: 'value',
+                                    },
                                 },
                             },
                         ],
@@ -438,8 +464,10 @@ export default [
             filter: [
                 {
                     match: {
-                        operator: 'and',
-                        some: 'query',
+                        some: {
+                            operator: 'and',
+                            query: 'query',
+                        },
                     },
                 },
                 {
@@ -447,8 +475,10 @@ export default [
                         must_not: [
                             {
                                 match: {
-                                    operator: 'and',
-                                    other: 'thing',
+                                    other: {
+                                        query: 'thing',
+                                        operator: 'and',
+                                    },
                                 },
                             },
                         ],

--- a/packages/xlucene-evaluator/test/cases/translator/logical-group.ts
+++ b/packages/xlucene-evaluator/test/cases/translator/logical-group.ts
@@ -10,11 +10,13 @@ export default [
                     filter: [
                         {
                             match: {
+                                operator: 'and',
                                 some: 'query',
                             },
                         },
                         {
                             match: {
+                                operator: 'and',
                                 other: 'thing',
                             },
                         },
@@ -33,6 +35,7 @@ export default [
                         must_not: [
                             {
                                 match: {
+                                    operator: 'and',
                                     value: 'awesome',
                                 },
                             },
@@ -41,6 +44,7 @@ export default [
                 },
                 {
                     match: {
+                        operator: 'and',
                         other: 'thing',
                     },
                 },
@@ -156,6 +160,7 @@ export default [
                         },
                         {
                             match: {
+                                operator: 'and',
                                 field: 'value',
                             },
                         },
@@ -247,6 +252,7 @@ export default [
                                                             },
                                                             {
                                                                 match: {
+                                                                    operator: 'and',
                                                                     sometype: 'thevalue',
                                                                 },
                                                             },
@@ -264,6 +270,7 @@ export default [
                                 must_not: [
                                     {
                                         match: {
+                                            operator: 'and',
                                             anotherfield: 'value',
                                         },
                                     },
@@ -302,6 +309,7 @@ export default [
                     filter: [
                         {
                             match: {
+                                operator: 'and',
                                 foo: 'bar',
                             },
                         },
@@ -310,6 +318,7 @@ export default [
                                 must_not: [
                                     {
                                         match: {
+                                            operator: 'and',
                                             bar: 'foo',
                                         },
                                     },
@@ -327,6 +336,7 @@ export default [
         [
             {
                 match: {
+                    operator: 'and',
                     some: 'key',
                 },
             },
@@ -387,6 +397,7 @@ export default [
                         filter: [
                             {
                                 match: {
+                                    operator: 'and',
                                     some: 'query',
                                 },
                             },
@@ -398,6 +409,7 @@ export default [
                         filter: [
                             {
                                 match: {
+                                    operator: 'and',
                                     other: 'thing',
                                 },
                             },
@@ -409,6 +421,7 @@ export default [
                         filter: [
                             {
                                 match: {
+                                    operator: 'and',
                                     next: 'value',
                                 },
                             },
@@ -425,6 +438,7 @@ export default [
             filter: [
                 {
                     match: {
+                        operator: 'and',
                         some: 'query',
                     },
                 },
@@ -433,6 +447,7 @@ export default [
                         must_not: [
                             {
                                 match: {
+                                    operator: 'and',
                                     other: 'thing',
                                 },
                             },

--- a/packages/xlucene-evaluator/test/cases/translator/term.ts
+++ b/packages/xlucene-evaluator/test/cases/translator/term.ts
@@ -15,6 +15,7 @@ export default [
         'query.constant_score.filter',
         {
             match: {
+                operator: 'and',
                 hello: 'world',
             },
         },
@@ -104,6 +105,7 @@ export default [
         'query.constant_score.filter',
         {
             match: {
+                operator: 'and',
                 'nested.*': 'hello-there',
             },
         },
@@ -113,6 +115,7 @@ export default [
         'query.constant_score.filter',
         {
             match: {
+                operator: 'and',
                 'field.subfield': 'value=something=*',
             },
         },

--- a/packages/xlucene-evaluator/test/cases/translator/term.ts
+++ b/packages/xlucene-evaluator/test/cases/translator/term.ts
@@ -15,8 +15,10 @@ export default [
         'query.constant_score.filter',
         {
             match: {
-                operator: 'and',
-                hello: 'world',
+                hello: {
+                    operator: 'and',
+                    query: 'world',
+                },
             },
         },
     ],
@@ -105,8 +107,10 @@ export default [
         'query.constant_score.filter',
         {
             match: {
-                operator: 'and',
-                'nested.*': 'hello-there',
+                'nested.*': {
+                    operator: 'and',
+                    query: 'hello-there',
+                },
             },
         },
     ],
@@ -115,8 +119,10 @@ export default [
         'query.constant_score.filter',
         {
             match: {
-                operator: 'and',
-                'field.subfield': 'value=something=*',
+                'field.subfield': {
+                    operator: 'and',
+                    query: 'value=something=*',
+                },
             },
         },
     ],

--- a/packages/xlucene-evaluator/test/cases/translator/term.ts
+++ b/packages/xlucene-evaluator/test/cases/translator/term.ts
@@ -1,67 +1,111 @@
 import { TestCase } from './interfaces';
 
 export default [
-    ['*', 'query.constant_score.filter', {
-        bool: {
-            filter:[]
-        }
-    }],
-    ['hello:world', 'query.constant_score.filter', {
-        term: {
-            hello: 'world'
-        }
-    }],
-    ['hello:w?rld', 'query.constant_score.filter', {
-        wildcard: {
-            hello: 'w?rld'
-        }
-    }],
-    ['hello:/w.*ld/', 'query.constant_score.filter', {
-        regexp: {
-            hello: 'w.*ld'
-        }
-    }],
-    ['_exists_:hello', 'query.constant_score.filter', {
-        exists: {
-            field: 'hello'
-        }
-    }],
-    ['example_count:>=30', 'query.constant_score.filter', {
-        range: {
-            example_count: {
-                gte: 30
-            }
-        }
-    }],
-    ['example_count:>30', 'query.constant_score.filter', {
-        range: {
-            example_count: {
-                gt: 30
-            }
-        }
-    }],
-    ['example_count:<50', 'query.constant_score.filter', {
-        range: {
-            example_count: {
-                lt: 50
-            }
-        }
-    }],
-    ['example_count:<=50', 'query.constant_score.filter', {
-        range: {
-            example_count: {
-                lte: 50
-            }
-        }
-    }],
-    ['hello-there', 'query.constant_score.filter', {
-        multi_match: {
-            query: 'hello-there'
-        }
-    }],
-    ['nested.*:hello-there', 'query.constant_score.filter', {
-        term: {
-            'nested.*': 'hello-there'
-        }
-    }],
+    [
+        '*',
+        'query.constant_score.filter',
+        {
+            bool: {
+                filter: [],
+            },
+        },
+    ],
+    [
+        'hello:world',
+        'query.constant_score.filter',
+        {
+            match: {
+                hello: 'world',
+            },
+        },
+    ],
+    [
+        'hello:w?rld',
+        'query.constant_score.filter',
+        {
+            wildcard: {
+                hello: 'w?rld',
+            },
+        },
+    ],
+    [
+        'hello:/w.*ld/',
+        'query.constant_score.filter',
+        {
+            regexp: {
+                hello: 'w.*ld',
+            },
+        },
+    ],
+    [
+        '_exists_:hello',
+        'query.constant_score.filter',
+        {
+            exists: {
+                field: 'hello',
+            },
+        },
+    ],
+    [
+        'example_count:>=30',
+        'query.constant_score.filter',
+        {
+            range: {
+                example_count: {
+                    gte: 30,
+                },
+            },
+        },
+    ],
+    [
+        'example_count:>30',
+        'query.constant_score.filter',
+        {
+            range: {
+                example_count: {
+                    gt: 30,
+                },
+            },
+        },
+    ],
+    [
+        'example_count:<50',
+        'query.constant_score.filter',
+        {
+            range: {
+                example_count: {
+                    lt: 50,
+                },
+            },
+        },
+    ],
+    [
+        'example_count:<=50',
+        'query.constant_score.filter',
+        {
+            range: {
+                example_count: {
+                    lte: 50,
+                },
+            },
+        },
+    ],
+    [
+        'hello-there',
+        'query.constant_score.filter',
+        {
+            multi_match: {
+                query: 'hello-there',
+            },
+        },
+    ],
+    [
+        'nested.*:hello-there',
+        'query.constant_score.filter',
+        {
+            match: {
+                'nested.*': 'hello-there',
+            },
+        },
+    ],
 ] as TestCase[];

--- a/packages/xlucene-evaluator/test/cases/translator/term.ts
+++ b/packages/xlucene-evaluator/test/cases/translator/term.ts
@@ -118,9 +118,8 @@ export default [
         'field.subfield:"value=something=*"',
         'query.constant_score.filter',
         {
-            match: {
+            match_phrase: {
                 'field.subfield': {
-                    operator: 'and',
                     query: 'value=something=*',
                 },
             },

--- a/packages/xlucene-evaluator/test/cases/translator/term.ts
+++ b/packages/xlucene-evaluator/test/cases/translator/term.ts
@@ -108,4 +108,13 @@ export default [
             },
         },
     ],
+    [
+        'field.subfield:"value=something=*"',
+        'query.constant_score.filter',
+        {
+            match: {
+                'field.subfield': 'value=something=*',
+            },
+        },
+    ],
 ] as TestCase[];


### PR DESCRIPTION
xlucene was previously translating term queries using a [Term Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-term-query.html), however that has issues querying analyzed fields since it won't do an exact match. This PR changes xlucene to use a [Match Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-match-query.html) instead.