### PR TITLE
ts-scripts bump and sync improvments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
       name: 'Publish packages, docs and expiremental docker image'
       # run a push to master
       if: tag IS blank AND branch = master AND type NOT IN (pull_request, cron)
-      script: yarn test --suite unit
+      script: yarn lint
       deploy:
           - provider: script
             skip_cleanup: true

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -9,7 +9,7 @@ sidebar_label: Overview
 # Clone the package
 git clone https://github.com/terascope/teraslice.git && cd teraslice
 # Install, link and compile packages together
-yarn && yarn setup
+yarn setup
 ```
 
 ### Running Teraslice

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "benchmark": "lerna run --concurrency=1 --no-prefix --stream benchmark",
         "prebuild": "lerna run prebuild",
         "build": "tsc --build",
-        "build:all": "yarn build:cleanup && env FORCE_COLOR=1 lerna run build",
+        "build:all": "yarn build:cleanup && yarn build",
         "build:cleanup": "./scripts/build-cleanup.sh",
         "build:fix": "./scripts/build-fix.sh",
         "build:pkg": "./scripts/build-pkg.sh",
@@ -26,7 +26,7 @@
         "lint:es": "eslint --cache --ext .js,.jsx,.ts,.tsx .",
         "lint:fix": "yarn lint:es --fix && yarn sync",
         "quick:setup": "yarn lerna link --force-local && yarn build",
-        "setup": "lerna bootstrap --force-local && yarn build:cleanup dist && yarn build",
+        "setup": "yarn && lerna bootstrap --force-local && yarn build:all && yarn sync -q",
         "start": "node service.js",
         "sync": "ts-scripts sync",
         "test": "ts-scripts test"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "benchmark": "lerna run --concurrency=1 --no-prefix --stream benchmark",
         "prebuild": "lerna run prebuild",
         "build": "tsc --build",
-        "build:all": "yarn build:cleanup && yarn build",
+        "build:all": "yarn build:cleanup && env FORCE_COLOR=1 yarn lerna run build",
         "build:cleanup": "./scripts/build-cleanup.sh",
         "build:fix": "./scripts/build-fix.sh",
         "build:pkg": "./scripts/build-pkg.sh",
@@ -26,7 +26,7 @@
         "lint:es": "eslint --cache --ext .js,.jsx,.ts,.tsx .",
         "lint:fix": "yarn lint:es --fix && yarn sync",
         "quick:setup": "yarn lerna link --force-local && yarn build",
-        "setup": "yarn && lerna bootstrap --force-local && yarn build:all && yarn sync -q",
+        "setup": "yarn && yarn lerna link --force-local && yarn build:cleanup && yarn build && yarn sync -q",
         "start": "node service.js",
         "sync": "ts-scripts sync",
         "test": "ts-scripts test"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.7.1",
+    "version": "0.8.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/cmds/sync.ts
+++ b/packages/scripts/src/cmds/sync.ts
@@ -6,6 +6,7 @@ import { coercePkgArg } from '../helpers/args';
 
 type Options = {
     verify: boolean;
+    quiet?: boolean;
     packages?: PackageInfo[];
 }
 
@@ -19,6 +20,12 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
                 type: 'boolean',
                 default: isCI,
             })
+            .option('quiet', {
+                alias: 'q',
+                description: 'This will disable out-of-sync warnings',
+                type: 'boolean',
+                default: false,
+            })
             .positional('packages', {
                 description: 'Run scripts for one or more a package',
                 type: 'string',
@@ -27,11 +34,11 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
                 },
             });
     },
-    handler({ packages, verify }) {
+    handler({ packages, verify, quiet }) {
         if (packages && packages.length) {
-            return syncPackages(packages, { verify });
+            return syncPackages(packages, { verify, quiet });
         }
-        return syncAll({ verify });
+        return syncAll({ verify, quiet });
     },
 };
 

--- a/packages/scripts/src/helpers/bump/index.ts
+++ b/packages/scripts/src/helpers/bump/index.ts
@@ -9,7 +9,7 @@ export async function bumpPackages(options: BumpPackageOptions) {
     const rootInfo = getRootInfo();
     const packages: PackageInfo[] = [...listPackages(), rootInfo as any];
 
-    const packagesToBump = utils.getPackagesToBump(packages, options);
+    const packagesToBump = await utils.getPackagesToBump(packages, options);
     utils.bumpPackagesList(packagesToBump, packages);
 
     const commitMsg = utils.getBumpCommitMessage(packagesToBump, options.release);

--- a/packages/scripts/src/helpers/bump/interfaces.ts
+++ b/packages/scripts/src/helpers/bump/interfaces.ts
@@ -6,6 +6,7 @@ export type BumpPackageOptions = {
     packages: PackageInfo[];
     deps: boolean;
     preId?: string;
+    noReset?: boolean;
 };
 
 export type BumpPkgInfo = {

--- a/packages/scripts/src/helpers/packages.ts
+++ b/packages/scripts/src/helpers/packages.ts
@@ -1,12 +1,14 @@
 import fs from 'fs';
 import path from 'path';
 import fse from 'fs-extra';
+import semver from 'semver';
 import {
     uniq, fastCloneDeep, get, trim
 } from '@terascope/utils';
 // @ts-ignore
 import QueryGraph from '@lerna/query-graph';
 import sortPackageJson from 'sort-package-json';
+import { getLatestNPMVersion } from './scripts';
 import * as misc from './misc';
 import * as i from './interfaces';
 
@@ -189,4 +191,24 @@ export function getDocPath(pkgInfo: i.PackageInfo, withFileName: boolean, withEx
 
 export function fixDepPkgName(name: string) {
     return trim(name).replace(/^\*\*\//, '').trim();
+}
+
+export async function getRemotePackageVersion(pkgInfo: i.PackageInfo): Promise<string> {
+    if (pkgInfo.private) return pkgInfo.version;
+
+    const registry: string|undefined = get(pkgInfo, 'publishConfig.registry');
+    return getLatestNPMVersion(
+        pkgInfo.name,
+        getPublishTag(pkgInfo.version),
+        registry
+    );
+}
+
+export function getPublishTag(version: string): string {
+    const parsed = semver.parse(version);
+    if (!parsed) {
+        throw new Error(`Unable to publish invalid version "${version}"`);
+    }
+    if (parsed.prerelease.length) return 'prelease';
+    return 'latest';
 }

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -1,13 +1,12 @@
 import ms from 'ms';
 import { get } from '@terascope/utils';
 import { PackageInfo } from '../interfaces';
-import { listPackages, getMainPackageInfo } from '../packages';
+import { listPackages, getMainPackageInfo, getPublishTag } from '../packages';
 import { PublishAction, PublishOptions, PublishType } from './interfaces';
 import {
     shouldNPMPublish,
     formatDailyTag,
     buildCacheLayers,
-    getPublishTag
 } from './utils';
 import {
     yarnPublish,

--- a/packages/scripts/src/helpers/sync/index.ts
+++ b/packages/scripts/src/helpers/sync/index.ts
@@ -6,7 +6,8 @@ import { getRootInfo } from '../misc';
 import * as utils from './utils';
 
 export async function syncAll(options: SyncOptions) {
-    await utils.verifyCommitted(options.verify);
+    await utils.verifyCommitted(options);
+
     const files: string[] = [];
 
     const pkgInfos = listPackages();
@@ -19,11 +20,11 @@ export async function syncAll(options: SyncOptions) {
     }
 
     await updateSidebarJSON();
-    await utils.verify(files, options.verify);
+    await utils.verify(files, options);
 }
 
 export async function syncPackages(pkgInfos: PackageInfo[], options: SyncOptions) {
-    await utils.verifyCommitted(options.verify);
+    await utils.verifyCommitted(options);
 
     const files: string[] = [];
 
@@ -37,5 +38,5 @@ export async function syncPackages(pkgInfos: PackageInfo[], options: SyncOptions
         })
     );
 
-    await utils.verify(files, options.verify);
+    await utils.verify(files, options);
 }

--- a/packages/scripts/src/helpers/sync/interfaces.ts
+++ b/packages/scripts/src/helpers/sync/interfaces.ts
@@ -1,5 +1,6 @@
 export type SyncOptions = {
     verify: boolean;
+    quiet?: boolean;
 };
 
 export enum DepKey {

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -223,6 +223,7 @@ function printAndGetEnv(suite: TestSuite, options: TestOptions) {
     if (options.debug || isCI) {
         const envStr = Object
             .entries(env)
+            .filter(([_, val]) => val != null && val !== '')
             .map(([key, val]) => `${key}: "${val}"`)
             .join(', ');
 

--- a/packages/scripts/src/helpers/test-runner/utils.ts
+++ b/packages/scripts/src/helpers/test-runner/utils.ts
@@ -82,7 +82,7 @@ export function getEnv(options: TestOptions, suite?: TestSuite): ExecEnv {
         });
     }
 
-    if (isE2E) {
+    if (config.DOCKER_NETWORK_NAME) {
         Object.assign(env, {
             DOCKER_NETWORK_NAME: config.DOCKER_NETWORK_NAME
         });

--- a/packages/scripts/test/bump-spec.ts
+++ b/packages/scripts/test/bump-spec.ts
@@ -68,12 +68,13 @@ describe('Bump Utils', () => {
             const options: BumpPackageOptions = {
                 release: 'minor',
                 deps: true,
+                noReset: true,
                 packages: [cloneDeep(pkgUtil1!)]
             };
             let result: Record<string, BumpPkgInfo>;
 
-            beforeAll(() => {
-                result = getPackagesToBump(testPackages, options);
+            beforeAll(async () => {
+                result = await getPackagesToBump(testPackages, options);
             });
 
             it('should return a list of correctly bump packages', () => {
@@ -172,12 +173,13 @@ describe('Bump Utils', () => {
             const options: BumpPackageOptions = {
                 release: 'patch',
                 deps: false,
+                noReset: true,
                 packages: [cloneDeep(pkgUtil1!)]
             };
             let result: Record<string, BumpPkgInfo>;
 
-            beforeAll(() => {
-                result = getPackagesToBump(testPackages, options);
+            beforeAll(async () => {
+                result = await getPackagesToBump(testPackages, options);
             });
 
             it('should return a list of correctly bump packages', () => {
@@ -270,12 +272,13 @@ describe('Bump Utils', () => {
             release: 'preminor',
             preId: 'rc',
             deps: true,
+            noReset: true,
             packages: [cloneDeep(pkgMain!), cloneDeep(pkgDep2!)]
         };
         let result: Record<string, BumpPkgInfo>;
 
-        beforeAll(() => {
-            result = getPackagesToBump(testPackages, options);
+        beforeAll(async () => {
+            result = await getPackagesToBump(testPackages, options);
         });
 
         it('should return a list of correctly bump packages', () => {


### PR DESCRIPTION
- fix: printing empty env when running test with debug
- feat: add `--quiet` flag to `yarn sync` and run `yarn sync` at the end of `yarn setup` to help prevent merge issues.
- feat: before bumping a package, reset the version to npm version to avoid issues after merging, ref #1496 