### PR TITLE
changed type analyzers to standard and removed index:true

### DIFF
--- a/packages/data-access-plugin/package.json
+++ b/packages/data-access-plugin/package.json
@@ -31,7 +31,7 @@
     "dependencies": {
         "@apollographql/graphql-playground-html": "^1.6.24",
         "@terascope/data-access": "^0.13.0",
-        "@terascope/data-types": "^0.5.2",
+        "@terascope/data-types": "^0.5.3",
         "@terascope/elasticsearch-api": "^2.1.3",
         "@terascope/utils": "^0.14.1",
         "accepts": "^1.3.7",

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -26,7 +26,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.5.2",
+        "@terascope/data-types": "^0.5.3",
         "@terascope/utils": "^0.14.1",
         "elasticsearch-store": "^0.11.0",
         "xlucene-evaluator": "^0.9.7"

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/data-types",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {

--- a/packages/data-types/src/types/versions/v1/keyword-tokens-case-insensitive.ts
+++ b/packages/data-types/src/types/versions/v1/keyword-tokens-case-insensitive.ts
@@ -13,7 +13,7 @@ export default class KeywordTokensCaseInsensitive extends BaseType {
                     fields: {
                         tokens: {
                             type: 'text' as ElasticSearchTypes,
-                            analyzer: 'simple',
+                            analyzer: 'standard',
                         },
                     },
                 },

--- a/packages/data-types/src/types/versions/v1/keyword-tokens.ts
+++ b/packages/data-types/src/types/versions/v1/keyword-tokens.ts
@@ -10,8 +10,7 @@ export default class KeywordTokens extends BaseType {
                     fields: {
                         tokens: {
                             type: 'text',
-                            index: 'true',
-                            analyzer: 'simple',
+                            analyzer: 'standard',
                         },
                     },
                 },

--- a/packages/data-types/test/data-type-spec.ts
+++ b/packages/data-types/test/data-type-spec.ts
@@ -466,7 +466,7 @@ describe('DataType', () => {
                                 analyzer: 'lowercase_keyword_analyzer',
                                 fields: {
                                     tokens: {
-                                        analyzer: 'simple',
+                                        analyzer: 'standard',
                                         type: 'text',
                                     },
                                 },

--- a/packages/data-types/test/types/v1/keyword-tokens-case-insensitive-spec.ts
+++ b/packages/data-types/test/types/v1/keyword-tokens-case-insensitive-spec.ts
@@ -34,7 +34,7 @@ describe('KeywordTokensCaseInsensitive V1', () => {
                     fields: {
                         tokens: {
                             type: 'text' as ElasticSearchTypes,
-                            analyzer: 'simple',
+                            analyzer: 'standard',
                         },
                     },
                 },

--- a/packages/data-types/test/types/v1/keyword-tokens-spec.ts
+++ b/packages/data-types/test/types/v1/keyword-tokens-spec.ts
@@ -32,8 +32,7 @@ describe('KeywordTokens V1', () => {
                     fields: {
                         tokens: {
                             type: 'text',
-                            index: 'true',
-                            analyzer: 'simple',
+                            analyzer: 'standard',
                         },
                     },
                 },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -25,7 +25,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.5.2",
+        "@terascope/data-types": "^0.5.3",
         "@terascope/utils": "^0.14.1",
         "ajv": "^6.10.0",
         "nanoid": "^2.0.3",

--- a/packages/ui-data-access/package.json
+++ b/packages/ui-data-access/package.json
@@ -24,7 +24,7 @@
     "dependencies": {},
     "devDependencies": {
         "@terascope/data-access": "^0.13.0",
-        "@terascope/data-types": "^0.5.2",
+        "@terascope/data-types": "^0.5.3",
         "@terascope/ui-components": "^0.3.6",
         "@terascope/utils": "^0.14.1",
         "@types/convict": "^4.2.1",


### PR DESCRIPTION
* all field types that use a non-custom analyzer use the standard analyzer
* removed index: true in keyword tokens to be consistent with other data fields

addresses issue #1313 