### PR TITLE
State storage sync

### DIFF
--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-state-storage",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {

--- a/packages/teraslice-state-storage/test/elasticsearch-state-storage-spec.ts
+++ b/packages/teraslice-state-storage/test/elasticsearch-state-storage-spec.ts
@@ -41,7 +41,6 @@ describe('elasticsearch cached state storage', () => {
         }
 
         async mget(mgetSearch: any) {
-            // this.mgetData = mgetSearch;
             return this.mgetData;
         }
 
@@ -242,6 +241,26 @@ describe('elasticsearch cached state storage', () => {
             const metaId = stateResponse[id].getMetadata(idField);
             expect(metaId).toEqual(id);
         });
+    });
+
+    it('sync should chech cache/fetch data but not return anything', async () => {
+        const results: DataEntity[] = [];
+        const setResults = (data: DataEntity) => results.push(data);
+        // set doc in cache
+        await stateStorage.mset(docArray.slice(0, 1));
+
+        // create bulk response
+        client.setMGetData({ docs: createMgetData(docArray.slice(1, 3)) });
+
+        // state response
+        const response = await stateStorage.sync(docArray);
+
+        expect(response).toBeUndefined();
+
+        await stateStorage.cache.values(setResults);
+
+        expect(results.length).toBe(3);
+        expect(results.reverse()).toEqual(docArray);
     });
 
     it('should return all the found and cached docs', async () => {


### PR DESCRIPTION
- refactored mget
- added sync method, which acts like mget but does not return results, its primarily used to update the cache
- added tests