### PR TITLE
Fix Docker build in CI

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/test-runner/utils.ts
+++ b/packages/scripts/src/helpers/test-runner/utils.ts
@@ -210,7 +210,8 @@ export async function reportCoverage(suite: TestSuite, chunkIndex: number) {
 }
 
 function getCacheFrom(): string[] {
-    if (isCI) return [];
+    if (!isCI) return [];
+
     const rootInfo = getRootInfo();
     const layers = rootInfo.docker.cache_layers || [];
     if (!layers.length) return [];


### PR DESCRIPTION
Previously it wasn't using the docker cache layers, now it should be. This should improve the e2e tests.