### PR TITLE
v0.55.2 - A few fixes

### DIFF
--- a/packages/chunked-file-reader/package.json
+++ b/packages/chunked-file-reader/package.json
@@ -20,7 +20,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "bluebird": "^3.5.5",
         "csvtojson": "^2.0.8",
         "lodash": "^4.17.11"

--- a/packages/data-access-plugin/package.json
+++ b/packages/data-access-plugin/package.json
@@ -34,7 +34,7 @@
         "@terascope/data-access": "^0.13.3",
         "@terascope/data-types": "^0.5.4",
         "@terascope/elasticsearch-api": "^2.1.4",
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "accepts": "^1.3.7",
         "apollo-server-express": "~2.6.5",
         "body-parser": "^1.19.0",
@@ -42,11 +42,11 @@
         "graphql": "^14.3.1",
         "graphql-iso-date": "^3.6.1",
         "graphql-type-json": "^0.3.0",
-        "terafoundation": "^0.12.0",
+        "terafoundation": "^0.12.1",
         "xlucene-evaluator": "^0.9.7"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.21.0",
+        "@terascope/job-components": "^0.21.1",
         "@types/express": "^4.17.1",
         "@types/got": "^9.6.7",
         "@types/graphql-iso-date": "^3.3.1",

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "@terascope/data-types": "^0.5.4",
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "elasticsearch-store": "^0.11.1",
         "xlucene-evaluator": "^0.9.7"
     },

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -29,7 +29,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "graphql": "^14.3.1",
         "lodash.defaultsdeep": "^4.6.1",
         "lodash.set": "^4.3.2",

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -17,7 +17,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "bluebird": "^3.5.5",
         "lodash": "^4.17.11"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "@terascope/data-types": "^0.5.4",
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "ajv": "^6.10.0",
         "nanoid": "^2.0.3",
         "rambda": "^2.14.5",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/job-components",
-    "version": "0.21.0",
+    "version": "0.21.1",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.6",
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^3.3.3"

--- a/packages/job-components/src/execution-context/api.ts
+++ b/packages/job-components/src/execution-context/api.ts
@@ -1,9 +1,10 @@
 import { EventEmitter } from 'events';
 import { AnyObject, Logger, isTest } from '@terascope/utils';
 import { OpAPI, Context, ExecutionConfig, APIConfig, WorkerContext } from '../interfaces';
-import { isOperationAPI, getOperationAPIType, makeContextLogger } from './utils';
+import { isOperationAPI, getOperationAPIType } from './utils';
 import { Observer, APIConstructor } from '../operations';
 import { JobAPIInstances } from './interfaces';
+import { makeExContextLogger } from '../utils';
 
 /**
  * A utility API exposed on the Terafoundation Context APIs.
@@ -132,7 +133,6 @@ export class ExecutionContextAPI {
      * Make a logger with a the job_id and ex_id in the logger context
      */
     makeLogger(moduleName: string, extra: AnyObject = {}) {
-        const { ex_id, job_id } = this._executionConfig;
-        return makeContextLogger(this._context, moduleName, { ex_id, job_id, ...extra });
+        return makeExContextLogger(this._context, this._executionConfig, moduleName, extra);
     }
 }

--- a/packages/job-components/src/execution-context/utils.ts
+++ b/packages/job-components/src/execution-context/utils.ts
@@ -1,6 +1,5 @@
-import { isFunction, get } from '@terascope/utils';
+import { isFunction } from '@terascope/utils';
 import { OperationAPI, OperationAPIType } from '../operations';
-import { Context } from '../interfaces';
 
 export function getMetric(input: number[], i: number): number {
     const val = input && input[i];
@@ -14,17 +13,4 @@ export function isOperationAPI(api: any): api is OperationAPI {
 
 export function getOperationAPIType(api: any): OperationAPIType {
     return isOperationAPI(api) ? 'api' : 'observer';
-}
-
-export function makeContextLogger(context: Context, moduleName: string, extra = {}) {
-    return context.apis.foundation.makeLogger(
-        Object.assign(
-            {
-                module: moduleName,
-                worker_id: get(context, 'cluster.worker.id'),
-                assignment: get(context, 'assignment'),
-            },
-            extra
-        )
-    );
 }

--- a/packages/job-components/src/index.ts
+++ b/packages/job-components/src/index.ts
@@ -1,3 +1,5 @@
+export * from '@terascope/utils';
+export * from './utils';
 export * from './builtin';
 export * from './config-validators';
 export * from './execution-context';
@@ -9,4 +11,3 @@ export * from './job-schemas';
 export * from './interfaces';
 export * from './register-apis';
 export * from './test-helpers';
-export * from '@terascope/utils';

--- a/packages/job-components/src/operations/core/api-core.ts
+++ b/packages/job-components/src/operations/core/api-core.ts
@@ -5,6 +5,7 @@ import {
     WorkerContext,
     APIConfig
 } from '../../interfaces';
+import { makeExContextLogger } from '../../utils';
 
 /**
  * A base class for supporting APIs that run within an Execution Context.
@@ -13,12 +14,8 @@ export default abstract class APICore<T = APIConfig> extends Core<WorkerContext>
     readonly apiConfig: Readonly<APIConfig & T>;
 
     constructor(context: WorkerContext, apiConfig: APIConfig & T, executionConfig: ExecutionConfig) {
-        const logger = context.apis.foundation.makeLogger({
-            module: 'operation-api',
+        const logger = makeExContextLogger(context, executionConfig, 'operation-api', {
             apiName: apiConfig._name,
-            jobName: executionConfig.name,
-            jobId: executionConfig.job_id,
-            exId: executionConfig.ex_id,
         });
 
         super(context, executionConfig, logger);

--- a/packages/job-components/src/operations/core/operation-core.ts
+++ b/packages/job-components/src/operations/core/operation-core.ts
@@ -9,6 +9,7 @@ import {
     DeadLetterAction,
     DeadLetterAPIFn,
 } from '../../interfaces';
+import { makeExContextLogger } from '../../utils';
 
 /**
  * A base class for supporting operations that run on a "Worker",
@@ -24,14 +25,9 @@ export default class OperationCore<T = OpConfig> extends Core<WorkerContext> imp
     deadLetterAction: DeadLetterAction;
 
     constructor(context: WorkerContext, opConfig: OpConfig & T, executionConfig: ExecutionConfig) {
-        const logger = context.apis.foundation.makeLogger({
-            module: 'operation',
+        const logger = makeExContextLogger(context, executionConfig, 'operation', {
             opName: opConfig._op,
-            jobName: executionConfig.name,
-            jobId: executionConfig.job_id,
-            exId: executionConfig.ex_id,
         });
-
         super(context, executionConfig, logger);
 
         this.deadLetterAction = opConfig._dead_letter_action || 'none';

--- a/packages/job-components/src/operations/core/slicer-core.ts
+++ b/packages/job-components/src/operations/core/slicer-core.ts
@@ -11,6 +11,7 @@ import {
 } from '../../interfaces';
 import Queue from '@terascope/queue';
 import Core from './core';
+import { makeExContextLogger } from '../../utils';
 
 /**
  * A base class for supporting "Slicers" that run on a "Execution Controller",
@@ -28,12 +29,8 @@ export default abstract class SlicerCore<T = OpConfig> extends Core<WorkerContex
     private readonly queue: Queue<Slice>;
 
     constructor(context: WorkerContext, opConfig: OpConfig & T, executionConfig: ExecutionConfig) {
-        const logger = context.apis.foundation.makeLogger({
-            module: 'slicer',
+        const logger = makeExContextLogger(context, executionConfig, 'slicer', {
             opName: opConfig._op,
-            jobName: executionConfig.name,
-            jobId: executionConfig.job_id,
-            exId: executionConfig.ex_id,
         });
 
         super(context, executionConfig, logger);

--- a/packages/job-components/src/utils.ts
+++ b/packages/job-components/src/utils.ts
@@ -1,0 +1,20 @@
+import { get } from '@terascope/utils';
+import { Context, ExecutionConfig } from './interfaces';
+
+export function makeContextLogger(context: Context, moduleName: string, extra = {}) {
+    return context.apis.foundation.makeLogger(
+        Object.assign(
+            {
+                module: moduleName,
+                worker_id: get(context, 'cluster.worker.id'),
+                assignment: get(context, 'assignment'),
+            },
+            extra
+        )
+    );
+}
+
+export function makeExContextLogger(context: Context, config: ExecutionConfig, moduleName: string, extra = {}) {
+    const { ex_id, job_id } = config;
+    return makeContextLogger(context, moduleName, { ex_id, job_id, ...extra });
+}

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.14.0",
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "@types/is-ci": "^2.0.0",
         "codecov": "^3.5.0",
         "execa": "^2.0.4",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "terafoundation",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@terascope/elasticsearch-api": "^2.1.4",
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "aws-sdk": "^2.512.0",
         "bluebird": "^3.5.5",
         "bunyan": "^1.8.12",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.6",
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "ms": "^2.1.2",
         "nanoid": "^2.0.3",
         "p-event": "^4.1.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -17,7 +17,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.21.0",
+        "@terascope/job-components": "^0.21.1",
         "bluebird": "^3.5.5",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "@terascope/elasticsearch-api": "^2.1.4",
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "bluebird": "^3.5.5",
         "mnemonist": "^0.30.0"
     },

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-state-storage",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {

--- a/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
+++ b/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
@@ -1,4 +1,4 @@
-import { DataEntity, Logger, TSError, chunk, isFunction } from '@terascope/utils';
+import { DataEntity, Logger, TSError, chunk, isFunction, pImmediate } from '@terascope/utils';
 import esApi, { Client } from '@terascope/elasticsearch-api';
 import { Promise as bPromise } from 'bluebird';
 import { ESStateStorageConfig, MGetCacheResponse } from '../interfaces';
@@ -129,6 +129,7 @@ export default class ESCachedStateStorage {
         }
 
         if (duplicates.length) {
+            await pImmediate();
             this.logger.info(`syncing the remaining ${duplicates.length} duplicate records`);
             return this.sync(duplicates, fn);
         }

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -32,7 +32,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.21.0",
+        "@terascope/job-components": "^0.21.1",
         "@terascope/teraslice-op-test-harness": "^1.7.2",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -33,10 +33,10 @@
     },
     "dependencies": {
         "@terascope/elasticsearch-api": "^2.1.4",
-        "@terascope/job-components": "^0.21.0",
+        "@terascope/job-components": "^0.21.1",
         "@terascope/queue": "^1.1.6",
         "@terascope/teraslice-messaging": "^0.3.5",
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "async-mutex": "^0.1.3",
         "barbe": "^3.0.15",
         "bluebird": "^3.5.5",
@@ -60,7 +60,7 @@
         "shortid": "^2.2.14",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.12.0",
+        "terafoundation": "^0.12.1",
         "uuid": "^3.3.3"
     },
     "devDependencies": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.55.1",
+    "version": "0.55.2",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -37,7 +37,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "@types/graphlib": "^2.1.5",
         "@types/shortid": "^0.0.29",
         "awesome-phonenumber": "^2.15.0",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -23,7 +23,7 @@
         "test": "echo '* tests not supported yet'"
     },
     "dependencies": {
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "apollo-boost": "^0.4.4",
         "apollo-client": "^2.6.4",
         "date-fns": "^1.30.1",

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -44,7 +44,7 @@
     "devDependencies": {
         "@craco/craco": "^5.3.0",
         "@terascope/ui-components": "^0.3.7",
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "@types/react": "16.9.2",
         "@types/react-dom": "16.8.5",
         "@types/react-router-dom": "^4.3.4",

--- a/packages/ui-data-access/package.json
+++ b/packages/ui-data-access/package.json
@@ -26,7 +26,7 @@
         "@terascope/data-access": "^0.13.3",
         "@terascope/data-types": "^0.5.4",
         "@terascope/ui-components": "^0.3.7",
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "@types/convict": "^4.2.1",
         "@types/react": "16.9.2",
         "@types/react-dom": "16.8.5",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/utils",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/xlucene-evaluator/package.json
+++ b/packages/xlucene-evaluator/package.json
@@ -32,7 +32,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.16.0",
+        "@terascope/utils": "^0.16.1",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-point-in-polygon": "^6.0.1",


### PR DESCRIPTION
- Use `pImmediate` when using a recursion in the `teraslice-state-storage`
- Use a consistent logger in operations
- Bump `utils` and `terafoundation` to fix `makeLogger` issue
