### PR TITLE
ts-scripts improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "root": true,
         "type": "monorepo",
         "docker": {
-            "registry": "terascope/teraslice",
+            "registries": ["terascope/teraslice"],
             "cache_layers": [
                 {
                     "from": "node:10.16.3-alpine",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.6.0-rc.0",
+    "version": "0.6.0-rc.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.5.6",
+    "version": "0.6.0-rc.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.6.0-rc.1",
+    "version": "0.6.0-rc.2",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.6.0-rc.3",
+    "version": "0.6.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.6.0-rc.2",
+    "version": "0.6.0-rc.3",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/cmds/test.ts
+++ b/packages/scripts/src/cmds/test.ts
@@ -14,10 +14,8 @@ type Options = {
     bail: boolean;
     suite?: TestSuite;
     'report-coverage': boolean;
-    'elasticsearch-host': string;
     'elasticsearch-version': string;
     'elasticsearch-api-version': string;
-    'kafka-broker': string;
     'kafka-version': string;
     'use-existing-services': boolean;
     packages?: PackageInfo[];
@@ -68,11 +66,6 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
                 type: 'boolean',
                 default: config.USE_EXISTING_SERVICES,
             })
-            .option('elasticsearch-host', {
-                description: 'The elasticsearch URL to use when needed (usually for --suite elasticsearch or e2e)',
-                type: 'string',
-                default: config.ELASTICSEARCH_HOST,
-            })
             .option('elasticsearch-version', {
                 description: 'The elasticsearch version to use',
                 type: 'string',
@@ -82,11 +75,6 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
                 description: 'The elasticsearch client API version to use',
                 type: 'string',
                 default: config.ELASTICSEARCH_API_VERSION,
-            })
-            .option('kafka-broker', {
-                description: 'The kafka brokers to use when needed (usually for --suite kafka or e2e)',
-                type: 'string',
-                default: config.KAFKA_BROKER,
             })
             .option('kafka-version', {
                 description: 'The kafka version to use',
@@ -119,10 +107,8 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
             bail,
             suite: argv.suite,
             useExistingServices: argv['use-existing-services'],
-            elasticsearchHost: argv['elasticsearch-host'],
             elasticsearchVersion: argv['elasticsearch-version'],
             elasticsearchAPIVersion: argv['elasticsearch-api-version'],
-            kafkaBroker: argv['kafka-broker'],
             kafkaVersion: argv['kafka-version'],
             all: !argv.packages || !argv.packages.length,
             reportCoverage: argv['report-coverage'],

--- a/packages/scripts/src/command.ts
+++ b/packages/scripts/src/command.ts
@@ -7,7 +7,6 @@ yargs
     .demandCommand(1, 'A command is required. Pass --help to see all available commands and options.')
     .recommendCommands()
     .strict()
-    .showHelpOnFail(true, 'Specify --help for available options')
     .alias('h', 'help')
     .alias('v', 'version')
     .wrap(yargs.terminalWidth()).argv;

--- a/packages/scripts/src/helpers/bump/utils.ts
+++ b/packages/scripts/src/helpers/bump/utils.ts
@@ -66,11 +66,12 @@ export function getBumpCommitMessage(
     const bumpResult = { ...result };
     const main = Object.entries(result).find(([, info]) => info.main);
     if (main) {
-        const [name] = main;
+        const [name, { to }] = main;
         delete bumpResult[name];
-        messages.push(`release: (${release}) ${name}`);
+        messages.push(`release: (${release}) ${name}@${to}`);
     }
-    const names = Object.keys(bumpResult);
+
+    const names = Object.entries(bumpResult).map(([name, { to }]) => `${name}@${to}`);
     if (names.length) {
         messages.push(`bump: (${release}) ${names.join(', ')}`);
     }

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -2,6 +2,7 @@ import isCI from 'is-ci';
 import { address } from 'ip';
 import { toBoolean } from '@terascope/utils';
 
+export const FORCE_COLOR = process.env.FORCE_COLOR || '1';
 export const HOST_IP = process.env.HOST_IP || address();
 export const USE_EXISTING_SERVICES = toBoolean(process.env.USE_EXISTING_SERVICES);
 export const SERVICE_HEAP_OPTS = process.env.SERVICE_HEAP_OPTS || '-Xms256m -Xmx256m';

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -2,15 +2,25 @@ import isCI from 'is-ci';
 import { address } from 'ip';
 import { toBoolean } from '@terascope/utils';
 
-export const HOST_IP = address();
+export const HOST_IP = process.env.HOST_IP || address();
 export const USE_EXISTING_SERVICES = toBoolean(process.env.USE_EXISTING_SERVICES);
+export const SERVICE_HEAP_OPTS = process.env.SERVICE_HEAP_OPTS || '-Xms256m -Xmx256m';
+export const USE_SERVICE_NETWORK = process.env.USE_SERVICE_NETWORK || undefined;
 
-export const ELASTICSEARCH_HOST = process.env.ELASTICSEARCH_HOST || `http://${HOST_IP}:49200`;
+export const ELASTICSEARCH_NAME = process.env.ELASTICSEARCH_HOSTNAME || 'ts_test_elasticsearch';
+export const ELASTICSEARCH_HOSTNAME = process.env.ELASTICSEARCH_HOSTNAME || HOST_IP;
+export const ELASTICSEARCH_PORT = process.env.ELASTICSEARCH_PORT || '49200';
+export const ELASTICSEARCH_HOST = `http://${ELASTICSEARCH_HOSTNAME}:${ELASTICSEARCH_PORT}`;
 export const ELASTICSEARCH_VERSION = process.env.ELASTICSEARCH_VERSION || '6.8';
 export const ELASTICSEARCH_API_VERSION = process.env.ELASTICSEARCH_API_VERSION || '6.5';
+export const ELASTICSEARCH_DOCKER_IMAGE = process.env.ELASTICSEARCH_DOCKER_IMAGE || 'blacktop/elasticsearch';
 
-export const KAFKA_BROKER = process.env.KAFKA_BROKER || `${HOST_IP}:49092`;
+export const KAFKA_NAME = process.env.KAFKA_HOSTNAME || 'ts_test_kafka';
+export const KAFKA_HOSTNAME = process.env.KAFKA_HOSTNAME || HOST_IP;
+export const KAFKA_PORT = process.env.KAFKA_PORT || '49092';
+export const KAFKA_BROKER = `${KAFKA_HOSTNAME}:${KAFKA_PORT}`;
 export const KAFKA_VERSION = process.env.KAFKA_VERSION || '2.1';
+export const KAFKA_DOCKER_IMAGE = process.env.KAFKA_DOCKER_IMAGE || 'blacktop/kafka';
 
 const reportCov = process.env.REPORT_COVERAGE;
 export const REPORT_COVERAGE = reportCov != null || reportCov !== ''

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -28,3 +28,4 @@ export const REPORT_COVERAGE = reportCov != null || reportCov !== ''
     : isCI;
 
 export const NPM_DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
+export const NPM_PUBLISH_TAG = 'latest';

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -8,7 +8,7 @@ export const USE_EXISTING_SERVICES = toBoolean(process.env.USE_EXISTING_SERVICES
 export const SERVICE_HEAP_OPTS = process.env.SERVICE_HEAP_OPTS || '-Xms256m -Xmx256m';
 export const USE_SERVICE_NETWORK = process.env.USE_SERVICE_NETWORK || undefined;
 
-export const ELASTICSEARCH_NAME = process.env.ELASTICSEARCH_HOSTNAME || 'ts_test_elasticsearch';
+export const ELASTICSEARCH_NAME = 'ts_test_elasticsearch';
 export const ELASTICSEARCH_HOSTNAME = process.env.ELASTICSEARCH_HOSTNAME || HOST_IP;
 export const ELASTICSEARCH_PORT = process.env.ELASTICSEARCH_PORT || '49200';
 export const ELASTICSEARCH_HOST = `http://${ELASTICSEARCH_HOSTNAME}:${ELASTICSEARCH_PORT}`;
@@ -16,7 +16,7 @@ export const ELASTICSEARCH_VERSION = process.env.ELASTICSEARCH_VERSION || '6.8';
 export const ELASTICSEARCH_API_VERSION = process.env.ELASTICSEARCH_API_VERSION || '6.5';
 export const ELASTICSEARCH_DOCKER_IMAGE = process.env.ELASTICSEARCH_DOCKER_IMAGE || 'blacktop/elasticsearch';
 
-export const KAFKA_NAME = process.env.KAFKA_HOSTNAME || 'ts_test_kafka';
+export const KAFKA_NAME = 'ts_test_kafka';
 export const KAFKA_HOSTNAME = process.env.KAFKA_HOSTNAME || HOST_IP;
 export const KAFKA_PORT = process.env.KAFKA_PORT || '49092';
 export const KAFKA_BROKER = `${KAFKA_HOSTNAME}:${KAFKA_PORT}`;

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -31,4 +31,4 @@ export const REPORT_COVERAGE = reportCov != null || reportCov !== ''
 export const JEST_MAX_WORKERS = process.env.JEST_MAX_WORKERS || undefined;
 
 export const NPM_DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
-export const NPM_PUBLISH_TAG = 'latest';
+export const NPM_PUBLISH_TAG = process.env.NPM_PUBLISH_TAG || 'latest';

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -28,5 +28,7 @@ export const REPORT_COVERAGE = reportCov != null || reportCov !== ''
     ? toBoolean(reportCov)
     : isCI;
 
+export const JEST_MAX_WORKERS = process.env.JEST_MAX_WORKERS || undefined;
+
 export const NPM_DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
 export const NPM_PUBLISH_TAG = 'latest';

--- a/packages/scripts/src/helpers/interfaces.ts
+++ b/packages/scripts/src/helpers/interfaces.ts
@@ -52,7 +52,7 @@ export type RootPackageInfo = {
         root: boolean;
         type: 'monorepo';
         docker: {
-            registry: string;
+            registries: string[];
             cache_layers: ({ from: string; name: string })[];
         };
         npm: {

--- a/packages/scripts/src/helpers/misc.ts
+++ b/packages/scripts/src/helpers/misc.ts
@@ -50,7 +50,7 @@ function _getRootInfo(pkgJSONPath: string): RootPackageInfo | undefined {
             root: isRoot,
             type: 'monorepo',
             docker: {
-                registry: `terascope/${folderName}`,
+                registries: [`terascope/${folderName}`],
                 cache_layers: [],
             },
             npm: {

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -10,7 +10,6 @@ import {
     dockerBuild,
     dockerPush
 } from '../scripts';
-import * as config from '../config';
 import { getRootInfo } from '../misc';
 import signale from '../signale';
 
@@ -42,7 +41,7 @@ async function npmPublish(pkgInfo: PackageInfo, options: PublishOptions) {
         signale.info(`[DRY RUN] - skipping publish for package ${pkgInfo.name}@v${pkgInfo.version}`);
         await yarnRun('prepublishOnly', [], pkgInfo.dir);
     } else {
-        await yarnPublish(pkgInfo, config.NPM_PUBLISH_TAG);
+        await yarnPublish(pkgInfo);
     }
 }
 

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -1,4 +1,5 @@
 import ms from 'ms';
+import { get } from '@terascope/utils';
 import { PackageInfo } from '../interfaces';
 import { listPackages, getMainPackageInfo } from '../packages';
 import { PublishAction, PublishOptions, PublishType } from './interfaces';
@@ -41,7 +42,8 @@ async function npmPublish(pkgInfo: PackageInfo, options: PublishOptions) {
         signale.info(`[DRY RUN] - skipping publish for package ${pkgInfo.name}@v${pkgInfo.version}`);
         await yarnRun('prepublishOnly', [], pkgInfo.dir);
     } else {
-        await yarnPublish(pkgInfo);
+        const registry: string|undefined = get(pkgInfo, 'publishConfig.registry');
+        await yarnPublish(pkgInfo, registry);
     }
 }
 

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -10,6 +10,7 @@ import {
     dockerBuild,
     dockerPush
 } from '../scripts';
+import * as config from '../config';
 import { getRootInfo } from '../misc';
 import signale from '../signale';
 
@@ -41,7 +42,7 @@ async function npmPublish(pkgInfo: PackageInfo, options: PublishOptions) {
         signale.info(`[DRY RUN] - skipping publish for package ${pkgInfo.name}@v${pkgInfo.version}`);
         await yarnRun('prepublishOnly', [], pkgInfo.dir);
     } else {
-        await yarnPublish(pkgInfo);
+        await yarnPublish(pkgInfo, config.NPM_PUBLISH_TAG);
     }
 }
 

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -49,39 +49,42 @@ async function publishToDocker(options: PublishOptions) {
     const imagesToPush = [];
     let imageToBuild = '';
     const rootInfo = getRootInfo();
-    const { registry } = rootInfo.terascope.docker;
 
-    if (options.type === PublishType.Latest) {
-        imageToBuild = `${registry}:latest`;
-    } else if (options.type === PublishType.Tag) {
-        const mainPkgInfo = getMainPackageInfo();
-        if (!mainPkgInfo) {
-            throw new Error('At least one package must be specified with `terascope.main`');
+    const { registries } = rootInfo.terascope.docker;
+
+    for (const registry of registries) {
+        if (options.type === PublishType.Latest) {
+            imageToBuild = `${registry}:latest`;
+        } else if (options.type === PublishType.Tag) {
+            const mainPkgInfo = getMainPackageInfo();
+            if (!mainPkgInfo) {
+                throw new Error('At least one package must be specified with `terascope.main`');
+            }
+            const image = `${registry}:v${mainPkgInfo.version}`;
+            const exists = await remoteDockerImageExists(image);
+            if (exists) {
+                throw new Error(`Docker Image ${image} already exists`);
+            }
+            imageToBuild = image;
+        } else if (options.type === PublishType.Dev) {
+            imageToBuild = `${registry}:dev`;
+        } else if (options.type === PublishType.Daily) {
+            const tag = await formatDailyTag();
+            imageToBuild = `${registry}:${tag}`;
         }
-        const image = `${registry}:v${mainPkgInfo.version}`;
-        const exists = await remoteDockerImageExists(image);
-        if (exists) {
-            throw new Error(`Docker Image ${image} already exists`);
-        }
-        imageToBuild = image;
-    } else if (options.type === PublishType.Dev) {
-        imageToBuild = `${registry}:dev`;
-    } else if (options.type === PublishType.Daily) {
-        const tag = await formatDailyTag();
-        imageToBuild = `${registry}:${tag}`;
+
+        const startTime = Date.now();
+        signale.pending(`building docker for ${options.type} release`);
+
+        const cacheLayersToPush = await buildCacheLayers(registry);
+        imagesToPush.push(...cacheLayersToPush);
+
+        signale.debug(`building docker image ${imageToBuild}`);
+        await dockerBuild(imageToBuild, cacheLayersToPush);
+        imagesToPush.push(imageToBuild);
+
+        signale.success(`built docker image ${imageToBuild}, took ${ms(Date.now() - startTime)}`);
     }
-
-    const startTime = Date.now();
-    signale.pending(`building docker for ${options.type} release`);
-
-    const cacheLayersToPush = await buildCacheLayers();
-    imagesToPush.push(...cacheLayersToPush);
-
-    signale.debug(`building docker image ${imageToBuild}`);
-    await dockerBuild(imageToBuild, cacheLayersToPush);
-    imagesToPush.push(imageToBuild);
-
-    signale.success(`built docker image ${imageToBuild}, took ${ms(Date.now() - startTime)}`);
 
     if (options.dryRun) {
         signale.info(`[DRY RUN] - skipping publish of docker images ${imagesToPush.join(', ')}`);

--- a/packages/scripts/src/helpers/publish/utils.ts
+++ b/packages/scripts/src/helpers/publish/utils.ts
@@ -69,7 +69,7 @@ export async function formatDailyTag() {
     return `daily-${date}-${hash}`;
 }
 
-export async function buildCacheLayers(): Promise<string[]> {
+export async function buildCacheLayers(registry: string): Promise<string[]> {
     const rootInfo = getRootInfo();
     const layers = rootInfo.terascope.docker.cache_layers;
     if (!layers.length) return [];
@@ -79,7 +79,7 @@ export async function buildCacheLayers(): Promise<string[]> {
         if (cacheFrom[from] == null) {
             cacheFrom[from] = from;
         }
-        cacheFrom[name] = `${rootInfo.terascope.docker.registry}:dev-${name}`;
+        cacheFrom[name] = `${registry}:dev-${name}`;
     });
 
     const layersToPull = Object.values(cacheFrom);

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -7,7 +7,7 @@ import {
 import { TSCommands, PackageInfo } from './interfaces';
 import { getRootDir } from './misc';
 import signale from './signale';
-import { NPM_DEFAULT_REGISTRY } from './config';
+import * as config from './config';
 
 const logger = debugLogger('ts-scripts:cmd');
 
@@ -72,7 +72,10 @@ export async function exec(opts: ExecOpts, log = true): Promise<string> {
 
 export async function fork(opts: ExecOpts): Promise<void> {
     try {
-        const env: ExecEnv = { FORCE_COLOR: '1', ...opts.env };
+        const env: ExecEnv = {
+            FORCE_COLOR: config.FORCE_COLOR,
+            ...opts.env
+        };
         const _opts: ExecOpts = { stdio: 'inherit', ...opts };
         _opts.env = env;
         await _exec(_opts);
@@ -354,7 +357,7 @@ export function mapToArgs(input: ArgsMap): string[] {
 
 export async function getLatestNPMVersion(
     name: string,
-    registry: string = NPM_DEFAULT_REGISTRY
+    registry: string = config.NPM_DEFAULT_REGISTRY
 ): Promise<string> {
     const subprocess = await execa(
         'npm',
@@ -367,7 +370,7 @@ export async function getLatestNPMVersion(
     return subprocess.stdout;
 }
 
-export async function yarnPublish(pkgInfo: PackageInfo, tag = 'latest') {
+export async function yarnPublish(pkgInfo: PackageInfo, tag = config.NPM_PUBLISH_TAG) {
     await fork({
         cmd: 'yarn',
         args: [

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -370,7 +370,7 @@ export async function getLatestNPMVersion(
     return subprocess.stdout;
 }
 
-export async function yarnPublish(pkgInfo: PackageInfo, tag = config.NPM_PUBLISH_TAG) {
+export async function yarnPublish(pkgInfo: PackageInfo, registry = config.NPM_DEFAULT_REGISTRY) {
     await fork({
         cmd: 'yarn',
         args: [
@@ -379,8 +379,10 @@ export async function yarnPublish(pkgInfo: PackageInfo, tag = config.NPM_PUBLISH
             '--new-version',
             pkgInfo.version,
             '--no-git-tag-version',
+            '--registry',
+            registry,
             '--tag',
-            tag
+            config.NPM_PUBLISH_TAG
         ],
         cwd: pkgInfo.dir,
     });

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -367,7 +367,7 @@ export async function getLatestNPMVersion(
     return subprocess.stdout;
 }
 
-export async function yarnPublish(pkgInfo: PackageInfo) {
+export async function yarnPublish(pkgInfo: PackageInfo, tag = 'latest') {
     await fork({
         cmd: 'yarn',
         args: [
@@ -375,7 +375,9 @@ export async function yarnPublish(pkgInfo: PackageInfo) {
             '--non-interactive',
             '--new-version',
             pkgInfo.version,
-            '--no-git-tag-version'
+            '--no-git-tag-version',
+            '--tag',
+            tag
         ],
         cwd: pkgInfo.dir,
     });

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -131,16 +131,15 @@ async function runTestSuite(
         try {
             await runJest(getRootDir(), args, env, options.jestArgs);
         } catch (err) {
+            const names = pkgs.map((pkgInfo) => pkgInfo.name).join(', ');
             if (pkgs.length > 1) {
-                const error = new TSError(err, {
-                    message: `At least one of these tests failed ${pkgs.map((pkgInfo) => pkgInfo.name).join(', ')} failed`,
-                });
-                errors.push(getFullErrorStack(error));
+                errors.push(
+                    `At least one of these tests failed ${names} failed, caused by ${err.message}`
+                );
             } else {
-                const error = new TSError(err, {
-                    message: `Test ${pkgs.map((pkgInfo) => pkgInfo.name).join(', ')} failed`,
-                });
-                errors.push(getFullErrorStack(error));
+                errors.push(
+                    `Test ${names} failed, caused by ${err.message}`
+                );
             }
 
             await utils.globalTeardown(options, pkgs.map(({ name, dir }) => ({ name, dir })));
@@ -201,10 +200,7 @@ async function runE2ETest(options: TestOptions): Promise<string[]> {
         try {
             await runJest(e2eDir, utils.getArgs(options), env, options.jestArgs);
         } catch (err) {
-            const error = new TSError(err, {
-                message: `Test suite "${suite}" failed`,
-            });
-            errors.push(getFullErrorStack(error));
+            errors.push(`Test suite "${suite}" failed, caused by ${err.message}`);
         }
 
         signale.timeEnd(timeLabel);

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -178,7 +178,8 @@ async function runE2ETest(options: TestOptions): Promise<string[]> {
     }
 
     const rootInfo = getRootInfo();
-    const image = `${rootInfo.terascope.docker.registry}:e2e`;
+    const [registry] = rootInfo.terascope.docker.registries;
+    const image = `${registry}:e2e`;
     if (!errors.length) {
         try {
             await utils.buildDockerImage(image);

--- a/packages/scripts/src/helpers/test-runner/interfaces.ts
+++ b/packages/scripts/src/helpers/test-runner/interfaces.ts
@@ -8,10 +8,8 @@ export type TestOptions = {
     reportCoverage: boolean;
     suite?: TestSuite;
     useExistingServices: boolean;
-    elasticsearchHost: string;
     elasticsearchVersion: string;
     elasticsearchAPIVersion: string;
-    kafkaBroker: string;
     kafkaVersion: string;
     jestArgs?: string[];
 };

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -3,11 +3,14 @@ import got from 'got';
 import semver from 'semver';
 import { debugLogger, pRetry, TSError } from '@terascope/utils';
 import {
-    dockerRun, DockerRunOptions, getContainerInfo, dockerStop
+    dockerRun,
+    DockerRunOptions,
+    getContainerInfo,
+    dockerStop
 } from '../scripts';
 import { TestOptions } from './interfaces';
 import { TestSuite } from '../interfaces';
-import { HOST_IP } from '../config';
+import * as config from '../config';
 import signale from '../signale';
 
 const logger = debugLogger('ts-scripts:cmd:test');
@@ -15,30 +18,32 @@ const logger = debugLogger('ts-scripts:cmd:test');
 type Service = TestSuite.Elasticsearch | TestSuite.Kafka;
 const services: { [service in Service]: DockerRunOptions } = {
     [TestSuite.Elasticsearch]: {
-        image: 'blacktop/elasticsearch',
-        name: 'ts_test_elasticsearch',
+        image: config.ELASTICSEARCH_DOCKER_IMAGE,
+        name: config.ELASTICSEARCH_NAME,
         tmpfs: ['/usr/share/elasticsearch/data'],
-        ports: ['49200:49200', '49300:9300'],
+        ports: [`${config.ELASTICSEARCH_PORT}:${config.ELASTICSEARCH_PORT}`],
         env: {
-            ES_JAVA_OPTS: '-Xms256m -Xmx256m',
+            ES_JAVA_OPTS: config.SERVICE_HEAP_OPTS,
             'network.host': '0.0.0.0',
-            'http.port': '49200',
+            'http.port': config.ELASTICSEARCH_PORT,
             'discovery.type': 'single-node',
         },
+        network: config.USE_SERVICE_NETWORK
     },
     [TestSuite.Kafka]: {
-        image: 'blacktop/kafka',
-        name: 'ts_test_kafka',
+        image: config.KAFKA_DOCKER_IMAGE,
+        name: config.KAFKA_NAME,
         tmpfs: ['/tmp/kafka-logs'],
-        ports: ['49092:49092', '42181:2181'],
+        ports: [`${config.KAFKA_PORT}:${config.KAFKA_PORT}`],
         env: {
-            KAFKA_HEAP_OPTS: '-Xms256m -Xmx256m',
+            KAFKA_HEAP_OPTS: config.SERVICE_HEAP_OPTS,
             KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true',
-            KAFKA_ADVERTISED_HOST_NAME: HOST_IP,
-            KAFKA_ADVERTISED_PORT: '49092',
-            KAFKA_PORT: '49092',
+            KAFKA_ADVERTISED_HOST_NAME: config.HOST_IP,
+            KAFKA_ADVERTISED_PORT: config.KAFKA_PORT,
+            KAFKA_PORT: config.KAFKA_PORT,
             KAFKA_NUM_PARTITIONS: '2',
         },
+        network: config.USE_SERVICE_NETWORK
     },
 };
 
@@ -53,7 +58,10 @@ export async function ensureServices(suite: TestSuite, options: TestOptions): Pr
         }
 
         if (suite === TestSuite.E2E) {
-            const fns = await Promise.all([ensureElasticsearch(options), ensureKafka(options)]);
+            const fns = await Promise.all([
+                ensureElasticsearch(options),
+                ensureKafka(options)
+            ]);
             return () => {
                 fns.forEach((fn) => fn());
             };
@@ -93,13 +101,14 @@ async function stopService(service: Service) {
 }
 
 async function checkElasticsearch(options: TestOptions, retries: number): Promise<void> {
+    const elasticsearchHost = config.ELASTICSEARCH_HOST;
     return pRetry(
         async () => {
-            logger.debug(`checking elasticsearch at ${options.elasticsearchHost}`);
+            logger.debug(`checking elasticsearch at ${elasticsearchHost}`);
 
             let body: any;
             try {
-                ({ body } = await got(options.elasticsearchHost, {
+                ({ body } = await got(elasticsearchHost, {
                     json: true,
                     throwHttpErrors: true,
                     retry: 0,
@@ -113,7 +122,7 @@ async function checkElasticsearch(options: TestOptions, retries: number): Promis
             logger.debug('got response from elasticsearch service', body);
 
             if (!body || !body.version || !body.version.number) {
-                throw new TSError(`Invalid response from elasticsearch at ${options.elasticsearchHost}`, {
+                throw new TSError(`Invalid response from elasticsearch at ${elasticsearchHost}`, {
                     retryable: true,
                 });
             }
@@ -123,12 +132,12 @@ async function checkElasticsearch(options: TestOptions, retries: number): Promis
 
             const satifies = semver.satisfies(actual, `^${expected}`);
             if (satifies) {
-                signale.debug(`elasticsearch@${actual} is running at ${options.elasticsearchHost}`);
+                signale.debug(`elasticsearch@${actual} is running at ${elasticsearchHost}`);
                 return;
             }
 
             throw new TSError(
-                `Elasticsearch at ${options.elasticsearchHost} does not satify required version of ${expected}, got ${actual}`,
+                `Elasticsearch at ${elasticsearchHost} does not satify required version of ${expected}, got ${actual}`,
                 {
                     retryable: false,
                 }
@@ -169,6 +178,6 @@ async function startService(options: TestOptions, service: Service): Promise<() 
     };
 }
 
-async function checkKafka(options: TestOptions) {
-    signale.debug(`kafka should be running at ${options.kafkaBroker}`);
+async function checkKafka(_options: TestOptions) {
+    signale.debug(`kafka should be running at ${config.KAFKA_BROKER}`);
 }

--- a/packages/scripts/src/helpers/test-runner/utils.ts
+++ b/packages/scripts/src/helpers/test-runner/utils.ts
@@ -41,6 +41,9 @@ export function getArgs(options: TestOptions): ArgsMap {
         args.runInBand = '';
     } else {
         args.silent = '';
+        if (config.JEST_MAX_WORKERS) {
+            args.maxWorkers = config.JEST_MAX_WORKERS;
+        }
     }
 
     if (options.watch) {

--- a/packages/scripts/src/helpers/test-runner/utils.ts
+++ b/packages/scripts/src/helpers/test-runner/utils.ts
@@ -19,7 +19,7 @@ import {
 import { TestOptions, GroupedPackages } from './interfaces';
 import { PackageInfo, TestSuite } from '../interfaces';
 import { getRootInfo } from '../misc';
-import { HOST_IP } from '../config';
+import * as config from '../config';
 import signale from '../signale';
 
 const logger = debugLogger('ts-scripts:cmd:test');
@@ -61,7 +61,7 @@ export function getArgs(options: TestOptions): ArgsMap {
 
 export function getEnv(options: TestOptions, suite?: TestSuite): ExecEnv {
     const env: ExecEnv = {
-        HOST_IP,
+        HOST_IP: config.HOST_IP,
         NODE_ENV: 'test',
         FORCE_COLOR: '1',
     };
@@ -71,7 +71,7 @@ export function getEnv(options: TestOptions, suite?: TestSuite): ExecEnv {
     if (!suite || suite === TestSuite.Elasticsearch || isE2E) {
         Object.assign(env, {
             TEST_INDEX_PREFIX: 'teratest_',
-            ELASTICSEARCH_HOST: options.elasticsearchHost,
+            ELASTICSEARCH_HOST: config.ELASTICSEARCH_HOST,
             ELASTICSEARCH_VERSION: options.elasticsearchVersion,
             ELASTICSEARCH_API_VERSION: options.elasticsearchAPIVersion,
         });
@@ -79,7 +79,7 @@ export function getEnv(options: TestOptions, suite?: TestSuite): ExecEnv {
 
     if (!suite || suite === TestSuite.Kafka || isE2E) {
         Object.assign(env, {
-            KAFKA_BROKER: options.kafkaBroker,
+            KAFKA_BROKER: config.KAFKA_BROKER,
             KAFKA_VERSION: options.kafkaVersion,
         });
     }

--- a/packages/scripts/src/helpers/test-runner/utils.ts
+++ b/packages/scripts/src/helpers/test-runner/utils.ts
@@ -238,11 +238,13 @@ function getCacheFrom(): string[] {
     const layers = rootInfo.terascope.docker.cache_layers || [];
     if (!layers.length) return [];
     const cacheFrom: { [name: string]: string } = {};
+    const [registry] = rootInfo.terascope.docker.registries;
+
     layers.forEach(({ from, name }) => {
         if (cacheFrom[from] == null) {
             cacheFrom[from] = from;
         }
-        cacheFrom[name] = `${rootInfo.terascope.docker.registry}:dev-${name}`;
+        cacheFrom[name] = `${registry}:dev-${name}`;
     });
     return Object.values(cacheFrom);
 }

--- a/packages/scripts/test/bump-spec.ts
+++ b/packages/scripts/test/bump-spec.ts
@@ -157,7 +157,7 @@ describe('Bump Utils', () => {
 
             it('should be able to get a readable commit message', () => {
                 const message = getBumpCommitMessage(result, options.release);
-                expect(message).toBe('bump: (minor) package-util-1, package-dep-1');
+                expect(message).toBe('bump: (minor) package-util-1@3.1.0, package-dep-1@2.1.0');
             });
         });
 
@@ -247,7 +247,7 @@ describe('Bump Utils', () => {
 
             it('should be able to get a readable commit message', () => {
                 const message = getBumpCommitMessage(result, options.release);
-                expect(message).toBe('bump: (patch) package-util-1');
+                expect(message).toBe('bump: (patch) package-util-1@3.0.1');
             });
         });
     });
@@ -339,7 +339,7 @@ describe('Bump Utils', () => {
 
         it('should be able to get a readable commit message', () => {
             const message = getBumpCommitMessage(result, options.release);
-            expect(message).toBe('release: (preminor) package-main AND bump: (preminor) package-dep-2');
+            expect(message).toBe('release: (preminor) package-main@1.1.0-rc.0 AND bump: (preminor) package-dep-2@2.1.0-rc.0');
         });
     });
 });


### PR DESCRIPTION
- feat: show version in bump commit message
- fix: add multiple docker registry support
- fix: better test errors
- fix: issue when ts-scripts cli fails
- feat: add the ability to set env JEST_MAX_WORKERS (to global constrained concurrency)
- fix: allow overriding FORCE_COLOR in ts-scripts
- feat: allow specifying a network to connect to for the test services

BREAKING CHANGES:
   - Removes flags for `--elasticsearch-host` and `--kafka-broker` 
   - Changes the configuration for docker registries from `registry` to `registries`