### PR TITLE
v0.58.3 - Stop sending execution analytics cluster shutdown (hopefully)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-workspace",
-    "version": "0.58.2",
+    "version": "0.58.3",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/lib/workers/execution-controller/index.js
+++ b/packages/teraslice/lib/workers/execution-controller/index.js
@@ -184,11 +184,6 @@ class ExecutionController {
 
         this.client.onExecutionPause(() => this.pause());
         this.client.onExecutionResume(() => this.resume());
-        this.client.onServerShutdown(() => {
-            this.logger.warn('Cluster Master shutdown, exiting...');
-            this.executionAnalytics.sendingAnalytics = false;
-            this._endExecution();
-        });
 
         this.server.onSliceSuccess((workerId, response) => {
             process.nextTick(() => {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.58.2",
+    "version": "0.58.3",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
fix: sending execution analytics when the cluster master is down

Fixes (hopefully) https://github.com/terascope/teraslice/issues/1461