### PR TITLE
Data Type mapping fixes

### DIFF
--- a/packages/data-access-plugin/bin/simple-migrate.js
+++ b/packages/data-access-plugin/bin/simple-migrate.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/* eslint-disable no-console */
+
+process.env.USE_DEBUG_LOGGER = 'true';
+process.env.DEBUG = '*teraslice*';
+
+const fs = require('fs');
+const path = require('path');
+const { get } = require('@terascope/utils');
+const { SimpleContext } = require('terafoundation');
+const { ACLManager } = require('@terascope/data-access');
+
+const scriptName = path.basename(process.argv[1]);
+
+const systemSchemaPath = path.join(process.cwd(), 'system_schema.js');
+if (!fs.existsSync(systemSchemaPath)) {
+    console.error(`${scriptName} must be ran in the root of teraserver`);
+    process.exit(1);
+}
+
+const { configSchema } = require(systemSchemaPath);
+
+simpleMigrate(
+    new SimpleContext({
+        name: scriptName,
+        config_schema: configSchema
+    })
+);
+
+async function simpleMigrate(context) {
+    const connection = get(context, 'sysconfig.data_access.connection', 'default');
+    const namespace = get(context, 'sysconfig.data_access.namespace');
+
+    const { client } = context.foundation.getConnection({
+        type: 'elasticsearch',
+        endpoint: connection,
+        cached: true
+    });
+
+    let manager;
+    try {
+        manager = new ACLManager(client, {
+            namespace,
+            logger: context.logger
+        });
+    } catch (err) {
+        console.error(err);
+        process.exit(1);
+    }
+
+    try {
+        const results = await manager.simpleMigrate();
+
+        console.log('succesfully migrated index', results);
+        process.exit(0);
+    } catch (err) {
+        console.error('Failure migrate index', err);
+        process.exit(1);
+    }
+}

--- a/packages/data-access-plugin/package.json
+++ b/packages/data-access-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/data-access-plugin",
-    "version": "0.11.6",
+    "version": "0.12.0",
     "description": "A teraserver plugin for managing data access and searching spaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-access-plugin#readme",
     "bugs": {
@@ -30,14 +30,14 @@
     },
     "dependencies": {
         "@apollographql/graphql-playground-html": "^1.6.24",
-        "@terascope/data-access": "^0.12.7",
+        "@terascope/data-access": "^0.13.0",
         "@terascope/data-types": "^0.5.2",
         "@terascope/elasticsearch-api": "^2.1.3",
         "@terascope/utils": "^0.14.1",
         "accepts": "^1.3.7",
         "apollo-server-express": "^2.6.5",
         "body-parser": "^1.19.0",
-        "elasticsearch-store": "^0.10.4",
+        "elasticsearch-store": "^0.11.0",
         "graphql": "^14.3.1",
         "graphql-iso-date": "^3.6.1",
         "graphql-type-json": "^0.3.0",

--- a/packages/data-access-plugin/package.json
+++ b/packages/data-access-plugin/package.json
@@ -15,7 +15,8 @@
     "main": "dist/src/index.js",
     "typings": "dist/src/index.d.ts",
     "bin": {
-        "create-superadmin": "./bin/create-superadmin.js"
+        "create-superadmin": "./bin/create-superadmin.js",
+        "simple-migrate": "./bin/simple-migrate.js"
     },
     "scripts": {
         "build": "tsc --build --pretty",

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/data-access",
-    "version": "0.12.7",
+    "version": "0.13.0",
     "description": "A tool designed to limit access to reading and querying data",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-access#readme",
     "bugs": {
@@ -28,7 +28,7 @@
     "dependencies": {
         "@terascope/data-types": "^0.5.2",
         "@terascope/utils": "^0.14.1",
-        "elasticsearch-store": "^0.10.4",
+        "elasticsearch-store": "^0.11.0",
         "xlucene-evaluator": "^0.9.7"
     },
     "devDependencies": {

--- a/packages/data-access/src/acl-manager.ts
+++ b/packages/data-access/src/acl-manager.ts
@@ -1,8 +1,8 @@
 import * as es from 'elasticsearch';
 import * as ts from '@terascope/utils';
-import { DataTypeConfig, LATEST_VERSION } from '@terascope/data-types';
-import { CreateRecordInput, UpdateRecordInput } from 'elasticsearch-store';
 import { CachedQueryAccess } from 'xlucene-evaluator';
+import { DataTypeConfig, LATEST_VERSION } from '@terascope/data-types';
+import { CreateRecordInput, UpdateRecordInput, MigrateIndexStoreOptions } from 'elasticsearch-store';
 import * as models from './models';
 import * as i from './interfaces';
 
@@ -55,6 +55,20 @@ export class ACLManager {
             this._views.shutdown(),
             this._dataTypes.shutdown(),
         ]);
+    }
+
+    async simpleMigrate() {
+        const results: ts.AnyObject = {};
+        results['dataTypes'] = await this._dataTypes.store.migrateIndex({});
+        results['roles'] = await this._roles.store.migrateIndex({});
+        results['users'] = await this._users.store.migrateIndex({});
+        results['spaces'] = await this._spaces.store.migrateIndex({});
+        results['views'] = await this._views.store.migrateIndex({});
+        return results;
+    }
+
+    async migrateIndex(model: i.ModelName, options: MigrateIndexStoreOptions) {
+        return this[`_${model}`].store.migrateIndex(options);
     }
 
     /**

--- a/packages/data-access/src/models/config/data-types.ts
+++ b/packages/data-access/src/models/config/data-types.ts
@@ -25,6 +25,7 @@ const config: IndexModelConfig<DataType> = {
                     },
                     fields: {
                         type: 'object',
+                        enabled: false,
                     },
                 },
             },

--- a/packages/data-access/src/models/config/data-types.ts
+++ b/packages/data-access/src/models/config/data-types.ts
@@ -2,7 +2,7 @@ import { IndexModelConfig, IndexModelRecord } from 'elasticsearch-store';
 import { DataTypeConfig, LATEST_VERSION } from '@terascope/data-types';
 
 const config: IndexModelConfig<DataType> = {
-    version: 1,
+    version: 2,
     name: 'data_types',
     mapping: {
         properties: {

--- a/packages/data-access/src/models/config/spaces.ts
+++ b/packages/data-access/src/models/config/spaces.ts
@@ -40,6 +40,7 @@ const config: IndexModelConfig<Space> = {
             },
             config: {
                 type: 'object',
+                enabled: false,
             },
         },
     },

--- a/packages/data-access/src/models/config/spaces.ts
+++ b/packages/data-access/src/models/config/spaces.ts
@@ -4,7 +4,7 @@ export type SpaceConfigType = 'SEARCH' | 'STREAMING';
 export const SpaceConfigTypes: ReadonlyArray<SpaceConfigType> = ['SEARCH', 'STREAMING'];
 
 const config: IndexModelConfig<Space> = {
-    version: 1,
+    version: 2,
     name: 'spaces',
     mapping: {
         properties: {

--- a/packages/data-types/src/interfaces.ts
+++ b/packages/data-types/src/interfaces.ts
@@ -115,6 +115,7 @@ export type ESTypeMapping = PropertyESTypeMapping | FieldsESTypeMapping | BasicE
 
 type BasicESTypeMapping = {
     type: ElasticSearchTypes;
+    [prop: string]: any;
 };
 
 type FieldsESTypeMapping = {
@@ -129,7 +130,7 @@ type FieldsESTypeMapping = {
 };
 
 type PropertyESTypeMapping = {
-    type?: 'nested';
+    type?: 'nested' | 'object';
     properties: {
         [key: string]: FieldsESTypeMapping | BasicESTypeMapping;
     };

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "elasticsearch-store",
-    "version": "0.10.4",
+    "version": "0.11.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/elasticsearch-store/src/index-manager.ts
+++ b/packages/elasticsearch-store/src/index-manager.ts
@@ -152,6 +152,9 @@ export default class IndexManager {
      *
      * **IMPORTANT** This is a potentionally dangerous operation
      * and should only when the cluster is properly shutdown.
+     *
+     * @todo add support for timeseries and templated indexes
+     * @todo add support for complicated reindexing behaviors
      */
     async migrateIndex(options: MigrateIndexOptions): Promise<any> {
         const { timeout, config, previousVersion, previousName, previousNamespace } = options;
@@ -182,6 +185,8 @@ export default class IndexManager {
         const newIndexName = this.formatIndexName(config);
         const previousIndexName = this.formatIndexName(previousConfig);
 
+        await this.indexSetup(config);
+
         if (newIndexName === previousIndexName) {
             console.error(
                 `No changes detected for index ${newIndexName},`,
@@ -190,8 +195,7 @@ export default class IndexManager {
             return;
         }
 
-        await this.indexSetup(config);
-        await this.client.reindex({
+        return this.client.reindex({
             timeout,
             waitForActiveShards: 'all',
             waitForCompletion: true,
@@ -204,8 +208,6 @@ export default class IndexManager {
                 },
             },
         });
-
-        return;
     }
 
     async getMapping(index: string) {

--- a/packages/elasticsearch-store/src/index-store.ts
+++ b/packages/elasticsearch-store/src/index-store.ts
@@ -270,6 +270,11 @@ export default class IndexStore<T extends Object, I extends Partial<T> = T> {
         return docs.map(this._toRecord);
     }
 
+    /** @see IndexManager#migrateIndex */
+    migrateIndex(options: i.MigrateIndexStoreOptions) {
+        return this.manager.migrateIndex({ ...options, config: this.config });
+    }
+
     /**
      * Refreshes the current index
      */

--- a/packages/elasticsearch-store/src/interfaces.ts
+++ b/packages/elasticsearch-store/src/interfaces.ts
@@ -257,3 +257,13 @@ export type FindOneOptions<T> = {
     includes?: (keyof T)[];
     excludes?: (keyof T)[];
 };
+
+export interface MigrateIndexOptions {
+    config: IndexConfig;
+    timeout?: string;
+    previousNamespace?: string;
+    previousName?: string;
+    previousVersion?: number;
+}
+
+export type MigrateIndexStoreOptions = Omit<MigrateIndexOptions, 'config'>;

--- a/packages/elasticsearch-store/test/helpers/simple-index.ts
+++ b/packages/elasticsearch-store/test/helpers/simple-index.ts
@@ -67,6 +67,7 @@ export const mapping: ESTypeMappings = {
         },
         test_object: {
             type: 'object',
+            enabled: false,
         },
         test_boolean: {
             type: 'boolean',

--- a/packages/elasticsearch-store/test/index-manager-migrate-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-migrate-spec.ts
@@ -1,0 +1,103 @@
+import 'jest-extended';
+import { debugLogger, times } from '@terascope/utils';
+import * as simple from './helpers/simple-index';
+import { IndexManager, IndexConfig } from '../src';
+import { makeClient, cleanupIndex } from './helpers/elasticsearch';
+import { TEST_INDEX_PREFIX } from './helpers/config';
+
+describe('IndexManager->migrateIndex()', () => {
+    const logger = debugLogger('index-manager-migrate');
+
+    describe('using a mapped index', () => {
+        const client = makeClient();
+
+        const previousConfig: IndexConfig = {
+            namespace: TEST_INDEX_PREFIX,
+            name: 'migrate',
+            index_schema: {
+                version: 1,
+                mapping: simple.mapping,
+                strict: true,
+            },
+            version: 1,
+            index_settings: {
+                'index.number_of_shards': 1,
+                'index.number_of_replicas': 0,
+            },
+            logger,
+        };
+
+        const newConfig: IndexConfig = {
+            namespace: TEST_INDEX_PREFIX,
+            name: 'migrate',
+            index_schema: {
+                version: 2,
+                mapping: simple.mapping,
+                strict: true,
+            },
+            version: 1,
+            index_settings: {
+                'index.number_of_shards': 1,
+                'index.number_of_replicas': 0,
+            },
+            logger,
+        };
+
+        const indexManager = new IndexManager(client);
+        const newIndex = indexManager.formatIndexName(newConfig);
+        const previousIndex = indexManager.formatIndexName(previousConfig);
+
+        beforeAll(async () => {
+            await Promise.all([cleanupIndex(client, newIndex), cleanupIndex(client, previousIndex)]);
+
+            await indexManager.indexSetup(previousConfig);
+            const body: any[] = [];
+            times(10, n => {
+                body.push(
+                    {
+                        index: {
+                            _index: previousIndex,
+                            _type: previousConfig.name,
+                        },
+                    },
+                    {
+                        test_id: `id-${n}`,
+                        test_keyword: 'hello',
+                        test_object: {
+                            hello: true,
+                        },
+                        test_boolean: false,
+                        _created: new Date().toISOString(),
+                        _updated: new Date().toISOString(),
+                    }
+                );
+            });
+
+            await client.bulk({
+                body,
+            });
+            await client.indices.refresh({ index: previousIndex });
+        });
+
+        afterAll(async () => {
+            await Promise.all([cleanupIndex(client, newIndex), cleanupIndex(client, previousIndex)]);
+            client.close();
+        });
+
+        it('should be able to migrate to the new index', async () => {
+            await expect(indexManager.exists(newIndex)).resolves.toBeFalse();
+
+            await expect(
+                indexManager.migrateIndex({
+                    config: newConfig,
+                    previousVersion: previousConfig.version,
+                })
+            ).resolves.toMatchObject({
+                total: 10,
+                failures: [],
+            });
+
+            await expect(indexManager.exists(newIndex)).resolves.toBeTrue();
+        });
+    });
+});

--- a/packages/elasticsearch-store/test/index-manager-migrate-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-migrate-spec.ts
@@ -90,7 +90,6 @@ describe('IndexManager->migrateIndex()', () => {
             await expect(
                 indexManager.migrateIndex({
                     config: newConfig,
-                    previousVersion: previousConfig.version,
                 })
             ).resolves.toMatchObject({
                 total: 10,
@@ -98,6 +97,12 @@ describe('IndexManager->migrateIndex()', () => {
             });
 
             await expect(indexManager.exists(newIndex)).resolves.toBeTrue();
+
+            await expect(
+                indexManager.migrateIndex({
+                    config: newConfig,
+                })
+            ).resolves.toBeNil();
         });
     });
 });

--- a/packages/elasticsearch-store/test/index-manager-migrate-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-migrate-spec.ts
@@ -85,6 +85,7 @@ describe('IndexManager->migrateIndex()', () => {
         });
 
         it('should be able to migrate to the new index', async () => {
+            // make sure it doesn't exist first
             await expect(indexManager.exists(newIndex)).resolves.toBeFalse();
 
             await expect(

--- a/packages/elasticsearch-store/test/index-manager-migrate-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-migrate-spec.ts
@@ -102,7 +102,7 @@ describe('IndexManager->migrateIndex()', () => {
                 indexManager.migrateIndex({
                     config: newConfig,
                 })
-            ).resolves.toBeNil();
+            ).resolves.toBeFalse();
         });
     });
 });

--- a/packages/elasticsearch-store/test/index-manager-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-spec.ts
@@ -64,13 +64,6 @@ describe('IndexManager', () => {
             });
         });
 
-        describe('->migrateIndex', () => {
-            it('should return a promise', () => {
-                // @ts-ignore
-                return indexManager.migrateIndex();
-            });
-        });
-
         describe('->formatIndexName', () => {
             describe('when passed just a name', () => {
                 it('should return a correctly formatted index name', () => {

--- a/packages/elasticsearch-store/test/index-model-spec.ts
+++ b/packages/elasticsearch-store/test/index-model-spec.ts
@@ -28,6 +28,7 @@ describe('IndexModel', () => {
                 },
                 config: {
                     type: 'object',
+                    enabled: false,
                 },
             },
         },

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -37,7 +37,7 @@
         "semantic-ui-react": "^0.87.2"
     },
     "devDependencies": {
-        "@terascope/data-access": "^0.12.7",
+        "@terascope/data-access": "^0.13.0",
         "@types/react": "16.8.23",
         "@types/react-dom": "16.8.5",
         "@types/react-router-dom": "^4.3.4",

--- a/packages/ui-data-access/package.json
+++ b/packages/ui-data-access/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@terascope/data-access": "^0.12.7",
+        "@terascope/data-access": "^0.13.0",
         "@terascope/data-types": "^0.5.2",
         "@terascope/ui-components": "^0.3.6",
         "@terascope/utils": "^0.14.1",


### PR DESCRIPTION
Fixes object mappings for `spaces` and `data-types` and adds basic migration functionality to `elasticsearch-store`.

TODO:
- [x] Add CLI script to migrate `data-access` in `data-access-plugin`
- [x] Manually test and verify 
 
Resolves #1307