### PR TITLE
v0.57.1 - Fixes to DataEntity API changes

### DIFF
--- a/packages/chunked-file-reader/package.json
+++ b/packages/chunked-file-reader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/chunked-file-reader",
-    "version": "2.1.5",
+    "version": "2.1.6",
     "description": "This module is an abstracted reader for use in various Teraslice readers. It uses an externally-defined reader to read data and the packages up the data in a DataEntity for use with other Teraslice processors.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/chunked-file-reader#readme",
     "bugs": {
@@ -20,7 +20,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.0",
+        "@terascope/utils": "^0.20.1",
         "bluebird": "^3.5.5",
         "csvtojson": "^2.0.8",
         "lodash": "^4.17.11"

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/data-types",
-    "version": "0.5.9",
+    "version": "0.5.10",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.0",
+        "@terascope/utils": "^0.20.1",
         "graphql": "^14.3.1",
         "lodash.defaultsdeep": "^4.6.1",
         "lodash.set": "^4.3.2",
@@ -37,7 +37,7 @@
         "@types/lodash.defaultsdeep": "^4.6.6",
         "@types/lodash.set": "^4.3.6",
         "@types/yargs": "^13.0.2",
-        "xlucene-evaluator": "^0.10.4"
+        "xlucene-evaluator": "^0.10.5"
     },
     "engines": {
         "node": ">=8.0.0"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/elasticsearch-api",
-    "version": "2.1.7",
+    "version": "2.1.8",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -17,7 +17,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.0",
+        "@terascope/utils": "^0.20.1",
         "bluebird": "^3.5.5",
         "lodash": "^4.17.11"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "elasticsearch-store",
-    "version": "0.11.6",
+    "version": "0.11.7",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -23,12 +23,12 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.5.9",
-        "@terascope/utils": "^0.20.0",
+        "@terascope/data-types": "^0.5.10",
+        "@terascope/utils": "^0.20.1",
         "ajv": "^6.10.0",
         "nanoid": "^2.0.3",
         "rambda": "^3.0.0",
-        "xlucene-evaluator": "^0.10.4"
+        "xlucene-evaluator": "^0.10.5"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/job-components",
-    "version": "0.23.4",
+    "version": "0.23.5",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.7",
-        "@terascope/utils": "^0.20.0",
+        "@terascope/utils": "^0.20.1",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^3.3.3"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.14.0",
-        "@terascope/utils": "^0.20.0",
+        "@terascope/utils": "^0.20.1",
         "@types/is-ci": "^2.0.0",
         "codecov": "^3.5.0",
         "execa": "^2.0.4",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "terafoundation",
-    "version": "0.12.4",
+    "version": "0.12.5",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -21,7 +21,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.0",
+        "@terascope/utils": "^0.20.1",
         "aws-sdk": "^2.513.0",
         "bluebird": "^3.5.5",
         "bunyan": "^1.8.12",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-cli",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.6.0",
-        "@terascope/utils": "^0.20.0",
+        "@terascope/utils": "^0.20.1",
         "archiver": "^3.0.0",
         "bluebird": "^3.5.5",
         "chalk": "^2.4.2",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -29,7 +29,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.23.4",
+        "@terascope/job-components": "^0.23.5",
         "auto-bind": "^2.1.0",
         "got": "^9.6.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-messaging",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.7",
-        "@terascope/utils": "^0.20.0",
+        "@terascope/utils": "^0.20.1",
         "ms": "^2.1.2",
         "nanoid": "^2.0.3",
         "p-event": "^4.1.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
-    "version": "1.7.6",
+    "version": "1.7.7",
     "description": "A testing harness to simplify testing Teraslice processors and operations.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-op-test-harness#readme",
     "bugs": {

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -17,7 +17,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.23.4",
+        "@terascope/job-components": "^0.23.5",
         "bluebird": "^3.5.5",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-state-storage",
-    "version": "0.7.4",
+    "version": "0.7.5",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.7",
-        "@terascope/utils": "^0.20.0",
+        "@terascope/elasticsearch-api": "^2.1.8",
+        "@terascope/utils": "^0.20.1",
         "bluebird": "^3.5.5",
         "mnemonist": "^0.30.0"
     },

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -30,7 +30,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.23.4",
+        "@terascope/job-components": "^0.23.5",
         "@terascope/teraslice-op-test-harness": "^1.7.6",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-test-harness",
-    "version": "0.8.7",
+    "version": "0.8.8",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/job-components": "^0.23.5",
-        "@terascope/teraslice-op-test-harness": "^1.7.6",
+        "@terascope/teraslice-op-test-harness": "^1.7.7",
         "lodash": "^4.17.11"
     },
     "devDependencies": {},

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.57.0",
+    "version": "0.57.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -64,7 +64,7 @@
         "uuid": "^3.3.3"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.7.6",
+        "@terascope/teraslice-op-test-harness": "^1.7.7",
         "archiver": "^3.0.0",
         "bufferstreams": "^2.0.1",
         "chance": "^1.0.18",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -32,11 +32,11 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.7",
-        "@terascope/job-components": "^0.23.4",
+        "@terascope/elasticsearch-api": "^2.1.8",
+        "@terascope/job-components": "^0.23.5",
         "@terascope/queue": "^1.1.7",
-        "@terascope/teraslice-messaging": "^0.4.3",
-        "@terascope/utils": "^0.20.0",
+        "@terascope/teraslice-messaging": "^0.4.4",
+        "@terascope/utils": "^0.20.1",
         "async-mutex": "^0.1.3",
         "barbe": "^3.0.15",
         "bluebird": "^3.5.5",
@@ -60,7 +60,7 @@
         "shortid": "^2.2.14",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.12.4",
+        "terafoundation": "^0.12.5",
         "uuid": "^3.3.3"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-transforms",
-    "version": "0.24.2",
+    "version": "0.24.3",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.0",
+        "@terascope/utils": "^0.20.1",
         "@types/graphlib": "^2.1.5",
         "@types/shortid": "^0.0.29",
         "awesome-phonenumber": "^2.15.0",
@@ -44,7 +44,7 @@
         "shortid": "^2.2.14",
         "valid-url": "^1.0.9",
         "validator": "^11.0.0",
-        "xlucene-evaluator": "^0.10.4",
+        "xlucene-evaluator": "^0.10.5",
         "yargs": "^14.0.0"
     },
     "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/utils",
-    "version": "0.20.0",
+    "version": "0.20.1",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -206,10 +206,6 @@ export class DataEntity<
         if (field === '_createTime') {
             throw new Error(`Cannot set readonly metadata property ${field}`);
         }
-        if (field === '_key') {
-            return this.setKey(value as any);
-        }
-
         this[i.__ENTITY_METADATA_KEY].metadata[field] = value as any;
     }
 

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -160,8 +160,7 @@ export class DataEntity<
         if (this.name !== 'DataEntity' && this.name !== 'Object') {
             return false;
         }
-        if (!utils.isDataEntity(instance)) return false;
-        return true;
+        return utils.isDataEntity(instance);
     }
 
     private readonly [i.__ENTITY_METADATA_KEY]: {

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -155,7 +155,13 @@ export class DataEntity<
     }
 
     static [Symbol.hasInstance](instance: any): boolean {
-        return utils.isDataEntity(instance);
+        // prevent automatically thinking a base DataEntity is
+        // an instance of a class that extends from a DataEntity
+        if (this.name !== 'DataEntity' && this.name !== 'Object') {
+            return false;
+        }
+        if (!utils.isDataEntity(instance)) return false;
+        return true;
     }
 
     private readonly [i.__ENTITY_METADATA_KEY]: {

--- a/packages/utils/test/data-entity-spec.ts
+++ b/packages/utils/test/data-entity-spec.ts
@@ -135,6 +135,14 @@ describe('DataEntity', () => {
                 expect(dataEntity.getMetadata('yellow')).toEqual('mellow');
             });
 
+            it('should be able to remove the metadata _key property', () => {
+                dataEntity.setMetadata('_key', undefined);
+                expect(dataEntity.getMetadata('_key')).toBeUndefined();
+                expect(() => {
+                    dataEntity.getKey();
+                }).toThrow();
+            });
+
             const cloneMethods = {
                 fastCloneDeep,
                 cloneDeep,

--- a/packages/utils/test/data-entity-spec.ts
+++ b/packages/utils/test/data-entity-spec.ts
@@ -567,6 +567,7 @@ describe('DataEntity', () => {
     describe('#isDataEntity', () => {
         it('should return false when given object', () => {
             expect(DataEntity.isDataEntity({})).toBeFalse();
+            expect({}).not.toBeInstanceOf(DataEntity);
         });
 
         it('should return false when given null', () => {
@@ -575,15 +576,24 @@ describe('DataEntity', () => {
 
         it('should return false when given array of object', () => {
             expect(DataEntity.isDataEntity([{}])).toBeFalse();
+            expect([{}]).not.toBeInstanceOf(DataEntity);
         });
 
         it('should return true when given a DataEntity', () => {
             expect(DataEntity.isDataEntity(DataEntity.make({}))).toBeTrue();
+            expect(DataEntity.make({})).toBeInstanceOf(DataEntity);
         });
 
         it('should return false when given an array of DataEntities', () => {
             const input = DataEntity.makeArray([{ hi: true }, { hi: true }]);
             expect(DataEntity.isDataEntity(input)).toBeFalse();
+        });
+
+        it('should return false when called with another type of DataEntity', () => {
+            class OtherEntity extends DataEntity {
+            }
+            const entity = new DataEntity({ og: true });
+            expect(entity).not.toBeInstanceOf(OtherEntity);
         });
     });
 

--- a/packages/xlucene-evaluator/package.json
+++ b/packages/xlucene-evaluator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xlucene-evaluator",
-    "version": "0.10.4",
+    "version": "0.10.5",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-evaluator#readme",
     "repository": {
@@ -28,7 +28,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.0",
+        "@terascope/utils": "^0.20.1",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-point-in-polygon": "^6.0.1",


### PR DESCRIPTION
- A `DataEntity` should be able to be remove a `_key` via `entity.setMetadata('_key', undefined);`
- Fix issue with extending a `DataEntity` and getting the instance of the a real `DataEntity`