### PR TITLE
v0.54.8 - Fix es compatibility in 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ jobs:
       name: 'ES Test Suite (elasticsearch 5) (node 10)'
       # run only on pull-requests
       if: branch = master AND type IN (pull_request) AND fork = false
-      script: yarn test --suite elasticsearch --elasticsearch-version 5.6 --elasticsearch-api-version 6.5 --report-coverage false
+      script: yarn test --suite elasticsearch --elasticsearch-version 5.6 --elasticsearch-api-version 5.6 --report-coverage false
 
     - script:
       name: 'ES Test Suite (elasticsearch 6) (node 10)'

--- a/e2e/test/misc.js
+++ b/e2e/test/misc.js
@@ -100,7 +100,7 @@ function indexStats(indexName) {
 }
 
 async function cleanupIndex(indexName) {
-    await es().indices.delete({ index: indexName, ignoreUnavailable: true });
+    await es().indices.delete({ index: indexName });
 }
 
 // Adds teraslice-workers to the environment

--- a/e2e/test/misc.js
+++ b/e2e/test/misc.js
@@ -100,7 +100,9 @@ function indexStats(indexName) {
 }
 
 async function cleanupIndex(indexName) {
-    await es().indices.delete({ index: indexName });
+    await es()
+        .indices.delete({ index: indexName })
+        .catch(() => {});
 }
 
 // Adds teraslice-workers to the environment

--- a/packages/data-access-plugin/package.json
+++ b/packages/data-access-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/data-access-plugin",
-    "version": "0.11.5",
+    "version": "0.11.6",
     "description": "A teraserver plugin for managing data access and searching spaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-access-plugin#readme",
     "bugs": {
@@ -29,19 +29,19 @@
     },
     "dependencies": {
         "@apollographql/graphql-playground-html": "^1.6.24",
-        "@terascope/data-access": "^0.12.6",
+        "@terascope/data-access": "^0.12.7",
         "@terascope/data-types": "^0.5.2",
-        "@terascope/elasticsearch-api": "^2.1.1",
+        "@terascope/elasticsearch-api": "^2.1.2",
         "@terascope/utils": "^0.14.1",
         "accepts": "^1.3.7",
         "apollo-server-express": "^2.6.5",
         "body-parser": "1.19.0",
-        "elasticsearch-store": "^0.10.3",
+        "elasticsearch-store": "^0.10.4",
         "graphql": "^14.3.1",
         "graphql-iso-date": "^3.6.1",
         "graphql-type-json": "^0.3.0",
         "terafoundation": "^0.11.2",
-        "xlucene-evaluator": "^0.9.6"
+        "xlucene-evaluator": "^0.9.7"
     },
     "devDependencies": {
         "@terascope/job-components": "^0.20.8",

--- a/packages/data-access-plugin/test/helpers/elasticsearch.ts
+++ b/packages/data-access-plugin/test/helpers/elasticsearch.ts
@@ -24,7 +24,6 @@ export function cleanupIndex(model: Model) {
         .delete({
             index: indexQuery,
             requestTimeout: 3000,
-            ignoreUnavailable: true,
         })
         .catch(() => {});
 }
@@ -65,7 +64,7 @@ export async function populateIndex(client: es.Client, index: string, _propertie
 }
 
 export function deleteIndices(client: es.Client, list: string[]) {
-    return Promise.all(list.map(index => client.indices.delete({ index, requestTimeout: 1000, ignoreUnavailable: true })));
+    return Promise.all(list.map(index => client.indices.delete({ index, requestTimeout: 1000 })));
 }
 
 export function cleanupIndexes(manager: ACLManager) {

--- a/packages/data-access-plugin/test/helpers/elasticsearch.ts
+++ b/packages/data-access-plugin/test/helpers/elasticsearch.ts
@@ -64,7 +64,7 @@ export async function populateIndex(client: es.Client, index: string, _propertie
 }
 
 export function deleteIndices(client: es.Client, list: string[]) {
-    return Promise.all(list.map(index => client.indices.delete({ index, requestTimeout: 1000 })));
+    return Promise.all(list.map(index => client.indices.delete({ index, requestTimeout: 1000 }).catch(() => {})));
 }
 
 export function cleanupIndexes(manager: ACLManager) {

--- a/packages/data-access-plugin/test/manager-plugin-spec.ts
+++ b/packages/data-access-plugin/test/manager-plugin-spec.ts
@@ -589,7 +589,6 @@ describe('Data Access Management', () => {
             await client.indices.delete({
                 index,
                 requestTimeout: 1000,
-                ignoreUnavailable: true,
             });
 
             const mapping = {
@@ -697,7 +696,6 @@ describe('Data Access Management', () => {
             await client.indices.delete({
                 index,
                 requestTimeout: 3000,
-                ignoreUnavailable: true,
             });
         });
 

--- a/packages/data-access-plugin/test/manager-plugin-spec.ts
+++ b/packages/data-access-plugin/test/manager-plugin-spec.ts
@@ -586,10 +586,12 @@ describe('Data Access Management', () => {
         const index = 'hello-space';
 
         beforeAll(async () => {
-            await client.indices.delete({
-                index,
-                requestTimeout: 1000,
-            });
+            await client.indices
+                .delete({
+                    index,
+                    requestTimeout: 1000,
+                })
+                .catch(() => {});
 
             const mapping = {
                 _all: {
@@ -693,10 +695,12 @@ describe('Data Access Management', () => {
         });
 
         afterAll(async () => {
-            await client.indices.delete({
-                index,
-                requestTimeout: 3000,
-            });
+            await client.indices
+                .delete({
+                    index,
+                    requestTimeout: 3000,
+                })
+                .catch(() => {});
         });
 
         it('should be able to search a space', async () => {

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/data-access",
-    "version": "0.12.6",
+    "version": "0.12.7",
     "description": "A tool designed to limit access to reading and querying data",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-access#readme",
     "bugs": {
@@ -28,8 +28,8 @@
     "dependencies": {
         "@terascope/data-types": "^0.5.2",
         "@terascope/utils": "^0.14.1",
-        "elasticsearch-store": "^0.10.3",
-        "xlucene-evaluator": "^0.9.6"
+        "elasticsearch-store": "^0.10.4",
+        "xlucene-evaluator": "^0.9.7"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/data-access/test/helpers/elasticsearch.ts
+++ b/packages/data-access/test/helpers/elasticsearch.ts
@@ -22,7 +22,6 @@ export function cleanupIndex(model: Model) {
         .delete({
             index: indexQuery,
             requestTimeout: 3000,
-            ignoreUnavailable: true,
         })
         .catch(() => {});
 }

--- a/packages/data-access/test/search-access-spec.ts
+++ b/packages/data-access/test/search-access-spec.ts
@@ -202,9 +202,8 @@ describe('SearchAccess', () => {
 
                 const params = searchAccess.getSearchParams(query);
 
-                expect(params).toEqual({
+                expect(params).toMatchObject({
                     body: {},
-                    ignoreUnavailable: true,
                     index: 'woot',
                     q: 'hello',
                     sort: 'example:asc',
@@ -259,9 +258,8 @@ describe('SearchAccess', () => {
 
                 const params = searchAccess.getSearchParams(query);
 
-                expect(params).toEqual({
+                expect(params).toMatchObject({
                     body: {},
-                    ignoreUnavailable: true,
                     index: 'woot',
                     q: 'example:hello',
                     sort: 'created:desc',
@@ -292,7 +290,7 @@ describe('SearchAccess', () => {
 
                 const params = searchAccess.getSearchParams(query);
 
-                expect(params).toEqual({
+                expect(params).toMatchObject({
                     body: {
                         sort: {
                             _geo_distance: {
@@ -305,7 +303,6 @@ describe('SearchAccess', () => {
                             },
                         },
                     },
-                    ignoreUnavailable: true,
                     index: 'woot',
                     from: 0,
                     q: 'example:hello',

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -38,7 +38,7 @@
         "@types/lodash.defaultsdeep": "^4.6.6",
         "@types/lodash.set": "^4.3.6",
         "@types/yargs": "^13.0.0",
-        "xlucene-evaluator": "^0.9.6"
+        "xlucene-evaluator": "^0.9.7"
     },
     "engines": {
         "node": ">=8.0.0"

--- a/packages/elasticsearch-api/index.js
+++ b/packages/elasticsearch-api/index.js
@@ -713,7 +713,7 @@ module.exports = function elasticsearchApi(client = {}, logger, _opConfig) {
     }
 
     function getESVersion() {
-        const esVersion = process.env.ELASTICSEARCH_VERSION || _.get(client, 'transport._config.apiVersion');
+        const esVersion = _.get(client, 'transport._config.apiVersion', '6.5');
         if (esVersion && _.isString(esVersion)) {
             const [majorVersion] = esVersion.split('.');
             return _.toNumber(majorVersion);

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/elasticsearch-api",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "elasticsearch-store",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,7 +30,7 @@
         "ajv": "^6.10.0",
         "nanoid": "^2.0.3",
         "rambda": "^2.11.1",
-        "xlucene-evaluator": "^0.9.6"
+        "xlucene-evaluator": "^0.9.7"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/elasticsearch-store/src/utils/elasticsearch.ts
+++ b/packages/elasticsearch-store/src/utils/elasticsearch.ts
@@ -161,7 +161,7 @@ export function getXluceneTypeFromESType(type?: string): FieldType | undefined {
 }
 
 export function getESVersion(client: Client): number {
-    const version = process.env.ELASTICSEARCH_VERSION || ts.get(client, 'transport._config.apiVersion');
+    const version = ts.get(client, 'transport._config.apiVersion', '6.5');
     if (version && ts.isString(version)) {
         const [majorVersion] = version.split('.');
         return ts.toNumber(majorVersion);

--- a/packages/elasticsearch-store/test/helpers/elasticsearch.ts
+++ b/packages/elasticsearch-store/test/helpers/elasticsearch.ts
@@ -18,7 +18,6 @@ export async function cleanupIndex(client: Client, index: string, template?: str
         .delete({
             index,
             requestTimeout: 3000,
-            ignoreUnavailable: true,
         })
         .catch(() => {});
 

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -21,7 +21,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.1",
+        "@terascope/elasticsearch-api": "^2.1.2",
         "@terascope/utils": "^0.14.1",
         "agentkeepalive": "^4.0.2",
         "aws-sdk": "^2.496.0",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -25,7 +25,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.1",
+        "@terascope/elasticsearch-api": "^2.1.2",
         "@terascope/job-components": "^0.20.8",
         "bluebird": "^3.5.5",
         "mnemonist": "^0.30.0"

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@newrelic/native-metrics": "^4.1.0",
-        "@terascope/elasticsearch-api": "^2.1.1",
+        "@terascope/elasticsearch-api": "^2.1.2",
         "@terascope/error-parser": "^1.0.2",
         "@terascope/job-components": "^0.20.8",
         "@terascope/queue": "^1.1.6",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.54.7",
+    "version": "0.54.8",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -46,7 +46,7 @@
         "shortid": "^2.2.14",
         "valid-url": "^1.0.9",
         "validator": "^11.0.0",
-        "xlucene-evaluator": "^0.9.6",
+        "xlucene-evaluator": "^0.9.7",
         "yargs": "^13.2.4"
     },
     "devDependencies": {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -37,7 +37,7 @@
         "semantic-ui-react": "^0.87.2"
     },
     "devDependencies": {
-        "@terascope/data-access": "^0.12.6",
+        "@terascope/data-access": "^0.12.7",
         "@types/jest": "24.0.15",
         "@types/node": "12.6.9",
         "@types/react": "16.8.23",

--- a/packages/ui-data-access/package.json
+++ b/packages/ui-data-access/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@terascope/data-access": "^0.12.6",
+        "@terascope/data-access": "^0.12.7",
         "@terascope/data-types": "^0.5.2",
         "@terascope/ui-components": "^0.3.6",
         "@terascope/utils": "^0.14.1",
@@ -49,7 +49,7 @@
         "ts-loader": "^6.0.3",
         "webpack": "^4.34.0",
         "webpack-cli": "^3.3.4",
-        "xlucene-evaluator": "^0.9.6"
+        "xlucene-evaluator": "^0.9.7"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/xlucene-evaluator/package.json
+++ b/packages/xlucene-evaluator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xlucene-evaluator",
-    "version": "0.9.6",
+    "version": "0.9.7",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-evaluator#readme",
     "repository": {

--- a/packages/xlucene-evaluator/src/query-access/query-access.ts
+++ b/packages/xlucene-evaluator/src/query-access/query-access.ts
@@ -143,6 +143,12 @@ export class QueryAccess<T extends ts.AnyObject = ts.AnyObject> {
             }
         }
 
+        if (esVersion < 6) {
+            if (searchParams.ignoreUnavailable != null) {
+                delete searchParams.ignoreUnavailable;
+            }
+        }
+
         return searchParams;
     }
 

--- a/packages/xlucene-evaluator/src/query-access/query-access.ts
+++ b/packages/xlucene-evaluator/src/query-access/query-access.ts
@@ -143,12 +143,6 @@ export class QueryAccess<T extends ts.AnyObject = ts.AnyObject> {
             }
         }
 
-        if (esVersion < 6) {
-            if (searchParams.ignoreUnavailable != null) {
-                delete searchParams.ignoreUnavailable;
-            }
-        }
-
         return searchParams;
     }
 


### PR DESCRIPTION
Fix compatibility for elasticsearch api version of `5.6`. Our cluster information should use the following `apiVersion`s in the connector configuration:

- for elasticsearch 7, `apiVersion: 7.2`
- for elasticsearch 6, `apiVersion: 6.5`
- for elasticsearch 5, `apiVersion: 5.6`