### PR TITLE
Fix has util function

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -39,7 +39,7 @@
         "nanoid": "^2.0.3",
         "semver": "^6.1.1",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.8.3",
+        "teraslice-client-js": "^0.8.4",
         "uuid": "^3.3.3"
     },
     "displayName": "E2E Tests",

--- a/packages/chunked-file-reader/package.json
+++ b/packages/chunked-file-reader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/chunked-file-reader",
-    "version": "2.1.7",
+    "version": "2.1.8",
     "description": "This module is an abstracted reader for use in various Teraslice readers. It uses an externally-defined reader to read data and the packages up the data in a DataEntity for use with other Teraslice processors.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/chunked-file-reader#readme",
     "bugs": {
@@ -20,7 +20,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.2",
+        "@terascope/utils": "^0.20.3",
         "bluebird": "^3.5.5",
         "csvtojson": "^2.0.8",
         "lodash": "^4.17.11"

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/data-types",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.2",
+        "@terascope/utils": "^0.20.3",
         "graphql": "^14.3.1",
         "lodash.defaultsdeep": "^4.6.1",
         "lodash.set": "^4.3.2",
@@ -37,7 +37,7 @@
         "@types/lodash.defaultsdeep": "^4.6.6",
         "@types/lodash.set": "^4.3.6",
         "@types/yargs": "^13.0.2",
-        "xlucene-evaluator": "^0.11.2"
+        "xlucene-evaluator": "^0.11.3"
     },
     "engines": {
         "node": ">=8.0.0"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/elasticsearch-api",
-    "version": "2.1.9",
+    "version": "2.1.10",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -17,7 +17,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.2",
+        "@terascope/utils": "^0.20.3",
         "bluebird": "^3.5.5",
         "lodash": "^4.17.11"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "elasticsearch-store",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -23,12 +23,12 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.6.0",
-        "@terascope/utils": "^0.20.2",
+        "@terascope/data-types": "^0.6.1",
+        "@terascope/utils": "^0.20.3",
         "ajv": "^6.10.0",
         "nanoid": "^2.0.3",
         "rambda": "^3.0.0",
-        "xlucene-evaluator": "^0.11.2"
+        "xlucene-evaluator": "^0.11.3"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/job-components",
-    "version": "0.23.6",
+    "version": "0.23.7",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.7",
-        "@terascope/utils": "^0.20.2",
+        "@terascope/utils": "^0.20.3",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^3.3.3"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.14.0",
-        "@terascope/utils": "^0.20.2",
+        "@terascope/utils": "^0.20.3",
         "@types/is-ci": "^2.0.0",
         "codecov": "^3.5.0",
         "execa": "^2.0.4",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "terafoundation",
-    "version": "0.13.1",
+    "version": "0.13.2",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.2",
+        "@terascope/utils": "^0.20.3",
         "aws-sdk": "^2.513.0",
         "bluebird": "^3.5.5",
         "bunyan": "^1.8.12",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-cli",
-    "version": "0.8.5",
+    "version": "0.8.6",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.6.0",
-        "@terascope/utils": "^0.20.2",
+        "@terascope/utils": "^0.20.3",
         "archiver": "^3.0.0",
         "bluebird": "^3.5.5",
         "chalk": "^2.4.2",
@@ -51,7 +51,7 @@
         "request": "^2.88.0",
         "request-promise": "^4.2.4",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.8.3",
+        "teraslice-client-js": "^0.8.4",
         "tmp": "^0.1.0",
         "tty-table": "^2.7.4",
         "yargs": "^14.0.0",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-client-js",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -29,7 +29,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.23.6",
+        "@terascope/job-components": "^0.23.7",
         "auto-bind": "^2.1.0",
         "got": "^9.6.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-messaging",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.7",
-        "@terascope/utils": "^0.20.2",
+        "@terascope/utils": "^0.20.3",
         "ms": "^2.1.2",
         "nanoid": "^2.0.3",
         "p-event": "^4.1.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
-    "version": "1.7.8",
+    "version": "1.7.9",
     "description": "A testing harness to simplify testing Teraslice processors and operations.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-op-test-harness#readme",
     "bugs": {
@@ -17,7 +17,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.23.6",
+        "@terascope/job-components": "^0.23.7",
         "bluebird": "^3.5.5",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-state-storage",
-    "version": "0.7.6",
+    "version": "0.7.7",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.9",
-        "@terascope/utils": "^0.20.2",
+        "@terascope/elasticsearch-api": "^2.1.10",
+        "@terascope/utils": "^0.20.3",
         "bluebird": "^3.5.5",
         "mnemonist": "^0.30.0"
     },

--- a/packages/teraslice-state-storage/test/elasticsearch-state-storage-spec.ts
+++ b/packages/teraslice-state-storage/test/elasticsearch-state-storage-spec.ts
@@ -529,7 +529,7 @@ describe('elasticsearch-state-storage', () => {
     });
 
     describe('when testing a large data set', () => {
-        jest.setTimeout(10000);
+        jest.setTimeout(15000);
 
         beforeEach(() => setup());
         afterEach(() => teardown());

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-test-harness",
-    "version": "0.8.9",
+    "version": "0.8.10",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {
@@ -30,8 +30,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.23.6",
-        "@terascope/teraslice-op-test-harness": "^1.7.8",
+        "@terascope/job-components": "^0.23.7",
+        "@terascope/teraslice-op-test-harness": "^1.7.9",
         "lodash": "^4.17.11"
     },
     "devDependencies": {},

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -32,11 +32,11 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.9",
-        "@terascope/job-components": "^0.23.6",
+        "@terascope/elasticsearch-api": "^2.1.10",
+        "@terascope/job-components": "^0.23.7",
         "@terascope/queue": "^1.1.7",
-        "@terascope/teraslice-messaging": "^0.4.5",
-        "@terascope/utils": "^0.20.2",
+        "@terascope/teraslice-messaging": "^0.4.6",
+        "@terascope/utils": "^0.20.3",
         "async-mutex": "^0.1.3",
         "barbe": "^3.0.15",
         "bluebird": "^3.5.5",
@@ -60,11 +60,11 @@
         "shortid": "^2.2.14",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.13.1",
+        "terafoundation": "^0.13.2",
         "uuid": "^3.3.3"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.7.8",
+        "@terascope/teraslice-op-test-harness": "^1.7.9",
         "archiver": "^3.0.0",
         "bufferstreams": "^2.0.1",
         "chance": "^1.0.18",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-transforms",
-    "version": "0.24.6",
+    "version": "0.24.7",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.2",
+        "@terascope/utils": "^0.20.3",
         "@types/graphlib": "^2.1.5",
         "@types/shortid": "^0.0.29",
         "awesome-phonenumber": "^2.15.0",
@@ -44,7 +44,7 @@
         "shortid": "^2.2.14",
         "valid-url": "^1.0.9",
         "validator": "^11.0.0",
-        "xlucene-evaluator": "^0.11.2",
+        "xlucene-evaluator": "^0.11.3",
         "yargs": "^14.0.0"
     },
     "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/utils",
-    "version": "0.20.2",
+    "version": "0.20.3",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -38,6 +38,14 @@ export class TSError extends Error {
      */
     context: TSErrorContext;
 
+    static [Symbol.hasInstance](instance: any): boolean {
+        if (instance == null) return false;
+        if (instance.message == null || instance.stack == null) return false;
+        if (instance.statusCode == null) return false;
+        if (typeof instance.cause !== 'function') return false;
+        return true;
+    }
+
     constructor(input: any, config: TSErrorConfig = {}) {
         const { fatalError = false } = config;
 

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -5,8 +5,12 @@ import cloneDeep from 'lodash.clonedeep';
 import isPlainObject from 'is-plain-object';
 
 /** Check in input has a key */
-export function has(data: object, key: any) {
-    if (key == null || data == null) return false;
+export function has(data: object, key: string|number|symbol): boolean {
+    if (data == null || typeof data !== 'object') return false;
+    if (data instanceof Set || data instanceof Map) {
+        if (key in data) return true;
+        return data.has(key);
+    }
     return key in data;
 }
 

--- a/packages/utils/test/objects-spec.ts
+++ b/packages/utils/test/objects-spec.ts
@@ -91,9 +91,10 @@ describe('Objects', () => {
             expect(has(0 as any, 'hi')).toBeFalse();
             expect(has(1 as any, 'hi')).toBeFalse();
             expect(has(NaN as any, 'hi')).toBeFalse();
+            expect(has((() => {}) as any, 'hi')).toBeFalse();
         });
 
-        it('should handle an non-string/number/symbol keys safely', () => {
+        it('should handle an non-(string/number/symbol) keys safely', () => {
             expect(has({ a: 'b' }, null as any)).toBeFalse();
             expect(has({ a: 'b' }, undefined as any)).toBeFalse();
             expect(has({ }, null as any)).toBeFalse();
@@ -101,6 +102,7 @@ describe('Objects', () => {
             expect(has({ a: 'b' }, {} as any)).toBeFalse();
             expect(has({ a: 'b' }, [] as any)).toBeFalse();
             expect(has({ a: 'b' }, NaN)).toBeFalse();
+            expect(has({ a: 'b' }, (() => {}) as any)).toBeFalse();
         });
     });
 });

--- a/packages/utils/test/objects-spec.ts
+++ b/packages/utils/test/objects-spec.ts
@@ -2,14 +2,16 @@ import 'jest-extended';
 import {
     DataEntity,
     isPlainObject,
+    has
 } from '../src';
 
 describe('Objects', () => {
+    class TestObj {
+        hi = true
+        has() {}
+    }
+
     describe('isPlainObject', () => {
-        class TestObj {
-
-        }
-
         it('should correctly detect the an object type', () => {
             // @ts-ignore
             expect(isPlainObject()).toBeFalse();
@@ -26,6 +28,79 @@ describe('Objects', () => {
             expect(isPlainObject(Object.create({ hello: true }))).toBeTrue();
             expect(isPlainObject({})).toBeTrue();
             expect(isPlainObject({ hello: true })).toBeTrue();
+        });
+    });
+
+    describe('has', () => {
+        const symbol = Symbol('__hello__');
+
+        it('should an object correctly', () => {
+            expect(has({ hi: true }, 'hi')).toBeTrue();
+            expect(has({ hi: false }, 'hi')).toBeTrue();
+            expect(has({ '': 'hi' }, '')).toBeTrue();
+            expect(has({ 1: 'hi' }, 1)).toBeTrue();
+            expect(has({ 0: 'hi' }, 0)).toBeTrue();
+            expect(has({ 3: 'hi' }, 2)).toBeFalse();
+            expect(has(new TestObj(), 'hi')).toBeTrue();
+
+            expect(has({}, 'hi')).toBeFalse();
+            expect(has({ a: 'b' }, Buffer.from('a') as any)).toBeTrue();
+            expect(has({
+                [symbol]: true
+            }, symbol)).toBeTrue();
+        });
+
+        it('should handle a Map correct', () => {
+            const map = new Map();
+            map.set('hi', 'hello');
+            expect(has(map, 'hi')).toBeTrue();
+            expect(has(map, 'hello')).toBeFalse();
+            expect(has(map, 0)).toBeFalse();
+            expect(has(map, null as any)).toBeFalse();
+            expect(has(map, undefined as any)).toBeFalse();
+            expect(has(map, [] as any)).toBeFalse();
+            expect(has(map, {} as any)).toBeFalse();
+        });
+
+        it('should an array correctly', () => {
+            expect(has(['hi', 'hello'], 0)).toBeTrue();
+            expect(has(['hi', 'hello'], 'hi')).toBeFalse();
+            expect(has(['hi', 'hello'], 1)).toBeTrue();
+            expect(has(['hi', 'hello'], 'hello')).toBeFalse();
+            expect(has(['hi', 'hello'], 2)).toBeFalse();
+        });
+
+        it('should handle a Set correct', () => {
+            const set = new Set();
+            set.add('hi');
+            expect(has(set, 'hi')).toBeTrue();
+            expect(has(set, 'hello')).toBeFalse();
+            expect(has(set, 0)).toBeFalse();
+            expect(has(set, null as any)).toBeFalse();
+            expect(has(set, undefined as any)).toBeFalse();
+            expect(has(set, [] as any)).toBeFalse();
+            expect(has(set, {} as any)).toBeFalse();
+        });
+
+        it('should handle non-objects safely', () => {
+            expect(has(['hi'], 'hi') as any).toBeFalse();
+            expect(has(Buffer.from('hi'), 'hi') as any).toBeFalse();
+            expect(has('hi' as any, 'hi')).toBeFalse();
+            expect(has(null as any, 'hi')).toBeFalse();
+            expect(has(undefined as any, 'hi')).toBeFalse();
+            expect(has(0 as any, 'hi')).toBeFalse();
+            expect(has(1 as any, 'hi')).toBeFalse();
+            expect(has(NaN as any, 'hi')).toBeFalse();
+        });
+
+        it('should handle an non-string/number/symbol keys safely', () => {
+            expect(has({ a: 'b' }, null as any)).toBeFalse();
+            expect(has({ a: 'b' }, undefined as any)).toBeFalse();
+            expect(has({ }, null as any)).toBeFalse();
+            expect(has({ }, undefined as any)).toBeFalse();
+            expect(has({ a: 'b' }, {} as any)).toBeFalse();
+            expect(has({ a: 'b' }, [] as any)).toBeFalse();
+            expect(has({ a: 'b' }, NaN)).toBeFalse();
         });
     });
 });

--- a/packages/utils/test/objects-spec.ts
+++ b/packages/utils/test/objects-spec.ts
@@ -34,7 +34,7 @@ describe('Objects', () => {
     describe('has', () => {
         const symbol = Symbol('__hello__');
 
-        it('should an object correctly', () => {
+        it('should handle a object correctly', () => {
             expect(has({ hi: true }, 'hi')).toBeTrue();
             expect(has({ hi: false }, 'hi')).toBeTrue();
             expect(has({ '': 'hi' }, '')).toBeTrue();
@@ -62,7 +62,7 @@ describe('Objects', () => {
             expect(has(map, {} as any)).toBeFalse();
         });
 
-        it('should an array correctly', () => {
+        it('should handle a array correctly', () => {
             expect(has(['hi', 'hello'], 0)).toBeTrue();
             expect(has(['hi', 'hello'], 'hi')).toBeFalse();
             expect(has(['hi', 'hello'], 1)).toBeTrue();

--- a/packages/xlucene-evaluator/package.json
+++ b/packages/xlucene-evaluator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xlucene-evaluator",
-    "version": "0.11.2",
+    "version": "0.11.3",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-evaluator#readme",
     "repository": {
@@ -28,7 +28,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.2",
+        "@terascope/utils": "^0.20.3",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-point-in-polygon": "^6.0.1",


### PR DESCRIPTION
Adds tests for a bunch of edge cases with the `has` utility from `@terascope/utils`. Prevents crash  when given a string or other non-object types as the first parameter.

Also fixes instanceof detection in `TSError` when there are multiple instances of `@terascope/utils` in a given a project.