### PR TITLE
v0.57.0 - Minor DataEntity API improvements

### DIFF
--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
-    "version": "1.7.5",
+    "version": "1.7.6",
     "description": "A testing harness to simplify testing Teraslice processors and operations.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-op-test-harness#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-test-harness",
-    "version": "0.8.6",
+    "version": "0.8.7",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/job-components": "^0.23.4",
-        "@terascope/teraslice-op-test-harness": "^1.7.5",
+        "@terascope/teraslice-op-test-harness": "^1.7.6",
         "lodash": "^4.17.11"
     },
     "devDependencies": {},

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.56.4",
+    "version": "0.57.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.56.3",
+    "version": "0.56.4",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -64,7 +64,7 @@
         "uuid": "^3.3.3"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.7.5",
+        "@terascope/teraslice-op-test-harness": "^1.7.6",
         "archiver": "^3.0.0",
         "bufferstreams": "^2.0.1",
         "chance": "^1.0.18",


### PR DESCRIPTION
bump `teraslice`
bump `teraslice-test-harness`,` teraslice-op-test-harness` to include latest `job-components`
All of the API changes were in #1424