### PR TITLE
Add more DataEntity methods

### DIFF
--- a/docs/jobs/data-entities.md
+++ b/docs/jobs/data-entities.md
@@ -237,32 +237,9 @@ dataEntity.setKey('bar');
 expect(dataEntity.getKey()).toEqual('bar');
 ```
 
-### DataEntity->getTime
+### DataEntity->getCreateTime
 
-Given a time field get the from metadata, returns a date.
-If none is found, `undefined` will be returned.
-If an invalid date is found, `false` will be returned.
-
-```js
-'use strict';
-
-const { DataEnity } = require('@terascope/utils');
-
-const dataEntity = new DataEntity({}, {
-    _key: 'foo',
-    _ingestTime: 'invalid-time'
-});
-
-expect(dataEntity.getTime('_eventTime')).toBe(undefined);
-expect(dataEntity.getTime('_ingestTime')).toBe(false);
-expect(dataEntity.getTime('_createTime')).toBeDate();
-```
-
-### DataEntity->setTime
-
-Given a time field and a valid date format, set the time field in the metadata using a UNIX Epoch time (milliseconds since 1970). If the value is empty it will set the time to now. If an invalid date is given, an error will be thrown.
-
-Any date formated accepted by [JavaScript Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Parameters) can be used.
+Get the time at which this entity was created.
 
 ```js
 'use strict';
@@ -271,17 +248,124 @@ const { DataEnity } = require('@terascope/utils');
 
 const dataEntity = new DataEntity();
 
-expect(() => {
-    dataEntity.setTime('_createTime', new Date());
-}).toThrowError();
+expect(dataEntity.getCreateTime()).toBeDate();
+```
 
-expect(() => {
-    dataEntity.setTime('_ingestTime', 'invalid-time');
-}).toThrowError();
+### DataEntity->getIngestTime / DataEntity->setIngestTime
 
-dataEntity.setTime('_processTime'); // sets the time to now
-dataEntity.setTime('_eventTime', '2019-09-06T16:13:24.439Z');
-dataEntity.setTime('_eventTime', Date.now() - 5000);
+The time at which the data was ingested into the source data.
+
+`->getIngestTime`:
+
+- If none is found, `undefined` will be returned.
+- If an invalid date is found, `false` will be returned.
+
+`->setIngestTime`:
+
+- If the value is empty it will set the time to now.
+- If an invalid date is given, an error will be thrown.
+
+Any date formated accepted by [JavaScript Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Parameters) can be used.
+
+```js
+'use strict';
+
+const { DataEnity } = require('@terascope/utils');
+
+const dataEntity = new DataEntity({}, {
+    _key: 'foo'
+});
+
+expect(dataEntity.getIngestTime()).toBe(undefined);
+
+// if nothing is passed in it is set Date.now()
+dataEntity.setIngestTime();
+// use a date
+dataEntity.setIngestTime(new Date());
+// use a ISO or JavaScript Date string
+dataEntity.setIngestTime('2019-09-06T16:13:24.439Z');
+// use a UNIX epoch time
+dataEntity.setIngestTime(Date.now() - 1000);
+
+expect(dataEntity.getIngestTime()).toBeDate();
+```
+
+### DataEntity->getProcessTime / DataEntity->setProcessTime
+
+The time at which the data was consumed by the reader.
+
+`->getProcessTime`:
+
+- If none is found, `undefined` will be returned.
+- If an invalid date is found, `false` will be returned.
+
+`->setProcessTime`:
+
+- If the value is empty it will set the time to now.
+- If an invalid date is given, an error will be thrown.
+
+Any date formated accepted by [JavaScript Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Parameters) can be used.
+
+```js
+'use strict';
+
+const { DataEnity } = require('@terascope/utils');
+
+const dataEntity = new DataEntity({}, {
+    _key: 'foo'
+});
+
+expect(dataEntity.getProcessTime()).toBe(undefined);
+
+// if nothing is passed in it is set Date.now()
+dataEntity.setProcessTime();
+// use a date
+dataEntity.setProcessTime(new Date());
+// use a ISO or JavaScript Date string
+dataEntity.setProcessTime('2019-09-06T16:13:24.439Z');
+// use a UNIX epoch time
+dataEntity.setProcessTime(Date.now() - 1000);
+
+expect(dataEntity.getProcessTime()).toBeDate();
+```
+
+### DataEntity->getEventTime / DataEntity->setEventTime
+
+The time associated from a specific field on source data or message.
+
+`->getEventTime`:
+
+- If none is found, `undefined` will be returned.
+- If an invalid date is found, `false` will be returned.
+
+`->setEventTime`:
+
+- If the value is empty it will set the time to now.
+- If an invalid date is given, an error will be thrown.
+
+Any date formated accepted by [JavaScript Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Parameters) can be used.
+
+```js
+'use strict';
+
+const { DataEnity } = require('@terascope/utils');
+
+const dataEntity = new DataEntity({}, {
+    _key: 'foo'
+});
+
+expect(dataEntity.getEventTime()).toBe(undefined);
+
+// if nothing is passed in it is set Date.now()
+dataEntity.setEventTime();
+// use a date
+dataEntity.setEventTime(new Date());
+// use a ISO or JavaScript Date string
+dataEntity.setEventTime('2019-09-06T16:13:24.439Z');
+// use a UNIX epoch time
+dataEntity.setEventTime(Date.now() - 1000);
+
+expect(dataEntity.getEventTime()).toBeDate();
 ```
 
 ### DataEntity->getRawData

--- a/docs/jobs/data-entities.md
+++ b/docs/jobs/data-entities.md
@@ -10,7 +10,7 @@ Check out the [API docs](../packages/utils/api/classes/dataentity.md) for more d
 
 ### new DataEntity
 
-This is more straightforward way of creating data entities but since it shallow clones the input, it is slower than `DataEntity.make`.
+This is more straightforward way of creating data entities but since `DataEntity.make` safely handles a `DataEntity` input and has potential performance improvements it is recommended to use that in production.
 
 ```js
 'use strict';
@@ -39,15 +39,10 @@ expect(dataEntity).toEqual(input);
 expect(DataEntity.isDataEntity(input)).toBeFalse();
 expect(DataEntity.isDataEntity(dataEntity)).toBeTrue();
 
-// use the method getMetadata to contain the metadata passed in
-expect(dataEntity.getMetadata()).toMatchObject(metadata);
-// it should set the _createTime timestamp
-expect(dataEntity.getMetadata('_createTime')).toBeNumber();
-// get a specific key
-expect(dataEntity.getMetadata('from')).toEqual('test');
-// should be able to set a specific key
-dataEntity.setMetadata('touchedAt', Date.now());
-expect(dataEntity.getMetadata('touchedAt')).toBeNumber();
+// should be able to set a time key key
+dataEntity.setTime('_eventTime', new Date());
+// it will set the getTime field
+expect(dataEntity.getTime('_eventTime')).toBeNumber();
 
 // should be able to convert it to a buffer
 expect(dataEntity.toBuffer()).toEqual(Buffer.from(JSON.stringify(dataEntity)));
@@ -55,13 +50,7 @@ expect(dataEntity.toBuffer()).toEqual(Buffer.from(JSON.stringify(dataEntity)));
 
 ### DataEntity.make
 
-A utility for safely converting an object a `DataEntity`. If the input is a DataEntity it will return it and have no side-effect. If you want a create new DataEntity from an existing DataEntity either use `new DataEntity` or shallow clone the input before
-passing it to `DataEntity.make`.
-
-**NOTE:** `DataEntity.make` is different from using `new DataEntity`
-because it attaching it doesn't shallow cloning the object
-onto the `DataEntity` instance, this is significatly faster and so it
-is recommended to use this in production.
+A utility for safely converting an object a `DataEntity`. If the input is a DataEntity it will return it and have no side-effect. If you want a create new DataEntity from an existing DataEntity either use `new DataEntity` or shallow clone the input before passing it to `DataEntity.make`.
 
 ```js
 'use strict';
@@ -76,24 +65,16 @@ const input = {
     }
 };
 
-const metadata = {
-    from: 'test'
-}
+const dataEntity = DataEntity.make(input);
+const result = DataEntity.make(dataEntity);
+expect(result).toBe(dataEntity);
 
-const dataEntity = DataEntity.make(input, metadata);
-
-// the input should NOT have been shallow cloned
-expect(dataEntity).toBe(input);
-expect(dataEntity).toEqual(input);
-expect(DataEntity.isDataEntity(input)).toBeTrue();
-expect(DataEntity.isDataEntity(dataEntity)).toBeTrue();
-
-// otherwise the behavoir should be the same as new DataEntity.
+// the behavoir should be the same as new DataEntity.
 ```
 
 ### DataEntity.makeArray
 
-A utility for safely converting an input of an object, or an array of objects, to an array of DataEntities. This will detect if passed an already converted input and return it. Since this uses `DataEntity.make` under the hood it won't shallow clone the input.
+A utility for safely converting an input of an object, or an array of objects, to an array of DataEntities. This will detect if passed an already converted input and return it.
 
 ```js
 'use strict';
@@ -114,6 +95,267 @@ expect(dataEntites).toBeArrayOfSize(2);
 expect(DataEntity.isDataEntityArray(dataEntities)).toBeTrue();
 ```
 
+### DataEntity.fork
+
+Create a new instance of a DataEntity. If the second param `withData` is set to `true` both the data and metadata will be forked, if set to `false` only the metadata will be copied. Defaults to `true`.
+
+```js
+const { DataEnity } = require('@terascope/utils');
+
+const input = {
+    foo: 'bar',
+};
+
+const metadata = {
+    _key: 'hello'
+};
+
+const dataEntity = DataEntity.make(input, metadata);
+
+// this is the default behavior
+const forkedWithData = DataEntity.fork(dataEntity, true);
+expect(forkedWithData).not.toBe(dataEntity);
+expect(forkedWithData).toHaveProperty('foo', 'bar');
+expect(forkedWithData.getKey()).toBe('hello');
+
+// useful for create barebones instance with the same metadata
+const forkedWithoutData = DataEntity.fork(dataEntity, false);
+expect(forkedWithoutData).not.toBe(dataEntity);
+expect(forkedWithoutData).not.toHaveProperty('foo', 'bar');
+expect(forkedWithData.getKey()).toBe('hello');
+```
+
+### DataEntity.fromBuffer
+
+A utility for converting a `Buffer` to a `DataEntity`, using the DataEntity encoding.
+
+```js
+const { DataEnity } = require('@terascope/utils');
+
+const jsonBuffer = Buffer.from(JSON.stringify({ foo: 'bar' }));
+const dataEntity = DataEntity.fromBuffer(jsonBuffer, {
+    // defaults to json
+    _encoding: 'json'
+});
+expect(dataEntity).toHaveProperty('foo', 'bar');
+
+const rawDataEntity = DataEntity.fromBuffer(jsonBuffer, {
+    // defaults to json
+    _encoding: 'raw'
+});
+
+expect(rawDataEntity).not.toHaveProperty('foo', 'bar');
+expect(rawDataEntity.getRawData().toString('utf8')).toEqual(jsonBuffer.toString('utf8'))
+```
+
+### DataEntity->getMetadata
+
+Get the metadata for the DataEntity. If a field is specified, it will get that property of the metadata.
+
+```js
+'use strict';
+
+const { DataEnity } = require('@terascope/utils');
+
+const metadata = {
+    from: 'test'
+}
+const dataEntity = new DataEntity({}, metadata);
+
+expect(dataEntity.getMetadata()).toMatchObject(metadata);
+expect(dataEntity.getMetadata('_createTime')).toBeNumber();
+expect(dataEntity.getMetadata('from')).toEqual('test');
+
+dataEntity.setMetadata('touched', 1);
+expect(dataEntity.getMetadata('touched')).toBeNumber();
+```
+
+### DataEntity->setMetadata
+
+Given a field and value set the metadata on the record. The field cannot be empty or `_createTime`.
+
+```js
+'use strict';
+
+const { DataEnity } = require('@terascope/utils');
+
+const dataEntity = new DataEntity();
+
+expect(() => {
+    dataEntity.setMetadata('_createTime');
+}).toThrow();
+
+expect(() => {
+    dataEntity.setMetadata('');
+}).toThrow();
+
+dataEntity.setMetadata('touched', 1);
+expect(dataEntity.getMetadata('touched')).toBeNumber();
+```
+
+### DataEntity->getKey
+
+Get the unique document `_key` from the metadata. If no `_key` is found, an error will be thrown. The key can be a `number` of `string`.
+
+```js
+'use strict';
+
+const { DataEnity } = require('@terascope/utils');
+
+expect(() => {
+    new DataEntity().getKey();
+}).toThrow();
+
+const dataEntity = new DataEntity({}, {
+    _key: 'foo'
+});
+expect(dataEntity.getKey()).toEqual('foo');
+```
+
+### DataEntity->setKey
+
+Set the unique document `_key` from the metadata. If no `_key` is found, an error will be thrown
+
+```js
+'use strict';
+
+const { DataEnity } = require('@terascope/utils');
+
+expect(() => {
+    new DataEntity().setKey({ invalid: 'key' });
+}).toThrow();
+
+expect(() => {
+    new DataEntity().setKey(null);
+}).toThrow();
+
+const dataEntity = new DataEntity({}, {
+    _key: 'foo'
+});
+
+dataEntity.setKey('bar');
+expect(dataEntity.getKey()).toEqual('bar');
+```
+
+### DataEntity->getTime
+
+Given a time field get the from metadata, returns a date.
+If none is found, `undefined` will be returned.
+If an invalid date is found, `false` will be returned.
+
+```js
+'use strict';
+
+const { DataEnity } = require('@terascope/utils');
+
+const dataEntity = new DataEntity({}, {
+    _key: 'foo',
+    _ingestTime: 'invalid-time'
+});
+
+expect(dataEntity.getTime('_eventTime')).toBe(undefined);
+expect(dataEntity.getTime('_ingestTime')).toBe(false);
+expect(dataEntity.getTime('_createTime')).toBeDate();
+```
+
+### DataEntity->setTime
+
+Given a time field and a valid date format, set the time field in the metadata using a UNIX Epoch time (milliseconds since 1970). If the value is empty it will set the time to now. If an invalid date is given, an error will be thrown.
+
+Any date formated accepted by [JavaScript Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Parameters) can be used.
+
+```js
+'use strict';
+
+const { DataEnity } = require('@terascope/utils');
+
+const dataEntity = new DataEntity();
+
+expect(() => {
+    dataEntity.setTime('_createTime', new Date());
+}).toThrowError();
+
+expect(() => {
+    dataEntity.setTime('_ingestTime', 'invalid-time');
+}).toThrowError();
+
+dataEntity.setTime('_processTime'); // sets the time to now
+dataEntity.setTime('_eventTime', '2019-09-06T16:13:24.439Z');
+dataEntity.setTime('_eventTime', Date.now() - 5000);
+```
+
+### DataEntity->getRawData
+
+Get the raw data, usually used for encoding type `raw`. If there is no data, an error will be thrown.
+
+```js
+'use strict';
+
+const { DataEnity } = require('@terascope/utils');
+
+expect(() => {
+    new DataEntity().getRawData();
+}).toThrowError();
+
+const buf = Buffer.from('foo:bar');
+const dataEntity = DataEntity.fromBuffer(buf, {
+    _encoding: 'raw'
+});
+
+expect(dataEntity.getRawData()).toBe(buf);
+```
+
+### DataEntity->setRawData
+
+Set the raw data, usually used for encoding type `raw`. If given `null`, it will unset the data.
+
+```js
+'use strict';
+
+const { DataEnity } = require('@terascope/utils');
+
+const dataEntity = new DataEntity();
+
+expect(() => {
+    dataEntity.setRawData();
+}).toThrowError();
+
+expect(() => {
+    dataEntity.setRawData({ invalid: 'buffer' });
+}).toThrowError();
+
+dataEntity.setRawData(Buffer.from('test'));
+// when given string it will convert it to a buffer
+dataEntity.setRawData('test');
+
+// when given null it will unset the data
+dataEntity.setRawData(null);
+```
+
+### DataEntity->toBuffer
+
+Convert the DataEntity to an encoded buffer.
+
+```js
+'use strict';
+
+const { DataEnity } = require('@terascope/utils');
+
+const dataEntity = new DataEntity({
+    foo: 'bar'
+});
+
+dataEntity.toBuffer({
+    // this is the default
+    _encoding: 'json'
+}); // this should out put a buffer with {"foo":"bar"}
+
+dataEntity.setRawData(Buffer.from('foo:bar'))
+dataEntity.toBuffer({
+    _encoding: 'raw'
+}); // this should out put a buffer with 'foo:bar'
+```
+
 ## Conventional Metadata
 
 As a convention we use the following metadata keys in many of our asset bundles
@@ -124,6 +366,6 @@ As a convention we use the following metadata keys in many of our asset bundles
 | `_ingestTime`  | The time at which the data was ingested into the source data                                         | `Unix Timestamp` | optional                        |
 | `_processTime` | The time at which the data was consumed by the reader                                                | `Unix Timestamp` | optional                        |
 | `_eventTime`   | The time associated with this data entity, usually off of a specific field on source data or message | `Unix Timestamp` | optional                        |
-| `_key`         | A unique key for the data which will be can be used to key the data                                  | `String`         | optional                        |
+| `_key`         | A unique key for the data which will be can be used to key the data                                  | `String|Number`  | optional                        |
 
 Checkout [this Github issue](https://github.com/terascope/teraslice/issues/950) for more details.

--- a/docs/jobs/types-of-operations.md
+++ b/docs/jobs/types-of-operations.md
@@ -129,7 +129,7 @@ export default class ExampleBatchProcessor extends BatchProcessor {
         let keys: string = [];
 
         for (const dataEntity of dataEntities) {
-            keys.push(dataEntity.getMetadata('_key'));
+            keys.push(dataEntity.getKey());
         }
 
         this.batchedKeys.push(keys);

--- a/packages/chunked-file-reader/package.json
+++ b/packages/chunked-file-reader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/chunked-file-reader",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "description": "This module is an abstracted reader for use in various Teraslice readers. It uses an externally-defined reader to read data and the packages up the data in a DataEntity for use with other Teraslice processors.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/chunked-file-reader#readme",
     "bugs": {
@@ -20,7 +20,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.17.1",
+        "@terascope/utils": "^0.18.0",
         "bluebird": "^3.5.5",
         "csvtojson": "^2.0.8",
         "lodash": "^4.17.11"

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/data-types",
-    "version": "0.5.7",
+    "version": "0.5.8",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.17.1",
+        "@terascope/utils": "^0.18.0",
         "graphql": "^14.3.1",
         "lodash.defaultsdeep": "^4.6.1",
         "lodash.set": "^4.3.2",
@@ -37,7 +37,7 @@
         "@types/lodash.defaultsdeep": "^4.6.6",
         "@types/lodash.set": "^4.3.6",
         "@types/yargs": "^13.0.2",
-        "xlucene-evaluator": "^0.10.2"
+        "xlucene-evaluator": "^0.10.3"
     },
     "engines": {
         "node": ">=8.0.0"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/elasticsearch-api",
-    "version": "2.1.5",
+    "version": "2.1.6",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -17,7 +17,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.17.1",
+        "@terascope/utils": "^0.18.0",
         "bluebird": "^3.5.5",
         "lodash": "^4.17.11"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "elasticsearch-store",
-    "version": "0.11.4",
+    "version": "0.11.5",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -23,12 +23,12 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.5.7",
-        "@terascope/utils": "^0.17.1",
+        "@terascope/data-types": "^0.5.8",
+        "@terascope/utils": "^0.18.0",
         "ajv": "^6.10.0",
         "nanoid": "^2.0.3",
         "rambda": "^3.0.0",
-        "xlucene-evaluator": "^0.10.2"
+        "xlucene-evaluator": "^0.10.3"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/job-components",
-    "version": "0.23.2",
+    "version": "0.23.3",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.7",
-        "@terascope/utils": "^0.17.1",
+        "@terascope/utils": "^0.18.0",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^3.3.3"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.14.0",
-        "@terascope/utils": "^0.17.1",
+        "@terascope/utils": "^0.18.0",
         "@types/is-ci": "^2.0.0",
         "codecov": "^3.5.0",
         "execa": "^2.0.4",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "terafoundation",
-    "version": "0.12.2",
+    "version": "0.12.3",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -21,7 +21,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.17.1",
+        "@terascope/utils": "^0.18.0",
         "aws-sdk": "^2.513.0",
         "bluebird": "^3.5.5",
         "bunyan": "^1.8.12",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-cli",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.6.0",
-        "@terascope/utils": "^0.17.1",
+        "@terascope/utils": "^0.18.0",
         "archiver": "^3.0.0",
         "bluebird": "^3.5.5",
         "chalk": "^2.4.2",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -29,7 +29,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.23.2",
+        "@terascope/job-components": "^0.23.3",
         "auto-bind": "^2.1.0",
         "got": "^9.6.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-messaging",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.7",
-        "@terascope/utils": "^0.17.1",
+        "@terascope/utils": "^0.18.0",
         "ms": "^2.1.2",
         "nanoid": "^2.0.3",
         "p-event": "^4.1.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -17,7 +17,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.23.2",
+        "@terascope/job-components": "^0.23.3",
         "bluebird": "^3.5.5",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-state-storage",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.5",
-        "@terascope/utils": "^0.17.1",
+        "@terascope/elasticsearch-api": "^2.1.6",
+        "@terascope/utils": "^0.18.0",
         "bluebird": "^3.5.5",
         "mnemonist": "^0.30.0"
     },

--- a/packages/teraslice-state-storage/src/cached-state-storage/index.ts
+++ b/packages/teraslice-state-storage/src/cached-state-storage/index.ts
@@ -16,11 +16,11 @@ export default class CachedStateStorage<T> extends EventEmitter {
         this._cache.items = new BigMap(config.max_big_map_size);
     }
 
-    get(key: string): T | undefined {
-        return this._cache.get(key);
+    get(key: string|number): T | undefined {
+        return this._cache.get(`${key}`);
     }
 
-    mget(keyArray: string[]): MGetCacheResponse {
+    mget(keyArray: (string|number)[]): MGetCacheResponse {
         return keyArray.reduce((cachedState, key) => {
             const state = this.get(key);
             if (state) cachedState[key] = state;
@@ -28,8 +28,8 @@ export default class CachedStateStorage<T> extends EventEmitter {
         }, {});
     }
 
-    set(key: string, value: T) {
-        const results = this._cache.setpop(key, value);
+    set(key: string|number, value: T) {
+        const results = this._cache.setpop(`${key}`, value);
         if (results && results.evicted) {
             this.emit('eviction', { key: results.key, data: results.value } as EvictedEvent<T>);
         }
@@ -56,8 +56,8 @@ export default class CachedStateStorage<T> extends EventEmitter {
         }
     }
 
-    has(key: string) {
-        return this._cache.has(key);
+    has(key: string|number) {
+        return this._cache.has(`${key}`);
     }
 
     clear() {

--- a/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
+++ b/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
@@ -55,7 +55,7 @@ export default class ESCachedStateStorage {
                 context: { doc }
             });
         }
-        return key;
+        return `${key}`;
     }
 
     async mset(docArray: DataEntity[]) {
@@ -76,7 +76,7 @@ export default class ESCachedStateStorage {
         return this.setCacheByKey(key, doc);
     }
 
-    setCacheByKey(key: string, doc: DataEntity): void {
+    setCacheByKey(key: string|number, doc: DataEntity): void {
         return this.cache.set(key, doc);
     }
 
@@ -85,7 +85,7 @@ export default class ESCachedStateStorage {
         return this.getFromCacheByKey(key);
     }
 
-    getFromCacheByKey(key: string) {
+    getFromCacheByKey(key: string|number) {
         return this.cache.get(key);
     }
 
@@ -94,7 +94,7 @@ export default class ESCachedStateStorage {
         return this.isKeyCached(key);
     }
 
-    isKeyCached(key: string) {
+    isKeyCached(key: string|number) {
         return this.cache.has(key);
     }
 

--- a/packages/teraslice-state-storage/src/interfaces.ts
+++ b/packages/teraslice-state-storage/src/interfaces.ts
@@ -27,6 +27,6 @@ export interface EvictedEvent<T> {
 }
 
 export interface SetTuple<T> {
-    key: string;
+    key: string|number;
     data: T;
 }

--- a/packages/teraslice-state-storage/test/cache-state-storage-spec.ts
+++ b/packages/teraslice-state-storage/test/cache-state-storage-spec.ts
@@ -21,9 +21,9 @@ describe('Cache Storage State', () => {
 
     const formattedMSet: SetTuple<DataEntity>[] = docArray.map((obj) => ({
         data: obj,
-        key: obj.getMetadata(idField)
+        key: obj.getKey()
     }));
-    const formattedMGet = docArray.map((data) => data.getMetadata(idField));
+    const formattedMGet = docArray.map((data) => data.getKey());
 
     const config = {
         id_field: idField,
@@ -41,13 +41,13 @@ describe('Cache Storage State', () => {
     });
 
     it('set should add items to the storage', () => {
-        const key = doc.getMetadata(idField);
+        const key = doc.getKey();
         cache.set(key, doc);
         expect(cache.count()).toBe(1);
     });
 
     it('get should return data from storage', () => {
-        const key = doc.getMetadata(idField);
+        const key = doc.getKey();
         cache.set(key, doc);
         const cachedData = cache.get(key);
 
@@ -56,7 +56,7 @@ describe('Cache Storage State', () => {
     });
 
     it('get should return undefined if not stored', () => {
-        const key = doc.getMetadata(idField);
+        const key = doc.getKey();
         const cachedData = cache.get(key);
         expect(cachedData).toBeUndefined();
     });
@@ -91,7 +91,7 @@ describe('Cache Storage State', () => {
             const id = Number(idStr);
             expect(data[id]).toEqual(docArray[id - 1]);
             expect(DataEntity.isDataEntity(data[id])).toEqual(true);
-            const metaId = data[id].getMetadata(idField);
+            const metaId = data[id].getKey();
             expect(metaId).toEqual(idStr);
         });
     });

--- a/packages/teraslice-state-storage/test/cache-state-storage-spec.ts
+++ b/packages/teraslice-state-storage/test/cache-state-storage-spec.ts
@@ -5,7 +5,7 @@ import { CachedStateStorage, SetTuple, EvictedEvent } from '../src';
 describe('Cache Storage State', () => {
     const idField = '_key';
 
-    const doc = DataEntity.make({ data: 'thisIsSomeData' }, { [idField]: 1 });
+    const doc = DataEntity.make({ data: 'thisIsSomeData' }, { [idField]: '1' });
 
     const docArray = [
         {
@@ -17,7 +17,7 @@ describe('Cache Storage State', () => {
         {
             data: 'thisIsThirdData',
         },
-    ].map((obj, index) => DataEntity.make(obj, { [idField]: index + 1 }));
+    ].map((obj, index) => DataEntity.make(obj, { [idField]: `${index + 1}` }));
 
     const formattedMSet: SetTuple<DataEntity>[] = docArray.map((obj) => ({
         data: obj,
@@ -92,7 +92,7 @@ describe('Cache Storage State', () => {
             expect(data[id]).toEqual(docArray[id - 1]);
             expect(DataEntity.isDataEntity(data[id])).toEqual(true);
             const metaId = data[id].getMetadata(idField);
-            expect(metaId).toEqual(id);
+            expect(metaId).toEqual(idStr);
         });
     });
 

--- a/packages/teraslice-state-storage/test/elasticsearch-state-storage-spec.ts
+++ b/packages/teraslice-state-storage/test/elasticsearch-state-storage-spec.ts
@@ -138,7 +138,7 @@ describe('elasticsearch-state-storage', () => {
 
         describe('when the record is in the cache', () => {
             const doc = makeTestDoc();
-            const key = doc.getMetadata('_key');
+            const key = doc.getKey();
             beforeEach(() => {
                 stateStorage.set(doc);
             });
@@ -157,7 +157,7 @@ describe('elasticsearch-state-storage', () => {
 
     describe('->isCached', () => {
         const doc = makeTestDoc();
-        const key = doc.getMetadata('_key');
+        const key = doc.getKey();
 
         beforeAll(async () => {
             await setup();
@@ -324,7 +324,7 @@ describe('elasticsearch-state-storage', () => {
             keys.forEach((id: string) => {
                 expect(stateResponse[id]).toEqual(docObj[id]);
                 expect(DataEntity.isDataEntity(stateResponse[id])).toEqual(true);
-                const metaId = stateResponse[id].getMetadata('_key');
+                const metaId = stateResponse[id].getKey();
                 expect(metaId).toEqual(id);
             });
         });
@@ -359,12 +359,12 @@ describe('elasticsearch-state-storage', () => {
         const updateFnResults: { key: string; current: DataEntity; prev?: DataEntity }[] = [];
         const fn: UpdateCacheFn = (key, current, prev) => {
             updateFnResults.push({ key, current, prev });
-            if (key === inCacheCurrent.getMetadata('_key')) {
+            if (key === inCacheCurrent.getKey()) {
                 inCacheCurrent.seen = true;
                 return current;
             }
-            if (key === inCacheUpdated.getMetadata('_key')) return false;
-            if (key === inCacheChanged.getMetadata('_key')) {
+            if (key === inCacheUpdated.getKey()) return false;
+            if (key === inCacheChanged.getKey()) {
                 return newInCacheChanged;
             }
             return true;
@@ -410,7 +410,7 @@ describe('elasticsearch-state-storage', () => {
         });
 
         it('should handle the current cache record correctly', () => {
-            const key = inCacheCurrent.getMetadata('_key');
+            const key = inCacheCurrent.getKey();
             const results = updateFnResults.filter((result) => result.key === key);
             expect(results).toBeArrayOfSize(1);
             const { current, prev } = results[0];
@@ -428,7 +428,7 @@ describe('elasticsearch-state-storage', () => {
         it('should handle the updated cache record correctly', () => {
             expect(inCacheUpdated).not.toBe(prevInCacheUpdated);
 
-            const key = inCacheUpdated.getMetadata('_key');
+            const key = inCacheUpdated.getKey();
 
             const results = updateFnResults.filter((result) => result.key === key);
             expect(results).toBeArrayOfSize(1);
@@ -447,7 +447,7 @@ describe('elasticsearch-state-storage', () => {
         it('should handle the new cache record correctly', () => {
             expect(inCacheChanged).not.toBe(newInCacheChanged);
 
-            const key = inCacheChanged.getMetadata('_key');
+            const key = inCacheChanged.getKey();
             const results = updateFnResults.filter((result) => result.key === key);
             expect(results).toBeArrayOfSize(1);
             const { current, prev } = results[0];
@@ -463,7 +463,7 @@ describe('elasticsearch-state-storage', () => {
         });
 
         it('should handle the current es record correctly (which was a duplicate)', () => {
-            const key = inESCurrent.getMetadata('_key');
+            const key = inESCurrent.getKey();
 
             const results = updateFnResults.filter((result) => result.key === key);
             expect(results).toBeArrayOfSize(2);
@@ -496,7 +496,7 @@ describe('elasticsearch-state-storage', () => {
         it('should handle the updated es record correctly', () => {
             expect(inESUpdated).not.toBe(prevInESUpdated);
 
-            const key = inESUpdated.getMetadata('_key');
+            const key = inESUpdated.getKey();
             const results = updateFnResults.filter((result) => result.key === key);
             expect(results).toBeArrayOfSize(1);
             const { current, prev } = results[0];
@@ -513,7 +513,7 @@ describe('elasticsearch-state-storage', () => {
         });
 
         it('should handle the NOT found in es record correctly', () => {
-            const key = notFoundInES.getMetadata('_key');
+            const key = notFoundInES.getKey();
 
             const results = updateFnResults.filter((result) => result.key === key);
             expect(results).toBeArrayOfSize(1);
@@ -590,14 +590,14 @@ function makeTestDoc() {
 function docsToObject(docs: DataEntity[]): { [key: string]: DataEntity } {
     const obj: { [key: string]: DataEntity } = {};
     for (const doc of docs) {
-        const key = doc.getMetadata('_key');
+        const key = doc.getKey();
         obj[key] = doc;
     }
     return obj;
 }
 
 function copyDataEntity(doc: DataEntity): DataEntity {
-    const key = doc.getMetadata('_key');
+    const key = doc.getKey();
     const updated = Object.assign({}, doc, { copy: `copy-${key}` });
     return DataEntity.make(updated, doc.getMetadata());
 }
@@ -622,7 +622,7 @@ class TestClient {
 
     createMGetResponse(dataArray: DataEntity[], found = true): ESMGetResponse {
         const docs = dataArray.map((item) => {
-            const id = item.getMetadata('_key');
+            const id = item.getKey();
             if (!id) throw new Error('Missing _key on test record');
             if (typeof id !== 'string') throw new Error('Invalid _key on test record');
 

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -30,7 +30,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.23.2",
+        "@terascope/job-components": "^0.23.3",
         "@terascope/teraslice-op-test-harness": "^1.7.5",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -32,11 +32,11 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.5",
-        "@terascope/job-components": "^0.23.2",
+        "@terascope/elasticsearch-api": "^2.1.6",
+        "@terascope/job-components": "^0.23.3",
         "@terascope/queue": "^1.1.7",
-        "@terascope/teraslice-messaging": "^0.4.1",
-        "@terascope/utils": "^0.17.1",
+        "@terascope/teraslice-messaging": "^0.4.2",
+        "@terascope/utils": "^0.18.0",
         "async-mutex": "^0.1.3",
         "barbe": "^3.0.15",
         "bluebird": "^3.5.5",
@@ -60,7 +60,7 @@
         "shortid": "^2.2.14",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.12.2",
+        "terafoundation": "^0.12.3",
         "uuid": "^3.3.3"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-transforms",
-    "version": "0.23.2",
+    "version": "0.23.3",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.17.1",
+        "@terascope/utils": "^0.18.0",
         "@types/graphlib": "^2.1.5",
         "@types/shortid": "^0.0.29",
         "awesome-phonenumber": "^2.15.0",
@@ -44,7 +44,7 @@
         "shortid": "^2.2.14",
         "valid-url": "^1.0.9",
         "validator": "^11.0.0",
-        "xlucene-evaluator": "^0.10.2",
+        "xlucene-evaluator": "^0.10.3",
         "yargs": "^14.0.0"
     },
     "devDependencies": {

--- a/packages/ts-transforms/src/operations/lib/transforms/extraction.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/extraction.ts
@@ -123,12 +123,12 @@ export default class Extraction {
     }
 
     run(doc: DataEntity): DataEntity | null {
-        let record;
+        let record: DataEntity;
 
         if (this.isMutation) {
             record = doc;
         } else {
-            record = DataEntity.makeRaw({}, doc.getMetadata()).entity;
+            record = DataEntity.fork(doc, false);
         }
 
         for (let i = 0; i < this.configs.length; i += 1) {

--- a/packages/ts-transforms/src/phases/extraction-phase.ts
+++ b/packages/ts-transforms/src/phases/extraction-phase.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/prefer-for-of */
 
-import { DataEntity } from '@terascope/utils';
 import _ from 'lodash';
+import { DataEntity } from '@terascope/utils';
 import { hasKeys } from './utils';
 import {
     WatcherConfig,
@@ -44,10 +44,10 @@ export default class ExtractionPhase extends PhaseBase {
     }
 }
 
-function createTargetResults(input: DataEntity) {
-    const { entity, metadata } = DataEntity.makeRaw({}, input.getMetadata());
+function createTargetResults(input: DataEntity): { entity: DataEntity; metadata: any } {
+    const entity = DataEntity.fork(input, false);
     return {
-        metadata,
+        metadata: entity.getMetadata(),
         entity,
     };
 }

--- a/packages/utils/bench/data-encoding-suite.js
+++ b/packages/utils/bench/data-encoding-suite.js
@@ -28,7 +28,7 @@ const run = async () => Suite('DataEncoding')
     .run({
         async: true,
         initCount: 1,
-        maxTime: 3,
+        maxTime: 5,
     });
 
 if (require.main === module) {

--- a/packages/utils/bench/data-entity-suite.js
+++ b/packages/utils/bench/data-entity-suite.js
@@ -74,8 +74,8 @@ const run = async () => Suite('DataEntity')
     .add('DataEntity.makeRaw', {
         fn() {
             const input = makeObj();
-            // eslint-disable-next-line
-                let entity = DataEntity.makeRaw(input, metadata).entity;
+            // eslint-disable-next-line prefer-destructuring
+            let entity = DataEntity.makeRaw(input, metadata).entity;
             entity.hello = Math.random();
             entity.hello;
             entity = null;
@@ -85,7 +85,7 @@ const run = async () => Suite('DataEntity')
     .run({
         async: true,
         initCount: 1,
-        maxTime: 3
+        maxTime: 5
     });
 
 if (require.main === module) {

--- a/packages/utils/bench/data-entity-suite.js
+++ b/packages/utils/bench/data-entity-suite.js
@@ -4,7 +4,7 @@
 
 const { Suite } = require('./helpers');
 const FakeDataEntity = require('./fixtures/fake-data-entity');
-const { DataEntity, times } = require('../dist/src');
+const { DataEntity, times, fastCloneDeep } = require('../dist/src');
 
 const data = {};
 
@@ -23,16 +23,12 @@ for (let i = 0; i < 50; i++) {
 
 data['big-array'] = times(50, (n) => `item-${n}`);
 
-function makeObj() {
-    return Object.assign({}, data);
-}
-
 const metadata = { id: Math.random() * 1000 * 1000 };
 
 const run = async () => Suite('DataEntity')
     .add('new data', {
         fn() {
-            const input = makeObj();
+            const input = fastCloneDeep(data);
             let entity = Object.assign({}, input);
             entity.metadata = Object.assign({}, metadata, { _createTime: Date.now() });
             entity.hello = Math.random();
@@ -43,7 +39,7 @@ const run = async () => Suite('DataEntity')
     })
     .add('new FakeDataEntity', {
         fn() {
-            const input = makeObj();
+            const input = fastCloneDeep(data);
             let entity = new FakeDataEntity(input, metadata);
             entity.hello = Math.random();
             entity.hello;
@@ -53,7 +49,7 @@ const run = async () => Suite('DataEntity')
     })
     .add('new DataEntity', {
         fn() {
-            const input = makeObj();
+            const input = fastCloneDeep(data);
             let entity = new DataEntity(input, metadata);
             entity.hello = Math.random();
             entity.hello;
@@ -63,7 +59,7 @@ const run = async () => Suite('DataEntity')
     })
     .add('DataEntity.make', {
         fn() {
-            const input = makeObj();
+            const input = fastCloneDeep(data);
             let entity = DataEntity.make(input, metadata);
             entity.hello = Math.random();
             entity.hello;
@@ -73,7 +69,7 @@ const run = async () => Suite('DataEntity')
     })
     .add('DataEntity.makeRaw', {
         fn() {
-            const input = makeObj();
+            const input = fastCloneDeep(data);
             // eslint-disable-next-line prefer-destructuring
             let entity = DataEntity.makeRaw(input, metadata).entity;
             entity.hello = Math.random();

--- a/packages/utils/bench/map-suite.js
+++ b/packages/utils/bench/map-suite.js
@@ -34,7 +34,7 @@ const run = async () => Suite('Map vs BigMap')
             return runTest(new BigMap());
         }
     })
-    .add('BigMap (mutliple maps)', {
+    .add('BigMap (multiple maps)', {
         fn() {
             return runTest(new BigMap(Math.round(iterationsPer / 2)));
         }
@@ -43,7 +43,7 @@ const run = async () => Suite('Map vs BigMap')
         async: true,
         minSamples: 3,
         initCount: 0,
-        maxTime: 3
+        maxTime: 5
     });
 
 if (require.main === module) {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/utils",
-    "version": "0.17.1",
+    "version": "0.18.0",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/dates.ts
+++ b/packages/utils/src/dates.ts
@@ -7,16 +7,27 @@ export function makeISODate(): string {
 
 /** A simplified implemation of moment(new Date(val)).isValid() */
 export function isValidDate(val: any): boolean {
-    const d = new Date(val);
-    // @ts-ignore
-    return d instanceof Date && !isNaN(d);
+    return getValidDate(val) !== false;
 }
 
 /** Check if the data is valid and return if it is */
 export function getValidDate(val: any): Date | false {
+    if (val == null) return false;
+    if (isValidDateInstance(val)) return val;
     const d = new Date(val);
-    // @ts-ignore
-    return d instanceof Date && !isNaN(d) && d;
+    return isValidDateInstance(d) && d;
+}
+
+export function isValidDateInstance(val: Date): boolean {
+    return val instanceof Date && !isNaN(val as any);
+}
+
+/** Ensure unix time */
+export function getUnixTime(val?: string|number|Date): number | false {
+    if (val == null) return Date.now();
+    const result = getValidDate(val);
+    if (result === false) return false;
+    return result.getTime();
 }
 
 /**

--- a/packages/utils/src/dates.ts
+++ b/packages/utils/src/dates.ts
@@ -14,6 +14,10 @@ export function isValidDate(val: any): boolean {
 export function getValidDate(val: any): Date | false {
     if (val == null) return false;
     if (isValidDateInstance(val)) return val;
+    if (typeof val === 'number'
+        && (val <= 0 || !Number.isSafeInteger(val))) {
+        return false;
+    }
     const d = new Date(val);
     return isValidDateInstance(d) && d;
 }

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -246,36 +246,100 @@ export class DataEntity<
     }
 
     /**
-     * Given a time field get the from metadata, returns a date
+     * Get the time at which this entity was created.
+    */
+    @locked()
+    getCreateTime(): Date {
+        const val = this[i.__DATAENTITY_METADATA_KEY].metadata._createTime;
+        const date = getValidDate(val);
+        if (date === false) {
+            throw new Error('Missing _createTime');
+        }
+        return date;
+    }
+
+    /**
+     * Get the time at which the data was ingested into the source data
+     *
      * If none is found, `undefined` will be returned.
      * If an invalid date is found, `false` will be returned.
     */
     @locked()
-    getTime(field: i.EntityTimeMetadataField): Date|false|undefined {
-        const val = this[i.__DATAENTITY_METADATA_KEY].metadata[field];
+    getIngestTime(): Date|false|undefined {
+        const val = this[i.__DATAENTITY_METADATA_KEY].metadata._ingestTime;
         if (val == null) return undefined;
         return getValidDate(val);
     }
 
     /**
-    * Given a time field and a valid date format, set the time
-    * field in the metadata using a UNIX Epoch time (milliseconds since 1970)
+     * Set the time at which the data was ingested into the source data
+     *
+     * If the value is empty it will set the time to now.
+     * If an invalid date is given, an error will be thrown.
+     */
+    @locked()
+    setIngestTime(val?: string|number|Date): void {
+        const unixTime = getUnixTime(val);
+        if (unixTime === false) {
+            throw new Error(`Invalid date format, got ${getTypeOf(val)}`);
+        }
+        this[i.__DATAENTITY_METADATA_KEY].metadata._ingestTime = unixTime;
+    }
+
+    /**
+     * Get the time at which the data was consumed by the reader
+     *
+     * If none is found, `undefined` will be returned.
+     * If an invalid date is found, `false` will be returned.
+    */
+    @locked()
+    getProcessTime(): Date|false|undefined {
+        const val = this[i.__DATAENTITY_METADATA_KEY].metadata._ingestTime;
+        if (val == null) return undefined;
+        return getValidDate(val);
+    }
+
+    /**
+    * Set the time at which the data was consumed by the reader
+    *
     * If the value is empty it will set the time to now.
     * If an invalid date is given, an error will be thrown.
     */
     @locked()
-    setTime(field: i.EntityTimeMetadataField, val?: string|number|Date): void {
-        if (!field) {
-            throw new Error('Missing field to set in metadata');
-        }
-        if (field === '_createTime') {
-            throw new Error(`Cannot set readonly metadata property ${field}`);
-        }
+    setProcessTime(val?: string|number|Date): void {
         const unixTime = getUnixTime(val);
         if (unixTime === false) {
-            throw new Error(`Invalid date format for field ${field}, got ${getTypeOf(val)}`);
+            throw new Error(`Invalid date format, got ${getTypeOf(val)}`);
         }
-        this[i.__DATAENTITY_METADATA_KEY].metadata[field] = unixTime;
+        this[i.__DATAENTITY_METADATA_KEY].metadata._ingestTime = unixTime;
+    }
+
+    /**
+     * Get time associated from a specific field on source data or message
+     *
+     * If none is found, `undefined` will be returned.
+     * If an invalid date is found, `false` will be returned.
+    */
+    @locked()
+    getEventTime(): Date|false|undefined {
+        const val = this[i.__DATAENTITY_METADATA_KEY].metadata._ingestTime;
+        if (val == null) return undefined;
+        return getValidDate(val);
+    }
+
+    /**
+     * Set time associated from a specific field on source data or message
+     *
+     * If the value is empty it will set the time to now.
+     * If an invalid date is given, an error will be thrown.
+     */
+    @locked()
+    setEventTime(val?: string|number|Date): void {
+        const unixTime = getUnixTime(val);
+        if (unixTime === false) {
+            throw new Error(`Invalid date format, got ${getTypeOf(val)}`);
+        }
+        this[i.__DATAENTITY_METADATA_KEY].metadata._ingestTime = unixTime;
     }
 
     /**

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -287,7 +287,7 @@ export class DataEntity<
     }
 
     /**
-     * Get the time at which the data was consumed by the reader
+     * Get the time at which the data was consumed by the reader.
      *
      * If none is found, `undefined` will be returned.
      * If an invalid date is found, `false` will be returned.

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -132,7 +132,7 @@ export class DataEntity<
     static isDataEntity<T extends AnyObject = AnyObject, M extends i.EntityMetadataType = any>(
         input: any
     ): input is DataEntity<T, M> {
-        return Boolean(input != null && input[i.__IS_ENTITY_KEY]);
+        return Boolean(input != null && input[i.__IS_ENTITY_KEY] === true);
     }
 
     /**

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -173,7 +173,7 @@ export class DataEntity<
         }
 
         utils.defineProperties(this);
-        this.__dataEntityMetadata.metadata = utils.makeMetadata(metadata);
+        this[i.__DATAENTITY_METADATA_KEY].metadata = utils.makeMetadata(metadata);
 
         if (data) {
             Object.assign(this, data);
@@ -190,9 +190,9 @@ export class DataEntity<
     @locked()
     getMetadata<K extends i.EntityMetadataKey<M>>(key?: K): i.EntityMetadataValue<M, K>|i.EntityMetadata<M> {
         if (key) {
-            return this.__dataEntityMetadata.metadata[key];
+            return this[i.__DATAENTITY_METADATA_KEY].metadata[key];
         }
-        return this.__dataEntityMetadata.metadata;
+        return this[i.__DATAENTITY_METADATA_KEY].metadata;
     }
 
     /**
@@ -210,7 +210,7 @@ export class DataEntity<
             throw new Error(`Cannot set readonly metadata property ${key}`);
         }
 
-        this.__dataEntityMetadata.metadata[key] = value as any;
+        this[i.__DATAENTITY_METADATA_KEY].metadata[key] = value as any;
     }
 
     /**
@@ -220,7 +220,7 @@ export class DataEntity<
 
     @locked()
     getRawData(): Buffer {
-        const buf = this.__dataEntityMetadata.rawData;
+        const buf = this[i.__DATAENTITY_METADATA_KEY].rawData;
         if (isBuffer(buf)) return buf;
         throw new Error('No data has been set');
     }
@@ -233,10 +233,10 @@ export class DataEntity<
     @locked()
     setRawData(buf: Buffer|string|null): void {
         if (buf == null) {
-            this.__dataEntityMetadata.rawData = null;
+            this[i.__DATAENTITY_METADATA_KEY].rawData = null;
             return;
         }
-        this.__dataEntityMetadata.rawData = ensureBuffer(buf, 'utf8');
+        this[i.__DATAENTITY_METADATA_KEY].rawData = ensureBuffer(buf, 'utf8');
     }
 
     /**
@@ -258,14 +258,6 @@ export class DataEntity<
         }
 
         throw new Error(`Unsupported encoding type, got "${_encoding}"`);
-    }
-
-    private get __dataEntityMetadata() {
-        return this[i.__DATAENTITY_METADATA_KEY];
-    }
-
-    private set __dataEntityMetadata(_value: i.__DataEntityProps<M>) {
-        throw new Error('Unable to set internal DataEntity metadata');
     }
 }
 

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -217,7 +217,6 @@ export class DataEntity<
      * Get the raw data, usually used for encoding type `raw`
      * If there is no data, an error will be thrown
     */
-
     @locked()
     getRawData(): Buffer {
         const buf = this[i.__DATAENTITY_METADATA_KEY].rawData;
@@ -229,7 +228,6 @@ export class DataEntity<
      * Set the raw data, usually used for encoding type `raw`
      * If given `null`, it will unset the data
     */
-
     @locked()
     setRawData(buf: Buffer|string|null): void {
         if (buf == null) {
@@ -245,7 +243,6 @@ export class DataEntity<
      * @param opConfig The operation config used to get the encoding type of the buffer,
      * @default `json`
      */
-
     @locked()
     toBuffer(opConfig: i.EncodingConfig = {}): Buffer {
         const { _encoding = i.DataEncoding.JSON } = opConfig;

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -189,9 +189,6 @@ export class DataEntity<
 
     @locked()
     getMetadata<K extends i.EntityMetadataKey<M>>(key?: K): i.EntityMetadataValue<M, K>|i.EntityMetadata<M> {
-        if (key === '_key') {
-            return this.getKey() as i.EntityMetadataValue<M, K>;
-        }
         if (key) {
             return this[i.__DATAENTITY_METADATA_KEY].metadata[key];
         }

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -20,7 +20,7 @@ import { locked } from '../misc';
  */
 export class DataEntity<
     T extends AnyObject = AnyObject,
-    M extends i.EntityMetadataType = any
+    M extends i.EntityMetadataType = {}
 > {
     /**
      * A utility for safely converting an object a `DataEntity`.
@@ -29,15 +29,15 @@ export class DataEntity<
      * either use `new DataEntity` or shallow clone the input before
      * passing it to `DataEntity.make`.
      */
-    static make<T extends DataEntity<any, any>, M extends i.EntityMetadataType = any>(
+    static make<T extends DataEntity<any, any>, M extends i.EntityMetadataType = {}>(
         input: T,
         metadata?: M
     ): T;
-    static make<T extends AnyObject = AnyObject, M extends i.EntityMetadataType = any>(
+    static make<T extends AnyObject = AnyObject, M extends i.EntityMetadataType = {}>(
         input: AnyObject,
         metadata?: M
     ): DataEntity<T, M>;
-    static make<T extends AnyObject|DataEntity<any, any> = AnyObject, M extends i.EntityMetadataType = any>(
+    static make<T extends AnyObject|DataEntity<any, any> = AnyObject, M extends i.EntityMetadataType = {}>(
         input: T,
         metadata?: M
     ): T|DataEntity<T, M> {
@@ -70,7 +70,7 @@ export class DataEntity<
      * A barebones method for creating data-entities.
      * @returns the metadata and entity
      */
-    static makeRaw<T extends AnyObject = AnyObject, M extends i.EntityMetadataType = any>(
+    static makeRaw<T extends AnyObject = AnyObject, M extends i.EntityMetadataType = {}>(
         input?: T,
         metadata?: M
     ): { entity: DataEntity<T, M>; metadata: i.EntityMetadata<M> } {
@@ -88,7 +88,7 @@ export class DataEntity<
      * defaults to "json"
      * @param metadata Optionally add any metadata
      */
-    static fromBuffer<T extends AnyObject = AnyObject, M extends i.EntityMetadataType = any>(
+    static fromBuffer<T extends AnyObject = AnyObject, M extends i.EntityMetadataType = {}>(
         input: Buffer|string,
         opConfig: i.EncodingConfig = {},
         metadata?: M
@@ -112,7 +112,7 @@ export class DataEntity<
      * or an array of objects, to an array of DataEntities.
      * This will detect if passed an already converted input and return it.
      */
-    static makeArray<T extends AnyObject = AnyObject, M extends i.EntityMetadataType = any>(
+    static makeArray<T extends AnyObject = AnyObject, M extends i.EntityMetadataType = {}>(
         input: DataArrayInput
     ): DataEntity<T, M>[] {
         if (!Array.isArray(input)) {
@@ -129,7 +129,7 @@ export class DataEntity<
     /**
      * Verify that an input is the `DataEntity`
      */
-    static isDataEntity<T extends AnyObject = AnyObject, M extends i.EntityMetadataType = any>(
+    static isDataEntity<T extends AnyObject = AnyObject, M extends i.EntityMetadataType = {}>(
         input: any
     ): input is DataEntity<T, M> {
         return Boolean(input != null && input[i.__IS_ENTITY_KEY] === true);
@@ -138,7 +138,7 @@ export class DataEntity<
     /**
      * Verify that an input is an Array of DataEntities,
      */
-    static isDataEntityArray<T extends AnyObject = AnyObject, M extends i.EntityMetadataType = any>(
+    static isDataEntityArray<T extends AnyObject = AnyObject, M extends i.EntityMetadataType = {}>(
         input: any
     ): input is DataEntity<T, M>[] {
         if (input == null) return false;

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -9,6 +9,7 @@ import {
 } from '../utils';
 import * as i from './interfaces';
 import * as utils from './utils';
+import { locked } from '../misc';
 
 /**
  * A wrapper for data that can hold additional metadata properties.
@@ -185,9 +186,9 @@ export class DataEntity<
     */
     getMetadata(key?: undefined): i.EntityMetadata<M>;
     getMetadata<K extends i.EntityMetadataKey<M>>(key: K): i.EntityMetadataValue<M, K>;
-    getMetadata<K extends i.EntityMetadataKey<M>>(
-        key?: K
-    ): i.EntityMetadataValue<M, K>|i.EntityMetadata<M> {
+
+    @locked()
+    getMetadata<K extends i.EntityMetadataKey<M>>(key?: K): i.EntityMetadataValue<M, K>|i.EntityMetadata<M> {
         if (key) {
             return this.__dataEntityMetadata.metadata[key];
         }
@@ -202,6 +203,8 @@ export class DataEntity<
         key: K,
         value: V
     ): void;
+
+    @locked()
     setMetadata<K extends i.EntityMetadataKey<M>|string>(key: K, value: any): void {
         if (key === '_createTime') {
             throw new Error(`Cannot set readonly metadata property ${key}`);
@@ -214,6 +217,8 @@ export class DataEntity<
      * Get the raw data, usually used for encoding type `raw`
      * If there is no data, an error will be thrown
     */
+
+    @locked()
     getRawData(): Buffer {
         const buf = this.__dataEntityMetadata.rawData;
         if (isBuffer(buf)) return buf;
@@ -224,6 +229,8 @@ export class DataEntity<
      * Set the raw data, usually used for encoding type `raw`
      * If given `null`, it will unset the data
     */
+
+    @locked()
     setRawData(buf: Buffer|string|null): void {
         if (buf == null) {
             this.__dataEntityMetadata.rawData = null;
@@ -238,6 +245,8 @@ export class DataEntity<
      * @param opConfig The operation config used to get the encoding type of the buffer,
      * @default `json`
      */
+
+    @locked()
     toBuffer(opConfig: i.EncodingConfig = {}): Buffer {
         const { _encoding = i.DataEncoding.JSON } = opConfig;
         if (_encoding === i.DataEncoding.JSON) {
@@ -259,8 +268,6 @@ export class DataEntity<
         throw new Error('Unable to set internal DataEntity metadata');
     }
 }
-
-// utils.definePrototypeProperties(DataEntity.prototype);
 
 export type DataInput = AnyObject | DataEntity;
 export type DataArrayInput = DataInput | DataInput[];

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -189,6 +189,9 @@ export class DataEntity<
 
     @locked()
     getMetadata<K extends i.EntityMetadataKey<M>>(key?: K): i.EntityMetadataValue<M, K>|i.EntityMetadata<M> {
+        if (key === '_key') {
+            return this.getKey() as i.EntityMetadataValue<M, K>;
+        }
         if (key) {
             return this[i.__DATAENTITY_METADATA_KEY].metadata[key];
         }
@@ -207,6 +210,9 @@ export class DataEntity<
         if (key === '_createTime') {
             throw new Error(`Cannot set readonly metadata property ${key}`);
         }
+        if (key === '_key') {
+            return this.setKey(value as any);
+        }
 
         this[i.__DATAENTITY_METADATA_KEY].metadata[key] = value as any;
     }
@@ -217,7 +223,7 @@ export class DataEntity<
     */
     @locked()
     getKey(): string|number {
-        const key = this.getMetadata('_key');
+        const key = this[i.__DATAENTITY_METADATA_KEY].metadata._key;
         if (!utils.isValidKey(key)) {
             throw new Error('No key has been set in the metadata');
         }
@@ -233,7 +239,7 @@ export class DataEntity<
         if (!utils.isValidKey(key)) {
             throw new Error('Invalid key to set in metadata');
         }
-        return this.setMetadata('_key', key);
+        this[i.__DATAENTITY_METADATA_KEY].metadata._key = key;
     }
 
     /**

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -151,14 +151,14 @@ export class DataEntity<
      * Safely get the metadata from a `DataEntity`.
      * If the input is object it will get the property from the object
      */
-    static getMetadata(input: DataInput, key?: i.EntityMetadataKey<AnyObject>) {
+    static getMetadata(input: DataInput, field?: i.EntityMetadataKey<AnyObject>) {
         if (input == null) return null;
 
         if (DataEntity.isDataEntity(input)) {
-            return key ? input.getMetadata(key) : input.getMetadata();
+            return field ? input.getMetadata(field) : input.getMetadata();
         }
 
-        return key ? input[key as string] : undefined;
+        return field ? input[field as string] : undefined;
     }
 
     // Add the ability to specify any additional properties
@@ -201,17 +201,20 @@ export class DataEntity<
 
     @locked()
     setMetadata<K extends i.EntityMetadataKey<M>, V extends i.EntityMetadataValue<M, K>>(
-        key: K,
+        field: K,
         value: V
     ): void {
-        if (key === '_createTime') {
-            throw new Error(`Cannot set readonly metadata property ${key}`);
+        if (field == null) {
+            throw new Error('Missing field to set in metadata');
         }
-        if (key === '_key') {
+        if (field === '_createTime') {
+            throw new Error(`Cannot set readonly metadata property ${field}`);
+        }
+        if (field === '_key') {
             return this.setKey(value as any);
         }
 
-        this[i.__DATAENTITY_METADATA_KEY].metadata[key] = value as any;
+        this[i.__DATAENTITY_METADATA_KEY].metadata[field] = value as any;
     }
 
     /**

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -151,7 +151,7 @@ export class DataEntity<
      * Safely get the metadata from a `DataEntity`.
      * If the input is object it will get the property from the object
      */
-    static getMetadata(input: DataInput, key?: i.EntityMetadataKey) {
+    static getMetadata(input: DataInput, key?: i.EntityMetadataKey<AnyObject>) {
         if (input == null) return null;
 
         if (DataEntity.isDataEntity(input)) {
@@ -198,19 +198,42 @@ export class DataEntity<
     /**
      * Given a key and value set the metadata on the record
     */
-    setMetadata<K extends string>(key: K, value: any): void
+
+    @locked()
     setMetadata<K extends i.EntityMetadataKey<M>, V extends i.EntityMetadataValue<M, K>>(
         key: K,
         value: V
-    ): void;
-
-    @locked()
-    setMetadata<K extends i.EntityMetadataKey<M>|string>(key: K, value: any): void {
+    ): void {
         if (key === '_createTime') {
             throw new Error(`Cannot set readonly metadata property ${key}`);
         }
 
         this[i.__DATAENTITY_METADATA_KEY].metadata[key] = value as any;
+    }
+
+    /**
+     * Get the unique document `_key` from the metadata.
+     * If no `_key` is found, an error will be thrown
+    */
+    @locked()
+    getKey(): string|number {
+        const key = this.getMetadata('_key');
+        if (!utils.isValidKey(key)) {
+            throw new Error('No key has been set in the metadata');
+        }
+        return key;
+    }
+
+    /**
+     * Set the unique document `_key` from the metadata.
+     * If no `_key` is found, an error will be thrown
+    */
+    @locked()
+    setKey(key: string|number): void {
+        if (!utils.isValidKey(key)) {
+            throw new Error('Invalid key to set in metadata');
+        }
+        return this.setMetadata('_key', key);
     }
 
     /**

--- a/packages/utils/src/entities/interfaces.ts
+++ b/packages/utils/src/entities/interfaces.ts
@@ -1,13 +1,38 @@
+import { AnyObject } from '../interfaces';
+
 export type TYPE_IS_ENTITY_KEY = '__isDataEntity';
 export type TYPE_DATAENTITY_METADATA_KEY = '___DataEntityMetadata';
 
 export const __IS_ENTITY_KEY: TYPE_IS_ENTITY_KEY = '__isDataEntity';
 export const __DATAENTITY_METADATA_KEY: TYPE_DATAENTITY_METADATA_KEY = '___DataEntityMetadata';
 
-export type __DataEntityProps<M extends object> = {
-    metadata: M & DataEntityMetadata;
+export type __DataEntityProps<M extends EntityMetadataType> = {
+    metadata: EntityMetadata<M>;
     rawData: Buffer|null;
 };
+
+export type EntityMetadataType = AnyObject|undefined;
+export type EntityMetadataKeyType = AnyObject|undefined;
+export type EntityMetadata<M extends EntityMetadataType = undefined> =
+    M extends undefined
+        ? DataEntityMetadata :
+        M & DataEntityMetadata;
+
+export type EntityMetadataKey<M extends EntityMetadataType =undefined> =
+    M extends undefined
+        ? (keyof DataEntityMetadata)|string :
+        (keyof M) | (keyof DataEntityMetadata) | string;
+
+export type EntityMetadataValue<M extends EntityMetadataType, K extends EntityMetadataKey<M>> =
+    M extends undefined
+        ? (
+            K extends (keyof DataEntityMetadata)
+                ? DataEntityMetadata[K] : any
+        ) : (
+            K extends (keyof M) ?
+                M[K] : K extends (keyof DataEntityMetadata)
+                    ? DataEntityMetadata[K] : any
+        );
 
 export interface DataEntityMetadata {
     /** The time at which this entity was created */

--- a/packages/utils/src/entities/interfaces.ts
+++ b/packages/utils/src/entities/interfaces.ts
@@ -7,36 +7,42 @@ export const __IS_ENTITY_KEY: TYPE_IS_ENTITY_KEY = '__isDataEntity';
 export const __DATAENTITY_METADATA_KEY: TYPE_DATAENTITY_METADATA_KEY = '___DataEntityMetadata';
 
 export type __DataEntityProps<M extends EntityMetadataType> = {
-    metadata: EntityMetadata<M>;
+    metadata: EntityMetadata<M> & AnyObject;
     rawData: Buffer|null;
 };
 
-export type EntityMetadataType = AnyObject|undefined;
-export type EntityMetadataKeyType = AnyObject|undefined;
-export type EntityMetadata<M extends EntityMetadataType = undefined> =
+export type EntityMetadataType = DataEntityMetadata|AnyObject|undefined;
+export type EntityMetadata<M extends EntityMetadataType = any> =
     M extends undefined
-        ? DataEntityMetadata :
-        M & DataEntityMetadata;
+        ? (DataEntityMetadata & AnyObject):
+        (M & DataEntityMetadata & AnyObject);
 
-export type EntityMetadataKey<M extends EntityMetadataType =undefined> =
+export type EntityMetadataKey<M extends EntityMetadataType|AnyObject = any> =
     M extends undefined
-        ? (keyof DataEntityMetadata)|string :
-        (keyof M) | (keyof DataEntityMetadata) | string;
+        ? (keyof DataEntityMetadata)|string : (keyof M) | (keyof DataEntityMetadata) | string;
 
-export type EntityMetadataValue<M extends EntityMetadataType, K extends EntityMetadataKey<M>> =
+export type EntityMetadataValue<
+    M extends EntityMetadataType,
+    K extends EntityMetadataKey<M>|string
+> =
     M extends undefined
         ? (
             K extends (keyof DataEntityMetadata)
                 ? DataEntityMetadata[K] : any
         ) : (
             K extends (keyof M) ?
-                M[K] : K extends (keyof DataEntityMetadata)
-                    ? DataEntityMetadata[K] : any
+                M[K] : (
+                    K extends (keyof DataEntityMetadata)
+                        ? DataEntityMetadata[K]
+                        : any)
         );
 
 export interface DataEntityMetadata {
-    /** The time at which this entity was created */
-    readonly _createTime: number;
+    /**
+     * The time at which this entity was created
+     * @readonly
+    */
+    _createTime?: number;
 
     /** The time at which the data was ingested into the source data */
     _ingestTime?: number;
@@ -52,9 +58,6 @@ export interface DataEntityMetadata {
 
     /** A unique key for the data which will be can be used to key the data */
     _key?: string;
-
-    // Add the ability to specify any additional properties
-    [prop: string]: any;
 }
 
 /**

--- a/packages/utils/src/entities/interfaces.ts
+++ b/packages/utils/src/entities/interfaces.ts
@@ -17,7 +17,8 @@ export type EntityMetadata<M> = M & DataEntityMetadata & AnyObject;
 export type EntityMetadataKey<M> =
     (keyof DataEntityMetadata)
     | (keyof M)
-    | string;
+    | string
+    | number;
 
 export type EntityMetadataValue<M, K> =
     K extends (keyof DataEntityMetadata) ?

--- a/packages/utils/src/entities/interfaces.ts
+++ b/packages/utils/src/entities/interfaces.ts
@@ -61,6 +61,12 @@ export interface DataEntityMetadata {
     _key?: string|number;
 }
 
+export type EntityTimeMetadataField =
+    '_createTime'
+    |'_ingestTime'
+    |'_processTime'
+    |'_eventTime';
+
 /**
  * available data encoding types
  */

--- a/packages/utils/src/entities/interfaces.ts
+++ b/packages/utils/src/entities/interfaces.ts
@@ -27,6 +27,16 @@ export type EntityMetadataValue<M, K> =
                 ? M[K]
                 : any);
 
+/**
+ * DataEntities have conventional metadata properties
+ * that can track source, destination and other process
+ * information.
+ *
+ * **NOTE** Time values are set in UNIX Epoch time,
+ * to reduce memory footput, the DataEntity has convenience
+ * apis for getting and setting the time given and handling
+ * the conversion between unix milliseconds to Date format.
+*/
 export interface DataEntityMetadata {
     /**
      * The time at which this entity was created

--- a/packages/utils/src/entities/interfaces.ts
+++ b/packages/utils/src/entities/interfaces.ts
@@ -7,39 +7,29 @@ export const __IS_ENTITY_KEY: TYPE_IS_ENTITY_KEY = '__isDataEntity';
 export const __DATAENTITY_METADATA_KEY: TYPE_DATAENTITY_METADATA_KEY = '___DataEntityMetadata';
 
 export type __DataEntityProps<M extends EntityMetadataType> = {
-    metadata: EntityMetadata<M> & AnyObject;
+    metadata: EntityMetadata<M>;
     rawData: Buffer|null;
 };
 
-export type EntityMetadataType = DataEntityMetadata|AnyObject|undefined;
-export type EntityMetadata<M extends EntityMetadataType = any> =
-    M extends undefined
-        ? (DataEntityMetadata & AnyObject):
-        (M & DataEntityMetadata & AnyObject);
+export type EntityMetadataType = DataEntityMetadata | AnyObject;
+export type EntityMetadata<M> = M & DataEntityMetadata & AnyObject;
 
-export type EntityMetadataKey<M extends EntityMetadataType|AnyObject = any> =
-    M extends undefined
-        ? (keyof DataEntityMetadata)|string : (keyof M) | (keyof DataEntityMetadata) | string;
+export type EntityMetadataKey<M> =
+    (keyof DataEntityMetadata)
+    | (keyof M)
+    | string;
 
-export type EntityMetadataValue<
-    M extends EntityMetadataType,
-    K extends EntityMetadataKey<M>|string
-> =
-    M extends undefined
-        ? (
-            K extends (keyof DataEntityMetadata)
-                ? DataEntityMetadata[K] : any
-        ) : (
-            K extends (keyof M) ?
-                M[K] : (
-                    K extends (keyof DataEntityMetadata)
-                        ? DataEntityMetadata[K]
-                        : any)
-        );
+export type EntityMetadataValue<M, K> =
+    K extends (keyof DataEntityMetadata) ?
+        DataEntityMetadata[K] : (
+            K extends (keyof M)
+                ? M[K]
+                : any);
 
 export interface DataEntityMetadata {
     /**
      * The time at which this entity was created
+     * (this is automatically set on DataEntity creation)
      * @readonly
     */
     _createTime?: number;
@@ -57,7 +47,7 @@ export interface DataEntityMetadata {
     _eventTime?: number;
 
     /** A unique key for the data which will be can be used to key the data */
-    _key?: string;
+    _key?: string|number;
 }
 
 /**

--- a/packages/utils/src/entities/utils.ts
+++ b/packages/utils/src/entities/utils.ts
@@ -34,3 +34,7 @@ export function createCoreMetadata<M extends i.EntityMetadataType>(): i.EntityMe
 export function jsonToBuffer(input: any): Buffer {
     return Buffer.from(JSON.stringify(input));
 }
+
+export function isValidKey(key: any): key is string|number {
+    return Boolean(key != null && key !== '');
+}

--- a/packages/utils/src/entities/utils.ts
+++ b/packages/utils/src/entities/utils.ts
@@ -1,29 +1,49 @@
 import * as i from './interfaces';
 
-export function makeDataEntityObj<T extends object, M extends i.DataEntityMetadata>(
+export function defineProperties<T extends object, M extends i.DataEntityMetadata>(
     entity: T,
     metadata: M
 ): void {
     Object.defineProperties(entity, {
-        [i.__IS_ENTITY_KEY]: {
-            value: true,
-            enumerable: false,
-            writable: false,
-        },
-        [i.__DATAENTITY_METADATA_KEY]: {
-            value: {
-                metadata,
-                rawData: null,
-            },
-            configurable: false,
-            enumerable: false,
-            writable: false,
-        },
+        [i.__IS_ENTITY_KEY]: _makeISEntityProp(),
+        [i.__DATAENTITY_METADATA_KEY]: _makeDataEntityMetadata(metadata),
     });
 }
 
+function _makeDataEntityMetadata<M>(metadata: M) {
+    return {
+        value: {
+            metadata,
+            rawData: null,
+        },
+        configurable: false,
+        enumerable: false,
+        writable: false,
+    };
+}
+
+function _makeISEntityProp() {
+    return {
+        value: true,
+        configurable: false,
+        enumerable: false,
+        writable: false,
+    };
+}
+
+export function createMetadata<M extends object>(metadata: M): i.DataEntityMetadata {
+    return { ..._baseMetadata(), ...metadata };
+}
+
 export function makeMetadata<M extends object>(metadata?: M): i.DataEntityMetadata {
-    const m = { _createTime: Date.now() };
-    if (!metadata) return m;
-    return Object.assign({}, m, metadata);
+    if (!metadata) return _baseMetadata();
+    return createMetadata(metadata);
+}
+
+function _baseMetadata() {
+    return { _createTime: Date.now() };
+}
+
+export function jsonToBuffer(input: any): Buffer {
+    return Buffer.from(JSON.stringify(input));
 }

--- a/packages/utils/src/entities/utils.ts
+++ b/packages/utils/src/entities/utils.ts
@@ -1,47 +1,34 @@
 import * as i from './interfaces';
 
-export function defineProperties<T extends object, M extends i.DataEntityMetadata>(
-    entity: T,
-    metadata: M
-): void {
-    Object.defineProperties(entity, {
-        [i.__IS_ENTITY_KEY]: _makeISEntityProp(),
-        [i.__DATAENTITY_METADATA_KEY]: _makeDataEntityMetadata(metadata),
-    });
-}
-
-function _makeDataEntityMetadata<M>(metadata: M) {
-    return {
-        value: {
-            metadata,
-            rawData: null,
-        },
-        configurable: false,
-        enumerable: false,
-        writable: false,
-    };
-}
-
-function _makeISEntityProp() {
-    return {
+export function defineProperties(entity: any): void {
+    Object.defineProperty(entity, i.__IS_ENTITY_KEY, {
         value: true,
         configurable: false,
         enumerable: false,
         writable: false,
-    };
+    });
+
+    Object.defineProperty(entity, i.__DATAENTITY_METADATA_KEY, {
+        value: {},
+        configurable: false,
+        enumerable: false,
+        writable: false,
+    });
 }
 
-export function createMetadata<M extends object>(metadata: M): i.DataEntityMetadata {
-    return { ..._baseMetadata(), ...metadata };
+export function createMetadata<M>(metadata: M): i.EntityMetadata<M> {
+    return { ...createCoreMetadata(), ...metadata } as i.EntityMetadata<M>;
 }
 
-export function makeMetadata<M extends object>(metadata?: M): i.DataEntityMetadata {
-    if (!metadata) return _baseMetadata();
+export function makeMetadata<M extends i.EntityMetadataType>(
+    metadata?: M|undefined
+): i.EntityMetadata<M> {
+    if (!metadata) return createCoreMetadata();
     return createMetadata(metadata);
 }
 
-function _baseMetadata() {
-    return { _createTime: Date.now() };
+export function createCoreMetadata<M extends i.EntityMetadataType>(): i.EntityMetadata<M> {
+    return { _createTime: Date.now() } as i.EntityMetadata<M>;
 }
 
 export function jsonToBuffer(input: any): Buffer {

--- a/packages/utils/src/interfaces.ts
+++ b/packages/utils/src/interfaces.ts
@@ -51,6 +51,9 @@ export type WithoutNil<T> = { [P in keyof T]: T[P] extends (undefined | null) ? 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Many<T> extends Array<T> {}
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface EmptyObject {}
+
 /** A simple object with any values */
 export interface AnyObject {
     [prop: string]: any;

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -6,7 +6,6 @@ export const isDev = NODE_ENV === 'development';
 
 /** A decorator for locking down a method */
 export function locked() {
-    // @ts-ignore
     return function _locked(
         target: any,
         propertyKey: string,
@@ -15,6 +14,17 @@ export function locked() {
         descriptor.configurable = false;
         descriptor.enumerable = false;
         descriptor.writable = false;
+    };
+}
+
+/** A decorator making changing the changing configurable property */
+export function configurable(value: boolean) {
+    return function _configurable(
+        target: any,
+        propertyKey: string,
+        descriptor: PropertyDescriptor
+    ) {
+        descriptor.configurable = value;
     };
 }
 

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -70,6 +70,10 @@ export function toBoolean(input: any): boolean {
     return thruthy.includes(val);
 }
 
+export function isBuffer(input: any): input is Buffer {
+    return input != null && Buffer.isBuffer(input);
+}
+
 export function ensureBuffer(input: string|Buffer, encoding: BufferEncoding = 'utf8'): Buffer {
     if (isString(input)) {
         return Buffer.from(input, encoding);

--- a/packages/utils/test/data-entity-spec.ts
+++ b/packages/utils/test/data-entity-spec.ts
@@ -79,8 +79,24 @@ describe('DataEntity', () => {
                 }
             });
 
+            it('should not be able to override the DataEntity properties via an input', () => {
+                const allProps = [
+                    ...methods,
+                    ...hiddenProps,
+                ] as string[];
+
+                const obj: Record<string, 'uhoh'> = {};
+                for (const prop of allProps) {
+                    obj[prop] = 'uhoh';
+                }
+
+                expect(() => {
+                    useClass ? new DataEntity(obj) : DataEntity.make(obj);
+                }).toThrow();
+            });
+
             it('should only convert non-metadata properties with stringified', () => {
-                const obj = JSON.parse(JSON.stringify(dataEntity));
+                const obj = fastCloneDeep(dataEntity);
                 for (const method of methods) {
                     expect(obj).not.toHaveProperty(method as string);
                 }

--- a/packages/utils/test/data-entity-spec.ts
+++ b/packages/utils/test/data-entity-spec.ts
@@ -7,6 +7,7 @@ import {
     __DATAENTITY_METADATA_KEY,
     cloneDeep,
     fastCloneDeep,
+    DataEntityMetadata,
 } from '../src';
 
 describe('DataEntity', () => {
@@ -286,6 +287,81 @@ describe('DataEntity', () => {
             it('should be able to set and get key with 0', () => {
                 expect(dataEntity.setKey(0)).toBeNil();
                 expect(dataEntity.getKey()).toBe(0);
+            });
+        });
+
+        describe('->getTime/->setTime', () => {
+            const metadata: DataEntityMetadata = {
+                _ingestTime: 'invalid-date-string' as any
+            };
+
+            const dataEntity = useClass
+                ? new DataEntity({}, metadata)
+                : DataEntity.make({}, metadata);
+
+            it('should return undefined if no field is given', () => {
+                expect(dataEntity.getTime('_eventTime')).toBeUndefined();
+            });
+
+            it('should return false if an invalid time is found', () => {
+                expect(dataEntity.getTime('_ingestTime')).toBeFalse();
+            });
+
+            it('should return a date for valid time', () => {
+                expect(dataEntity.getTime('_createTime')).toBeDate();
+            });
+
+            it('should throw if setting _createTime', () => {
+                expect(() => {
+                    dataEntity.setTime('_createTime');
+                }).toThrowError('Cannot set readonly metadata property _createTime');
+            });
+
+            it('should throw if setting an invalid date', () => {
+                expect(() => {
+                    dataEntity.setTime('_processTime', new Date('invalid-date'));
+                }).toThrowError('Invalid date format for field _processTime');
+            });
+
+            it('should throw if setting an invalid date string', () => {
+                expect(() => {
+                    dataEntity.setTime('_processTime', 'invalid-date-string');
+                }).toThrowError('Invalid date format for field _processTime');
+            });
+
+            it('should throw if setting an invalid unix time', () => {
+                expect(() => {
+                    dataEntity.setTime('_processTime', -10);
+                }).toThrowError('Invalid date format for field _processTime');
+            });
+
+            it('should be able to set a valid date', () => {
+                const date = new Date();
+                expect(dataEntity.setTime('_processTime', date)).toBeNil();
+                expect(dataEntity.getTime('_processTime')).toBeDate();
+                expect(dataEntity.getTime('_processTime')).toEqual(date);
+            });
+
+            it('should be able to set a valid date string', () => {
+                const date = new Date();
+                expect(dataEntity.setTime('_processTime', date.toISOString())).toBeNil();
+                const result = dataEntity.getTime('_processTime') as Date;
+                expect(result).toBeDate();
+                expect(result.toISOString()).toEqual(date.toISOString());
+            });
+
+            it('should be able to set a valid unix time', () => {
+                const date = new Date();
+                expect(dataEntity.setTime('_processTime', date.getTime())).toBeNil();
+                const result = dataEntity.getTime('_processTime') as Date;
+                expect(result).toBeDate();
+                expect(result.toISOString()).toEqual(date.toISOString());
+            });
+
+            it('should be able default now', () => {
+                expect(dataEntity.setTime('_eventTime')).toBeNil();
+                const result = dataEntity.getTime('_eventTime') as Date;
+                expect(result).toBeDate();
             });
         });
 

--- a/packages/utils/test/data-entity-spec.ts
+++ b/packages/utils/test/data-entity-spec.ts
@@ -14,6 +14,9 @@ describe('DataEntity', () => {
         'getMetadata',
         'setMetadata',
         'getKey',
+        'setKey',
+        'getTime',
+        'setTime',
         'getRawData',
         'setRawData',
         'toBuffer'

--- a/packages/utils/test/data-entity-spec.ts
+++ b/packages/utils/test/data-entity-spec.ts
@@ -10,13 +10,7 @@ import {
 } from '../src';
 
 describe('DataEntity', () => {
-    const methods: (keyof DataEntity)[] = [
-        'getMetadata',
-        'setMetadata',
-        'getRawData',
-        'setRawData',
-        'toBuffer'
-    ];
+    const methods = Object.keys(Object.getPrototypeOf(DataEntity));
 
     const hiddenProps: string[] = [
         __IS_ENTITY_KEY,
@@ -65,7 +59,7 @@ describe('DataEntity', () => {
             it('should not be able to enumerate metadata methods', () => {
                 const keys = Object.keys(dataEntity);
                 for (const method of methods) {
-                    expect(keys).not.toInclude(method as string);
+                    expect(keys).not.toInclude(method);
                 }
                 for (const hiddenProp of hiddenProps) {
                     expect(keys).not.toInclude(hiddenProp);
@@ -74,7 +68,7 @@ describe('DataEntity', () => {
                 // eslint-disable-next-line guard-for-in
                 for (const prop in dataEntity) {
                     for (const method of methods) {
-                        expect(prop).not.toEqual(method as string);
+                        expect(prop).not.toEqual(method);
                     }
                     for (const hiddenProp of hiddenProps) {
                         expect(prop).not.toEqual(hiddenProp);
@@ -85,7 +79,7 @@ describe('DataEntity', () => {
             it('should only convert non-metadata properties with stringified', () => {
                 const obj = JSON.parse(JSON.stringify(dataEntity));
                 for (const method of methods) {
-                    expect(obj).not.toHaveProperty(method as string);
+                    expect(obj).not.toHaveProperty(method);
                 }
 
                 for (const hiddenProp of hiddenProps) {
@@ -385,6 +379,40 @@ describe('DataEntity', () => {
             expect(dataEntities[1]).toHaveProperty('howdy', 'partner');
 
             expect(DataEntity.makeArray(dataEntities)).toEqual(dataEntities);
+        });
+    });
+
+    describe('#fork', () => {
+        describe('when withData is not set (it should default to true)', () => {
+            it('should create a new instance and copy the data', () => {
+                const entity = new DataEntity({ a: 1 }, { b: 2 });
+                const forked = DataEntity.fork(entity);
+                expect(forked).toHaveProperty('a', 1);
+                const b = forked.getMetadata('b');
+                expect(b).toBe(2);
+            });
+        });
+
+        describe('when withData is true', () => {
+            it('should create a new instance and copy the data', () => {
+                const entity = new DataEntity({ a: 1 }, { b: 2 });
+                const forked = DataEntity.fork(entity, true);
+                expect(forked.a).toBe(1);
+                expect(forked.getMetadata()).toHaveProperty('b', 2);
+            });
+        });
+
+        describe('when withData is false', () => {
+            it('should create a new instance and copy the data', () => {
+                const entity = new DataEntity({ a: 1 }, { b: 2 });
+                const forked = DataEntity.fork(entity, false);
+                expect(forked).not.toHaveProperty('a', 1);
+                expect(forked.getMetadata('b')).toBe(2);
+            });
+        });
+
+        it('should throw if not given a data entity', () => {
+            expect(() => DataEntity.fork(null as any)).toThrowError(/Invalid input to fork/);
         });
     });
 

--- a/packages/utils/test/data-entity-spec.ts
+++ b/packages/utils/test/data-entity-spec.ts
@@ -13,6 +13,7 @@ describe('DataEntity', () => {
     const methods: readonly (keyof DataEntity)[] = [
         'getMetadata',
         'setMetadata',
+        'getKey',
         'getRawData',
         'setRawData',
         'toBuffer'
@@ -177,7 +178,7 @@ describe('DataEntity', () => {
 
             it('should not be able to set _createTime', () => {
                 expect(() => {
-                    dataEntity.setMetadata('_createTime', 'hello');
+                    dataEntity.setMetadata('_createTime', 10);
                 }).toThrowError('Cannot set readonly metadata property _createTime');
             });
 
@@ -251,6 +252,37 @@ describe('DataEntity', () => {
                         DataEntity.make(buf);
                     }
                 }).toThrowError('Invalid data source, must be an object, got "Buffer"');
+            });
+        });
+
+        describe('->getKey/->setKey', () => {
+            const dataEntity = useClass ? new DataEntity({}) : DataEntity.make({});
+
+            it('should throw an if there is no key', () => {
+                expect(() => {
+                    dataEntity.getKey();
+                }).toThrowError('No key has been set in the metadata');
+            });
+
+            it('should throw an when setting an invalid key', () => {
+                expect(() => {
+                    dataEntity.setKey('');
+                }).toThrowError('Invalid key to set in metadata');
+            });
+
+            it('should be able to set and get a string key', () => {
+                expect(dataEntity.setKey('hello')).toBeNil();
+                expect(dataEntity.getKey()).toBe('hello');
+            });
+
+            it('should be able to set and get a numeric key', () => {
+                expect(dataEntity.setKey(1)).toBeNil();
+                expect(dataEntity.getKey()).toBe(1);
+            });
+
+            it('should be able to set and get key with 0', () => {
+                expect(dataEntity.setKey(0)).toBeNil();
+                expect(dataEntity.getKey()).toBe(0);
             });
         });
 

--- a/packages/xlucene-evaluator/package.json
+++ b/packages/xlucene-evaluator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xlucene-evaluator",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-evaluator#readme",
     "repository": {
@@ -28,7 +28,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.17.1",
+        "@terascope/utils": "^0.18.0",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-point-in-polygon": "^6.0.1",

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -126,6 +126,10 @@ cleanup_top_level() {
 }
 
 post_cleanup() {
+    prompt "Do you want to clear the yarn cache?" &&
+        echoerr "* running yarn cache clean" &&
+        yarn cache clean
+
     prompt "Do you want to verify/rebuild the node_modules?" &&
         echoerr "* running yarn --force --check-files --update-checksums" &&
         rm -rf ./.yarn-cache/* &&

--- a/scripts/publish-documentation.sh
+++ b/scripts/publish-documentation.sh
@@ -25,6 +25,9 @@ main() {
         ;;
     esac
 
+    echo '* cleaning up node_modules...'
+    rm -rf node_modules
+
     cd website &&
         yarn install --prod &&
         GIT_USER="${GITHUB_NAME}" \


### PR DESCRIPTION
- [x] Add `->getKey(): string|number` and `->setKey(key: string|number): void` methods to `DataEntity` for getting/setting the `_key` in the metadata
- [x] Add `DataEntity.fork(entity: DataEntity, withData = true): DataEntity` to create a new `DataEntity` from an existing `DataEntity` with the metadata and optionally copy the data from the `DataEntity` (defaults to true).
- [x] Refactor and more typescript improvements
- [x] Add `->getCreateTime(): Date`
- [x] Add `->getIngestTime(): Date|false|undefined` and `->setIngestTime(input: Date|number|string): void`
- [x] Add `->getProcessTime(): Date|false|undefined` and `->setProcessTime(input: Date|number|string): void`
- [x] Add `->getEventTime(): Date|false|undefined` and `->setEventTime(input: Date|number|string): void`
- [x] Update documentation for the new methods

Resolves #950 