### PR TITLE
v0.55.5 - Set pingTimeout on socket.io client

### DIFF
--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-messaging",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {

--- a/packages/teraslice-messaging/src/cluster-master/client.ts
+++ b/packages/teraslice-messaging/src/cluster-master/client.ts
@@ -1,4 +1,4 @@
-import { isString } from '@terascope/utils';
+import { isString, isNumber } from '@terascope/utils';
 import * as i from './interfaces';
 import * as core from '../messenger';
 
@@ -6,7 +6,16 @@ export class Client extends core.Client {
     public readonly exId: string;
 
     constructor(opts: i.ClientOptions) {
-        const { clusterMasterUrl, socketOptions, networkLatencyBuffer, actionTimeout, exId, connectTimeout, logger } = opts;
+        const {
+            clusterMasterUrl,
+            socketOptions,
+            nodeDisconnectTimeout,
+            networkLatencyBuffer,
+            actionTimeout,
+            exId,
+            connectTimeout,
+            logger
+        } = opts;
 
         if (!clusterMasterUrl || !isString(clusterMasterUrl)) {
             throw new Error('ClusterMaster.Client requires a valid clusterMasterUrl');
@@ -16,11 +25,16 @@ export class Client extends core.Client {
             throw new Error('ClusterMaster.Client requires a valid exId');
         }
 
+        if (!isNumber(nodeDisconnectTimeout)) {
+            throw new Error('ClusterMaster.Client requires a valid nodeDisconnectTimeout');
+        }
+
         super({
             socketOptions,
             networkLatencyBuffer,
             actionTimeout,
             connectTimeout,
+            clientDisconnectTimeout: nodeDisconnectTimeout,
             hostUrl: clusterMasterUrl,
             clientType: 'execution-controller',
             clientId: exId,

--- a/packages/teraslice-messaging/src/cluster-master/interfaces.ts
+++ b/packages/teraslice-messaging/src/cluster-master/interfaces.ts
@@ -4,6 +4,7 @@ import { Logger } from '@terascope/utils';
 export interface ClientOptions {
     exId: string;
     clusterMasterUrl: string;
+    nodeDisconnectTimeout: number;
     socketOptions: SocketIOClient.ConnectOpts;
     networkLatencyBuffer?: number;
     actionTimeout: number;

--- a/packages/teraslice-messaging/src/execution-controller/client.ts
+++ b/packages/teraslice-messaging/src/execution-controller/client.ts
@@ -1,4 +1,4 @@
-import { isString, withoutNil } from '@terascope/utils';
+import { isString, withoutNil, isNumber } from '@terascope/utils';
 import * as core from '../messenger';
 import * as i from './interfaces';
 
@@ -8,7 +8,16 @@ export class Client extends core.Client {
     public workerId: string;
 
     constructor(opts: i.ClientOptions) {
-        const { executionControllerUrl, socketOptions, workerId, networkLatencyBuffer, actionTimeout, connectTimeout, logger } = opts;
+        const {
+            executionControllerUrl,
+            socketOptions,
+            workerId,
+            workerDisconnectTimeout,
+            networkLatencyBuffer,
+            actionTimeout,
+            connectTimeout,
+            logger
+        } = opts;
 
         if (!isString(executionControllerUrl)) {
             throw new Error('ExecutionController.Client requires a valid executionControllerUrl');
@@ -18,11 +27,16 @@ export class Client extends core.Client {
             throw new Error('ExecutionController.Client requires a valid workerId');
         }
 
+        if (!isNumber(workerDisconnectTimeout)) {
+            throw new Error('ExecutionController.Client requires a valid workerDisconnectTimeout');
+        }
+
         super({
             socketOptions,
             networkLatencyBuffer,
             actionTimeout,
             connectTimeout,
+            clientDisconnectTimeout: workerDisconnectTimeout,
             hostUrl: executionControllerUrl,
             clientId: workerId,
             clientType: 'worker',

--- a/packages/teraslice-messaging/src/execution-controller/interfaces.ts
+++ b/packages/teraslice-messaging/src/execution-controller/interfaces.ts
@@ -4,6 +4,7 @@ export interface ClientOptions {
     executionControllerUrl: string;
     workerId: string;
     socketOptions: SocketIOClient.ConnectOpts;
+    workerDisconnectTimeout: number;
     networkLatencyBuffer?: number;
     actionTimeout: number;
     connectTimeout: number;

--- a/packages/teraslice-messaging/src/messenger/client.ts
+++ b/packages/teraslice-messaging/src/messenger/client.ts
@@ -19,7 +19,17 @@ export class Client extends Core {
     protected serverShutdown: boolean;
 
     constructor(opts: i.ClientOptions) {
-        const { hostUrl, clientId, clientType, serverName, socketOptions = {}, connectTimeout, logger, ...coreOpts } = opts;
+        const {
+            hostUrl,
+            clientId,
+            clientType,
+            serverName,
+            socketOptions = {},
+            connectTimeout,
+            clientDisconnectTimeout,
+            logger,
+            ...coreOpts
+        } = opts;
 
         super({
             logger: logger
@@ -50,16 +60,24 @@ export class Client extends Core {
             throw new Error('Messenger.Client requires a valid connectTimeout');
         }
 
+        // The pingTimeout should be the client disconnect timeout
+        // (which is greater than the pingTimeout on the server which uses actionTimeout)
+        // to avoid disconnecting from the server before the connection
+        // is considered
+        const pingTimeout = clientDisconnectTimeout;
+        const pingInterval = clientDisconnectTimeout + this.networkLatencyBuffer;
+
         const options: SocketIOClient.ConnectOpts = Object.assign({}, socketOptions, {
             autoConnect: false,
             forceNew: true,
+            pingTimeout,
+            pingInterval,
             perMessageDeflate: false,
             query: { clientId, clientType },
             timeout: connectTimeout,
         });
 
-        // @ts-ignore
-        this.socket = new SocketIOClient(hostUrl, options);
+        this.socket = SocketIOClient(hostUrl, options);
         this.socket.on('error', (err: any) => {
             this.logger.error(err, 'unhandled socket.io-client error');
         });

--- a/packages/teraslice-messaging/src/messenger/client.ts
+++ b/packages/teraslice-messaging/src/messenger/client.ts
@@ -168,8 +168,8 @@ export class Client extends Core {
             });
         });
 
-        this.socket.on('disconnect', () => {
-            this.logger.info(`client ${this.clientId} disconnected`);
+        this.socket.on('disconnect', (reason: string) => {
+            this.logger.info(`client ${this.clientId} disconnected`, { reason });
             this.ready = false;
         });
 

--- a/packages/teraslice-messaging/src/messenger/interfaces.ts
+++ b/packages/teraslice-messaging/src/messenger/interfaces.ts
@@ -13,6 +13,7 @@ export interface ClientOptions extends CoreOptions {
     clientId: string;
     clientType: string;
     serverName: string;
+    clientDisconnectTimeout: number;
     connectTimeout: number;
     socketOptions?: SocketIOClient.ConnectOpts;
 }

--- a/packages/teraslice-messaging/src/messenger/server.ts
+++ b/packages/teraslice-messaging/src/messenger/server.ts
@@ -64,8 +64,7 @@ export class Server extends Core {
         const pingTimeout = this.actionTimeout;
         const pingInterval = this.actionTimeout + this.networkLatencyBuffer;
 
-        // @ts-ignore
-        this.server = new SocketIOServer({
+        this.server = SocketIOServer({
             pingTimeout,
             pingInterval,
             perMessageDeflate: false,

--- a/packages/teraslice-messaging/src/messenger/server.ts
+++ b/packages/teraslice-messaging/src/messenger/server.ts
@@ -383,12 +383,8 @@ export class Server extends Core {
             });
         });
 
-        socket.on('disconnect', (error?: Error | string) => {
-            if (error) {
-                this.logger.info(`client ${clientId} disconnected`, { error });
-            } else {
-                this.logger.info(`client ${clientId} disconnected`);
-            }
+        socket.on('disconnect', (reason: string) => {
+            this.logger.info(`client ${clientId} disconnected`, { reason });
 
             socket.removeAllListeners();
             socket.disconnect(true);

--- a/packages/teraslice-messaging/test/cluster-master-spec.ts
+++ b/packages/teraslice-messaging/test/cluster-master-spec.ts
@@ -25,6 +25,18 @@ describe('ClusterMaster', () => {
             });
         });
 
+        describe('when constructed without a nodeDisconnectTimeout', () => {
+            it('should throw an error', () => {
+                expect(() => {
+                    // @ts-ignore
+                    new ClusterMaster.Client({
+                        clusterMasterUrl: 'example.com',
+                        exId: 'test',
+                    });
+                }).toThrowError('ClusterMaster.Client requires a valid nodeDisconnectTimeout');
+            });
+        });
+
         describe('when constructed with an invalid clusterMasterUrl', () => {
             let client: ClusterMaster.Client;
 
@@ -32,6 +44,7 @@ describe('ClusterMaster', () => {
                 client = new ClusterMaster.Client({
                     clusterMasterUrl: 'http://idk.example.com',
                     exId: 'hello',
+                    nodeDisconnectTimeout: 1000,
                     actionTimeout: 1000,
                     connectTimeout: 1000,
                     socketOptions: {
@@ -83,6 +96,7 @@ describe('ClusterMaster', () => {
                 exId,
                 clusterMasterUrl,
                 networkLatencyBuffer: 0,
+                nodeDisconnectTimeout: 1000,
                 actionTimeout: 1000,
                 connectTimeout: 1000,
                 socketOptions: {

--- a/packages/teraslice-messaging/test/execution-controller-spec.ts
+++ b/packages/teraslice-messaging/test/execution-controller-spec.ts
@@ -25,6 +25,18 @@ describe('ExecutionController', () => {
             });
         });
 
+        describe('when constructed without a workerDisconnectTimeout', () => {
+            it('should throw an error', () => {
+                expect(() => {
+                    // @ts-ignore
+                    new ExecutionController.Client({
+                        executionControllerUrl: 'example.com',
+                        workerId: 'test'
+                    });
+                }).toThrowError('ExecutionController.Client requires a valid workerDisconnectTimeout');
+            });
+        });
+
         describe('when constructed with an invalid executionControllerUrl', () => {
             let client: ExecutionController.Client;
 
@@ -32,6 +44,7 @@ describe('ExecutionController', () => {
                 client = new ExecutionController.Client({
                     executionControllerUrl: 'http://idk.example.com',
                     workerId: 'hello',
+                    workerDisconnectTimeout: 1000,
                     actionTimeout: 1000,
                     connectTimeout: 1000,
                     socketOptions: {
@@ -85,6 +98,7 @@ describe('ExecutionController', () => {
                 workerId,
                 executionControllerUrl,
                 networkLatencyBuffer: 0,
+                workerDisconnectTimeout: 1000,
                 actionTimeout: 1000,
                 connectTimeout: 1000,
                 socketOptions: {

--- a/packages/teraslice-messaging/test/messenger-spec.ts
+++ b/packages/teraslice-messaging/test/messenger-spec.ts
@@ -226,6 +226,7 @@ describe('Messenger', () => {
                     clientId,
                     clientType: 'example',
                     hostUrl,
+                    clientDisconnectTimeout: 1000,
                     networkLatencyBuffer: 0,
                     actionTimeout: 1000,
                     connectTimeout: 2000,

--- a/packages/teraslice/lib/workers/execution-controller/index.js
+++ b/packages/teraslice/lib/workers/execution-controller/index.js
@@ -49,6 +49,7 @@ class ExecutionController {
             executionContext,
             networkLatencyBuffer,
             actionTimeout,
+            nodeDisconnectTimeout,
             connectTimeout: nodeDisconnectTimeout,
             exId: executionContext.exId,
             logger
@@ -944,7 +945,7 @@ class ExecutionController {
 
         const timeout = this.context.sysconfig.teraslice.slicer_timeout;
         const err = new Error(
-            `No workers have connected to slicer in the allotted time: ${timeout} ms`
+            `No workers have connected to slicer in the allotted time: ${ms(timeout)}`
         );
 
         this.workerConnectTimeoutId = setTimeout(() => {

--- a/packages/teraslice/lib/workers/worker/index.js
+++ b/packages/teraslice/lib/workers/worker/index.js
@@ -37,6 +37,8 @@ class Worker {
             workerId,
             networkLatencyBuffer,
             workerDisconnectTimeout,
+            // the connect timeout should be set to the same timeout that will
+            // cause the execution fail if no Workers connect
             connectTimeout: slicerTimeout,
             actionTimeout,
             logger

--- a/packages/teraslice/lib/workers/worker/index.js
+++ b/packages/teraslice/lib/workers/worker/index.js
@@ -29,13 +29,15 @@ class Worker {
         const networkLatencyBuffer = get(config, 'network_latency_buffer');
         const actionTimeout = get(config, 'action_timeout');
         const workerDisconnectTimeout = get(config, 'worker_disconnect_timeout');
+        const slicerTimeout = get(config, 'slicer_timeout');
         const shutdownTimeout = get(config, 'shutdown_timeout');
 
         this.client = new ExecutionController.Client({
             executionControllerUrl: formatURL(slicerHostname, slicerPort),
             workerId,
             networkLatencyBuffer,
-            connectTimeout: workerDisconnectTimeout,
+            workerDisconnectTimeout,
+            connectTimeout: slicerTimeout,
             actionTimeout,
             logger
         });
@@ -150,7 +152,7 @@ class Worker {
 
             await this.slice.run();
 
-            this.logger.info(`slice ${sliceId} complete`);
+            this.logger.info(`slice ${sliceId} completed`);
 
             await this._sendSliceComplete({
                 slice: this.slice.slice,

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.55.4",
+    "version": "0.55.5",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "@terascope/elasticsearch-api": "^2.1.4",
         "@terascope/job-components": "^0.21.1",
         "@terascope/queue": "^1.1.6",
-        "@terascope/teraslice-messaging": "^0.4.0",
+        "@terascope/teraslice-messaging": "^0.4.1",
         "@terascope/utils": "^0.16.1",
         "async-mutex": "^0.1.3",
         "barbe": "^3.0.15",

--- a/packages/teraslice/test/workers/execution-controller/execution-special-test-cases-spec.js
+++ b/packages/teraslice/test/workers/execution-controller/execution-special-test-cases-spec.js
@@ -275,6 +275,7 @@ describe('ExecutionController Special Tests', () => {
                     executionControllerUrl: `http://localhost:${port}`,
                     workerId,
                     networkLatencyBuffer,
+                    workerDisconnectTimeout: 5000,
                     actionTimeout,
                     connectTimeout: 1000,
                     socketOptions

--- a/packages/teraslice/test/workers/execution-controller/execution-test-cases-spec.js
+++ b/packages/teraslice/test/workers/execution-controller/execution-test-cases-spec.js
@@ -227,6 +227,7 @@ describe('ExecutionController Test Cases', () => {
                     executionControllerUrl: `http://localhost:${port}`,
                     workerId,
                     networkLatencyBuffer,
+                    workerDisconnectTimeout: 1000,
                     actionTimeout,
                     connectTimeout: 1000,
                     socketOptions


### PR DESCRIPTION
Set the `pingTimeout` on the `socket.io` client to be `worker_disconnect_timeout` to avoid disconnecting the client before the connection is actually dead.