### PR TITLE
v0.54.11 - Fix unhandled rejection and teraslice-state-storage improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "devDependencies": {
         "@types/bluebird": "^3.5.27",
         "@types/convict": "^4.2.1",
-        "@types/debug": "^4.1.5",
         "@types/elasticsearch": "^5.0.34",
         "@types/fs-extra": "^8.0.0",
         "@types/jest": "^24.0.17",
@@ -41,8 +40,6 @@
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/nanoid": "^2.0.0",
         "@types/node": "^12.7.1",
-        "@types/socket.io": "^2.1.2",
-        "@types/socket.io-client": "^1.4.32",
         "@types/uuid": "^3.4.4",
         "eslint": "^6.1.0",
         "eslint-config-airbnb-base": "^14.0.0",

--- a/packages/data-access-plugin/package.json
+++ b/packages/data-access-plugin/package.json
@@ -32,7 +32,7 @@
         "@apollographql/graphql-playground-html": "^1.6.24",
         "@terascope/data-access": "^0.13.2",
         "@terascope/data-types": "^0.5.3",
-        "@terascope/elasticsearch-api": "^2.1.3",
+        "@terascope/elasticsearch-api": "^2.1.4",
         "@terascope/utils": "^0.15.0",
         "accepts": "^1.3.7",
         "apollo-server-express": "~2.6.5",

--- a/packages/elasticsearch-api/index.js
+++ b/packages/elasticsearch-api/index.js
@@ -86,7 +86,10 @@ module.exports = function elasticsearchApi(client = {}, logger, _opConfig) {
         return _clientRequest('mget', query);
     }
 
-    function get(query) {
+    function get(query, fullResponse = false) {
+        if (fullResponse) {
+            return _clientRequest('get', query);
+        }
         return _clientRequest('get', query).then((result) => result._source);
     }
 

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/elasticsearch-api",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-api/types/index.d.ts
+++ b/packages/elasticsearch-api/types/index.d.ts
@@ -18,7 +18,7 @@ declare namespace elasticsearchAPI {
     export interface Client {
         search: (query: es.SearchParams) => Promise<es.SearchResponse | any[]>;
         count: (query: es.CountParams) => Promise<number>;
-        get: (query: es.GetParams) => Promise<any>;
+        get: (query: es.GetParams, fullResponse?: boolean) => Promise<any>;
         mget: (query: es.MGetParams) => Promise<any>;
         index: (query: es.IndexDocumentParams) => Promise<any>;
         indexWithId: (query: es.IndexDocumentParams) => Promise<any>;

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -21,7 +21,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.3",
+        "@terascope/elasticsearch-api": "^2.1.4",
         "@terascope/utils": "^0.15.0",
         "agentkeepalive": "^4.0.2",
         "aws-sdk": "^2.507.0",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -41,7 +41,11 @@
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4"
     },
-    "devDependencies": {},
+    "devDependencies": {
+        "@types/ms": "^0.7.30",
+        "@types/socket.io": "^2.1.2",
+        "@types/socket.io-client": "^1.4.32"
+    },
     "engines": {
         "node": ">=8.0.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -34,6 +34,7 @@
     "dependencies": {
         "@terascope/queue": "^1.1.6",
         "@terascope/utils": "^0.15.0",
+        "ms": "^2.1.2",
         "nanoid": "^2.0.3",
         "p-event": "^4.1.0",
         "porty": "^3.1.1",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-messaging",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {

--- a/packages/teraslice-messaging/src/messenger/client.ts
+++ b/packages/teraslice-messaging/src/messenger/client.ts
@@ -1,5 +1,6 @@
-import { isString, isInteger, debugLogger, toString } from '@terascope/utils';
+import ms from 'ms';
 import SocketIOClient from 'socket.io-client';
+import { isString, isInteger, debugLogger, toString } from '@terascope/utils';
 import * as i from './interfaces';
 import { Core } from './core';
 import { newMsgId } from '../utils';
@@ -122,10 +123,10 @@ export class Client extends Core {
 
             connectTimeout = setTimeout(() => {
                 cleanup();
-                reject(new Error(`Unable to connect to ${this.serverName} at ${this.hostUrl} after ${this.connectTimeout}ms`));
+                reject(new Error(`Unable to connect to ${this.serverName} at ${this.hostUrl} after ${ms(this.connectTimeout)}`));
             }, this.connectTimeout);
 
-            this.logger.debug(`attempting to ${this.serverName} at ${this.hostUrl}, timeout after ${this.connectTimeout}ms`);
+            this.logger.debug(`attempting to ${this.serverName} at ${this.hostUrl}, timeout after ${ms(this.connectTimeout)}`);
         });
 
         this.socket.on('reconnecting', () => {

--- a/packages/teraslice-messaging/src/messenger/client.ts
+++ b/packages/teraslice-messaging/src/messenger/client.ts
@@ -74,9 +74,13 @@ export class Client extends Core {
     }
 
     onServerShutdown(fn: () => void) {
-        this.on('server:shutdown', async () => {
+        this.on('server:shutdown', () => {
             this.serverShutdown = true;
-            fn();
+            try {
+                fn();
+            } catch (err) {
+                this.logger.error(err);
+            }
             setImmediate(() => {
                 this.socket.close();
             });

--- a/packages/teraslice-messaging/src/messenger/core.ts
+++ b/packages/teraslice-messaging/src/messenger/core.ts
@@ -1,6 +1,7 @@
-import { toString, isInteger, debugLogger, Logger } from '@terascope/utils';
-import { EventEmitter } from 'events';
+import ms from 'ms';
 import pEvent from 'p-event';
+import { EventEmitter } from 'events';
+import { toString, isInteger, debugLogger, Logger } from '@terascope/utils';
 import * as i from './interfaces';
 
 const _logger = debugLogger('teraslice-messaging:core');
@@ -49,7 +50,7 @@ export class Core extends EventEmitter {
             if (sent.volatile || this.closed) {
                 return null;
             }
-            throw new Error(`Timed out after ${remaining}ms, waiting for message "${sent.eventName}"`);
+            throw new Error(`Timed out after ${ms(remaining)}, waiting for message "${sent.eventName}"`);
         }
 
         if (response.error) {

--- a/packages/teraslice-messaging/src/messenger/core.ts
+++ b/packages/teraslice-messaging/src/messenger/core.ts
@@ -84,10 +84,14 @@ export class Core extends EventEmitter {
 
             if (!msg.volatile && !this.isClientReady(message.to)) {
                 const remaining = msg.respondBy - Date.now();
-                await this.waitForClientReady(message.to, remaining);
+                try {
+                    await this.waitForClientReady(message.to, remaining);
+                } catch (err) {
+                    // don't throw an unhandledRejection because the client isn't ready
+                    this.logger.error(err);
+                }
             }
 
-            // @ts-ignore
             socket.emit('message:response', message);
         });
     }

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-state-storage",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -25,7 +25,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.3",
+        "@terascope/elasticsearch-api": "^2.1.4",
         "@terascope/utils": "^0.15.0",
         "bluebird": "^3.5.5",
         "mnemonist": "^0.30.0"

--- a/packages/teraslice-state-storage/src/cached-state-storage/index.ts
+++ b/packages/teraslice-state-storage/src/cached-state-storage/index.ts
@@ -11,7 +11,7 @@ export default class CachedStateStorage<T> extends EventEmitter {
         super();
         this._cache = new LRUMap(config.cache_size);
         // @ts-ignore
-        this._cache.items = new BigMap();
+        this._cache.items = new BigMap(config.max_big_map_size);
     }
 
     get(key: string): T | undefined {

--- a/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
+++ b/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
@@ -102,7 +102,7 @@ export default class ESCachedStateStorage {
     async mget(docArray: DataEntity[]): Promise<MGetCacheResponse> {
         const savedDocs = {};
         const setDocs: UpdateCacheFn = (key, current, prev) => {
-            savedDocs[key] = prev;
+            if (prev) savedDocs[key] = prev;
             return true;
         };
 
@@ -192,14 +192,15 @@ export default class ESCachedStateStorage {
 
         const results: DataEntity[] = [];
         for (const result of response.docs) {
+            const key = result._id;
+            let prev: DataEntity|undefined;
             if (result.found) {
-                const key = result._id;
-                const prev = makeDataEntity(result);
-                const current = docs[key];
-                const updateCache = fn(key, current, prev);
-                if (updateCache) {
-                    this.setCacheByKey(key, current);
-                }
+                prev = makeDataEntity(result);
+            }
+            const current = docs[key];
+            const updateCache = fn(key, current, prev);
+            if (updateCache) {
+                this.setCacheByKey(key, current);
             }
         }
         return results;
@@ -280,7 +281,7 @@ export interface ESGetResponse {
     _source?: any;
 }
 
-export type UpdateCacheFn = (key: string, current: DataEntity, prev: DataEntity) => boolean;
+export type UpdateCacheFn = (key: string, current: DataEntity, prev?: DataEntity) => boolean;
 
 type UncachedChunk = { [key: string]: DataEntity; };
 type UncachedChunks = { [key: string]: DataEntity; }[];

--- a/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
+++ b/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
@@ -1,4 +1,4 @@
-import { DataEntity, Logger, TSError, chunk } from '@terascope/utils';
+import { DataEntity, Logger, TSError, chunk, isFunction } from '@terascope/utils';
 import esApi, { Client } from '@terascope/elasticsearch-api';
 import { Promise as bPromise } from 'bluebird';
 import { ESStateStorageConfig, MGetCacheResponse } from '../interfaces';
@@ -111,6 +111,14 @@ export default class ESCachedStateStorage {
     }
 
     async sync(docArray: DataEntity[], fn: UpdateCacheFn) {
+        if (!docArray || !Array.isArray(docArray)) {
+            throw new Error('Invalid docs given to sync, expected Array');
+        }
+
+        if (!fn || !isFunction(fn)) {
+            throw new Error('Invalid function given to sync');
+        }
+
         const uncachedDocs = this._updateCache(docArray, fn);
         if (uncachedDocs.length) {
             // es search for keys not in cache

--- a/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
+++ b/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
@@ -1,20 +1,19 @@
 import { DataEntity, Logger, TSError, chunk } from '@terascope/utils';
 import esApi, { Client } from '@terascope/elasticsearch-api';
 import { Promise as bPromise } from 'bluebird';
-import { ESStateStorageConfig, ESBulkQuery, ESQUery, MGetResponse } from '../interfaces';
+import { ESStateStorageConfig, ESBulkQuery, ESMGetParams, ESMGetResponse, ESGetResponse, ESGetParams } from '../interfaces';
 import CachedStateStorage from '../cached-state-storage';
 
-type ForEachCB = (key: string, doc: DataEntity) => void;
+type UpdateCacheFn = (key: string, updatedDoc: DataEntity, lastDoc: DataEntity) => boolean;
 
 export default class ESCachedStateStorage {
     private index: string;
     private type: string;
-    private IDField: string;
     private concurrency: number;
     private sourceFields: string[];
     private chunkSize: number;
     private persist: boolean;
-    private persistField: string;
+    private persistField?: string;
     private es: Client;
     private logger: Logger;
     public cache: CachedStateStorage<DataEntity>;
@@ -22,145 +21,197 @@ export default class ESCachedStateStorage {
     constructor(client: Client, logger: Logger, config: ESStateStorageConfig) {
         this.index = config.index;
         this.type = config.type;
-        this.IDField = '_key';
         this.concurrency = config.concurrency;
         this.sourceFields = config.source_fields || [];
         this.chunkSize = config.chunk_size;
         this.persist = config.persist;
-        this.persistField = config.persist_field || this.IDField;
+        if (config.persist_field && config.persist_field !== '_key') {
+            this.persistField = config.persist_field;
+        }
         this.cache = new CachedStateStorage(config);
         this.logger = logger;
         this.es = esApi(client, logger);
     }
 
-    private getIdentifier(doc: DataEntity) {
-        const id = doc.getMetadata(this.IDField);
-        if (id === '' || id == null) {
-            throw new TSError(`There is no field "${this.IDField}" set in the metadata`, { context: { doc } });
+    getIdentifier(doc: DataEntity): string {
+        const key = doc.getMetadata('_key');
+        if (key === '' || key == null) {
+            throw new TSError('There is no field "_key" set in the metadata', {
+                context: { doc }
+            });
         }
-        return id;
+        return key;
     }
 
     private _esBulkUpdatePrep(dataArray: DataEntity[]) {
         const bulkRequest: ESBulkQuery[] = [];
 
-        dataArray.forEach((item) => {
-            const id = item.getMetadata(this.persistField);
+        for (const doc of dataArray) {
+            let key: string;
+            if (this.persistField) {
+                key = doc.getMetadata(this.persistField);
+            } else {
+                key = this.getIdentifier(doc);
+            }
             bulkRequest.push({
                 index: {
                     _index: this.index,
                     _type: this.type,
-                    _id: id,
+                    _id: key,
                 },
-            });
-            bulkRequest.push(item);
-        });
+            }, doc);
+        }
 
         return bulkRequest;
     }
 
-    private _esBulkUpdate(docArray: DataEntity[]) {
-        const bulkRequest = this._esBulkUpdatePrep(docArray);
-        const chunkedArray = chunk<ESBulkQuery>(bulkRequest, this.chunkSize);
-        return bPromise.map<ESBulkQuery[], ESBulkQuery[]>(chunkedArray, (chunkedData) => this.es.bulkSend(chunkedData));
+    private async _esBulkUpdate(docArray: DataEntity[]): Promise<void> {
+        const chunked = chunk(docArray, this.chunkSize);
+
+        await bPromise.map(chunked, (chunkedData) => {
+            const bulkRequest = this._esBulkUpdatePrep(chunkedData);
+            return this.es.bulkSend(bulkRequest);
+        }, {
+            concurrency: this.concurrency
+        });
     }
 
-    private async _esGet(doc: DataEntity) {
-        const id = this.getIdentifier(doc);
-        const request = {
+    private async _esGet(key: string): Promise<DataEntity|undefined> {
+        const request: ESGetParams = {
             index: this.index,
             type: this.type,
-            id,
+            id: key
         };
 
-        const results = await this.es.get(request);
-        return DataEntity.make(results, { [this.IDField]: id });
+        if (this.sourceFields.length > 0) {
+            request._sourceIncludes = this.sourceFields;
+        }
+        const response = await this.es.get(request, true);
+        if (!response.found) return undefined;
+
+        const updated = makeDataEntity(response);
+        this.setCacheByKey(key, updated);
+        return updated;
     }
 
-    private async _esMget(query: string[]) {
-        const request: ESQUery = {
+    private async _esMGet(docs: UncachedChunk, fn: UpdateCacheFn) {
+        const request: ESMGetParams = {
             index: this.index,
             type: this.type,
             body: {
-                ids: query,
+                ids: Object.keys(docs),
             },
         };
-        if (this.sourceFields.length > 0) request._source = this.sourceFields;
-        const response: MGetResponse = await this.es.mget(request);
+        if (this.sourceFields.length > 0) {
+            request._sourceIncludes = this.sourceFields;
+        }
+        const response: ESMGetResponse = await this.es.mget(request);
 
-        return response.docs.filter((doc) => doc.found).map((doc) => DataEntity.make(doc._source, { [this.IDField]: doc._id }));
-    }
-
-    getFromCache(doc: DataEntity) {
-        const indentifier = this.getIdentifier(doc);
-        return this.cache.get(indentifier);
-    }
-
-    isCached(doc: DataEntity) {
-        const indentifier = this.getIdentifier(doc);
-        return this.cache.has(indentifier);
-    }
-
-    async get(doc: DataEntity) {
-        const cached = this.getFromCache(doc);
-        if (cached) return cached;
-        const results = await this._esGet(doc);
-        this.set(results);
+        const results: DataEntity[] = [];
+        for (const result of response.docs) {
+            if (result.found) {
+                const key = result._id;
+                const updatedDoc = makeDataEntity(result);
+                const lastDoc = docs[key];
+                const updateCache = fn(key, updatedDoc, lastDoc);
+                if (updateCache) {
+                    this.setCacheByKey(key, updatedDoc);
+                }
+            }
+        }
         return results;
     }
 
-    private _checkCache(docArray: DataEntity[], fn?: ForEachCB): Set<string> {
-        const cachedDocsDict = {};
-        const unCachedDocKeys = new Set<string>();
-        let cachedHits = 0;
+    getFromCache(doc: DataEntity) {
+        const key = this.getIdentifier(doc);
+        return this.getFromCacheByKey(key);
+    }
+
+    getFromCacheByKey(key: string) {
+        return this.cache.get(key);
+    }
+
+    isCached(doc: DataEntity) {
+        const key = this.getIdentifier(doc);
+        return this.isKeyCached(key);
+    }
+
+    isKeyCached(key: string) {
+        return this.cache.has(key);
+    }
+
+    async get(doc: DataEntity): Promise<DataEntity|undefined> {
+        const key = this.getIdentifier(doc);
+        const cached = this.getFromCacheByKey(key);
+        if (cached) return cached;
+
+        return this._esGet(key);
+    }
+
+    private _updateCache(docArray: DataEntity[], fn: UpdateCacheFn): UncachedChunks {
+        const cachedDocsDict: { [key: string]: boolean; } = {};
+        const uncachedChunks: UncachedChunks = [];
+        let hits = 0;
+        const missesPerChunk: number[] = [];
+        let uncachedIndex = 0;
 
         for (const doc of docArray) {
             const key = this.getIdentifier(doc);
-            const cachedDoc = this.cache.get(key);
+            const cachedDoc = this.getFromCacheByKey(key);
 
             if (cachedDoc) {
                 if (!cachedDocsDict[key]) {
                     cachedDocsDict[key] = true;
-                    cachedHits++;
-                    if (fn) fn(key, cachedDoc);
+                    hits++;
+                    const updateCache = fn(key, doc, cachedDoc);
+                    if (updateCache) {
+                        this.setCacheByKey(key, doc);
+                    }
                 }
             } else {
-                unCachedDocKeys.add(key);
+                if (missesPerChunk[uncachedIndex] != null &&
+                    missesPerChunk[uncachedIndex] >= this.chunkSize) {
+                    uncachedIndex++;
+                }
+                if (missesPerChunk[uncachedIndex] == null) {
+                    missesPerChunk.push(0);
+                }
+                if (uncachedChunks[uncachedIndex] == null) {
+                    uncachedChunks.push({});
+                }
+
+                uncachedChunks[uncachedIndex][key] = doc;
+                missesPerChunk[uncachedIndex]++;
             }
         }
 
-        const logMsg = `elasticsearch-state-storage hit ${cachedHits} cached records and is fetching ${unCachedDocKeys.size}`;
-        this.logger.info(logMsg);
+        const misses = missesPerChunk.reduce((total, current) => total + current, 0);
+        this.logger.info(`elasticsearch-state-storage hit ${hits} cached records and is fetching ${misses}`);
 
-        return unCachedDocKeys;
+        return uncachedChunks;
     }
 
-    private async _fetchRecords(unCachedDocKeys: Set<string>) {
-        const chunkedArray = chunk<string>([...unCachedDocKeys], this.chunkSize);
+    private async _fetchRecords(uncachedDocs: UncachedChunks, fn: UpdateCacheFn): Promise<void> {
         // es search for keys not in cache
-        return bPromise.map<string[], DataEntity[]>(chunkedArray, (chunked) => this._esMget(chunked), { concurrency: this.concurrency });
+        await bPromise.map(uncachedDocs, (chunked) => this._esMGet(chunked, fn), {
+            concurrency: this.concurrency
+        });
     }
 
-    private _cacheFetchedRecords(recordLists: DataEntity<object>[][], fn?: ForEachCB) {
-        for (const list of recordLists) {
-            for (const doc of list) {
-                this.set(doc);
-                if (fn) fn(this.getIdentifier(doc), doc);
-            }
-        }
-    }
-
-    async sync(docArray: DataEntity[], fn?: ForEachCB) {
-        const unCachedDocKeys = this._checkCache(docArray, fn);
-        if (unCachedDocKeys.size > 1) {
-            const results = await this._fetchRecords(unCachedDocKeys);
-            this._cacheFetchedRecords(results, fn);
+    async sync(docArray: DataEntity[], fn: UpdateCacheFn) {
+        const uncachedDocs = this._updateCache(docArray, fn);
+        if (uncachedDocs.length) {
+            await this._fetchRecords(uncachedDocs, fn);
         }
     }
 
     async mget(docArray: DataEntity[]) {
         const savedDocs = {};
-        const setDocs: ForEachCB = (key, doc) => (savedDocs[key] = doc);
+        const setDocs: UpdateCacheFn = (key, doc) => {
+            savedDocs[key] = doc;
+            return true;
+        };
+
         await this.sync(docArray, setDocs);
         return savedDocs;
     }
@@ -168,13 +219,20 @@ export default class ESCachedStateStorage {
     set(doc: DataEntity) {
         // update cache, if persistance is needed use mset
         const identifier = this.getIdentifier(doc);
-        return this.cache.set(identifier, doc);
+        return this.setCacheByKey(identifier, doc);
+    }
+
+    setCacheByKey(key: string, doc: DataEntity) {
+        return this.cache.set(key, doc);
     }
 
     async mset(docArray: DataEntity[]) {
         const formattedDocs = docArray.map((doc) => ({ data: doc, key: this.getIdentifier(doc) }));
         if (this.persist) {
-            const [results] = await Promise.all([this.cache.mset(formattedDocs), this._esBulkUpdate(docArray)]);
+            const [results] = await Promise.all([
+                this.cache.mset(formattedDocs),
+                this._esBulkUpdate(docArray)
+            ]);
             return results;
         }
         return this.cache.mset(formattedDocs);
@@ -184,11 +242,24 @@ export default class ESCachedStateStorage {
         return this.cache.count();
     }
 
-    async initialize() {
-        this.cache.initialize();
-    }
+    async initialize() {}
 
     async shutdown() {
         this.cache.clear();
     }
+}
+
+type UncachedChunk = { [key: string]: DataEntity; };
+type UncachedChunks = { [key: string]: DataEntity; }[];
+
+function makeDataEntity(result: ESGetResponse): DataEntity {
+    const key = result._id;
+    return DataEntity.make(result._source, {
+        _key: key,
+        _processTime: Date.now(),
+        // TODO Add event and ingest time
+        _index: result._index,
+        _type: result._type,
+        _version: result._version,
+    });
 }

--- a/packages/teraslice-state-storage/src/interfaces.ts
+++ b/packages/teraslice-state-storage/src/interfaces.ts
@@ -22,12 +22,19 @@ export interface ESQuery {
 
 export type ESBulkQuery = ESQuery | DataEntity;
 
-export interface ESQUery {
+export interface ESMGetParams {
     index: string;
     type: string;
     id?: string;
     body?: any;
-    _source?: string[];
+    _sourceIncludes?: string[];
+}
+
+export interface ESGetParams {
+    index: string;
+    type: string;
+    id: string;
+    _sourceIncludes?: string[];
 }
 
 export interface CacheConfig {
@@ -38,11 +45,11 @@ export interface MGetCacheResponse {
     [key: string]: DataEntity;
 }
 
-export interface MGetResponse {
-    docs: MGetDoc[];
+export interface ESMGetResponse {
+    docs: ESGetResponse[];
 }
 
-export interface MGetDoc {
+export interface ESGetResponse {
     _index: string;
     _type: string;
     _version: number;

--- a/packages/teraslice-state-storage/src/interfaces.ts
+++ b/packages/teraslice-state-storage/src/interfaces.ts
@@ -10,33 +10,6 @@ export interface ESStateStorageConfig extends CacheConfig {
     persist_field?: string;
 }
 
-interface ESMeta {
-    _index: string;
-    _type: string;
-    _id: string;
-}
-
-export interface ESQuery {
-    index: ESMeta;
-}
-
-export type ESBulkQuery = ESQuery | DataEntity;
-
-export interface ESMGetParams {
-    index: string;
-    type: string;
-    id?: string;
-    body?: any;
-    _sourceIncludes?: string[];
-}
-
-export interface ESGetParams {
-    index: string;
-    type: string;
-    id: string;
-    _sourceIncludes?: string[];
-}
-
 export interface CacheConfig {
     cache_size: number;
     max_big_map_size?: number;
@@ -44,19 +17,6 @@ export interface CacheConfig {
 
 export interface MGetCacheResponse {
     [key: string]: DataEntity;
-}
-
-export interface ESMGetResponse {
-    docs: ESGetResponse[];
-}
-
-export interface ESGetResponse {
-    _index: string;
-    _type: string;
-    _version: number;
-    _id: string;
-    found: boolean;
-    _source?: any;
 }
 
 export type ValuesFn<T> = (doc: T) => void;

--- a/packages/teraslice-state-storage/src/interfaces.ts
+++ b/packages/teraslice-state-storage/src/interfaces.ts
@@ -39,6 +39,7 @@ export interface ESGetParams {
 
 export interface CacheConfig {
     cache_size: number;
+    max_big_map_size?: number;
 }
 
 export interface MGetCacheResponse {

--- a/packages/teraslice-state-storage/test/elasticsearch-state-storage-spec.ts
+++ b/packages/teraslice-state-storage/test/elasticsearch-state-storage-spec.ts
@@ -21,6 +21,7 @@ describe('elasticsearch-state-storage', () => {
         source_fields: [],
         chunk_size: 10,
         cache_size: 100000,
+        max_big_map_size: 5,
         persist: false,
     };
 

--- a/packages/teraslice-state-storage/test/elasticsearch-state-storage-spec.ts
+++ b/packages/teraslice-state-storage/test/elasticsearch-state-storage-spec.ts
@@ -1,102 +1,18 @@
 import 'jest-extended';
 import { DataEntity, debugLogger } from '@terascope/utils';
-import { ESCachedStateStorage, ESBulkQuery, ESStateStorageConfig } from '../src';
+import {
+    ESCachedStateStorage,
+    ESBulkQuery,
+    ESStateStorageConfig,
+    ESMGetResponse,
+    ESGetResponse,
+    ESGetParams,
+    ESMGetParams
+} from '../src';
 
-describe('elasticsearch cached state storage', () => {
-    interface Doc {
-        _index: string;
-        _type: string;
-        _version: number;
-        _id: string;
-        found: boolean;
-        _source?: any;
-    }
-
-    interface MGetData {
-        docs: Doc[];
-    }
-
-    interface BulkRequest {
-        body: ESBulkQuery[];
-    }
-
-    class TestClient {
-        public getData!: Doc;
-        public mgetData!: MGetData;
-        public mgetSearch!: any;
-        public bulkRequest!: ESBulkQuery[];
-
-        setGetData(data: Doc) {
-            this.getData = data;
-        }
-
-        setMGetData(data: MGetData) {
-            this.mgetData = data;
-        }
-
-        async get(_doc: Doc) {
-            return this.getData;
-        }
-
-        async mget(mgetSearch: any) {
-            return this.mgetData;
-        }
-
-        async bulk(request: BulkRequest) {
-            this.bulkRequest = request.body;
-            return request;
-        }
-    }
-
+describe('elasticsearch-state-storage', () => {
     const logger = debugLogger('ESCachedStateStorage');
-    const client = new TestClient();
-
-    const idField = '_key';
-
-    const doc = DataEntity.make({ data: 'thisIsSomeData' }, { [idField]: 1 });
-    // @ts-ignore
-    const docArray = [
-        {
-            data: 'thisIsFirstData',
-        },
-        {
-            data: 'thisIsSecondData',
-        },
-        {
-            data: 'thisIsThirdData',
-        },
-    ].map((obj, index) => DataEntity.make(obj, { [idField]: index + 1 }));
-
-    const otherDocArray = [
-        {
-            data: 'thisIsFirstData',
-        },
-        {
-            data: 'thisIsSecondData',
-        },
-        {
-            data: 'thisIsThirdData',
-        },
-    ].map((obj, index) => DataEntity.make(obj, { [idField]: index + 1, otherField: `other${index + 1}` }));
-
-    function createMgetData(dataArray: DataEntity[], found = true) {
-        return dataArray.map((item) => {
-            const response: Doc = {
-                _index: 'index',
-                _type: 'type',
-                _version: 1,
-                _id: item.getMetadata(idField),
-                found,
-            };
-
-            if (found) {
-                // convert to reg obj to simulate ES response
-                response._source = Object.assign({}, item);
-            }
-
-            return response;
-        });
-    }
+    let client: TestClient;
 
     const config: ESStateStorageConfig = {
         index: 'some_index',
@@ -106,174 +22,204 @@ describe('elasticsearch cached state storage', () => {
         chunk_size: 10,
         cache_size: 100000,
         persist: false,
-        persist_field: idField,
     };
 
     let stateStorage: ESCachedStateStorage;
 
     beforeEach(() => {
-        // @ts-ignore
-        stateStorage = new ESCachedStateStorage(client, logger, config);
+        client = new TestClient(config);
+        stateStorage = new ESCachedStateStorage(client as any, logger, config);
     });
 
     afterEach(() => {
-        stateStorage.shutdown();
+        if (stateStorage) {
+            stateStorage.shutdown();
+            // @ts-ignore
+            stateStorage = undefined;
+        }
     });
 
-    it('get can pull record from cache', async () => {
-        stateStorage.set(doc);
-        const stateDoc = await stateStorage.get(doc);
+    describe('->get', () => {
+        it('should pull record from cache', async () => {
+            const doc = makeTestDoc();
+            stateStorage.set(doc);
+            const stateDoc = await stateStorage.get(doc);
 
-        expect(stateDoc).toEqual(doc);
-        expect(DataEntity.isDataEntity(stateDoc)).toEqual(true);
-    });
-
-    it('get can pull record from elasticsearch if not in cache', async () => {
-        const myDoc = docArray.slice(0, 1)[0];
-        const getData = createMgetData([myDoc])[0];
-        client.setGetData(getData);
-
-        const stateDoc = await stateStorage.get(myDoc);
-
-        expect(stateDoc).toEqual(myDoc);
-        expect(DataEntity.isDataEntity(stateDoc)).toEqual(true);
-    });
-
-    it('getFromCache/isCached checks cache, not elasticsearch for doc', async () => {
-        const myDoc = docArray.slice(0, 1)[0];
-        // @ts-ignore
-        const notFoundData = createMgetData([myDoc], false)[0];
-        const foundData = createMgetData([myDoc])[0];
-
-        client.setGetData(notFoundData);
-
-        const empty = stateStorage.getFromCache(myDoc);
-
-        expect(empty).toBeUndefined();
-        expect(stateStorage.isCached(myDoc)).toEqual(false);
-
-        client.setGetData(foundData);
-
-        const stateDoc = await stateStorage.get(myDoc);
-
-        expect(stateDoc).toEqual(myDoc);
-        expect(DataEntity.isDataEntity(stateDoc)).toEqual(true);
-        expect(stateStorage.isCached(myDoc)).toEqual(true);
-    });
-
-    it('should save many docs to cache and retrieve', async () => {
-        await stateStorage.mset(docArray);
-
-        const saved1 = await stateStorage.get(docArray[0]);
-        const saved2 = await stateStorage.get(docArray[1]);
-        const saved3 = await stateStorage.get(docArray[2]);
-
-        expect(saved1).toEqual(docArray[0]);
-        expect(saved2).toEqual(docArray[1]);
-        expect(saved3).toEqual(docArray[2]);
-
-        expect(DataEntity.isDataEntity(saved1)).toEqual(true);
-        expect(DataEntity.isDataEntity(saved2)).toEqual(true);
-        expect(DataEntity.isDataEntity(saved3)).toEqual(true);
-    });
-
-    it('should make an es bulk request if persist is true', async () => {
-        const testConfig = Object.assign({}, config, { persist: true, persist_field: '_key' });
-        // @ts-ignore
-        const testStateStorage = new ESCachedStateStorage(client, logger, testConfig);
-
-        await testStateStorage.mset(docArray, '_key');
-        const data = client.bulkRequest;
-
-        expect(data.length).toBe(6);
-        expect(data[1]).toEqual(docArray[0]);
-    });
-
-    it('should allow mset to use a persist field', async () => {
-        const testConfig = Object.assign({}, config, { persist: true, persist_field: 'otherField' });
-        // @ts-ignore
-        const testStateStorage = new ESCachedStateStorage(client, logger, testConfig);
-
-        await testStateStorage.mset(otherDocArray);
-        const data = client.bulkRequest;
-
-        expect(data[0].index._id).toBe('other1');
-        expect(data[2].index._id).toBe('other2');
-        expect(data[4].index._id).toBe('other3');
-    });
-
-    it('should ake an es request if doc not in cache', async () => {
-        // metadata props are not transfered, we are returning a regular obj at _source
-        const cloneDoc = Object.assign({}, doc);
-        client.setGetData({
-            _index: config.index,
-            _type: config.type,
-            _version: 1,
-            _id: doc.getMetadata(idField),
-            found: true,
-            _source: cloneDoc,
+            expect(stateDoc).toEqual(doc);
+            expect(DataEntity.isDataEntity(stateDoc)).toEqual(true);
         });
-        const getResult = await stateStorage.get(doc);
 
-        expect(getResult).toEqual(doc);
-        expect(DataEntity.isDataEntity(getResult)).toEqual(true);
-    });
+        it('should pull record from elasticsearch if not in cache', async () => {
+            const doc = makeTestDoc();
+            client.setGetResponse(client.createGetResponse(doc));
 
-    it('should return object with all docs in cache and in es request', async () => {
-        // set doc in cache
-        await stateStorage.mset(docArray.slice(0, 1));
+            const stateDoc = await stateStorage.get(doc);
 
-        // create bulk response
-        client.setMGetData({ docs: createMgetData(docArray.slice(1, 3)) });
+            expect(stateDoc).toEqual(doc);
+            expect(DataEntity.isDataEntity(stateDoc)).toEqual(true);
+        });
 
-        // state response
-        const stateResponse = await stateStorage.mget(docArray);
-        const keys = Object.keys(stateResponse);
-        expect(keys.length).toBe(3);
+        it('should make an es request if doc not in cache', async () => {
+            const doc = makeTestDoc();
+            // metadata props are not transfered, we are returning a regular obj at _source
+            client.setGetResponse(client.createGetResponse(doc));
+            const getResult = await stateStorage.get(doc);
 
-        keys.forEach((idStr: string) => {
-            const id = Number(idStr);
-            expect(stateResponse[id]).toEqual(docArray[id - 1]);
-            expect(DataEntity.isDataEntity(stateResponse[id])).toEqual(true);
-            const metaId = stateResponse[id].getMetadata(idField);
-            expect(metaId).toEqual(id);
+            expect(getResult).toEqual(doc);
+            expect(DataEntity.isDataEntity(getResult)).toEqual(true);
         });
     });
 
-    it('sync should chech cache/fetch data but not return anything', async () => {
-        const results: DataEntity[] = [];
-        const setResults = (data: DataEntity) => results.push(data);
-        // set doc in cache
-        await stateStorage.mset(docArray.slice(0, 1));
+    describe('->getFromCache/->isCached', () => {
+        it('checks cache, not elasticsearch for doc', async () => {
+            const doc = makeTestDoc();
+            const notFoundData = client.createGetResponse(doc, false);
+            const foundData = client.createGetResponse(doc);
 
-        // create bulk response
-        client.setMGetData({ docs: createMgetData(docArray.slice(1, 3)) });
+            client.setGetResponse(notFoundData);
 
-        // state response
-        const response = await stateStorage.sync(docArray);
+            const empty = stateStorage.getFromCache(doc);
 
-        expect(response).toBeUndefined();
+            expect(empty).toBeUndefined();
+            expect(stateStorage.isCached(doc)).toEqual(false);
 
-        await stateStorage.cache.values(setResults);
+            client.setGetResponse(foundData);
 
-        expect(results.length).toBe(3);
-        expect(results.reverse()).toEqual(docArray);
+            const stateDoc = await stateStorage.get(doc);
+
+            expect(stateDoc).toEqual(doc);
+            expect(DataEntity.isDataEntity(stateDoc)).toEqual(true);
+            expect(stateStorage.isCached(doc)).toEqual(true);
+        });
+    });
+
+    describe('->mset', () => {
+        it('should save many docs to cache and retrieve', async () => {
+            const docArray = makeTestDocs();
+            await stateStorage.mset(docArray);
+
+            const saved = [];
+            for (const doc of docArray) {
+                const savedDoc = await stateStorage.get(doc);
+                saved.push(savedDoc);
+                expect(DataEntity.isDataEntity(savedDoc)).toEqual(true);
+            }
+
+            expect(saved).toEqual(docArray);
+        });
+
+        it('should make an es bulk request if persist is true', async () => {
+            const testConfig = Object.assign({}, config, {
+                persist: true,
+                persist_field: '_key'
+            });
+            const testClient = new TestClient(testConfig);
+            const testStateStorage = new ESCachedStateStorage(testClient as any, logger, testConfig);
+
+            const docArray = makeTestDocs();
+            await testStateStorage.mset(docArray);
+            const data = testClient._bulkRequest;
+
+            expect(data).toBeArrayOfSize(6);
+            expect(data[0].index._id).toBe('1');
+            expect(data[1]).toEqual(docArray[0]);
+            expect(data[2].index._id).toBe('2');
+            expect(data[3]).toEqual(docArray[1]);
+            expect(data[4].index._id).toBe('3');
+            expect(data[5]).toEqual(docArray[2]);
+
+            await testStateStorage.shutdown();
+        });
+
+        it('should allow mset to use a persist field', async () => {
+            const testConfig = Object.assign({}, config, {
+                persist: true,
+                persist_field: 'otherField'
+            });
+            const testClient = new TestClient(testConfig);
+            const testStateStorage = new ESCachedStateStorage(testClient as any, logger, testConfig);
+
+            const otherDocArray = makeTestDocs(true);
+            await testStateStorage.mset(otherDocArray);
+            const data = testClient._bulkRequest;
+
+            expect(data).toBeArrayOfSize(6);
+            expect(data[0].index._id).toBe('other1');
+            expect(data[1]).toEqual(otherDocArray[0]);
+            expect(data[2].index._id).toBe('other2');
+            expect(data[3]).toEqual(otherDocArray[1]);
+            expect(data[4].index._id).toBe('other3');
+            expect(data[5]).toEqual(otherDocArray[2]);
+
+            await testStateStorage.shutdown();
+        });
+    });
+
+    describe('->mget', () => {
+        it('should return object with all docs in cache and in es request', async () => {
+            const docArray = makeTestDocs();
+            const [inCache, ...inES] = docArray;
+            stateStorage.set(inCache);
+
+            // create bulk response
+            client.setMGetResponse(client.createMGetResponse(inES));
+
+            // state response
+            const stateResponse = await stateStorage.mget(docArray);
+            const keys = Object.keys(stateResponse);
+            expect(keys).toBeArrayOfSize(3);
+
+            keys.forEach((idStr: string) => {
+                const id = Number(idStr);
+                expect(stateResponse[id]).toEqual(docArray[id - 1]);
+                expect(DataEntity.isDataEntity(stateResponse[id])).toEqual(true);
+                const metaId = stateResponse[id].getMetadata('_key');
+                expect(`${metaId}`).toEqual(`${id}`);
+            });
+        });
+    });
+
+    describe('->sync', () => {
+        it('should chech cache/fetch data but not return anything', async () => {
+            const results: DataEntity[] = [];
+            const setResults = (data: DataEntity) => results.push(data);
+
+            const docArray = makeTestDocs();
+            const [inCache, ...inES] = docArray;
+            stateStorage.set(inCache);
+            expect(stateStorage.isCached(inCache)).toBeTrue();
+
+            // create bulk response
+            client.setMGetResponse(client.createMGetResponse(inES));
+
+            const fn = jest.fn(() => true);
+            // state response
+            const response = await stateStorage.sync(docArray, fn);
+            expect(response).toBeUndefined();
+
+            expect(fn).toHaveBeenCalledTimes(3);
+
+            await stateStorage.cache.values(setResults);
+
+            expect(results).toBeArrayOfSize(3);
+            expect(results.reverse()).toEqual(docArray);
+        });
     });
 
     it('should return all the found and cached docs', async () => {
         const mgetDocArray: DataEntity[] = [];
-        for (let i = 0; i < 5000; i += 1) {
-            mgetDocArray.push(DataEntity.make({ data: `dataFor${i}` }, { [idField]: i }));
+        for (let i = 0; i < 5000; i++) {
+            mgetDocArray.push(DataEntity.make({ data: `dataFor${i}` }, { _key: `${i}` }));
         }
 
         // found by es
-        const mgetDocs = createMgetData(mgetDocArray.slice(0, 2000));
+        const mgetDocs = client.createMGetResponse(mgetDocArray.slice(0, 2000));
 
         // not found by es
-        const notFoundDocs = createMgetData(mgetDocArray.slice(2000, 3000), false);
-        notFoundDocs.forEach((item) => mgetDocs.push(item));
+        const notFoundDocs = client.createMGetResponse(mgetDocArray.slice(2000, 3000), false);
+        notFoundDocs.docs.forEach((item) => mgetDocs.docs.push(item));
 
-        client.setMGetData({ docs: mgetDocs });
+        client.setMGetResponse(mgetDocs);
 
         // some docs already saved in cache
         await stateStorage.mset(mgetDocArray.slice(3000, 5000));
@@ -291,7 +237,7 @@ describe('elasticsearch cached state storage', () => {
         // should not be any unfound docs
         expect(Object.keys(mgetResult).length).toBe(4000);
 
-        // check a found mget doc
+        // check a found es mget doc
         expect(mgetResult['1283']).toEqual(mgetDocArray['1283']);
 
         // check a found cached doc
@@ -302,13 +248,121 @@ describe('elasticsearch cached state storage', () => {
     });
 
     it('should not create get or mget requests with undefined keys', async () => {
-        expect.hasAssertions();
         const testDocs = [DataEntity.make({ data: 'someValue' })];
-        try {
-            // @ts-ignore
-            await stateStorage.get(testDocs[0]);
-        } catch (err) {
-            expect(err.message.includes('There is no field "_key" set in the metadata')).toEqual(true);
-        }
+        await expect(stateStorage.get(testDocs[0])).rejects.toThrowError(/There is no field "_key" set in the metadata/);
     });
 });
+
+function makeTestDocs(other = false): DataEntity[] {
+    return [
+        {
+            data: 'thisIsFirstData',
+        },
+        {
+            data: 'thisIsSecondData',
+        },
+        {
+            data: 'thisIsThirdData',
+        },
+    ].map((obj, index) => DataEntity.make(obj, {
+        _key: `${index + 1}`,
+        ...(other && { otherField: `other${index + 1}` })
+    }));
+}
+
+function makeTestDoc() {
+    return makeTestDocs()[0];
+}
+
+interface BulkRequest {
+    body: ESBulkQuery[];
+}
+
+class TestClient {
+    private _getResponse!: ESGetResponse;
+    private _mgetResponse!: ESMGetResponse;
+    _bulkRequest!: ESBulkQuery[];
+    private _config: ESStateStorageConfig;
+
+    constructor(config: ESStateStorageConfig) {
+        this._config = config;
+    }
+
+    createGetResponse(doc: DataEntity, found = true): ESGetResponse {
+        return this.createMGetResponse([doc], found).docs[0];
+    }
+
+    createMGetResponse(dataArray: DataEntity[], found = true): ESMGetResponse {
+        const docs = dataArray.map((item) => {
+            const response: ESGetResponse = {
+                _index: this._config.index,
+                _type: this._config.type,
+                _version: 1,
+                _id: `${item.getMetadata('_key')}`,
+                found,
+            };
+
+            if (found) {
+                // convert to reg obj to simulate ES response
+                response._source = Object.assign({}, item);
+            } else {
+                // @ts-ignore
+                response._type = null;
+                delete response._version;
+            }
+
+            return response;
+        });
+
+        return {
+            docs,
+        };
+    }
+
+    setGetResponse(response: ESGetResponse) {
+        this._getResponse = response;
+    }
+
+    setMGetResponse(response: ESMGetResponse) {
+        this._mgetResponse = response;
+    }
+
+    async get(params: ESGetParams) {
+        if (params.index !== this._config.index) {
+            throw new Error(`Invalid index ${params.index} on fake get`);
+        }
+        if (params.type !== this._config.type) {
+            throw new Error(`Invalid type ${params.type} on fake get`);
+        }
+        if (!params.id) {
+            throw new Error('Invalid ids to get');
+        }
+        return this._getResponse;
+    }
+
+    async mget(params: ESMGetParams) {
+        if (!params.body.ids || !Array.isArray(params.body.ids)) {
+            throw new Error('Invalid ids to mget');
+        }
+        if (params.index !== this._config.index) {
+            throw new Error(`Invalid index ${params.index} on fake get`);
+        }
+        if (params.type !== this._config.type) {
+            throw new Error(`Invalid type ${params.type} on fake get`);
+        }
+        for (const doc of this._mgetResponse.docs) {
+            if (doc._index !== this._config.index) {
+                throw new Error(`Invalid index ${doc._index} on fake mget`);
+            }
+            if (doc.found && doc._type !== this._config.type) {
+                throw new Error(`Invalid type ${doc._type} on fake mget`);
+            }
+        }
+        return this._mgetResponse;
+    }
+
+    async bulk(request: BulkRequest) {
+        this._bulkRequest = request.body;
+        return request;
+    }
+}

--- a/packages/teraslice-state-storage/test/elasticsearch-state-storage-spec.ts
+++ b/packages/teraslice-state-storage/test/elasticsearch-state-storage-spec.ts
@@ -11,7 +11,7 @@ import {
 } from '../src';
 
 describe('elasticsearch-state-storage', () => {
-    const logger = debugLogger('ESCachedStateStorage');
+    const logger = debugLogger('elasticsearch-state-storage');
     let client: TestClient;
 
     const config: ESStateStorageConfig = {

--- a/packages/teraslice/lib/cluster/node_master.js
+++ b/packages/teraslice/lib/cluster/node_master.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const ms = require('ms');
 const _ = require('lodash');
 const Promise = require('bluebird');
 const { Mutex } = require('async-mutex');
@@ -62,9 +63,9 @@ module.exports = async function nodeMaster(context) {
                 const workers = await fn();
                 const elapsed = Date.now() - startTime;
                 if (workers.length === count) {
-                    logger.info(`allocated ${workers.length} workers, took ${elapsed}ms`);
+                    logger.info(`allocated ${workers.length} workers, took ${ms(elapsed)}`);
                 } else {
-                    logger.info(`allocated ${workers.length} out of the requested ${count} workers, took ${elapsed}ms`);
+                    logger.info(`allocated ${workers.length} out of the requested ${count} workers, took ${ms(elapsed)}`);
                 }
                 return workers.length;
             } catch (err) {

--- a/packages/teraslice/lib/cluster/storage/backends/elasticsearch_store.js
+++ b/packages/teraslice/lib/cluster/storage/backends/elasticsearch_store.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const ms = require('ms');
 const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
@@ -233,7 +234,7 @@ module.exports = function elasticsearchStorage(backendConfig) {
             const timeout = setTimeout(_destroy, config.shutdown_timeout).unref();
 
             function _destroy(err) {
-                logger.trace(`shutdown store, took ${Date.now() - startTime}ms`);
+                logger.trace(`shutdown store, took ${ms(Date.now() - startTime)}`);
 
                 bulkQueue.length = [];
                 isShutdown = true;

--- a/packages/teraslice/lib/workers/execution-controller/index.js
+++ b/packages/teraslice/lib/workers/execution-controller/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const ms = require('ms');
 const _ = require('lodash');
 const pWhilst = require('p-whilst');
 const Messaging = require('@terascope/teraslice-messaging');
@@ -800,7 +801,7 @@ class ExecutionController {
             const now = Date.now();
             if (now > shutdownAt) {
                 this.logger.error(
-                    `Shutdown timeout of ${timeout}ms waiting for execution ${
+                    `Shutdown timeout of ${ms(timeout)} waiting for execution ${
                         this.exId
                     } to finish...`
                 );

--- a/packages/teraslice/lib/workers/helpers/worker-shutdown.js
+++ b/packages/teraslice/lib/workers/helpers/worker-shutdown.js
@@ -3,6 +3,7 @@
 const {
     get, pDelay, pRaceWithTimeout, isError
 } = require('@terascope/utils');
+const ms = require('ms');
 const { makeLogger } = require('./terafoundation');
 
 function waitForWorkerShutdown(context, eventName) {
@@ -70,11 +71,11 @@ function shutdownHandler(context, shutdownFn) {
 
     function exitingIn() {
         if (!api.exiting) {
-            return `exiting in ${shutdownTimeout}ms...`;
+            return `exiting in ${ms(shutdownTimeout)}...`;
         }
 
         const elapsed = Date.now() - startTime;
-        return `already shutting down, remaining ${shutdownTimeout - elapsed}ms`;
+        return `already shutting down, remaining ${ms(shutdownTimeout - elapsed)}`;
     }
 
     async function callShutdownFn(event, err) {
@@ -97,7 +98,7 @@ function shutdownHandler(context, shutdownFn) {
 
         try {
             await shutdownWithTimeout(event, err);
-            logger.info(`${assignment} shutdown took ${Date.now() - startTime}ms`);
+            logger.info(`${assignment} shutdown took ${ms(Date.now() - startTime)}`);
         } catch (error) {
             logger.error(error, `${assignment} while shutting down`);
         } finally {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -52,6 +52,7 @@
         "kubernetes-client": "^6.12.1",
         "lodash": "^4.17.11",
         "moment": "^2.24.0",
+        "ms": "^2.1.2",
         "nanoid": "^2.0.3",
         "p-whilst": "^2.1.0",
         "porty": "^3.1.1",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.54.10",
+    "version": "0.54.11",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "@terascope/elasticsearch-api": "^2.1.3",
         "@terascope/job-components": "^0.20.8",
         "@terascope/queue": "^1.1.6",
-        "@terascope/teraslice-messaging": "^0.3.4",
+        "@terascope/teraslice-messaging": "^0.3.5",
         "@terascope/utils": "^0.15.0",
         "async-mutex": "^0.1.3",
         "barbe": "^3.0.15",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -32,7 +32,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.3",
+        "@terascope/elasticsearch-api": "^2.1.4",
         "@terascope/job-components": "^0.20.8",
         "@terascope/queue": "^1.1.6",
         "@terascope/teraslice-messaging": "^0.3.5",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,6 +34,7 @@
         "lodash.set": "^4.3.2"
     },
     "devDependencies": {
+        "@types/debug": "^4.1.5",
         "@types/lodash.get": "^4.4.6",
         "@types/lodash.set": "^4.3.6",
         "benchmark": "^2.1.4"

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -68,13 +68,13 @@ export function fastMap<T, U>(arr: T[], fn: (val: T, index: number) => U): U[] {
     return result;
 }
 
-export function chunk<T>(dataArray: T[], size:number) {
-    if (size < 1) return [dataArray];
+export function chunk<T>(dataArray: T[]|Set<T>, size: number): T[][] {
+    if (size < 1) return Array.isArray(dataArray) ? [dataArray] : [[...dataArray]];
     const results: T[][] = [];
     let chunked: T[] = [];
 
-    for (let i = 0; i < dataArray.length; i += 1) {
-        chunked.push(dataArray[i]);
+    for (const data of dataArray) {
+        chunked.push(data);
         if (chunked.length === size) {
             results.push(chunked);
             chunked = [];


### PR DESCRIPTION
Fix `unhandledRejection` in `teraslice-messaging` when client is not ready
Better millisecond logs in `teraslice-messaging` and `teraslice`
Minor cleanup in cached-state-storage
Many improvements and fixes elasticsearch-state-storage
More accurate and understandable tests for elasticsearch-state-storage