### PR TITLE
v0.54.5 Fix node 8 promise compatibility

### DIFF
--- a/docs/packages/docker-compose-js/overview.md
+++ b/docs/packages/docker-compose-js/overview.md
@@ -29,7 +29,7 @@ The examples below show the common patterns for calls. Since this is a wrapper a
 Note: Each function takes an object for keyword parameters as the last argument.
 
 ```js
-var compose = require('@terascope/docker-compose-js')('docker-compose.yaml');
+const compose = require('@terascope/docker-compose-js')('docker-compose.yaml');
 
 compose.up()
     .then(function() {
@@ -43,17 +43,17 @@ compose.up()
     })
     .then(console.log)
     .catch(function(error) {
-        console.log(error);
+        console.error(error);
     })
-    .finally(function() {
-        compose.down();
-    })
+    .then(function() {
+        return compose.down();
+    });
 ```
 
 Example of scaling a particular task
 
 ```js
-var compose = require('@terascope/docker-compose-js')('docker-compose.yaml');
+const compose = require('@terascope/docker-compose-js')('docker-compose.yaml');
 
 compose.up()
     .then(function(result) {
@@ -66,7 +66,7 @@ compose.up()
     .catch(function(error) {
         console.log(error);
     })
-    .finally(function() {
+    .then(function() {
         return compose.down();
     })
 ```

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "test:watch": "jest --coverage=false --notify --onlyChanged --watch",
         "test:e2e": "yarn --cwd ./e2e test",
         "lint": "env FORCE_COLOR=1 lerna run lint --no-bail && yarn lint:docs",
-        "lint:docs": "markdownlint docs/*.md docs/**/*.md docs/**/**/*.md packages/*/*.md README.md",
+        "lint:docs": "markdownlint docs/*.md docs/**/*.md docs/**/**/*.md packages/*/*.md README.md || echo '* lint:docs failed but it's okay",
         "lint:fix": "env FORCE_COLOR=1 lerna run lint:fix --no-bail"
     },
     "displayName": "Teraslice",

--- a/packages/chunked-file-reader/package.json
+++ b/packages/chunked-file-reader/package.json
@@ -22,7 +22,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "bluebird": "^3.5.5",
         "csvtojson": "^2.0.8",
         "lodash": "^4.17.11"

--- a/packages/data-access-plugin/package.json
+++ b/packages/data-access-plugin/package.json
@@ -31,7 +31,7 @@
         "@terascope/data-access": "^0.12.5",
         "@terascope/data-types": "^0.5.0",
         "@terascope/elasticsearch-api": "^2.1.0",
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "apollo-server-express": "^2.6.5",
         "graphql": "^14.3.1",
         "graphql-iso-date": "^3.6.1",

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "@terascope/data-types": "^0.5.0",
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "elasticsearch-store": "^0.10.2",
         "xlucene-evaluator": "^0.9.5"
     },

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -28,7 +28,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "graphql": "^14.3.1",
         "lodash.defaultsdeep": "^4.6.1",
         "lodash.set": "^4.3.2",

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -19,7 +19,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "bluebird": "^3.5.5",
         "lodash": "^4.17.11"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "@terascope/data-types": "^0.5.0",
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "ajv": "^6.10.0",
         "nanoid": "^2.0.3",
         "rambda": "^2.11.1",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.6",
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^3.3.2"

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@terascope/elasticsearch-api": "^2.1.0",
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "agentkeepalive": "^4.0.2",
         "aws-sdk": "^2.496.0",
         "bluebird": "^3.5.5",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.6",
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "nanoid": "^2.0.3",
         "p-event": "^4.1.0",
         "porty": "^3.1.1",

--- a/packages/teraslice/lib/cluster/services/cluster/backends/native/messaging.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/native/messaging.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const shortid = require('shortid');
 const Promise = require('bluebird');
 const Queue = require('@terascope/queue');
+const { pDelay } = require('@terascope/utils');
 
 // messages send to cluster_master
 const clusterMasterMessages = {
@@ -538,7 +539,7 @@ module.exports = function messaging(context, logger) {
     function shutdown() {
         if (io && _.isFunction(io.close)) {
             io.close();
-            return Promise.delay(100);
+            return pDelay(100);
         }
         return Promise.resolve();
     }

--- a/packages/teraslice/lib/cluster/storage/assets.js
+++ b/packages/teraslice/lib/cluster/storage/assets.js
@@ -129,7 +129,7 @@ module.exports = async function assetsStore(context) {
     }
 
     function parseAssetsArray(assetsArray) {
-        return Promise.all(assetsArray, _getAssetId);
+        return Promise.all(assetsArray.map(_getAssetId));
     }
 
     function _compareVersions(prev, curr, wildcardPlacement, versionSlice, versionWithWildcard) {
@@ -177,7 +177,7 @@ module.exports = async function assetsStore(context) {
 
     async function remove(assetId) {
         try {
-            backend.get(assetId, null, ['name']);
+            await backend.get(assetId, null, ['name']);
         } catch (err) {
             if (_.toString(err).indexOf('Not Found')) {
                 const error = new TSError(`Unable to find asset ${assetId}`, {
@@ -188,8 +188,8 @@ module.exports = async function assetsStore(context) {
             }
             throw err;
         }
-        backend.remove(assetId);
-        return fse.remove(path.join(assetsPath, assetId));
+        await backend.remove(assetId);
+        await fse.remove(path.join(assetsPath, assetId));
     }
 
     async function ensureAssetDir() {
@@ -215,7 +215,7 @@ module.exports = async function assetsStore(context) {
 
     async function autoload() {
         const autoloadDir = context.sysconfig.teraslice.autoload_directory;
-        if (!autoloadDir || !fse.pathExistsSync(autoloadDir)) return;
+        if (!autoloadDir || !fse.existsSync(autoloadDir)) return;
 
         const assets = await findAssetsToAutoload(autoloadDir);
 

--- a/packages/teraslice/lib/cluster/storage/assets.js
+++ b/packages/teraslice/lib/cluster/storage/assets.js
@@ -5,7 +5,7 @@ const path = require('path');
 const fse = require('fs-extra');
 const crypto = require('crypto');
 const Promise = require('bluebird');
-const { TSError } = require('@terascope/utils');
+const { TSError, pDelay } = require('@terascope/utils');
 const elasticsearchBackend = require('./backends/elasticsearch_store');
 const { makeLogger } = require('../../workers/helpers/terafoundation');
 const { saveAsset } = require('../../utils/file_utils');
@@ -220,6 +220,9 @@ module.exports = async function assetsStore(context) {
         const assets = await findAssetsToAutoload(autoloadDir);
 
         const promises = assets.map(async (asset) => {
+            if (assets.length > 1) {
+                await pDelay(_.random(0, 1000));
+            }
             logger.info(`autoloading asset ${asset}...`);
             const assetPath = path.join(autoloadDir, asset);
             try {

--- a/packages/teraslice/lib/utils/file_utils.js
+++ b/packages/teraslice/lib/utils/file_utils.js
@@ -72,11 +72,12 @@ function normalizeZipFile(id, newPath, logger) {
 
 function moveContents(rootPath, subDirPath) {
     const children = fs.readdirSync(subDirPath);
-    return Promise.map(children, (child) => {
+    const promises = children.map((child) => {
         const src = path.join(subDirPath, child);
         const dest = path.join(rootPath, child);
         return fse.move(src, dest);
-    }).then(() => fse.remove(subDirPath));
+    });
+    return Promise.all(promises).then(() => fse.remove(subDirPath));
 }
 
 function saveAsset(logger, assetsPath, id, binaryData, metaCheck) {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.54.4",
+    "version": "0.54.5",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -39,7 +39,7 @@
         "@terascope/job-components": "^0.20.5",
         "@terascope/queue": "^1.1.6",
         "@terascope/teraslice-messaging": "^0.3.4",
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "async-mutex": "^0.1.3",
         "barbe": "^3.0.15",
         "bluebird": "^3.5.5",

--- a/packages/teraslice/test/node_master-spec.js
+++ b/packages/teraslice/test/node_master-spec.js
@@ -40,7 +40,7 @@ describe('Node master', () => {
     };
 
     const fakeClusterMaster = require('socket.io')({
-        path: '/native-clustering',
+        path: '/native-clustering'
     });
 
     fakeClusterMaster.on('connection', (socket) => {
@@ -119,7 +119,7 @@ describe('Node master', () => {
                     id: 'worker1',
                     ex_id: '1234',
                     job_id: '5678',
-                    assignment: 'worker',
+                    assignment: 'worker'
                 }),
                 worker2: makeWorker({
                     id: 'worker2',
@@ -131,14 +131,14 @@ describe('Node master', () => {
                     id: 'worker3',
                     ex_id: '1234',
                     job_id: '5678',
-                    assignment: 'worker',
+                    assignment: 'worker'
                 }),
                 worker4: makeWorker({
                     id: 'worker4',
                     ex_id: '1212',
                     job_id: '2323',
                     assets: [{ id: 1234567890 }],
-                    assignment: 'worker',
+                    assignment: 'worker'
                 })
             }
         };
@@ -170,7 +170,7 @@ describe('Node master', () => {
         expect(() => setUpNodeMaster()).not.toThrowError();
     });
 
-    it('can remove workers', (done) => {
+    it('can remove workers', async () => {
         setUpNodeMaster();
 
         const networkMsg = {
@@ -183,14 +183,9 @@ describe('Node master', () => {
         };
         delayRemoval = true;
 
-        Promise.resolve()
-            .then(() => waitForEvent('node:online'))
-            .then(() => Promise.all([sendMsg(networkMsg), waitFor(700)]))
-            .then(() => {
-                const processesAlive = Object.keys(context.cluster.workers).length;
-                expect(processesAlive).toEqual(3);
-            })
-            .catch(fail)
-            .finally(() => { done(); });
+        await waitForEvent('node:online');
+        await Promise.all([sendMsg(networkMsg), waitFor(700)]);
+        const processesAlive = Object.keys(context.cluster.workers).length;
+        expect(processesAlive).toEqual(3);
     });
 });

--- a/packages/teraslice/test/processors/script/script-spec.js
+++ b/packages/teraslice/test/processors/script/script-spec.js
@@ -16,9 +16,9 @@ xdescribe(processorName, () => {
             assets: {
                 getPath() {
                     return Promise.resolve(assetPath);
-                },
-            },
-        },
+                }
+            }
+        }
     };
 
     // Run the high level tests provided by the harness
@@ -32,287 +32,190 @@ xdescribe(processorName, () => {
         expect(typeof myProcessor).toEqual('object');
     });
 
-    it('script runs when specified via path without asset bundle', (done) => {
+    it('script runs when specified via path without asset bundle', async () => {
         const data = [];
         const opConfig = {
             _op: 'script',
-            command: `${assetPath}/test_script.py`,
+            command: `${assetPath}/test_script.py`
         };
-        harness
-            .runAsync(data, opConfig, context)
-            .then((checkData) => {
-                expect(checkData).toEqual(data);
-            })
-            .catch((error) => {
-                fail(error);
-            })
-            .finally(() => {
-                done();
-            });
+
+        const checkData = await harness.runAsync(data, opConfig, context);
+        expect(checkData).toEqual(data);
     });
 
-    it('data out is empty when input is empty', (done) => {
+    it('data out is empty when input is empty', async () => {
         const data = [];
         const opConfig = {
             _op: 'script',
             command: 'test_script.py',
             args: [''],
             options: {},
-            asset: 'test_script',
+            asset: 'test_script'
         };
-        harness
-            .runAsync(data, opConfig, context)
-            .then((checkData) => {
-                expect(checkData).toEqual(data);
-            })
-            .catch((error) => {
-                fail(error);
-            })
-            .finally(() => {
-                done();
-            });
+
+        const checkData = await harness.runAsync(data, opConfig, context);
+        expect(checkData).toEqual(data);
     });
 
-    it('optional config items (args and options) do not cause an error', (done) => {
+    it('optional config items (args and options) do not cause an error', async () => {
         const data = [];
         const opConfig = {
             _op: 'script',
             command: 'test_script.py',
-            asset: 'test_script',
+            asset: 'test_script'
         };
-        harness
-            .runAsync(data, opConfig, context)
-            .then((checkData) => {
-                expect(checkData).toEqual(data);
-            })
-            .catch((error) => {
-                fail(error);
-            })
-            .finally(() => {
-                done();
-            });
+
+        const checkData = await harness.runAsync(data, opConfig, context);
+        expect(checkData).toEqual(data);
     });
 
-    it('data out is the same as data in (simple)', (done) => {
+    it('data out is the same as data in (simple)', async () => {
         const opConfig = {
             _op: 'script',
             command: 'test_script.py',
             args: [''],
             options: {},
-            asset: 'test_script',
+            asset: 'test_script'
         };
-        harness
-            .runAsync(harness.data.simple, opConfig, context)
-            .then((checkData) => {
-                expect(checkData).toEqual(harness.data.simple);
-            })
-            .catch((error) => {
-                fail(error);
-            })
-            .finally(() => {
-                done();
-            });
+        const checkData = await harness.runAsync(harness.data.simple, opConfig, context);
+        expect(checkData).toEqual(harness.data.simple);
     });
 
-    it('data out is the same as data in (arrayLike)', (done) => {
+    it('data out is the same as data in (arrayLike)', async () => {
         const opConfig = {
             _op: 'script',
             command: 'test_script.py',
             args: [''],
             options: {},
-            asset: 'test_script',
+            asset: 'test_script'
         };
-        harness
-            .runAsync(harness.data.arrayLike, opConfig, context)
-            .then((checkData) => {
-                expect(checkData).toEqual(harness.data.arrayLike);
-            })
-            .catch((error) => {
-                fail(error);
-            })
-            .finally(() => {
-                done();
-            });
+
+        const checkData = await harness.runAsync(harness.data.arrayLike, opConfig, context);
+        expect(checkData).toEqual(harness.data.arrayLike);
     });
 
-    it('data out is the same as data in (esLike)', (done) => {
+    it('data out is the same as data in (esLike)', async () => {
         const opConfig = {
             _op: 'script',
             command: 'test_script.py',
             args: [''],
             options: {},
-            asset: 'test_script',
+            asset: 'test_script'
         };
-        harness
-            .runAsync(harness.data.esLike, opConfig, context)
-            .then((checkData) => {
-                expect(checkData).toEqual(harness.data.esLike);
-            })
-            .catch((error) => {
-                fail(error);
-            })
-            .finally(() => {
-                done();
-            });
+
+        const checkData = await harness.runAsync(harness.data.esLike, opConfig, context);
+        expect(checkData).toEqual(harness.data.esLike);
     });
 
-    it('spawn options passed to spawn call', (done) => {
+    it('spawn options passed to spawn call', async () => {
         const opConfig = {
             _op: 'script',
             command: 'test_script.py',
             args: [''],
             options: {},
-            asset: 'test_script',
+            asset: 'test_script'
         };
-        harness
-            .runAsync(harness.data.simple, opConfig, context)
-            .then((checkData) => {
-                expect(checkData).toEqual(harness.data.simple);
-            })
-            .catch((error) => {
-                fail(error);
-            })
-            .finally(() => {
-                done();
-            });
+
+        const checkData = await harness.runAsync(harness.data.simple, opConfig, context);
+        expect(checkData).toEqual(harness.data.simple);
     });
 
-    it('data out size is one less than data in (simple)', (done) => {
+    it('data out size is one less than data in (simple)', async () => {
         const opConfig = {
             _op: 'script',
             command: 'test_script_delete_record.py',
             args: [],
             options: {},
-            asset: 'test_script',
+            asset: 'test_script'
         };
-        harness
-            .runAsync(harness.data.simple, opConfig, context)
-            .then((checkData) => {
-                expect(checkData.length).toEqual(harness.data.simple.length - 1);
-            })
-            .catch((error) => {
-                fail(error);
-            })
-            .finally(() => {
-                done();
-            });
+
+        const checkData = await harness.runAsync(harness.data.simple, opConfig, context);
+        expect(checkData.length).toEqual(harness.data.simple.length - 1);
     });
 
-    it('arguments get passed to script', (done) => {
+    it('arguments get passed to script', async () => {
         const opConfig = {
             _op: 'script',
             command: 'test_script_delete_record.py',
             args: ['2'],
             options: {},
-            asset: 'test_script',
+            asset: 'test_script'
         };
-        harness
-            .runAsync(harness.data.simple, opConfig, context)
-            .then((checkData) => {
-                expect(checkData.length).toEqual(harness.data.simple.length - 2);
-            })
-            .catch((error) => {
-                fail(error);
-            })
-            .finally(() => {
-                done();
-            });
+
+        const checkData = await harness.runAsync(harness.data.simple, opConfig, context);
+        expect(checkData.length).toEqual(harness.data.simple.length - 2);
     });
 
-    it('named args get passed to script', (done) => {
+    it('named args get passed to script', async () => {
         const opConfig = {
             _op: 'script',
             command: 'test_script_delete_record_options.py',
             args: ['--delete=3'],
             options: {},
-            asset: 'test_script',
+            asset: 'test_script'
         };
-        harness
-            .runAsync(harness.data.simple, opConfig, context)
-            .then((checkData) => {
-                expect(checkData.length).toEqual(harness.data.simple.length - 3);
-            })
-            .catch((error) => {
-                fail(error);
-            })
-            .finally(() => {
-                done();
-            });
+        const checkData = await harness.runAsync(harness.data.simple, opConfig, context);
+        expect(checkData.length).toEqual(harness.data.simple.length - 3);
     });
 
-    it('handles error when script does not exist', (done) => {
+    it('handles error when script does not exist', async () => {
         const data = [];
         const opConfig = {
             _op: 'script',
             command: 'test_script_x.py',
             args: [''],
             options: {},
-            asset: 'test_script',
+            asset: 'test_script'
         };
-        harness
-            .runAsync(data, opConfig, context)
-            .then((checkData) => {
-                expect(checkData).toEqual('');
-            })
-            .catch((error) => {
-                expect(error.code).toEqual('ENOENT');
-                expect(error.errno).toEqual('ENOENT');
-                expect(error.syscall).toEqual(`spawn ${assetPath}/test_script_x.py`);
-            })
-            .finally(() => {
-                done();
-            });
+        try {
+            const checkData = await harness.runAsync(data, opConfig, context);
+            expect(checkData).toEqual('');
+        } catch (error) {
+            expect(error.code).toEqual('ENOENT');
+            expect(error.errno).toEqual('ENOENT');
+            expect(error.syscall).toEqual(`spawn ${assetPath}/test_script_x.py`);
+        }
     });
 
-    it('handles error when script has an error', (done) => {
+    it('handles error when script has an error', async () => {
         const data = [];
         const opConfig = {
             _op: 'script',
             command: 'test_script_with_error.py',
             args: [''],
             options: {},
-            asset: 'test_script',
+            asset: 'test_script'
         };
-        harness
-            .runAsync(data, opConfig, context)
-            .then((checkData) => {
-                fail(checkData);
-            })
-            .catch((error) => {
-                const errorLines = error.toString().split('\n');
-                expect(errorLines[0].trim()).toEqual('Traceback (most recent call last):');
-                expect(errorLines[1].trim()).toEqual(
-                    `File "${assetPath}/test_script_with_error.py", line 5, in <module>`
-                );
-                expect(errorLines[2].trim()).toEqual('json_data = json.loads(json_string)');
-                expect(errorLines[3].trim()).toEqual("NameError: name 'json' is not defined");
-            })
-            .finally(() => {
-                done();
-            });
+        try {
+            const checkData = await harness.runAsync(data, opConfig, context);
+            fail(checkData);
+        } catch (error) {
+            const errorLines = error.toString().split('\n');
+            expect(errorLines[0].trim()).toEqual('Traceback (most recent call last):');
+            expect(errorLines[1].trim()).toEqual(
+                `File "${assetPath}/test_script_with_error.py", line 5, in <module>`
+            );
+            expect(errorLines[2].trim()).toEqual('json_data = json.loads(json_string)');
+            expect(errorLines[3].trim()).toEqual("NameError: name 'json' is not defined");
+        }
     });
 
-    it('handles error when script does not have exec permissions', (done) => {
+    it('handles error when script does not have exec permissions', async () => {
         const data = [];
         const opConfig = {
             _op: 'script',
             command: 'test_script_with_no_exec.py',
             args: [''],
             options: {},
-            asset: 'test_script',
+            asset: 'test_script'
         };
-        harness
-            .runAsync(data, opConfig, context)
-            .then((checkData) => {
-                fail(checkData);
-            })
-            .catch((error) => {
-                expect(error.code).toEqual('ENOENT');
-                expect(error.errno).toEqual('ENOENT');
-                expect(error.syscall).toEqual(`spawn ${assetPath}/test_script_with_no_exec.py`);
-            })
-            .finally(() => {
-                done();
-            });
+        try {
+            const checkData = await harness.runAsync(data, opConfig, context);
+            fail(checkData);
+        } catch (error) {
+            expect(error.code).toEqual('ENOENT');
+            expect(error.errno).toEqual('ENOENT');
+            expect(error.syscall).toEqual(`spawn ${assetPath}/test_script_with_no_exec.py`);
+        }
     });
 });

--- a/packages/teraslice/test/workers/execution-controller/execution-controller-spec.js
+++ b/packages/teraslice/test/workers/execution-controller/execution-controller-spec.js
@@ -1,11 +1,10 @@
 'use strict';
 
 const Promise = require('bluebird');
+const { pDelay } = require('@terascope/utils');
 const { TestContext } = require('../helpers');
 const { findPort } = require('../../../lib/utils/port_utils');
 const ExecutionController = require('../../../lib/workers/execution-controller');
-
-process.env.BLUEBIRD_LONG_STACK_TRACES = '1';
 
 describe('ExecutionController', () => {
     describe('when the execution context is invalid', () => {
@@ -18,7 +17,7 @@ describe('ExecutionController', () => {
 
             testContext = new TestContext({
                 assignment: 'execution_controller',
-                slicerPort: port,
+                slicerPort: port
             });
 
             await testContext.initialize(true);
@@ -26,7 +25,7 @@ describe('ExecutionController', () => {
 
             exController = new ExecutionController(
                 testContext.context,
-                testContext.executionContext,
+                testContext.executionContext
             );
 
             exController.isExecutionFinished = true;
@@ -34,8 +33,9 @@ describe('ExecutionController', () => {
             await testContext.addExStore();
             ({ exStore } = testContext.stores);
 
-            testContext.attachCleanup(() => exController.shutdown()
-                .catch(() => { /* ignore-error */ }));
+            testContext.attachCleanup(() => exController.shutdown().catch(() => {
+                /* ignore-error */
+            }));
         });
 
         afterEach(() => testContext.cleanup());
@@ -50,7 +50,9 @@ describe('ExecutionController', () => {
                 try {
                     await exController.initialize();
                 } catch (err) {
-                    expect(err.message).toStartWith(`Cannot get execution status ${testContext.exId}`);
+                    expect(err.message).toStartWith(
+                        `Cannot get execution status ${testContext.exId}`
+                    );
                     expect(err.message).toInclude('Not Found');
                 }
             });
@@ -103,7 +105,7 @@ describe('ExecutionController', () => {
 
             exController = new ExecutionController(
                 testContext.context,
-                testContext.executionContext,
+                testContext.executionContext
             );
 
             await exController.initialize();
@@ -111,8 +113,9 @@ describe('ExecutionController', () => {
             await testContext.addExStore();
             ({ exStore } = testContext.stores);
 
-            testContext.attachCleanup(() => exController.shutdown()
-                .catch(() => { /* ignore-error */ }));
+            testContext.attachCleanup(() => exController.shutdown().catch(() => {
+                /* ignore-error */
+            }));
         });
 
         afterEach(() => testContext.cleanup());
@@ -132,18 +135,16 @@ describe('ExecutionController', () => {
             await exController._startSliceFailureWatchDog();
             expect(exController.sliceFailureInterval).toBe(sliceFailureInterval);
 
-            await expect(exStore.getStatus(testContext.exId))
-                .resolves.toEqual('failing');
+            await expect(exStore.getStatus(testContext.exId)).resolves.toEqual('failing');
 
-            await Promise.delay(probationWindow + 100);
+            await pDelay(probationWindow + 100);
 
             // should be able to setr the status back to running if more slices are processed
             exController.executionAnalytics.increment('processed');
 
-            await Promise.delay(probationWindow + 100);
+            await pDelay(probationWindow + 100);
 
-            await expect(exStore.getStatus(testContext.exId))
-                .resolves.toEqual('running');
+            await expect(exStore.getStatus(testContext.exId)).resolves.toEqual('running');
 
             expect(exController.sliceFailureInterval).toBeNil();
 
@@ -158,14 +159,14 @@ describe('ExecutionController', () => {
 
         beforeEach(async () => {
             testContext = new TestContext({
-                assignment: 'execution_controller',
+                assignment: 'execution_controller'
             });
 
             await testContext.initialize();
 
             exController = new ExecutionController(
                 testContext.context,
-                testContext.executionContext,
+                testContext.executionContext
             );
         });
 
@@ -181,7 +182,7 @@ describe('ExecutionController', () => {
                 exController.stores = {
                     exStore: {
                         setStatus,
-                        executionMetaData,
+                        executionMetaData
                     }
                 };
                 exController.logger.error = logErr;
@@ -190,7 +191,10 @@ describe('ExecutionController', () => {
                 await exController.setFailingStatus();
 
                 expect(setStatus).toHaveBeenCalledWith(testContext.exId, 'failing', errMeta);
-                expect(executionMetaData).toHaveBeenCalledWith(stats, `execution ${testContext.exId} has encountered a processing error`);
+                expect(executionMetaData).toHaveBeenCalledWith(
+                    stats,
+                    `execution ${testContext.exId} has encountered a processing error`
+                );
                 expect(logErr).toHaveBeenCalledTimes(2);
             });
         });
@@ -202,14 +206,14 @@ describe('ExecutionController', () => {
 
         beforeEach(async () => {
             testContext = new TestContext({
-                assignment: 'execution_controller',
+                assignment: 'execution_controller'
             });
 
             await testContext.initialize();
 
             exController = new ExecutionController(
                 testContext.context,
-                testContext.executionContext,
+                testContext.executionContext
             );
         });
 
@@ -226,7 +230,7 @@ describe('ExecutionController', () => {
                 exController.stores = {
                     exStore: {
                         setStatus,
-                        executionMetaData,
+                        executionMetaData
                     }
                 };
                 exController.logger.error = logErr;
@@ -237,12 +241,16 @@ describe('ExecutionController', () => {
                 expect(exController.slicerFailed).toBeTrue();
 
                 expect(setStatus).toHaveBeenCalledWith(testContext.exId, 'failed', errMeta);
-                const errMsg = `TSError: slicer for ex ${testContext.exId} had an error, shutting down execution, caused by Uh oh`;
+                const errMsg = `TSError: slicer for ex ${
+                    testContext.exId
+                } had an error, shutting down execution, caused by Uh oh`;
                 expect(executionMetaData.mock.calls[0][0]).toEqual(stats);
                 expect(executionMetaData.mock.calls[0][1]).toStartWith(errMsg);
 
                 expect(logErr).toHaveBeenCalledTimes(2);
-                expect(logFatal).toHaveBeenCalledWith(`execution ${testContext.exId} is ended because of slice failure`);
+                expect(logFatal).toHaveBeenCalledWith(
+                    `execution ${testContext.exId} is ended because of slice failure`
+                );
             });
         });
 
@@ -278,8 +286,9 @@ describe('ExecutionController', () => {
                 testContext.executionContext
             );
 
-            testContext.attachCleanup(() => exController.shutdown()
-                .catch(() => { /* ignore-error */ }));
+            testContext.attachCleanup(() => exController.shutdown().catch(() => {
+                /* ignore-error */
+            }));
         });
 
         afterEach(() => testContext.cleanup());

--- a/packages/teraslice/test/workers/helpers/execution-controller-helper.js
+++ b/packages/teraslice/test/workers/helpers/execution-controller-helper.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const Promise = require('bluebird');
+const { pDelay } = require('@terascope/utils');
 
 function makeShutdownEarlyFn({ exController, enabled = false }) {
     let resolve;
@@ -36,11 +37,11 @@ function makeShutdownEarlyFn({ exController, enabled = false }) {
         shutdown: async () => {
             if (!enabled) return;
 
-            await Promise.delay(100);
+            await pDelay(100);
 
             catchShutdown();
 
-            await Promise.delay(100);
+            await pDelay(100);
         }
     };
 }
@@ -49,14 +50,18 @@ function getTestCases(testCases) {
     const onlyCases = _.filter(testCases, ts => ts[1].only);
     if (onlyCases.length > 0) {
         // eslint-disable-next-line no-console
-        console.warn('[WARNING]: test cases includes a "only" property, make sure to remove this before committing');
+        console.warn(
+            '[WARNING]: test cases includes a "only" property, make sure to remove this before committing'
+        );
         return onlyCases;
     }
 
     const cases = _.reject(testCases, ts => ts[1].skip);
     if (cases.length !== testCases.length) {
         // eslint-disable-next-line no-console
-        console.warn('[WARNING]: test cases includes a "skip" property, make sure to remove this before committing');
+        console.warn(
+            '[WARNING]: test cases includes a "skip" property, make sure to remove this before committing'
+        );
     }
     return cases;
 }

--- a/packages/teraslice/test/workers/worker/worker-spec.js
+++ b/packages/teraslice/test/workers/worker/worker-spec.js
@@ -3,10 +3,11 @@
 /* eslint-disable no-console */
 
 const Promise = require('bluebird');
+const { pDelay } = require('@terascope/utils');
 const { ExecutionController } = require('@terascope/teraslice-messaging');
+const { findPort } = require('../../../lib/utils/port_utils');
 const Worker = require('../../../lib/workers/worker');
 const { TestContext } = require('../helpers');
-const { findPort } = require('../../../lib/utils/port_utils');
 
 describe('Worker', () => {
     async function setupTest(options = {}) {
@@ -20,7 +21,7 @@ describe('Worker', () => {
             port: slicerPort,
             networkLatencyBuffer: 0,
             actionTimeout: 1000,
-            workerDisconnectTimeout: 3000,
+            workerDisconnectTimeout: 3000
         });
 
         testContext.attachCleanup(() => server.shutdown());
@@ -76,7 +77,7 @@ describe('Worker', () => {
             expect(sliceFailure).toBeNil();
 
             expect(sliceSuccess).toMatchObject({
-                slice: sliceConfig,
+                slice: sliceConfig
             });
         });
     });
@@ -127,7 +128,7 @@ describe('Worker', () => {
             expect(sliceFailure).toBeNil();
 
             expect(sliceSuccess).toMatchObject({
-                slice: sliceConfig,
+                slice: sliceConfig
             });
         });
     });
@@ -162,7 +163,7 @@ describe('Worker', () => {
             await worker.runOnce();
 
             // avoid on slice events don't fire immediatley now
-            await Promise.delay(0);
+            await pDelay(0);
         });
 
         afterEach(async () => {
@@ -173,7 +174,7 @@ describe('Worker', () => {
             expect(sliceFailure).toBeNil();
 
             expect(sliceSuccess).toMatchObject({
-                slice: sliceConfig,
+                slice: sliceConfig
             });
         });
     });
@@ -203,7 +204,7 @@ describe('Worker', () => {
 
             const workerStart = worker.runOnce();
 
-            await Promise.delay(500);
+            await pDelay(500);
             sliceConfig = await testContext.newSlice();
 
             await server.dispatchSlice(sliceConfig, worker.workerId);
@@ -212,7 +213,7 @@ describe('Worker', () => {
 
             msg = await msgPromise;
 
-            await Promise.delay(100);
+            await pDelay(100);
         });
 
         afterEach(async () => {
@@ -222,7 +223,7 @@ describe('Worker', () => {
         it('should re-enqueue the worker after receiving the slice complete message', () => {
             expect(msg).not.toBeNil();
             expect(sliceSuccess).toMatchObject({
-                slice: sliceConfig,
+                slice: sliceConfig
             });
             expect(sliceFailure).toBeNil();
         });
@@ -266,7 +267,7 @@ describe('Worker', () => {
 
             msg = await msgPromise;
 
-            await Promise.delay(100);
+            await pDelay(100);
         });
 
         afterEach(() => testContext.cleanup());
@@ -297,7 +298,7 @@ describe('Worker', () => {
 
             worker.context.sysconfig.teraslice.shutdown_timeout = 1000;
             worker.shutdownTimeout = 1000;
-            worker.slice.run = jest.fn(async () => Promise.delay(500));
+            worker.slice.run = jest.fn(async () => pDelay(500));
 
             const sliceConfig = await testContext.newSlice();
 
@@ -331,7 +332,7 @@ describe('Worker', () => {
             worker.context.sysconfig.teraslice.shutdown_timeout = 500;
             worker.shutdownTimeout = 500;
 
-            worker.slice.run = jest.fn(() => Promise.delay(1000));
+            worker.slice.run = jest.fn(() => pDelay(1000));
             const sliceConfig = await testContext.newSlice();
 
             server.onClientAvailable(() => {
@@ -415,7 +416,7 @@ describe('Worker', () => {
 
                     worker.stores = {};
                     worker.stores.someStore = {
-                        shutdown: () => Promise.reject(new Error('Store Error')),
+                        shutdown: () => Promise.reject(new Error('Store Error'))
                     };
 
                     worker.slice = {};

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -37,7 +37,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "@types/graphlib": "^2.1.5",
         "@types/shortid": "^0.0.29",
         "awesome-phonenumber": "^2.12.0",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@terascope/data-access": "^0.12.5",
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "apollo-boost": "^0.4.3",
         "apollo-client": "^2.6.3",
         "date-fns": "^1.30.1",

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -44,7 +44,7 @@
     "devDependencies": {
         "@craco/craco": "^5.2.3",
         "@terascope/ui-components": "^0.3.6",
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "@types/jest": "24.0.15",
         "@types/node": "12.6.8",
         "@types/react": "16.8.23",

--- a/packages/ui-data-access/package.json
+++ b/packages/ui-data-access/package.json
@@ -26,7 +26,7 @@
         "@terascope/data-access": "^0.12.5",
         "@terascope/data-types": "^0.5.0",
         "@terascope/ui-components": "^0.3.6",
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "@types/jest": "24.0.15",
         "@types/node": "12.6.8",
         "@types/react": "16.8.23",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/utils",
-    "version": "0.13.0",
+    "version": "0.14.0",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/xlucene-evaluator/package.json
+++ b/packages/xlucene-evaluator/package.json
@@ -32,7 +32,7 @@
         "test:watch": "jest --coverage=false --notify --watch --onlyChanged"
     },
     "dependencies": {
-        "@terascope/utils": "^0.13.0",
+        "@terascope/utils": "^0.14.0",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-point-in-polygon": "^6.0.1",

--- a/scripts/build-cleanup.sh
+++ b/scripts/build-cleanup.sh
@@ -8,7 +8,7 @@ main() {
         if [ -z "$remove_only" ] || [ "$remove_only" == "dist" ]; then
             local dist_dir="$cwd/packages/$package/dist"
             if [ -d "$dist_dir" ]; then
-                rm -rf "${dist_dir:?}/*"
+                rm -rf "${dist_dir:?}"/*
             fi
         fi
 


### PR DESCRIPTION
I have been slowly converting things to async await and we have been been using bluebird specific APIs that either aren't compatible in node 8 or won't exist in the spec. This PR changes the usage of `Promise.finally`, `Promise.map`, `Promise.delay`, `Promise.race` and `Promise.spread`, to avoid being dependent a resulting bluebird promise when it may or may not be returned.

This PR also fixes the build:cleanup script and adds a `pRace` to `@terascope/utils`

Resolves #1290 