### PR TITLE
elasticsearch api changes for id-slicer

### DIFF
--- a/packages/elasticsearch-api/index.js
+++ b/packages/elasticsearch-api/index.js
@@ -468,10 +468,15 @@ module.exports = function elasticsearchApi(client = {}, logger, _opConfig) {
 
             body.query.bool.must.push({ range: dateObj });
         }
-
+        // TODO: deprecate this logic and remove in the future
         // elasticsearch _id based query
         if (msg.key) {
             body.query.bool.must.push({ wildcard: { _uid: msg.key } });
+        }
+
+        if (msg.wildcard) {
+            const { field, value } = msg.wildcard;
+            body.query.bool.must.push({ wildcard: { [field]: value } });
         }
 
         // elasticsearch lucene based query

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/elasticsearch-api",
-    "version": "2.1.13",
+    "version": "2.2.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-api/test/api-spec.js
+++ b/packages/elasticsearch-api/test/api-spec.js
@@ -815,10 +815,11 @@ describe('elasticsearch-api', () => {
             query: 'someLucene:query',
             fields: ['field1', 'field2']
         };
-
+        const field = 'someField';
         const msg1 = { count: 100, key: 'someKey' };
         const msg2 = { count: 100, start: new Date(), end: new Date() };
         const msg3 = { count: 100 };
+        const msg4 = { count: 100, wildcard: { field, value: 'someKey' } };
 
         function makeResponse(opConfig, msg, data) {
             const query = {
@@ -845,12 +846,17 @@ describe('elasticsearch-api', () => {
             { wildcard: { _uid: 'someKey' } },
             { query_string: { query: opConfig3.query } }
         ];
+        const response5 = [
+            { wildcard: { [field]: 'someKey' } },
+            { query_string: { query: opConfig3.query } }
+        ];
 
         expect(api.buildQuery(opConfig1, msg1)).toEqual(makeResponse(opConfig1, msg1, response1));
         expect(api.buildQuery(opConfig2, msg2)).toEqual(makeResponse(opConfig2, msg2, response2));
         expect(api.buildQuery(opConfig3, msg3)).toEqual(makeResponse(opConfig3, msg3, response3));
         expect(api.buildQuery(opConfig4, msg3)).toEqual(makeResponse(opConfig4, msg3, response3));
         expect(api.buildQuery(opConfig3, msg1)).toEqual(makeResponse(opConfig3, msg1, response4));
+        expect(api.buildQuery(opConfig3, msg4)).toEqual(makeResponse(opConfig3, msg1, response5));
     });
 
     it('can set up an index', () => {

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-state-storage",
-    "version": "0.7.10",
+    "version": "0.8.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.13",
+        "@terascope/elasticsearch-api": "^2.2.0",
         "@terascope/utils": "^0.20.5",
         "bluebird": "^3.5.5",
         "mnemonist": "^0.30.0"

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -32,7 +32,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.1.13",
+        "@terascope/elasticsearch-api": "^2.2.0",
         "@terascope/job-components": "^0.23.9",
         "@terascope/queue": "^1.1.7",
         "@terascope/teraslice-messaging": "^0.4.8",


### PR DESCRIPTION
- changes needed for elasticsearch-assets to allow id-reader to query off of a field