### PR TITLE
Fix daily docker tag name and e2e test improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ autoload/*
 # e2e files
 e2e/autoload/*
 !e2e/autoload/.gitkeep
+e2e/logs/*
+!e2e/logs/.gitkeep
 e2e/.config
 
 # package dist directory

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -12,6 +12,7 @@ services:
             - NODE_OPTIONS=--max-old-space-size=256
         volumes:
             - teraslice-assets:/app/assets
+            - ./logs:/app/logs:cached
             - ./autoload:/app/autoload:ro
             - ./.config:/app/config:ro
     teraslice-worker:
@@ -24,6 +25,7 @@ services:
             - NODE_OPTIONS=--max-old-space-size=256
         volumes:
             - teraslice-assets:/app/assets
+            - ./logs:/app/logs:cached
             - ./autoload:/app/autoload:ro
             - ./.config:/app/config:ro
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -21,7 +21,7 @@
     "scripts": {
         "clean": "docker-compose down --volumes --remove-orphans --timeout=5",
         "logs": "./scripts/logs.sh",
-        "logs-follow": "./scripts/logs.sh --follow",
+        "logs-follow": "./scripts/logs.sh -f",
         "test": "ts-scripts test --suite e2e"
     },
     "devDependencies": {

--- a/e2e/scripts/logs.sh
+++ b/e2e/scripts/logs.sh
@@ -1,28 +1,31 @@
 #!/bin/bash
+
 set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+LOG_PATH="$DIR/../logs/teraslice.log"
 
 echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi; }
 
-
 get_logs() {
     local args=("$@")
-    docker-compose logs --no-color "${args[@]}" teraslice-worker teraslice-master | awk -F' [|] ' '{print $2}'
+    tail "${args[@]}" "$LOG_PATH"
 }
 
 main() {
     local args=("$@")
-    local ps_result
-    ps_result="$(docker-compose ps -q 2>/dev/null)"
-    if [ -n "$ps_result" ]; then
-        if [ "$RAW_LOGS" == "true" ] || [ "$RAW_LOGS" == "1" ]; then
-            get_logs "${args[@]}" 2>&1
-        else
-            local color="--color"
-            if [ "$FORCE_COLOR" == "0" ]; then
-                color="--no-color"
-            fi
-            get_logs "${args[@]}" | bunyan "$color" -o short -l "${LOG_LEVEL:-"DEBUG"}"
+    if [ ! -f "$LOG_PATH" ]; then
+        echo -n '' > "$LOG_PATH"
+    fi
+
+    if [ "$RAW_LOGS" == "true" ] || [ "$RAW_LOGS" == "1" ]; then
+        get_logs "${args[@]}" 2>&1
+    else
+        local color="--color"
+        if [ "$FORCE_COLOR" == "0" ]; then
+            color="--no-color"
         fi
+        get_logs "${args[@]}" | bunyan "$color" -o short -l "${LOG_LEVEL:-"DEBUG"}"
     fi
 }
 

--- a/e2e/test/cases/assets/simple-spec.js
+++ b/e2e/test/cases/assets/simple-spec.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const misc = require('../../misc');
 const wait = require('../../wait');
-const { resetState } = require('../../helpers');
+const { resetState, submitAndStart } = require('../../helpers');
 
 const { waitForJobStatus } = wait;
 
@@ -33,9 +33,8 @@ describe('assets', () => {
         // assigned by teraslice and not it's name.
         jobSpec.assets = [result._id, 'elasticsearch'];
 
-        const job = await teraslice.jobs.submit(jobSpec);
+        const job = await submitAndStart(jobSpec);
 
-        await waitForJobStatus(job, 'running');
         const r = await wait.forWorkersJoined(job.id(), workers, 25);
         expect(r).toEqual(workers);
 
@@ -104,8 +103,7 @@ describe('assets', () => {
         const assetResponse = await teraslice.assets.post(fileStream);
         const assetId = assetResponse._id;
 
-        const job = await teraslice.jobs.submit(jobSpec);
-        await waitForJobStatus(job, 'running');
+        const job = await submitAndStart(jobSpec);
 
         const waitResponse = await wait.forWorkersJoined(job.id(), workers, 25);
         expect(waitResponse).toEqual(workers);
@@ -124,8 +122,7 @@ describe('assets', () => {
         const assetResponse = await teraslice.assets.get('ex1/0.1.1');
         const assetId = assetResponse[0].id;
 
-        const job = await teraslice.jobs.submit(jobSpec);
-        await waitForJobStatus(job, 'running');
+        const job = await submitAndStart(jobSpec);
 
         const waitResponse = await wait.forWorkersJoined(job.id(), workers, 25);
         expect(waitResponse).toEqual(workers);

--- a/e2e/test/cases/assets/simple-spec.js
+++ b/e2e/test/cases/assets/simple-spec.js
@@ -38,7 +38,8 @@ describe('assets', () => {
         await waitForJobStatus(job, 'running');
         const r = await wait.forWorkersJoined(job.id(), workers, 25);
         expect(r).toEqual(workers);
-        return job.stop();
+
+        await job.stop({ blocking: true });
     }
 
     it('after uploading an asset, it can be deleted', async () => {
@@ -112,7 +113,7 @@ describe('assets', () => {
         const execution = await job.execution();
         expect(execution.assets[0]).toEqual(assetId);
 
-        await job.stop();
+        await job.stop({ blocking: true });
     });
 
     it('can directly ask for the new asset to be used', async () => {
@@ -132,6 +133,6 @@ describe('assets', () => {
         const execution = await job.execution();
         expect(execution.assets[0]).toEqual(assetId);
 
-        await job.stop();
+        await job.stop({ blocking: true });
     });
 });

--- a/e2e/test/cases/cluster/job-state-spec.js
+++ b/e2e/test/cases/cluster/job-state-spec.js
@@ -25,9 +25,10 @@ describe('job state', () => {
         await waitForJobStatus(job1, 'paused');
         await job1.resume();
         await waitForJobStatus(job1, 'running');
-        await job1.stop();
-        await waitForJobStatus(job1, 'stopped');
-        await job2.stop();
-        await waitForJobStatus(job2, 'stopped');
+
+        await Promise.all([
+            job1.stop({ blocking: true }),
+            job2.stop({ blocking: true }),
+        ]);
     });
 });

--- a/e2e/test/fixtures/jobs/generator-asset.json
+++ b/e2e/test/fixtures/jobs/generator-asset.json
@@ -9,8 +9,7 @@
     "operations": [
         {
             "_op": "elasticsearch_data_generator",
-            "size": 1000,
-            "stress_test": true
+            "size": 1000
         },
         {
             "_op": "drop_property",

--- a/e2e/test/global.setup.js
+++ b/e2e/test/global.setup.js
@@ -205,6 +205,7 @@ async function generateTestData() {
 
 module.exports = async () => {
     await misc.globalTeardown(false);
+    await misc.cleanupLogs();
 
     signale.time('global setup');
 

--- a/e2e/test/global.setup.js
+++ b/e2e/test/global.setup.js
@@ -205,7 +205,7 @@ async function generateTestData() {
 
 module.exports = async () => {
     await misc.globalTeardown(false);
-    await misc.cleanupLogs();
+    await misc.resetLogs();
 
     signale.time('global setup');
 

--- a/e2e/test/misc.js
+++ b/e2e/test/misc.js
@@ -133,11 +133,9 @@ function newId(prefix, lowerCase = false, length = 15) {
     return id;
 }
 
-async function cleanupLogs() {
+async function resetLogs() {
     const logPath = path.join(__dirname, '..', 'logs', 'teraslice.log');
-    if (!fse.existsSync(logPath)) {
-        await fse.unlink(logPath);
-    }
+    await fse.writeFile(logPath, '');
 }
 
 async function globalTeardown(shouldThrow) {
@@ -179,7 +177,7 @@ module.exports = {
     getExampleIndex,
     globalTeardown,
     newSpecIndex,
-    cleanupLogs,
+    resetLogs,
     EXAMLPE_INDEX_SIZES,
     EXAMPLE_INDEX_PREFIX,
     SPEC_INDEX_PREFIX,

--- a/e2e/test/misc.js
+++ b/e2e/test/misc.js
@@ -133,6 +133,13 @@ function newId(prefix, lowerCase = false, length = 15) {
     return id;
 }
 
+async function cleanupLogs() {
+    const logPath = path.join(__dirname, '..', 'logs', 'teraslice.log');
+    if (!fse.existsSync(logPath)) {
+        await fse.unlink(logPath);
+    }
+}
+
 async function globalTeardown(shouldThrow) {
     process.stdout.write('\n');
     signale.time('tear down');
@@ -172,6 +179,7 @@ module.exports = {
     getExampleIndex,
     globalTeardown,
     newSpecIndex,
+    cleanupLogs,
     EXAMLPE_INDEX_SIZES,
     EXAMPLE_INDEX_PREFIX,
     SPEC_INDEX_PREFIX,

--- a/e2e/test/setup-config.js
+++ b/e2e/test/setup-config.js
@@ -2,7 +2,6 @@
 
 const _ = require('lodash');
 const path = require('path');
-const isCI = require('is-ci');
 const fse = require('fs-extra');
 const {
     WORKERS_PER_NODE,
@@ -17,14 +16,22 @@ module.exports = async function setupTerasliceConfig() {
     const baseConfig = {
         terafoundation: {
             environment: 'development',
-            log_level: isCI ? 'info' : 'debug',
+            log_level: [
+                { console: 'warn' },
+                { file: 'info', }
+            ],
+            logging: [
+                'console',
+                'file'
+            ],
+            log_path: '/app/logs',
             connectors: {
                 elasticsearch: {
                     default: {
                         host: [ELASTICSEARCH_HOST],
                         apiVersion: ELASTICSEARCH_API_VERSION,
-                        requestTimeout: 60000,
-                        deadTimeout: 45000,
+                        requestTimeout: '1 minute',
+                        deadTimeout: '45 seconds',
                         sniffOnStart: false,
                         sniffOnConnectionFault: false,
                         suggestCompression: false
@@ -38,11 +45,13 @@ module.exports = async function setupTerasliceConfig() {
             }
         },
         teraslice: {
-            worker_disconnect_timeout: 120000,
-            node_disconnect_timeout: 120000,
-            slicer_timeout: 180000,
-            shutdown_timeout: 30000,
-            action_timeout: 30000,
+            worker_disconnect_timeout: '2 minutes',
+            node_disconnect_timeout: '2 minutes',
+            slicer_timeout: '2 minutes',
+            shutdown_timeout: '30 seconds',
+            action_timeout: '15 seconds',
+            network_latency_buffer: '5 seconds',
+            analytics_rate: '15 seconds',
             slicer_allocation_attempts: 0,
             assets_directory: '/app/assets',
             autoload_directory: '/app/autoload',
@@ -75,7 +84,6 @@ module.exports = async function setupTerasliceConfig() {
     };
 
     const configPath = path.join(__dirname, '..', '.config');
-
     if (!fse.existsSync(configPath)) {
         await fse.emptyDir(configPath);
     }

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/publish/utils.ts
+++ b/packages/scripts/src/helpers/publish/utils.ts
@@ -44,9 +44,12 @@ function padNumber(n: number): string {
 
 function formatShortDate() {
     const date = new Date();
+    // get the full year
     const year = date.getFullYear();
-    const month = date.getMonth();
-    const day = date.getDay();
+    // zero based month
+    const month = date.getMonth() + 1;
+    // get the day of the month
+    const day = date.getDate();
     return `${year}.${padNumber(month)}.${padNumber(day)}`;
 }
 

--- a/packages/scripts/src/helpers/test-runner/utils.ts
+++ b/packages/scripts/src/helpers/test-runner/utils.ts
@@ -170,7 +170,7 @@ async function getE2ELogs(dir: string, env: ExecEnv): Promise<string> {
         const result = await exec(
             {
                 cmd: 'yarn',
-                args: ['run', 'logs'],
+                args: ['run', 'logs', '-n', '2000'],
                 cwd: dir,
                 env,
             },
@@ -190,19 +190,6 @@ export async function logE2E(dir: string, failed: boolean): Promise<void> {
         });
         process.stderr.write(`${errLogs}\n`);
     }
-
-    const rawLogs = await getE2ELogs(dir, {
-        RAW_LOGS: 'true',
-    });
-
-    const logFilePath = path.join(dir, 'e2e-test.log');
-    if (!rawLogs) {
-        await fse.remove(logFilePath);
-        return;
-    }
-
-    await fse.writeFile(logFilePath, rawLogs);
-    signale.debug(`Wrote e2e log files to ${path.relative(process.cwd(), logFilePath)}`);
 }
 
 const abc = 'abcdefghijklmnopqrstuvwxyz';

--- a/packages/teraslice/lib/cluster/services/cluster/backends/native/messaging.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/native/messaging.js
@@ -257,7 +257,7 @@ module.exports = function messaging(context, logger) {
             io = require('socket.io-client')(hostURL, {
                 forceNew: true,
                 path: '/native-clustering',
-                // transports: ['websocket'],
+                perMessageDeflate: false,
                 query,
             });
             _registerFns(io);
@@ -278,6 +278,9 @@ module.exports = function messaging(context, logger) {
             // cluster_master
             io = require('socket.io')(server, {
                 path: '/native-clustering',
+                pingTimeout: configTimeout,
+                pingInterval: configTimeout + networkLatencyBuffer,
+                perMessageDeflate: false,
                 serveClient: false,
             });
             _attachRoomsSocketIO();


### PR DESCRIPTION
- Fixes formatting of docker build tag name
- Fix simple asset test in e2e to cleanup properly
- Minor fixes to e2e tests
- Write e2e teraslice logs to file so we can get logs from containers that have been removed
- Minor fixes to node_master messaging in native clustering to use the same `pingTimeout` logic as in `teraslice-messaging` 