### PR TITLE
More ts-scripts fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,6 @@
 **/coverage
 **/test
 **/spec
-**/docs
 **/website
 **/examples
 **/e2e
@@ -18,6 +17,7 @@
 .cache
 .*cache
 .vscode
+docs
 assets
 autoload
 packages/*/assets

--- a/.dockerignore
+++ b/.dockerignore
@@ -24,17 +24,4 @@ packages/*/assets
 packages/*/autoload
 packages/*/bench
 
-# exclude packages that are not needed inside the docker image
-packages/chunked-file-reader
-packages/data-types
-packages/docker-compose-js
-packages/elasticsearch-store
-packages/eslint-config
 packages/generator-teraslice
-packages/scripts
-packages/teraslice-client-js
-packages/teraslice-cli
-packages/teraslice-state-store
-packages/teraslice-test-harness
-packages/ts-transforms
-packages/xlucene-evaluator

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,7 +14,9 @@
 **/dist
 **/build
 **/.cache
+**/.*cache
 .cache
+.*cache
 .vscode
 assets
 autoload

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,8 @@ builds/*
 # cache directory
 .cache
 .eslintcache
-.yarn-cache/*
-!.yarn-cache/.gitkeep
+.yarn-cache
+.jest-cache
 
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,14 @@ node_js:
 
 cache:
   npm: false
-  yarn: false
+  yarn: true
   directories:
-    - '$TRAVIS_BUILD_DIR/.yarn-cache'
     - '$TRAVIS_BUILD_DIR/.eslintcache'
 
 before_install: . ./scripts/ci-setup.sh
 install:
     # Install the dependencies
-    - yarn
+    - yarn --forzen-lockfile --ignore-optional
     # Build setup the build
     - yarn quick:setup
 

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,2 @@
 workspaces-experimental true
-cache-folder ".yarn-cache"
 prefer-offline true

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,6 @@ RUN npm init --yes > /dev/null \
 # the deps image should contain all of dev code
 FROM base AS deps
 
-COPY .yarn-cache .yarn-cache
 COPY package.json yarn.lock lerna.json .yarnrc /app/source/
 COPY packages /app/source/packages
 
@@ -58,9 +57,7 @@ COPY packages /app/source/packages
 RUN yarn \
     --prod=true \
     --frozen-lockfile \
-    --no-progress \
-    --prefer-offline \
-    --no-emoji \
+    --ignore-optional \
     && cp -Rp node_modules /app/node_modules
 
 ENV NODE_ENV development
@@ -69,17 +66,14 @@ ENV NODE_ENV development
 RUN yarn \
     --prod=false \
     --frozen-lockfile \
-    --no-progress \
-    --prefer-offline \
-    --ignore-optional \
-    --no-emoji
+    --ignore-optional
 
 # Prepare the node modules for isntallation
 COPY types /app/source/types
 COPY tsconfig.json /app/source/
 
 # Build the packages
-RUN yarn lerna link --force-local && yarn lerna run build
+RUN yarn quick:setup
 
 # the prod image should small
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,17 +53,11 @@ FROM base AS deps
 COPY package.json yarn.lock lerna.json .yarnrc /app/source/
 COPY packages /app/source/packages
 
-# Build just the production node_modules and copy them over
-RUN yarn \
-    --prod=true \
-    --frozen-lockfile \
-    --ignore-optional \
-    && cp -Rp node_modules /app/node_modules
-
 ENV NODE_ENV development
 
 # install both dev and production dependencies
 RUN yarn \
+    --no-cache \
     --prod=false \
     --frozen-lockfile \
     --ignore-optional
@@ -100,7 +94,7 @@ COPY scripts /app/source/scripts
 # copy the compiled packages
 COPY --from=deps /app/source/packages /app/source/packages
 # copy the production node_modules
-COPY --from=deps /app/node_modules /app/source/node_modules
+COPY --from=deps /app/source/node_modules /app/source/node_modules
 
 # verify teraslice is installed right
 RUN node -e "require('teraslice')"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "lint": "yarn lint:es && yarn sync --verify",
         "lint:es": "eslint --cache --ext .js,.jsx,.ts,.tsx .",
         "lint:fix": "yarn lint:es --fix && yarn sync",
-        "quick:setup": "yarn lerna link --force-local && tsc --build",
+        "quick:setup": "yarn lerna link --force-local && yarn build",
         "setup": "lerna bootstrap --force-local && yarn build:cleanup dist && yarn build",
         "start": "node service.js",
         "sync": "ts-scripts sync",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "lint": "yarn lint:es && yarn sync --verify",
         "lint:es": "eslint --cache --ext .js,.jsx,.ts,.tsx .",
         "lint:fix": "yarn lint:es --fix && yarn sync",
-        "quick:setup": "yarn lerna link --force-local && yarn lerna run build",
+        "quick:setup": "yarn lerna link --force-local && tsc --build",
         "setup": "lerna bootstrap --force-local && yarn build:cleanup dist && yarn build",
         "start": "node service.js",
         "sync": "ts-scripts sync",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "lint": "yarn lint:es && yarn sync --verify",
         "lint:es": "eslint --cache --ext .js,.jsx,.ts,.tsx .",
         "lint:fix": "yarn lint:es --fix && yarn sync",
-        "quick:setup": "yarn lerna link --force-local && yarn build",
+        "quick:setup": "yarn lerna link --force-local && yarn lerna run build",
         "setup": "lerna bootstrap --force-local && yarn build:cleanup dist && yarn build",
         "start": "node service.js",
         "sync": "ts-scripts sync",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.6.2-rc.0",
+    "version": "0.6.2-rc.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.6.2-rc.1",
+    "version": "0.6.2-rc.2",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.6.1",
+    "version": "0.6.2-rc.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.6.2-rc.2",
+    "version": "0.6.2",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -2,7 +2,11 @@ import isCI from 'is-ci';
 import { address } from 'ip';
 import { toBoolean } from '@terascope/utils';
 
-export const FORCE_COLOR = process.env.FORCE_COLOR || '1';
+const forceColor = process.env.FORCE_COLOR || '1';
+export const FORCE_COLOR = toBoolean(forceColor)
+    ? '1'
+    : '0';
+
 export const HOST_IP = process.env.HOST_IP || address();
 export const USE_EXISTING_SERVICES = toBoolean(process.env.USE_EXISTING_SERVICES);
 export const SERVICE_HEAP_OPTS = process.env.SERVICE_HEAP_OPTS || '-Xms256m -Xmx256m';

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -28,12 +28,9 @@ export const KAFKA_BROKER = `${KAFKA_HOSTNAME}:${KAFKA_PORT}`;
 export const KAFKA_VERSION = process.env.KAFKA_VERSION || '2.1';
 export const KAFKA_DOCKER_IMAGE = process.env.KAFKA_DOCKER_IMAGE || 'blacktop/kafka';
 
-const reportCov = process.env.REPORT_COVERAGE;
-export const REPORT_COVERAGE = reportCov != null || reportCov !== ''
-    ? toBoolean(reportCov)
-    : isCI;
+const reportCov = process.env.REPORT_COVERAGE || `${isCI}`;
+export const REPORT_COVERAGE = toBoolean(reportCov);
 
 export const JEST_MAX_WORKERS = process.env.JEST_MAX_WORKERS || undefined;
 
 export const NPM_DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
-export const NPM_PUBLISH_TAG = process.env.NPM_PUBLISH_TAG || 'latest';

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -9,6 +9,7 @@ export const FORCE_COLOR = toBoolean(forceColor)
 
 export const HOST_IP = process.env.HOST_IP || address();
 export const USE_EXISTING_SERVICES = toBoolean(process.env.USE_EXISTING_SERVICES);
+export const SERVICES_USE_TMPFS = toBoolean(process.env.SERVICES_USE_TMPFS || 'true');
 export const SERVICE_HEAP_OPTS = process.env.SERVICE_HEAP_OPTS || '-Xms256m -Xmx256m';
 export const USE_SERVICE_NETWORK = process.env.USE_SERVICE_NETWORK || undefined;
 export const TEST_NAMESPACE = process.env.TEST_NAMESPACE || 'ts_test';

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -7,8 +7,9 @@ export const HOST_IP = process.env.HOST_IP || address();
 export const USE_EXISTING_SERVICES = toBoolean(process.env.USE_EXISTING_SERVICES);
 export const SERVICE_HEAP_OPTS = process.env.SERVICE_HEAP_OPTS || '-Xms256m -Xmx256m';
 export const USE_SERVICE_NETWORK = process.env.USE_SERVICE_NETWORK || undefined;
+export const TEST_NAMESPACE = process.env.TEST_NAMESPACE || 'ts_test';
 
-export const ELASTICSEARCH_NAME = 'ts_test_elasticsearch';
+export const ELASTICSEARCH_NAME = process.env.ELASTICSEARCH_NAME || 'elasticsearch';
 export const ELASTICSEARCH_HOSTNAME = process.env.ELASTICSEARCH_HOSTNAME || HOST_IP;
 export const ELASTICSEARCH_PORT = process.env.ELASTICSEARCH_PORT || '49200';
 export const ELASTICSEARCH_HOST = `http://${ELASTICSEARCH_HOSTNAME}:${ELASTICSEARCH_PORT}`;
@@ -16,7 +17,7 @@ export const ELASTICSEARCH_VERSION = process.env.ELASTICSEARCH_VERSION || '6.8';
 export const ELASTICSEARCH_API_VERSION = process.env.ELASTICSEARCH_API_VERSION || '6.5';
 export const ELASTICSEARCH_DOCKER_IMAGE = process.env.ELASTICSEARCH_DOCKER_IMAGE || 'blacktop/elasticsearch';
 
-export const KAFKA_NAME = 'ts_test_kafka';
+export const KAFKA_NAME = process.env.KAFKA_NAME || 'kafka';
 export const KAFKA_HOSTNAME = process.env.KAFKA_HOSTNAME || HOST_IP;
 export const KAFKA_PORT = process.env.KAFKA_PORT || '49092';
 export const KAFKA_BROKER = `${KAFKA_HOSTNAME}:${KAFKA_PORT}`;

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -15,7 +15,7 @@ import { getRootInfo } from '../misc';
 import signale from '../signale';
 
 export async function publish(action: PublishAction, options: PublishOptions) {
-    signale.info(`publishing to ${action}`);
+    signale.info(`publishing to ${action}`, { dryRun: options.dryRun });
 
     if (action === PublishAction.NPM) {
         return publishToNPM(options);

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -3,7 +3,12 @@ import { get } from '@terascope/utils';
 import { PackageInfo } from '../interfaces';
 import { listPackages, getMainPackageInfo } from '../packages';
 import { PublishAction, PublishOptions, PublishType } from './interfaces';
-import { shouldNPMPublish, formatDailyTag, buildCacheLayers } from './utils';
+import {
+    shouldNPMPublish,
+    formatDailyTag,
+    buildCacheLayers,
+    getPublishTag
+} from './utils';
 import {
     yarnPublish,
     yarnRun,
@@ -38,12 +43,14 @@ async function npmPublish(pkgInfo: PackageInfo, options: PublishOptions) {
     const shouldPublish = await shouldNPMPublish(pkgInfo, options.type);
     if (!shouldPublish) return;
 
+    const tag = getPublishTag(pkgInfo.version);
+
     if (options.dryRun) {
-        signale.info(`[DRY RUN] - skipping publish for package ${pkgInfo.name}@v${pkgInfo.version}`);
+        signale.info(`[DRY RUN] - skipping publish for package ${pkgInfo.name}@v${pkgInfo.version} (${tag})`);
         await yarnRun('prepublishOnly', [], pkgInfo.dir);
     } else {
         const registry: string|undefined = get(pkgInfo, 'publishConfig.registry');
-        await yarnPublish(pkgInfo, registry);
+        await yarnPublish(pkgInfo, tag, registry);
     }
 }
 

--- a/packages/scripts/src/helpers/publish/utils.ts
+++ b/packages/scripts/src/helpers/publish/utils.ts
@@ -15,7 +15,11 @@ export async function shouldNPMPublish(pkgInfo: PackageInfo, type?: PublishType)
     if (pkgInfo.private) return false;
 
     const registry: string|undefined = get(pkgInfo, 'publishConfig.registry');
-    const remote = await getLatestNPMVersion(pkgInfo.name, registry);
+    const remote = await getLatestNPMVersion(
+        pkgInfo.name,
+        getPublishTag(pkgInfo.version),
+        registry
+    );
     const local = pkgInfo.version;
 
     if (semver.gt(local, remote)) {
@@ -45,6 +49,15 @@ export async function shouldNPMPublish(pkgInfo: PackageInfo, type?: PublishType)
 
     signale.warn(`* local version of ${pkgInfo.name}@v${local} is behind, expected v${remote}`);
     return false;
+}
+
+export function getPublishTag(version: string): string {
+    const parsed = semver.parse(version);
+    if (!parsed) {
+        throw new Error(`Unable to publish invalid version "${version}"`);
+    }
+    if (parsed.prerelease.length) return 'prelease';
+    return 'latest';
 }
 
 function padNumber(n: number): string {

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -95,7 +95,7 @@ async function runTestSuite(
     const errors: string[] = [];
 
     // jest or our tests have a memory leak, limiting this seems to help
-    const MAX_CHUNK_SIZE = isCI ? 5 : 10;
+    const MAX_CHUNK_SIZE = isCI ? 7 : 10;
     const CHUNK_SIZE = options.debug ? 1 : MAX_CHUNK_SIZE;
 
     if (options.watch && pkgInfos.length > MAX_CHUNK_SIZE) {

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -20,7 +20,9 @@ const services: { [service in Service]: DockerRunOptions } = {
     [TestSuite.Elasticsearch]: {
         image: config.ELASTICSEARCH_DOCKER_IMAGE,
         name: `${config.TEST_NAMESPACE}_${config.ELASTICSEARCH_NAME}`,
-        tmpfs: ['/usr/share/elasticsearch/data'],
+        tmpfs: config.SERVICES_USE_TMPFS
+            ? ['/usr/share/elasticsearch/data']
+            : undefined,
         ports: [`${config.ELASTICSEARCH_PORT}:${config.ELASTICSEARCH_PORT}`],
         env: {
             ES_JAVA_OPTS: config.SERVICE_HEAP_OPTS,
@@ -33,7 +35,9 @@ const services: { [service in Service]: DockerRunOptions } = {
     [TestSuite.Kafka]: {
         image: config.KAFKA_DOCKER_IMAGE,
         name: `${config.TEST_NAMESPACE}_${config.ELASTICSEARCH_NAME}`,
-        tmpfs: ['/tmp/kafka-logs'],
+        tmpfs: config.SERVICES_USE_TMPFS
+            ? ['/tmp/kafka-logs']
+            : undefined,
         ports: [`${config.KAFKA_PORT}:${config.KAFKA_PORT}`],
         env: {
             KAFKA_HEAP_OPTS: config.SERVICE_HEAP_OPTS,

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -19,7 +19,7 @@ type Service = TestSuite.Elasticsearch | TestSuite.Kafka;
 const services: { [service in Service]: DockerRunOptions } = {
     [TestSuite.Elasticsearch]: {
         image: config.ELASTICSEARCH_DOCKER_IMAGE,
-        name: config.ELASTICSEARCH_NAME,
+        name: `${config.TEST_NAMESPACE}_${config.ELASTICSEARCH_NAME}`,
         tmpfs: ['/usr/share/elasticsearch/data'],
         ports: [`${config.ELASTICSEARCH_PORT}:${config.ELASTICSEARCH_PORT}`],
         env: {
@@ -32,7 +32,7 @@ const services: { [service in Service]: DockerRunOptions } = {
     },
     [TestSuite.Kafka]: {
         image: config.KAFKA_DOCKER_IMAGE,
-        name: config.KAFKA_NAME,
+        name: `${config.TEST_NAMESPACE}_${config.ELASTICSEARCH_NAME}`,
         tmpfs: ['/tmp/kafka-logs'],
         ports: [`${config.KAFKA_PORT}:${config.KAFKA_PORT}`],
         env: {

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -15,6 +15,8 @@ import signale from '../signale';
 
 const logger = debugLogger('ts-scripts:cmd:test');
 
+const disableXPackSecurity = !config.ELASTICSEARCH_DOCKER_IMAGE.includes('blacktop');
+
 type Service = TestSuite.Elasticsearch | TestSuite.Kafka;
 const services: { [service in Service]: DockerRunOptions } = {
     [TestSuite.Elasticsearch]: {
@@ -29,6 +31,9 @@ const services: { [service in Service]: DockerRunOptions } = {
             'network.host': '0.0.0.0',
             'http.port': config.ELASTICSEARCH_PORT,
             'discovery.type': 'single-node',
+            ...disableXPackSecurity && {
+                'xpack.security.enabled': 'false'
+            }
         },
         network: config.USE_SERVICE_NETWORK
     },

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -34,7 +34,7 @@ const services: { [service in Service]: DockerRunOptions } = {
     },
     [TestSuite.Kafka]: {
         image: config.KAFKA_DOCKER_IMAGE,
-        name: `${config.TEST_NAMESPACE}_${config.ELASTICSEARCH_NAME}`,
+        name: `${config.TEST_NAMESPACE}_${config.KAFKA_NAME}`,
         tmpfs: config.SERVICES_USE_TMPFS
             ? ['/tmp/kafka-logs']
             : undefined,

--- a/packages/scripts/src/helpers/test-runner/utils.ts
+++ b/packages/scripts/src/helpers/test-runner/utils.ts
@@ -29,7 +29,9 @@ export function getArgs(options: TestOptions): ArgsMap {
     args.forceExit = '';
     args.passWithNoTests = '';
     args.coverage = 'true';
-    args.color = '';
+    if (config.FORCE_COLOR === '1') {
+        args.color = '';
+    }
 
     if (options.bail) {
         args.bail = '';
@@ -66,7 +68,7 @@ export function getEnv(options: TestOptions, suite?: TestSuite): ExecEnv {
     const env: ExecEnv = {
         HOST_IP: config.HOST_IP,
         NODE_ENV: 'test',
-        FORCE_COLOR: '1',
+        FORCE_COLOR: config.FORCE_COLOR,
     };
 
     const isE2E = suite === TestSuite.E2E;

--- a/packages/scripts/src/helpers/test-runner/utils.ts
+++ b/packages/scripts/src/helpers/test-runner/utils.ts
@@ -73,7 +73,7 @@ export function getEnv(options: TestOptions, suite?: TestSuite): ExecEnv {
 
     if (!suite || suite === TestSuite.Elasticsearch || isE2E) {
         Object.assign(env, {
-            TEST_INDEX_PREFIX: 'teratest_',
+            TEST_INDEX_PREFIX: `${config.TEST_NAMESPACE}_`,
             ELASTICSEARCH_HOST: config.ELASTICSEARCH_HOST,
             ELASTICSEARCH_VERSION: options.elasticsearchVersion,
             ELASTICSEARCH_API_VERSION: options.elasticsearchAPIVersion,

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -132,7 +132,6 @@ post_cleanup() {
 
     prompt "Do you want to verify/rebuild the node_modules?" &&
         echoerr "* running yarn --force --check-files --update-checksums" &&
-        rm -rf ./.yarn-cache/v4 &&
         yarn --force --check-files --update-checksums
 
     prompt "Do you want to rebuild the packages?" &&


### PR DESCRIPTION
- fix: ts-scripts test namespace
- fix: ts-scripts `FORCE_COLOR`
- fix: infer prelease tag from version not env
- fix: coverage reporting
- fix: official elasticsearch docker image usage in v5.6.16
- fix: some of the yarn-caches issues I have found and other docker issues