### PR TITLE
Fix "v1" vs "v2" API compatability

### DIFF
--- a/packages/data-access-plugin/package.json
+++ b/packages/data-access-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/data-access-plugin",
-    "version": "0.11.2",
+    "version": "0.11.3",
     "description": "A teraserver plugin for managing data access and searching spaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-access-plugin#readme",
     "bugs": {
@@ -28,7 +28,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged --forceExit"
     },
     "dependencies": {
-        "@terascope/data-access": "^0.12.3",
+        "@terascope/data-access": "^0.12.4",
         "@terascope/data-types": "^0.4.1",
         "@terascope/elasticsearch-api": "^2.1.0",
         "@terascope/utils": "^0.12.4",

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/data-access",
-    "version": "0.12.3",
+    "version": "0.12.4",
     "description": "A tool designed to limit access to reading and querying data",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-access#readme",
     "bugs": {

--- a/packages/data-access/src/interfaces.ts
+++ b/packages/data-access/src/interfaces.ts
@@ -24,7 +24,7 @@ export interface InputQuery {
     q?: string;
     start?: number | string;
     fields?: string | string[];
-    history?: boolean;
+    history?: number;
     history_start?: string;
     geo_sort_point?: string;
     geo_sort_order?: SortOrder;

--- a/packages/data-access/src/search-access.ts
+++ b/packages/data-access/src/search-access.ts
@@ -221,8 +221,8 @@ export class SearchAccess {
         }
 
         let info = `${response.hits.total} results found.`;
-        if (params.size && response.hits.total > params.size) {
-            returning = params.size;
+        if (response.hits.total > params.size!) {
+            returning = params.size!;
             info += ` Returning ${returning}.`;
         }
 

--- a/packages/data-access/src/search-access.ts
+++ b/packages/data-access/src/search-access.ts
@@ -110,11 +110,9 @@ export class SearchAccess {
             throw new ts.TSError(...validationErr('size', `must be less than ${maxQuerySize}`, query));
         }
 
-        const start = ts.get(query, 'start');
-        if (start) {
-            if (!ts.isNumber(start)) {
-                throw new ts.TSError(...validationErr('start', 'must be a valid number', query));
-            }
+        const start = ts.toInteger(ts.get(query, 'start', 0));
+        if (start === false) {
+            throw new ts.TSError(...validationErr('start', 'must be a valid number', query));
         }
 
         let sort = ts.get(query, 'sort');
@@ -173,7 +171,7 @@ export class SearchAccess {
 
         params.q = q;
         params.size = size;
-        params.from = ts.toInteger(start) || 0;
+        params.from = start;
         params.sort = sort;
         params.index = this._getIndex(query);
         params.ignoreUnavailable = true;

--- a/packages/data-access/test/search-access-spec.ts
+++ b/packages/data-access/test/search-access-spec.ts
@@ -213,6 +213,28 @@ describe('SearchAccess', () => {
                 });
             });
 
+            it('should be able to handle stringified values', () => {
+                const searchAccess = makeWith({
+                    sort_default: 'default:asc',
+                    sort_enabled: true,
+                    index: 'cool',
+                });
+
+                const query: InputQuery = {
+                    q: 'howdy',
+                    size: '1000',
+                    start: '10',
+                };
+
+                const params = searchAccess.getSearchParams(query);
+
+                expect(params).toMatchObject({
+                    q: 'howdy',
+                    size: 1000,
+                    from: 10,
+                });
+            });
+
             it('should be able to handle complex query options', () => {
                 const query: InputQuery = {
                     q: 'example:hello',

--- a/packages/data-access/test/search-access-spec.ts
+++ b/packages/data-access/test/search-access-spec.ts
@@ -355,6 +355,87 @@ describe('SearchAccess', () => {
 
                 const query = {
                     sort: 'example:asc',
+                    start: 0,
+                    size: 2,
+                };
+
+                const params = searchAccess.getSearchParams(query);
+
+                const result = searchAccess.getSearchResponse(input as SearchResponse<any>, query, params);
+                expect(result).toEqual({
+                    total,
+                    info: '5 results found. Returning 2.',
+                    returning: 2,
+                    results: ts.times(total, n => ({
+                        example: n,
+                    })),
+                });
+            });
+
+            it('should be able to return a valid "Returning" result', () => {
+                const total = 150;
+                const input: unknown = {
+                    _shards: {
+                        total: 2,
+                    },
+                    hits: {
+                        hits: ts.times(total, n => ({
+                            _index: 'example',
+                            _source: {
+                                example: n,
+                            },
+                        })),
+                        total,
+                    },
+                };
+
+                const searchAccess = makeWith({
+                    index: 'example',
+                    sort_enabled: true,
+                });
+
+                const query = {
+                    sort: 'example:asc',
+                    start: 0,
+                };
+
+                const params = searchAccess.getSearchParams(query);
+
+                const result = searchAccess.getSearchResponse(input as SearchResponse<any>, query, params);
+                expect(result).toEqual({
+                    total,
+                    info: '150 results found. Returning 100.',
+                    returning: 100,
+                    results: ts.times(total, n => ({
+                        example: n,
+                    })),
+                });
+            });
+
+            it('should be able to return a valid result when not requesting a "size"', () => {
+                const total = 5;
+                const input: unknown = {
+                    _shards: {
+                        total: 2,
+                    },
+                    hits: {
+                        hits: ts.times(total, n => ({
+                            _index: 'example',
+                            _source: {
+                                example: n,
+                            },
+                        })),
+                        total,
+                    },
+                };
+
+                const searchAccess = makeWith({
+                    index: 'example',
+                    sort_enabled: true,
+                });
+
+                const query = {
+                    sort: 'example:asc',
                 };
 
                 const params: SearchParams = {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -23,7 +23,7 @@
         "test": "echo '* tests not supported yet'"
     },
     "dependencies": {
-        "@terascope/data-access": "^0.12.3",
+        "@terascope/data-access": "^0.12.4",
         "@terascope/utils": "^0.12.4",
         "apollo-boost": "^0.4.3",
         "apollo-client": "^2.6.3",

--- a/packages/ui-data-access/package.json
+++ b/packages/ui-data-access/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@terascope/data-access": "^0.12.3",
+        "@terascope/data-access": "^0.12.4",
         "@terascope/data-types": "^0.4.1",
         "@terascope/ui-components": "^0.3.6",
         "@terascope/utils": "^0.12.4",


### PR DESCRIPTION
Fixes the "Returning" response and fixes converting the `start` query parameter to a string.

Resolves #1268 
Resolves #1267 