### PR TITLE
v0.58.1 - terafoundation schema fix and Elasticsearch API error fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-workspace",
-    "version": "0.58.0",
+    "version": "0.58.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/elasticsearch-api/index.js
+++ b/packages/elasticsearch-api/index.js
@@ -827,7 +827,8 @@ module.exports = function elasticsearchApi(client = {}, logger, _opConfig) {
                     .then((results) => results)
                     .catch((err) => {
                         // It's not really an error if it's just that the index is already there
-                        if (parseError(err).match(/index_already_exists_exception/) === null) {
+                        const errStr = parseError(err, true);
+                        if (!errStr.includes('already_exists_exception')) {
                             const error = new TSError(err, {
                                 reason: `Could not create index: ${index}`,
                             });
@@ -926,7 +927,7 @@ module.exports = function elasticsearchApi(client = {}, logger, _opConfig) {
         _time
     ) {
         // eslint-disable-line
-        const giveupAfter = Date.now() + (_time || 3000);
+        const giveupAfter = Date.now() + (_time || 10000);
         return new Promise((resolve, reject) => {
             const attemptToCreateIndex = () => {
                 _createIndex(newIndex, migrantIndexName, mapping, recordType, clusterName)
@@ -943,6 +944,7 @@ module.exports = function elasticsearchApi(client = {}, logger, _opConfig) {
                                 connection,
                             },
                         });
+
                         logger.error(error);
 
                         logger.info(`Attempting to connect to elasticsearch: ${clientName}`);

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/elasticsearch-api",
-    "version": "2.1.10",
+    "version": "2.1.11",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "terafoundation",
-    "version": "0.13.2",
+    "version": "0.13.3",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-state-storage",
-    "version": "0.7.7",
+    "version": "0.7.8",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.10",
+        "@terascope/elasticsearch-api": "^2.1.11",
         "@terascope/utils": "^0.20.3",
         "bluebird": "^3.5.5",
         "mnemonist": "^0.30.0"

--- a/packages/teraslice/lib/cluster/storage/backends/elasticsearch_store.js
+++ b/packages/teraslice/lib/cluster/storage/backends/elasticsearch_store.js
@@ -334,7 +334,7 @@ module.exports = function elasticsearchStorage(backendConfig) {
                     .then((results) => results)
                     .catch((err) => {
                         // It's not really an error if it's just that the index is already there
-                        if (parseError(err).match(/already_exists_exception/)) {
+                        if (parseError(err).includes('already_exists_exception')) {
                             return true;
                         }
 

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -32,7 +32,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.10",
+        "@terascope/elasticsearch-api": "^2.1.11",
         "@terascope/job-components": "^0.23.7",
         "@terascope/queue": "^1.1.7",
         "@terascope/teraslice-messaging": "^0.4.6",
@@ -60,7 +60,7 @@
         "shortid": "^2.2.14",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.13.2",
+        "terafoundation": "^0.13.3",
         "uuid": "^3.3.3"
     },
     "devDependencies": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.58.0",
+    "version": "0.58.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
- Fix `terafoundation` to apply schema for keys that aren't specified in the user config file.
- Fix logging the index exists during index creation in `elasticsearch-api->indexSetup` 