### PR TITLE
elasticsearch-store changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
       name: 'ES Test Suite (elasticsearch 5) (node 10)'
       node_js: '10.16'
       # run only on pull-requests
-      if: branch = master AND type IN (pull_request)
+      if: branch = master AND type IN (pull_request) AND commit_message !~ /^WIP/
       script: yarn --silent test --suite elasticsearch --elasticsearch-version 5.6 --elasticsearch-api-version 5.6 --report-coverage false
 
     - script:
@@ -56,7 +56,7 @@ jobs:
     - script:
       name: 'ES Test Suite (elasticsearch 7) (node 10)'
       # run only on pull-requests
-      if: branch = master AND type IN (pull_request)
+      if: branch = master AND type IN (pull_request) AND commit_message !~ /^WIP/
       script: yarn --silent test --suite elasticsearch --elasticsearch-version 7.2 --elasticsearch-api-version 7.0 --report-coverage false
 
     - script:
@@ -66,6 +66,16 @@ jobs:
       script: yarn --silent test --suite e2e --elasticsearch-version 6.8 --elasticsearch-api-version 6.5 --kafka-version 2.3
 
     - stage: "Releases"
+      name: 'Publish pre-release packages'
+      # Run a push to master and when the commit message includes a prerelease bump
+      if: branch = master AND commit_message =~ /^bump:.*(prerelease|preminor|prepatch|prerelease)/
+      script: true
+      deploy:
+          - provider: script
+            skip_cleanup: true
+            script: yarn ts-scripts publish -t dev npm
+
+    - script:
       name: 'Publish packages, docs and expiremental docker image'
       # run a push to master
       if: tag IS blank AND branch = master AND type NOT IN (pull_request, cron)

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ jobs:
     - stage: "Releases"
       name: 'Publish pre-release packages'
       # Run a push to master and when the commit message includes a prerelease bump
-      if: branch = master AND commit_message =~ /^bump:.*(prerelease|preminor|prepatch|prerelease)/
+      if: branch = master AND commit_message =~ /bump:.*\((prerelease|preminor|prepatch|prerelease)\).*/
       script: true
       deploy:
           - provider: script

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -39,7 +39,7 @@
         "nanoid": "^2.1.6",
         "semver": "^6.1.1",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.8.7",
+        "teraslice-client-js": "^0.8.8",
         "uuid": "^3.3.3"
     },
     "resolutions": {

--- a/packages/chunked-file-reader/package.json
+++ b/packages/chunked-file-reader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/chunked-file-reader",
-    "version": "2.1.10",
+    "version": "2.1.11",
     "description": "This module is an abstracted reader for use in various Teraslice readers. It uses an externally-defined reader to read data and the packages up the data in a DataEntity for use with other Teraslice processors.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/chunked-file-reader#readme",
     "bugs": {
@@ -20,7 +20,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.5",
+        "@terascope/utils": "^0.20.6",
         "bluebird": "^3.5.5",
         "csvtojson": "^2.0.8",
         "lodash": "^4.17.11"

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/data-types",
-    "version": "0.6.4",
+    "version": "0.6.5",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.5",
+        "@terascope/utils": "^0.20.6",
         "graphql": "^14.3.1",
         "lodash.defaultsdeep": "^4.6.1",
         "yargs": "^14.2.0"
@@ -35,7 +35,7 @@
     "devDependencies": {
         "@types/lodash.defaultsdeep": "^4.6.6",
         "@types/yargs": "^13.0.3",
-        "xlucene-evaluator": "^0.11.8"
+        "xlucene-evaluator": "^0.12.0"
     },
     "engines": {
         "node": ">=8.0.0"

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -35,7 +35,7 @@
     "devDependencies": {
         "@types/lodash.defaultsdeep": "^4.6.6",
         "@types/yargs": "^13.0.3",
-        "xlucene-evaluator": "^0.12.0"
+        "xlucene-evaluator": "^0.12.0-rc.0"
     },
     "engines": {
         "node": ">=8.0.0"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/elasticsearch-api",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -17,7 +17,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.5",
+        "@terascope/utils": "^0.20.6",
         "bluebird": "^3.5.5",
         "lodash": "^4.17.11"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "elasticsearch-store",
-    "version": "0.12.8",
+    "version": "0.13.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -23,14 +23,14 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.5",
+        "@terascope/utils": "^0.20.6",
         "ajv": "^6.10.0",
         "nanoid": "^2.1.6",
         "rambda": "^3.0.0",
-        "xlucene-evaluator": "^0.11.8"
+        "xlucene-evaluator": "^0.12.0"
     },
     "devDependencies": {
-        "@terascope/data-types": "^0.6.4",
+        "@terascope/data-types": "^0.6.5",
         "elasticsearch": "^15.4.1"
     },
     "publishConfig": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "elasticsearch-store",
-    "version": "0.13.0",
+    "version": "0.13.0-rc.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "ajv": "^6.10.0",
         "nanoid": "^2.1.6",
         "rambda": "^3.0.0",
-        "xlucene-evaluator": "^0.12.0"
+        "xlucene-evaluator": "^0.12.0-rc.0"
     },
     "devDependencies": {
         "@terascope/data-types": "^0.6.5",

--- a/packages/elasticsearch-store/src/index-manager.ts
+++ b/packages/elasticsearch-store/src/index-manager.ts
@@ -78,7 +78,7 @@ export default class IndexManager {
         }
 
         const esVersion = utils.getESVersion(this.client);
-        logger.debug(`Using elasticsearch version ${esVersion}`);
+        logger.trace(`Using elasticsearch version ${esVersion}`);
 
         const mapping: any = utils.getIndexMapping(config);
 

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -79,6 +79,7 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
         options?: i.FindOneOptions<T>,
         queryAccess?: QueryAccess<T>
     ) {
+        utils.validateId(anyId, 'fetchRecord');
         const fields: Partial<T> = {};
 
         for (const field of this._uniqueFields) {
@@ -106,11 +107,7 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
     }
 
     async updateRecord(id: string, record: i.UpdateRecordInput<T>): Promise<T> {
-        if (!id || !ts.isString(id)) {
-            throw new ts.TSError(`${this.name} update requires _key`, {
-                statusCode: 422,
-            });
-        }
+        utils.validateId(id, 'updateRecord');
 
         return this.updatePartial(id, async (existing) => {
             const doc = this._sanitizeRecord({
@@ -129,6 +126,8 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
      * Soft deletes a record by ID
      */
     async deleteRecord(id: string) {
+        utils.validateId(id, 'deleteRecord');
+
         await this.update(id, {
             doc: {
                 _deleted: true

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -102,7 +102,7 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
         const doc = this._sanitizeRecord(docInput);
 
         await this._ensureUnique(doc);
-        return this.createWithId(doc, id);
+        return this.createWithId(id, doc);
     }
 
     async updateRecord(record: i.UpdateRecordInput<T>) {

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -75,7 +75,7 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
      * Fetch a record by any unique ID
     */
     async fetchRecord(
-        anyId: string|number,
+        anyId: string,
         options?: i.FindOneOptions<T>,
         queryAccess?: QueryAccess<T>
     ) {

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -140,15 +140,6 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
         return true;
     }
 
-    /**
-     * Soft deletes records by ID
-     */
-    async deleteRecords(ids: string[]): Promise<void> {
-        if (!ids || !ids.length) return;
-
-        await Promise.all(ts.uniq(ids).map((id) => this.deleteRecord(id)));
-    }
-
     async countRecords(
         fields: AnyInput<T>,
         clientId?: number,

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -1,7 +1,7 @@
 import * as es from 'elasticsearch';
 import * as ts from '@terascope/utils';
-import { QueryAccess, createJoinQuery } from 'xlucene-evaluator';
-import IndexStore from './index-store';
+import { QueryAccess } from 'xlucene-evaluator';
+import IndexStore, { AnyInput } from './index-store';
 import * as utils from './utils';
 import * as i from './interfaces';
 
@@ -9,8 +9,7 @@ import * as i from './interfaces';
  * An high-level, opionionated, abstract class
  * for an elasticsearch DataType, with a CRUD-like interface
  */
-export default abstract class IndexModel<T extends i.IndexModelRecord> {
-    readonly store: IndexStore<T>;
+export default abstract class IndexModel<T extends i.IndexModelRecord> extends IndexStore<T> {
     readonly name: string;
     readonly logger: ts.Logger;
 
@@ -59,126 +58,13 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> {
             default_sort: 'updated:desc',
         };
 
+        super(client, indexConfig);
         this.name = utils.toInstanceName(modelConfig.name);
-        this.store = new IndexStore(client, indexConfig);
-
         const debugLoggerName = `elasticsearch-store:index-model:${this.name}`;
         this.logger = options.logger || ts.debugLogger(debugLoggerName);
 
         this._uniqueFields = ts.concat('id', modelConfig.unique_fields);
         this._sanitizeFields = modelConfig.sanitize_fields || {};
-    }
-
-    get xluceneTypeConfig() {
-        return this.store.xluceneTypeConfig;
-    }
-
-    async initialize() {
-        return this.store.initialize();
-    }
-
-    async shutdown() {
-        return this.store.shutdown();
-    }
-
-    async count(q = '', queryAccess?: QueryAccess<T>): Promise<number> {
-        if (queryAccess) return this.store.count(queryAccess.restrict(q));
-        return this.store.count(q);
-    }
-
-    async countBy(fields: AnyInput<T>, joinBy?: JoinBy, arrayJoinBy?: JoinBy): Promise<number> {
-        return this.store.count(this._createJoinQuery(fields, joinBy, arrayJoinBy));
-    }
-
-    async create(record: i.CreateRecordInput<T>): Promise<T> {
-        const docInput = {
-            ...record,
-            created: ts.makeISODate(),
-            updated: ts.makeISODate(),
-        } as T;
-
-        const id = await utils.makeId();
-        docInput.id = id;
-
-        const doc = this._sanitizeRecord(docInput);
-
-        await this._ensureUnique(doc);
-        await this.store.createWithId(doc, id);
-
-        // @ts-ignore
-        return ts.DataEntity.make(this._postProcess(doc));
-    }
-
-    async deleteById(id: string): Promise<void> {
-        await this.store.remove(id);
-    }
-
-    async deleteAll(ids: string[]): Promise<void> {
-        if (!ids || !ids.length) return;
-
-        await Promise.all(ts.uniq(ids).map((id) => this.deleteById(id)));
-    }
-
-    async exists(id: string[] | string): Promise<boolean> {
-        const ids = ts.castArray(id);
-        if (!ids.length) return true;
-
-        const count = await this.countBy({
-            id: ids,
-        } as AnyInput<T>);
-
-        return count === ids.length;
-    }
-
-    async findBy(
-        fields: AnyInput<T>,
-        joinBy?: JoinBy,
-        options?: i.FindOneOptions<T>,
-        queryAccess?: QueryAccess<T>
-    ) {
-        const query = this._createJoinQuery(fields, joinBy);
-
-        const results = await this._find(
-            query,
-            {
-                ...options,
-                size: 1,
-            },
-            queryAccess
-        );
-
-        const record = ts.getFirst(results);
-        if (record == null) {
-            throw new ts.TSError(`Unable to find ${this.name} by ${query}`, {
-                statusCode: 404,
-            });
-        }
-
-        return record;
-    }
-
-    async findAllBy(
-        fields: AnyInput<T>,
-        joinBy?: JoinBy,
-        options?: i.FindOptions<T>,
-        queryAccess?: QueryAccess<T>
-    ): Promise<T[]> {
-        const query = this._createJoinQuery(fields, joinBy);
-
-        return this._find(
-            query,
-            options,
-            queryAccess
-        );
-    }
-
-    async findById(
-        id: string,
-        options?: i.FindOneOptions<T>,
-        queryAccess?: QueryAccess<T>
-    ): Promise<T> {
-        const fields = { id } as Partial<T>;
-        return this.findBy(fields, 'AND', options, queryAccess);
     }
 
     async findByAnyId(anyId: any, options?: i.FindOneOptions<T>, queryAccess?: QueryAccess<T>) {
@@ -191,60 +77,23 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> {
         return this.findBy(fields, 'OR', options, queryAccess);
     }
 
-    async findAndApply(
-        updates: Partial<T> | undefined,
-        options?: i.FindOneOptions<T>,
-        queryAccess?: QueryAccess<T>
-    ): Promise<Partial<T>> {
-        if (!updates) {
-            throw new ts.TSError(`Invalid input for ${this.name}`, {
-                statusCode: 422,
-            });
-        }
+    async createRecord(record: i.CreateRecordInput<T>): Promise<T> {
+        const docInput = {
+            ...record,
+            created: ts.makeISODate(),
+            updated: ts.makeISODate(),
+        } as T;
 
-        const { id } = updates;
-        if (!id) return { ...updates };
+        const id = await utils.makeId();
+        docInput.id = id;
 
-        const current = await this.findById(id, options, queryAccess);
-        return { ...current, ...updates };
+        const doc = this._sanitizeRecord(docInput);
+
+        await this._ensureUnique(doc);
+        return this.createWithId(doc, id);
     }
 
-    async findAll(
-        input: string[] | string | undefined,
-        options?: i.FindOneOptions<T>,
-        queryAccess?: QueryAccess<T>
-    ): Promise<T[]> {
-        const ids: string[] = ts.parseList(input);
-        if (!ids || !ids.length) return [];
-
-        const query = this._createJoinQuery({ id: ids } as AnyInput<T>);
-
-        const result = await this._find(
-            query,
-            {
-                ...options,
-                size: ids.length,
-            },
-            queryAccess
-        );
-
-        if (result.length !== ids.length) {
-            const foundIds = result.map((doc) => doc.id);
-            const notFoundIds = ids.filter((id) => !foundIds.includes(id));
-            throw new ts.TSError(`Unable to find ${this.name}'s ${notFoundIds.join(', ')}`, {
-                statusCode: 404,
-            });
-        }
-
-        // maintain sort order
-        return ids.map((id) => result.find((doc) => doc.id === id)!);
-    }
-
-    async find(q = '', options: i.FindOptions<T> = {}, queryAccess?: QueryAccess<T>): Promise<T[]> {
-        return this._find(q, options, queryAccess);
-    }
-
-    async update(record: i.UpdateRecordInput<T>) {
+    async updateRecord(record: i.UpdateRecordInput<T>) {
         const { id } = record;
         if (!id || !ts.isString(id)) {
             throw new ts.TSError(`${this.name} update requires id`, {
@@ -252,7 +101,7 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> {
             });
         }
 
-        return this.store.updatePartial(id, async (existing) => {
+        return this.updatePartial(id, async (existing) => {
             const doc = this._sanitizeRecord({
                 ...existing,
                 ...record,
@@ -264,89 +113,28 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> {
         });
     }
 
-    protected async _updateWith(id: string, body: any): Promise<void> {
-        await this.store.update(body, id);
-    }
+    protected _sanitizeRecord(record: T): T {
+        const entries = Object.entries(this._sanitizeFields);
 
-    protected async _appendToArray(
-        id: string,
-        field: keyof T,
-        values: string[] | string
-    ): Promise<void> {
-        const valueArray = values && ts.uniq(ts.castArray(values)).filter((v) => !!v);
-        if (!valueArray || !valueArray.length) return;
+        for (const [field, method] of entries) {
+            if (!record[field]) continue;
 
-        await this._updateWith(id, {
-            script: {
-                source: `
-                    for(int i = 0; i < params.values.length; i++) {
-                        if (!ctx._source["${field}"].contains(params.values[i])) {
-                            ctx._source["${field}"].add(params.values[i])
-                        }
-                    }
-                `,
-                lang: 'painless',
-                params: {
-                    values: valueArray,
-                },
-            },
-        });
-    }
-
-    protected async _removeFromArray(
-        id: string,
-        field: keyof T,
-        values: string[] | string
-    ): Promise<void> {
-        const valueArray = values && ts.uniq(ts.castArray(values)).filter((v) => !!v);
-        if (!valueArray || !valueArray.length) return;
-
-        try {
-            await this._updateWith(id, {
-                script: {
-                    source: `
-                        for(int i = 0; i < params.values.length; i++) {
-                            if (ctx._source["${field}"].contains(params.values[i])) {
-                                int itemIndex = ctx._source["${field}"].indexOf(params.values[i]);
-                                ctx._source["${field}"].remove(itemIndex)
-                            }
-                        }
-                    `,
-                    lang: 'painless',
-                    params: {
-                        values: valueArray,
-                    },
-                },
-            });
-        } catch (err) {
-            if (err && err.statusCode === 404) {
-                return;
+            switch (method) {
+                case 'trim':
+                    record[field] = ts.trim(record[field]);
+                    break;
+                case 'trimAndToLower':
+                    record[field] = ts.trimAndToLower(record[field]);
+                    break;
+                case 'toSafeString':
+                    record[field] = ts.toSafeString(record[field]);
+                    break;
+                default:
+                    continue;
             }
-            throw err;
-        }
-    }
-
-    protected async _find(q = '', options: i.FindOptions<T> = {}, queryAccess?: QueryAccess<T>) {
-        const params: Partial<es.SearchParams> = {
-            size: options.size,
-            sort: options.sort,
-            from: options.from,
-            _sourceExclude: options.excludes as string[],
-            _sourceInclude: options.includes as string[],
-        };
-
-        let records: T[];
-        if (queryAccess) {
-            const query = queryAccess.restrictSearchQuery(q, {
-                params,
-                elasticsearch_version: utils.getESVersion(this.store.client)
-            });
-            records = await this.store._search(query);
-        } else {
-            records = await this.store.search(q, params);
         }
 
-        return records.map((record) => this._postProcess(record));
+        return record;
     }
 
     protected async _ensureUnique(record: T, existing?: T) {
@@ -374,51 +162,4 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> {
             }
         }
     }
-
-    protected _sanitizeRecord(record: T): T {
-        const entries = Object.entries(this._sanitizeFields);
-
-        for (const [field, method] of entries) {
-            if (!record[field]) continue;
-
-            switch (method) {
-                case 'trim':
-                    record[field] = ts.trim(record[field]);
-                    break;
-                case 'trimAndToLower':
-                    record[field] = ts.trimAndToLower(record[field]);
-                    break;
-                case 'toSafeString':
-                    record[field] = ts.toSafeString(record[field]);
-                    break;
-                default:
-                    continue;
-            }
-        }
-
-        return this._preProcess(record);
-    }
-
-    protected _postProcess(record: T): T {
-        return record;
-    }
-
-    protected _preProcess(record: T): T {
-        return record;
-    }
-
-    protected _createJoinQuery(fields: AnyInput<T>, joinBy: JoinBy = 'AND', arrayJoinBy: JoinBy = 'OR'): string {
-        const result = createJoinQuery(fields, {
-            joinBy,
-            arrayJoinBy,
-            typeConfig: this.xluceneTypeConfig
-        });
-        if (result) return result;
-
-        return `${ts.getFirst(Object.keys(fields))}: "__undefined__"`;
-    }
 }
-
-type AnyInput<T> = { [P in keyof T]?: T[P] | any };
-
-type JoinBy = 'AND' | 'OR';

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -103,7 +103,7 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
         const doc = this._sanitizeRecord(docInput);
 
         await this._ensureUnique(doc);
-        return this.createWithId(id, doc);
+        return this.createById(id, doc);
     }
 
     async updateRecord(id: string, record: i.UpdateRecordInput<T>): Promise<T> {

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -105,8 +105,7 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
         return this.createWithId(id, doc);
     }
 
-    async updateRecord(record: i.UpdateRecordInput<T>): Promise<T> {
-        const { _key: id } = record;
+    async updateRecord(id: string, record: i.UpdateRecordInput<T>): Promise<T> {
         if (!id || !ts.isString(id)) {
             throw new ts.TSError(`${this.name} update requires _key`, {
                 statusCode: 422,
@@ -118,6 +117,7 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
                 ...existing,
                 ...record,
                 _updated: ts.makeISODate(),
+                _key: id
             } as T);
 
             await this._ensureUnique(doc, existing);

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -74,11 +74,15 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
     /**
      * Fetch a record by any unique ID
     */
-    async fetchRecord(anyId: any, options?: i.FindOneOptions<T>, queryAccess?: QueryAccess<T>) {
+    async fetchRecord(
+        anyId: string|number,
+        options?: i.FindOneOptions<T>,
+        queryAccess?: QueryAccess<T>
+    ) {
         const fields: Partial<T> = {};
 
         for (const field of this._uniqueFields) {
-            fields[field] = anyId;
+            fields[field] = anyId as any;
         }
 
         return this.findBy(fields, 'OR', options, queryAccess);
@@ -92,24 +96,24 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
             _updated: ts.makeISODate(),
         } as T;
 
-        const _key = await utils.makeId();
-        docInput._key = _key;
+        const id = await utils.makeId();
+        docInput._key = id;
 
         const doc = this._sanitizeRecord(docInput);
 
         await this._ensureUnique(doc);
-        return this.createWithId(doc, _key);
+        return this.createWithId(doc, id);
     }
 
     async updateRecord(record: i.UpdateRecordInput<T>) {
-        const { _key } = record;
-        if (!_key || !ts.isString(_key)) {
+        const { _key: id } = record;
+        if (!id || !ts.isString(id)) {
             throw new ts.TSError(`${this.name} update requires _key`, {
                 statusCode: 422,
             });
         }
 
-        return this.updatePartial(_key, async (existing) => {
+        return this.updatePartial(id, async (existing) => {
             const doc = this._sanitizeRecord({
                 ...existing,
                 ...record,

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -105,7 +105,7 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
         return this.createWithId(id, doc);
     }
 
-    async updateRecord(record: i.UpdateRecordInput<T>) {
+    async updateRecord(record: i.UpdateRecordInput<T>): Promise<T> {
         const { _key: id } = record;
         if (!id || !ts.isString(id)) {
             throw new ts.TSError(`${this.name} update requires _key`, {

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -184,6 +184,7 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
                 ...(record.client_id && {
                     client_id: [record.client_id, 0],
                 }),
+                _deleted: false
             } as AnyInput<T>);
 
             if (count > 0) {

--- a/packages/elasticsearch-store/src/index-store.ts
+++ b/packages/elasticsearch-store/src/index-store.ts
@@ -84,7 +84,8 @@ export default class IndexStore<T extends Record<string, any>, I extends Partial
             });
 
             const validate = ajv.compile(schema);
-            this.validateRecord = (input: T | I, strictMode: boolean = strict === true) => {
+            const defaultStrictMode = strict === true;
+            this.validateRecord = (input: T | I, strictMode = defaultStrictMode) => {
                 if (validate(input)) return;
 
                 if (strictMode) {

--- a/packages/elasticsearch-store/src/index-store.ts
+++ b/packages/elasticsearch-store/src/index-store.ts
@@ -154,8 +154,8 @@ export default class IndexStore<T extends Record<string, any>> {
      *
      * @returns the created record
      */
-    async createWithId(id: string, doc: Partial<T>, params?: PartialParam<es.CreateDocumentParams, 'id' | 'body'>) {
-        utils.validateId(id, 'createWithId');
+    async createById(id: string, doc: Partial<T>, params?: PartialParam<es.CreateDocumentParams, 'id' | 'body'>) {
+        utils.validateId(id, 'createById');
         return this.create(doc, Object.assign({}, params, { id }));
     }
 
@@ -239,8 +239,8 @@ export default class IndexStore<T extends Record<string, any>> {
     /**
      * A convenience method for indexing a document with an ID
      */
-    async indexWithId(id: string, doc: T | Partial<T>, params?: PartialParam<es.IndexDocumentParams<T>, 'index' | 'type' | 'id'>) {
-        utils.validateId(id, 'indexWithId');
+    async indexById(id: string, doc: T | Partial<T>, params?: PartialParam<es.IndexDocumentParams<T>, 'index' | 'type' | 'id'>) {
+        utils.validateId(id, 'indexById');
         return this.index(doc, Object.assign({}, params, { id }));
     }
 
@@ -348,7 +348,7 @@ export default class IndexStore<T extends Record<string, any>> {
         utils.validateId('updatePartial', id);
         try {
             const existing = await this.get(id);
-            return await this.indexWithId(
+            return await this.indexById(
                 id,
                 await applyChanges(existing)
             );

--- a/packages/elasticsearch-store/src/index-store.ts
+++ b/packages/elasticsearch-store/src/index-store.ts
@@ -482,13 +482,13 @@ export default class IndexStore<T extends Record<string, any>> {
         options?: i.FindOneOptions<T>,
         queryAccess?: QueryAccess<T>
     ): Promise<Partial<T>> {
-        if (!updates) {
+        if (ts.isEmpty(updates) || !ts.isPlainObject(updates)) {
             throw new ts.TSError(`Invalid input for ${this.name}`, {
                 statusCode: 422,
             });
         }
 
-        const id = updates[this.config.id_field as any];
+        const id = updates![this.config.id_field as any];
         if (!id) return { ...updates };
 
         const current = await this.findById(id, options, queryAccess);

--- a/packages/elasticsearch-store/src/index-store.ts
+++ b/packages/elasticsearch-store/src/index-store.ts
@@ -294,15 +294,6 @@ export default class IndexStore<T extends Record<string, any>> {
     }
 
     /**
-     * Delete multiple documents by id
-    */
-    async deleteAll(ids: string[]): Promise<void> {
-        if (!ids || !ids.length) return;
-
-        await Promise.all(ts.uniq(ids).map((id) => this.deleteById(id)));
-    }
-
-    /**
      * Shutdown, flush any pending requests and cleanup
      */
     async shutdown() {

--- a/packages/elasticsearch-store/src/index-store.ts
+++ b/packages/elasticsearch-store/src/index-store.ts
@@ -416,7 +416,7 @@ export default class IndexStore<T extends Record<string, any>> {
         if (!ids.length) return true;
 
         const count = await this.countBy({
-            id: ids,
+            [this.config.id_field!]: ids,
         } as AnyInput<T>);
 
         return count === ids.length;

--- a/packages/elasticsearch-store/src/index-store.ts
+++ b/packages/elasticsearch-store/src/index-store.ts
@@ -437,7 +437,7 @@ export default class IndexStore<T extends Record<string, any>> {
                 size: 1,
             },
             queryAccess,
-            true
+            false
         );
 
         const record = ts.getFirst(results);
@@ -462,7 +462,7 @@ export default class IndexStore<T extends Record<string, any>> {
             query,
             { size: 10000, ...options },
             queryAccess,
-            true
+            false
         );
     }
 
@@ -514,7 +514,7 @@ export default class IndexStore<T extends Record<string, any>> {
                 size: ids.length,
             },
             queryAccess,
-            true
+            false
         );
 
         if (result.length !== ids.length) {

--- a/packages/elasticsearch-store/src/index-store.ts
+++ b/packages/elasticsearch-store/src/index-store.ts
@@ -174,7 +174,7 @@ export default class IndexStore<T extends Record<string, any>> {
 
     /** Count records by a given Lucene Query */
     async count(
-        query: string,
+        query = '',
         params: PartialParam<es.CountParams, 'q' | 'body'> = {},
         queryAccess?: QueryAccess<T>
     ): Promise<number> {
@@ -381,10 +381,13 @@ export default class IndexStore<T extends Record<string, any>> {
         id: string,
         applyChanges: ApplyPartialUpdates<T>,
         retriesOnConlfict = 3
-    ): Promise<void> {
+    ): Promise<T> {
         try {
             const existing = await this.get(id);
-            await this.indexWithId(id, await applyChanges(existing));
+            return await this.indexWithId(
+                id,
+                await applyChanges(existing)
+            );
         } catch (error) {
             // if there is a version conflict
             if (error.statusCode === 409 && error.message.includes('version conflict')) {
@@ -457,7 +460,7 @@ export default class IndexStore<T extends Record<string, any>> {
 
         return this.search(
             query,
-            options,
+            { size: 10000, ...options },
             queryAccess,
             true
         );

--- a/packages/elasticsearch-store/src/index-store.ts
+++ b/packages/elasticsearch-store/src/index-store.ts
@@ -196,7 +196,7 @@ export default class IndexStore<T extends Record<string, any>> {
      *
      * @returns the created record
      */
-    async createWithId(doc: Partial<T>, id: string, params?: PartialParam<es.CreateDocumentParams, 'id' | 'body'>) {
+    async createWithId(id: string, doc: Partial<T>, params?: PartialParam<es.CreateDocumentParams, 'id' | 'body'>) {
         return this.create(doc, Object.assign({}, params, { id }));
     }
 
@@ -279,7 +279,7 @@ export default class IndexStore<T extends Record<string, any>> {
     /**
      * A convenience method for indexing a document with an ID
      */
-    async indexWithId(doc: T | Partial<T>, id: string, params?: PartialParam<es.IndexDocumentParams<T>, 'index' | 'type' | 'id'>) {
+    async indexWithId(id: string, doc: T | Partial<T>, params?: PartialParam<es.IndexDocumentParams<T>, 'index' | 'type' | 'id'>) {
         return this.index(doc, Object.assign({}, params, { id }));
     }
 
@@ -384,7 +384,7 @@ export default class IndexStore<T extends Record<string, any>> {
     ): Promise<void> {
         try {
             const existing = await this.get(id);
-            await this.indexWithId(await applyChanges(existing), id);
+            await this.indexWithId(id, await applyChanges(existing));
         } catch (error) {
             // if there is a version conflict
             if (error.statusCode === 409 && error.message.includes('version conflict')) {

--- a/packages/elasticsearch-store/src/interfaces.ts
+++ b/packages/elasticsearch-store/src/interfaces.ts
@@ -134,11 +134,6 @@ export interface DataSchema {
     strict?: boolean;
 
     /**
-     * When logging invalid record, optionally set the log level
-     */
-    log_level?: Logger.LogLevel | 'none';
-
-    /**
      * If enabled this will allow the use of some of
      * the slower but more correct JSON Schema's formatters:
      *
@@ -189,6 +184,11 @@ export interface IndexModelRecord {
      * The mutli-tenant ID representing the client
      */
     client_id: number;
+
+    /**
+     * Indicates whether the record is deleted or not
+     */
+    _deleted?: boolean;
 
     /**
      * Updated date

--- a/packages/elasticsearch-store/src/interfaces.ts
+++ b/packages/elasticsearch-store/src/interfaces.ts
@@ -209,7 +209,6 @@ export type UpdateRecordInput<T extends IndexModelRecord> =
     Partial<Omit<T, keyof IndexModelRecord>>
     & {
         client_id?: number;
-        _key: string;
     };
 
 export interface IndexModelConfig<T extends IndexModelRecord> {

--- a/packages/elasticsearch-store/src/interfaces.ts
+++ b/packages/elasticsearch-store/src/interfaces.ts
@@ -183,7 +183,7 @@ export interface IndexModelRecord {
     /**
      * A unique ID for the record - nanoid 12 digit
      */
-    id: string;
+    _key: string;
 
     /**
      * The mutli-tenant ID representing the client
@@ -193,12 +193,12 @@ export interface IndexModelRecord {
     /**
      * Updated date
      */
-    updated: string;
+    _updated: string;
 
     /**
      * Creation date
      */
-    created: string;
+    _created: string;
 }
 
 export type CreateRecordInput<T extends IndexModelRecord> = Omit<T, keyof IndexModelRecord> & {
@@ -209,7 +209,7 @@ export type UpdateRecordInput<T extends IndexModelRecord> =
     Partial<Omit<T, keyof IndexModelRecord>>
     & {
         client_id?: number;
-        id: string;
+        _key: string;
     };
 
 export interface IndexModelConfig<T extends IndexModelRecord> {

--- a/packages/elasticsearch-store/src/utils/errors.ts
+++ b/packages/elasticsearch-store/src/utils/errors.ts
@@ -14,7 +14,7 @@ export function throwValidationError(errors: ErrorLike[] | null | undefined): st
     const errorMsg = getErrorMessages(errors);
 
     const error = new ts.TSError(errorMsg, {
-        statusCode: 422,
+        statusCode: 400,
     });
 
     Error.captureStackTrace(error, throwValidationError);

--- a/packages/elasticsearch-store/src/utils/model.ts
+++ b/packages/elasticsearch-store/src/utils/model.ts
@@ -16,6 +16,9 @@ export const mapping: ESTypeMappings = {
         client_id: {
             type: 'integer',
         },
+        _deleted: {
+            type: 'boolean',
+        },
         _created: {
             type: 'date',
         },
@@ -37,6 +40,10 @@ export const schema = {
             multipleOf: 1.0,
             minimum: 0,
             default: 1,
+        },
+        _deleted: {
+            type: 'boolean',
+            default: false
         },
         _created: {
             format: 'date-time',

--- a/packages/elasticsearch-store/src/utils/model.ts
+++ b/packages/elasticsearch-store/src/utils/model.ts
@@ -10,16 +10,16 @@ export const mapping: ESTypeMappings = {
     },
     dynamic: false,
     properties: {
-        id: {
+        _key: {
             type: 'keyword',
         },
         client_id: {
             type: 'integer',
         },
-        created: {
+        _created: {
             type: 'date',
         },
-        updated: {
+        _updated: {
             type: 'date',
         },
     },
@@ -29,7 +29,7 @@ export const mapping: ESTypeMappings = {
 export const schema = {
     additionalProperties: false,
     properties: {
-        id: {
+        _key: {
             type: 'string',
         },
         client_id: {
@@ -38,14 +38,14 @@ export const schema = {
             minimum: 0,
             default: 1,
         },
-        created: {
+        _created: {
             format: 'date-time',
         },
-        updated: {
+        _updated: {
             format: 'date-time',
         },
     },
-    required: ['id', 'client_id', 'created', 'updated'],
+    required: ['_key', 'client_id', '_created', '_updated'],
 };
 
 export function addDefaultMapping(input: ESTypeMappings): ESTypeMappings {

--- a/packages/elasticsearch-store/src/utils/model.ts
+++ b/packages/elasticsearch-store/src/utils/model.ts
@@ -52,7 +52,7 @@ export const schema = {
             format: 'date-time',
         },
     },
-    required: ['_key', 'client_id', '_created', '_updated'],
+    required: ['_key', 'client_id'],
 };
 
 export function addDefaultMapping(input: ESTypeMappings): ESTypeMappings {

--- a/packages/elasticsearch-store/src/utils/validation.ts
+++ b/packages/elasticsearch-store/src/utils/validation.ts
@@ -10,12 +10,17 @@ export function isValidName(name: string) {
     return ts.isString(name) && name && !name.includes('-');
 }
 
-export function validateId(id: any, action: string): id is string|number {
+export function validateId(id: any, action: string, throwError = true): id is string {
     if (ts.isString(id) && id) return true;
-    if (ts.isInteger(id)) return true;
-    throw new ts.TSError(`Invalid ID given to ${action}, expected string or integer, got ${ts.getTypeOf(id)}`, {
+    if (!throwError) return false;
+
+    throw new ts.TSError(`Invalid ID given to ${action}, expected string, got ${ts.getTypeOf(id)}`, {
         statusCode: 400
     });
+}
+
+export function validateIds(ids: any, action: string): string[] {
+    return ts.uniq(ts.castArray(ids)).filter((id) => validateId(id, action, false));
 }
 
 export function isValidNamespace(namespace: string) {

--- a/packages/elasticsearch-store/src/utils/validation.ts
+++ b/packages/elasticsearch-store/src/utils/validation.ts
@@ -1,17 +1,59 @@
+import Ajv from 'ajv';
 import * as R from 'rambda';
 import * as es from 'elasticsearch';
 import * as ts from '@terascope/utils';
 import { isNotNil } from './misc';
-import { IndexConfig, IndexSchema } from '../interfaces';
-import { throwValidationError } from './errors';
+import { IndexConfig, IndexSchema, DataSchema } from '../interfaces';
+import { throwValidationError, getErrorMessages } from './errors';
 
 export function isValidName(name: string) {
     return ts.isString(name) && name && !name.includes('-');
 }
 
+export function validateId(id: any, action: string): id is string|number {
+    if (ts.isString(id) && id) return true;
+    if (ts.isInteger(id)) return true;
+    throw new ts.TSError(`Invalid ID given to ${action}, expected string or integer, got ${ts.getTypeOf(id)}`, {
+        statusCode: 400
+    });
+}
+
 export function isValidNamespace(namespace: string) {
     if (namespace == null) return true;
     return ts.isString(namespace) && namespace && !namespace.includes('-');
+}
+
+export function makeDataValidator(dataSchema: DataSchema, logger: ts.Logger) {
+    const {
+        all_formatters: allFormatters,
+        schema,
+        strict
+    } = dataSchema;
+    const ajv = new Ajv({
+        useDefaults: true,
+        format: allFormatters ? 'full' : 'fast',
+        allErrors: true,
+        coerceTypes: true,
+        logger: {
+            log: logger.trace,
+            warn: logger.debug,
+            error: logger.warn,
+        },
+    });
+    const validate = ajv.compile(schema);
+
+    return (input: any, critical: boolean) => {
+        if (validate(input)) return input;
+
+        if (critical) {
+            throwValidationError(validate.errors);
+        } else if (strict === true) {
+            logger.warn('Invalid record', input, getErrorMessages(validate.errors || []));
+        } else {
+            logger.trace('Record validation warnings', input, getErrorMessages(validate.errors || []));
+        }
+        return input;
+    };
 }
 
 export function validateIndexConfig(config: any): config is IndexConfig {

--- a/packages/elasticsearch-store/test/index-manager-index-setup-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-index-setup-spec.ts
@@ -134,10 +134,7 @@ describe('IndexManager->indexSetup()', () => {
         });
 
         it('should be able upsert the same template safely', async () => {
-            // @ts-ignore
-            const { mapping } = config.index_schema;
-            // @ts-ignore
-            const { version } = config.index_schema;
+            const { mapping, version } = config.index_schema!;
 
             const mappings = {};
             mappings[config.name] = mapping;

--- a/packages/elasticsearch-store/test/index-model-spec.ts
+++ b/packages/elasticsearch-store/test/index-model-spec.ts
@@ -17,7 +17,7 @@ describe('IndexModel', () => {
 
     const client = makeClient();
     const exampleConfig: IndexModelConfig<ExampleRecord> = {
-        name: 'index_model',
+        name: 'example_model',
         mapping: {
             properties: {
                 name: {
@@ -156,7 +156,7 @@ describe('IndexModel', () => {
                     },
                 });
             } catch (err) {
-                expect(err.message).toEqual('IndexModel requires name to be unique');
+                expect(err.message).toEqual('ExampleModel requires name to be unique');
                 expect(err).toBeInstanceOf(TSError);
                 expect(err.statusCode).toEqual(409);
             }
@@ -184,10 +184,9 @@ describe('IndexModel', () => {
             expect.hasAssertions();
 
             try {
-                // @ts-ignore
-                await indexModel.createRecord({});
+                await indexModel.createRecord({} as any);
             } catch (err) {
-                expect(err.message).toEqual('IndexModel requires field name');
+                expect(err.message).toEqual('ExampleModel requires field name');
                 expect(err).toBeInstanceOf(TSError);
                 expect(err.statusCode).toEqual(422);
             }
@@ -200,7 +199,7 @@ describe('IndexModel', () => {
                     try {
                         await indexModel.findAndApply(undefined);
                     } catch (err) {
-                        expect(err.message).toEqual('Invalid input for IndexModel');
+                        expect(err.message).toEqual('Invalid input for ExampleModel');
                         expect(err).toBeInstanceOf(TSError);
                         expect(err.statusCode).toEqual(422);
                     }
@@ -239,7 +238,7 @@ describe('IndexModel', () => {
                     name,
                 });
             } catch (err) {
-                expect(err.message).toEqual('IndexModel requires name to be unique');
+                expect(err.message).toEqual('ExampleModel requires name to be unique');
                 expect(err).toBeInstanceOf(TSError);
                 expect(err.statusCode).toEqual(409);
             }
@@ -249,12 +248,11 @@ describe('IndexModel', () => {
             expect.hasAssertions();
 
             try {
-                // @ts-ignore
-                await indexModel.updateRecord({});
+                await indexModel.updateRecord(undefined as any, {} as any);
             } catch (err) {
-                expect(err.message).toEqual('IndexModel update requires _key');
+                expect(err.message).toStartWith('Invalid ID given to updateRecord, expected string or integer');
                 expect(err).toBeInstanceOf(TSError);
-                expect(err.statusCode).toEqual(422);
+                expect(err.statusCode).toEqual(400);
             }
         });
 
@@ -284,7 +282,7 @@ describe('IndexModel', () => {
             try {
                 await indexModel.fetchRecord('WrongBilly');
             } catch (err) {
-                expect(err.message).toEqual('Unable to find IndexModel by _key: "WrongBilly" OR name: "WrongBilly"');
+                expect(err.message).toEqual('Unable to find ExampleModel by _key: "WrongBilly" OR name: "WrongBilly"');
                 expect(err.statusCode).toEqual(404);
                 expect(err).toBeInstanceOf(TSError);
             }
@@ -328,7 +326,7 @@ describe('IndexModel', () => {
         it('should be able to delete the record', async () => {
             await indexModel.deleteById(fetched._key);
 
-            return expect(indexModel.findById(fetched._key)).rejects.toThrowError(/Unable to find IndexModel/);
+            return expect(indexModel.findById(fetched._key)).rejects.toThrowError(/Unable to find ExampleModel/);
         });
     });
 
@@ -542,15 +540,13 @@ describe('IndexModel', () => {
 
     describe('when appending to an array', () => {
         it('should return early if given empty values', async () => {
-            // @ts-ignore
-            await indexModel._appendToArray('example', 'name', []);
+            await indexModel.appendToArray('example', 'name', []);
         });
     });
 
     describe('when removing from an array', () => {
         it('should return early if given empty values', async () => {
-            // @ts-ignore
-            await indexModel._removeFromArray('example', 'name', []);
+            await indexModel.removeFromArray('example', 'name', []);
         });
     });
 });

--- a/packages/elasticsearch-store/test/index-model-spec.ts
+++ b/packages/elasticsearch-store/test/index-model-spec.ts
@@ -234,8 +234,7 @@ describe('IndexModel', () => {
             });
 
             try {
-                await indexModel.updateRecord({
-                    ...created,
+                await indexModel.updateRecord(created._key, {
                     type: 'billy',
                     name,
                 });
@@ -294,7 +293,7 @@ describe('IndexModel', () => {
         it('should be able to update the record', async () => {
             const updateInput = { ...fetched, name: 'Hello' };
 
-            const updateResult = await indexModel.updateRecord(updateInput);
+            const updateResult = await indexModel.updateRecord(fetched._key, updateInput);
             expect(updateResult).not.toBe(updateInput);
 
             const result = await indexModel.findById(fetched._key);
@@ -304,9 +303,9 @@ describe('IndexModel', () => {
         });
 
         it('should be able to correctly handle a partial update', async () => {
-            const updateInput = { _key: fetched._key, config: { foo: 1 } };
+            const updateInput = { config: { foo: 1 } };
 
-            await indexModel.updateRecord(updateInput);
+            await indexModel.updateRecord(fetched._key, updateInput);
 
             const result = await indexModel.findById(fetched._key);
             expect(result).toHaveProperty('config', {

--- a/packages/elasticsearch-store/test/index-model-spec.ts
+++ b/packages/elasticsearch-store/test/index-model-spec.ts
@@ -180,7 +180,7 @@ describe('IndexModel', () => {
             });
 
             it('should be to soft delete the record and create a new one with the same name', async () => {
-                await indexModel.deleteRecord(id);
+                await expect(indexModel.deleteRecord(id)).resolves.toBeTrue();
 
                 await expect(indexModel.createRecord({
                     client_id: 5,
@@ -327,7 +327,8 @@ describe('IndexModel', () => {
 
         it('should be able to soft delete the record', async () => {
             expect.hasAssertions();
-            await indexModel.deleteRecord(fetched._key);
+            await expect(indexModel.deleteRecord(fetched._key)).resolves.toBeTrue();
+            await expect(indexModel.deleteRecord(fetched._key)).resolves.toBeFalse();
 
             try {
                 await indexModel.findById(fetched._key);
@@ -335,9 +336,11 @@ describe('IndexModel', () => {
                 expect(err.message).toInclude('Record Missing');
                 expect(err.statusCode).toEqual(410);
             }
+
+            return expect(indexModel.recordExists(fetched._key)).resolves.toBeFalse();
         });
 
-        it('should be able to delete the record', async () => {
+        it('should be able to hard delete the record', async () => {
             await indexModel.deleteById(fetched._key);
 
             return expect(indexModel.findById(fetched._key)).rejects.toThrowError(/Unable to find ExampleModel/);

--- a/packages/elasticsearch-store/test/index-model-spec.ts
+++ b/packages/elasticsearch-store/test/index-model-spec.ts
@@ -250,7 +250,7 @@ describe('IndexModel', () => {
             try {
                 await indexModel.updateRecord(undefined as any, {} as any);
             } catch (err) {
-                expect(err.message).toStartWith('Invalid ID given to updateRecord, expected string or integer');
+                expect(err.message).toStartWith('Invalid ID given to updateRecord, expected string');
                 expect(err).toBeInstanceOf(TSError);
                 expect(err.statusCode).toEqual(400);
             }

--- a/packages/elasticsearch-store/test/index-store-spec.ts
+++ b/packages/elasticsearch-store/test/index-store-spec.ts
@@ -340,7 +340,7 @@ describe('IndexStore', () => {
 
             xit('compare xlucene query', async () => {
                 const q = '_exists_:test_number OR test_number:<0 OR test_number:100000 NOT test_keyword:other-keyword';
-                const realResult = await indexStore._search({
+                const realResult = await indexStore.searchRequest({
                     q,
                     _sourceInclude: ['test_id', 'test_boolean'],
                     sort: 'test_number:asc',
@@ -352,7 +352,7 @@ describe('IndexStore', () => {
                     sort: 'test_number:asc',
                 });
 
-                await indexStore._search({
+                await indexStore.searchRequest({
                     body: {
                         query: {
                             constant_score: {
@@ -411,7 +411,7 @@ describe('IndexStore', () => {
             });
 
             xit('test lucene query', async () => {
-                const result = await indexStore._search({
+                const result = await indexStore.searchRequest({
                     q: '*rec?rd',
                     size: 200,
                     _sourceInclude: ['test_id', 'test_number'],

--- a/packages/elasticsearch-store/test/index-store-spec.ts
+++ b/packages/elasticsearch-store/test/index-store-spec.ts
@@ -89,13 +89,13 @@ describe('IndexStore', () => {
                 _updated: new Date().toISOString(),
             };
 
-            beforeAll(() => indexStore.createWithId(record.test_id, record));
+            beforeAll(() => indexStore.createById(record.test_id, record));
 
             it('should not be able to create a record again', async () => {
                 expect.hasAssertions();
 
                 try {
-                    await indexStore.createWithId(record.test_id, record);
+                    await indexStore.createById(record.test_id, record);
                 } catch (err) {
                     expect(err).toBeInstanceOf(TSError);
                     expect(err.message).toInclude('Document Already Exists');
@@ -103,7 +103,7 @@ describe('IndexStore', () => {
                 }
             });
 
-            it('should be able to index the same record', () => indexStore.indexWithId(record.test_id, record));
+            it('should be able to index the same record', () => indexStore.indexById(record.test_id, record));
 
             it('should be able to index the record without an id', async () => {
                 const lonelyRecord: SimpleRecordInput = {
@@ -129,7 +129,7 @@ describe('IndexStore', () => {
                     test_boolean: false,
                 };
 
-                await indexStore.indexWithId(otherRecord.test_id, otherRecord);
+                await indexStore.indexById(otherRecord.test_id, otherRecord);
 
                 const count = await indexStore.count(`test_id: ${otherRecord.test_id}`);
                 expect(count).toBe(1);
@@ -265,7 +265,7 @@ describe('IndexStore', () => {
 
             beforeAll(async () => {
                 await Promise.all(
-                    records.map((record) => indexStore.createWithId(record.test_id, record, {
+                    records.map((record) => indexStore.createById(record.test_id, record, {
                         refresh: false,
                     }))
                 );
@@ -534,7 +534,7 @@ describe('IndexStore', () => {
             };
 
             try {
-                await indexStore.indexWithId(record.test_id!, record);
+                await indexStore.indexById(record.test_id!, record);
             } catch (err) {
                 expect(err).toBeInstanceOf(TSError);
                 expect(err.message).toMatch(/(test_keyword|_created)/);
@@ -589,9 +589,9 @@ describe('IndexStore', () => {
                     input.map((record, i) => {
                         if (inputType === 'input') {
                             if (i === 0) {
-                                return indexStore.createWithId(record.test_id, record);
+                                return indexStore.createById(record.test_id, record);
                             }
-                            return indexStore.indexWithId(record.test_id, record, {
+                            return indexStore.indexById(record.test_id, record, {
                                 refresh: false,
                             });
                         }

--- a/packages/elasticsearch-store/test/index-store-spec.ts
+++ b/packages/elasticsearch-store/test/index-store-spec.ts
@@ -17,8 +17,7 @@ describe('IndexStore', () => {
     describe('when constructed with nothing', () => {
         it('should throw an error', () => {
             expect(() => {
-                // @ts-ignore
-                new IndexStore();
+                new IndexStore(undefined as any, undefined as any);
             }).toThrowWithMessage(TSError, 'IndexStore requires elasticsearch client');
         });
     });
@@ -26,8 +25,7 @@ describe('IndexStore', () => {
     describe('when constructed without a config', () => {
         it('should throw an error', () => {
             expect(() => {
-                // @ts-ignore
-                new IndexStore(client);
+                new IndexStore(client as any, undefined as any);
             }).toThrowError();
         });
     });
@@ -177,8 +175,7 @@ describe('IndexStore', () => {
             });
 
             it('should be able to get the record by id', async () => {
-                // @ts-ignore
-                const r = (await indexStore.get(record.test_id)) as DataEntity<T>;
+                const r: DataEntity<SimpleRecord> = (await indexStore.get(record.test_id)) as any;
 
                 expect(DataEntity.isDataEntity(r)).toBeTrue();
                 expect(r).toEqual(record);
@@ -529,20 +526,19 @@ describe('IndexStore', () => {
         it('should fail when given an invalid record', async () => {
             expect.hasAssertions();
 
-            const record = {
+            const record: Partial<SimpleRecord> = {
                 test_id: 'invalid-record-id',
-                test_boolean: Buffer.from('wrong'),
-                test_number: '123',
+                test_boolean: Buffer.from('wrong') as any,
+                test_number: '123' as any,
                 _created: 'wrong-date',
             };
 
             try {
-                // @ts-ignore
-                await indexStore.indexWithId(record, record.test_id);
+                await indexStore.indexWithId(record.test_id!, record);
             } catch (err) {
                 expect(err).toBeInstanceOf(TSError);
                 expect(err.message).toMatch(/(test_keyword|_created)/);
-                expect(err.statusCode).toEqual(422);
+                expect(err.statusCode).toEqual(400);
             }
         });
 

--- a/packages/elasticsearch-store/test/index-store-spec.ts
+++ b/packages/elasticsearch-store/test/index-store-spec.ts
@@ -143,18 +143,18 @@ describe('IndexStore', () => {
 
             it('should be able to update the record', async () => {
                 await indexStore.update(
+                    record.test_id,
                     {
                         doc: {
                             test_number: 4231,
                         },
                     },
-                    record.test_id
                 );
 
                 const updated = await indexStore.get(record.test_id);
                 expect(updated).toHaveProperty('test_number', 4231);
 
-                await indexStore.update({ doc: record }, record.test_id);
+                await indexStore.update(record.test_id, { doc: record });
             });
 
             it('should throw when updating a record that does not exist', async () => {
@@ -162,12 +162,12 @@ describe('IndexStore', () => {
 
                 try {
                     await indexStore.update(
+                        'wrong-id',
                         {
                             doc: {
                                 test_number: 1,
                             },
                         },
-                        'wrong-id'
                     );
                 } catch (err) {
                     expect(err).toBeInstanceOf(TSError);
@@ -211,13 +211,15 @@ describe('IndexStore', () => {
                 }
             });
 
-            it('should be able to remove the record', () => indexStore.remove(record.test_id));
+            it('should be able to remove the record', async () => {
+                await indexStore.deleteById(record.test_id);
+            });
 
             it('should throw when trying to remove a record that does not exist', async () => {
                 expect.hasAssertions();
 
                 try {
-                    await indexStore.remove('wrong-id');
+                    await indexStore.deleteById('wrong-id');
                 } catch (err) {
                     expect(err).toBeInstanceOf(TSError);
                     expect(err.message).toInclude('Not Found');
@@ -346,7 +348,7 @@ describe('IndexStore', () => {
                 });
                 const xluceneResult = await indexStore.search(q, {
                     size: 200,
-                    _sourceInclude: ['test_id', 'test_boolean'],
+                    includes: ['test_id', 'test_boolean'],
                     sort: 'test_number:asc',
                 });
 
@@ -638,12 +640,12 @@ describe('IndexStore', () => {
 
             it('should be able to update a record with a proper field', async () => {
                 const result = await indexStore.update(
+                    expected[2].test_id,
                     {
                         doc: {
                             test_number: 77777,
                         },
-                    },
-                    expected[2].test_id
+                    }
                 );
 
                 expect(result).toBeNil();

--- a/packages/elasticsearch-store/test/index-store-spec.ts
+++ b/packages/elasticsearch-store/test/index-store-spec.ts
@@ -56,7 +56,7 @@ describe('IndexStore', () => {
     describe('when constructed without a data schema', () => {
         const _client = makeClient();
 
-        const indexStore = new IndexStore<SimpleRecord, SimpleRecordInput>(_client, config);
+        const indexStore = new IndexStore<SimpleRecord>(_client, config);
 
         beforeAll(async () => {
             await cleanupIndexStore(indexStore);
@@ -91,13 +91,13 @@ describe('IndexStore', () => {
                 _updated: new Date().toISOString(),
             };
 
-            beforeAll(() => indexStore.createWithId(record, record.test_id));
+            beforeAll(() => indexStore.createWithId(record.test_id, record));
 
             it('should not be able to create a record again', async () => {
                 expect.hasAssertions();
 
                 try {
-                    await indexStore.createWithId(record, record.test_id);
+                    await indexStore.createWithId(record.test_id, record);
                 } catch (err) {
                     expect(err).toBeInstanceOf(TSError);
                     expect(err.message).toInclude('Document Already Exists');
@@ -105,7 +105,7 @@ describe('IndexStore', () => {
                 }
             });
 
-            it('should be able to index the same record', () => indexStore.indexWithId(record, record.test_id));
+            it('should be able to index the same record', () => indexStore.indexWithId(record.test_id, record));
 
             it('should be able to index the record without an id', async () => {
                 const lonelyRecord: SimpleRecordInput = {
@@ -131,7 +131,7 @@ describe('IndexStore', () => {
                     test_boolean: false,
                 };
 
-                await indexStore.indexWithId(otherRecord, otherRecord.test_id);
+                await indexStore.indexWithId(otherRecord.test_id, otherRecord);
 
                 const count = await indexStore.count(`test_id: ${otherRecord.test_id}`);
                 expect(count).toBe(1);
@@ -268,7 +268,7 @@ describe('IndexStore', () => {
 
             beforeAll(async () => {
                 await Promise.all(
-                    records.map((record) => indexStore.createWithId(record, record.test_id, {
+                    records.map((record) => indexStore.createWithId(record.test_id, record, {
                         refresh: false,
                     }))
                 );
@@ -509,7 +509,7 @@ describe('IndexStore', () => {
             },
         });
 
-        const indexStore = new IndexStore<SimpleRecord, SimpleRecordInput>(
+        const indexStore = new IndexStore<SimpleRecord>(
             _client,
             configWithDataSchema
         );
@@ -593,9 +593,9 @@ describe('IndexStore', () => {
                     input.map((record, i) => {
                         if (inputType === 'input') {
                             if (i === 0) {
-                                return indexStore.createWithId(record, record.test_id);
+                                return indexStore.createWithId(record.test_id, record);
                             }
-                            return indexStore.indexWithId(record, record.test_id, {
+                            return indexStore.indexWithId(record.test_id, record, {
                                 refresh: false,
                             });
                         }

--- a/packages/elasticsearch-store/test/utils-spec.ts
+++ b/packages/elasticsearch-store/test/utils-spec.ts
@@ -23,15 +23,13 @@ describe('Elasticsearch Store Utils', () => {
 
         it('should return false when given missing map', () => {
             expect(
-                // @ts-ignore
                 isSimpleIndex({
                     version: 'v1',
-                })
+                } as any)
             ).toBeFalse();
         });
 
         it('should return false when given a templated index', () => {
-            // @ts-ignore
             expect(
                 isSimpleIndex({
                     mapping: { properties: {} },
@@ -55,10 +53,9 @@ describe('Elasticsearch Store Utils', () => {
 
         it('should return false when given missing map', () => {
             expect(
-                // @ts-ignore
                 isTemplatedIndex({
                     version: 'v1',
-                })
+                } as any)
             ).toBeFalse();
         });
 
@@ -73,7 +70,6 @@ describe('Elasticsearch Store Utils', () => {
         });
 
         it('should return true when given a timeseries index', () => {
-            // @ts-ignore
             expect(
                 isTemplatedIndex({
                     mapping: {
@@ -102,15 +98,13 @@ describe('Elasticsearch Store Utils', () => {
 
         it('should return false when given missing map', () => {
             expect(
-                // @ts-ignore
                 isTimeSeriesIndex({
                     version: 1,
-                })
+                } as any)
             ).toBeFalse();
         });
 
         it('should return false when given a templated index', () => {
-            // @ts-ignore
             expect(
                 isTimeSeriesIndex({
                     mapping: { properties: {} },
@@ -121,14 +115,13 @@ describe('Elasticsearch Store Utils', () => {
         });
 
         it('should return true when given a timeseries index', () => {
-            // @ts-ignore
             expect(
                 isTimeSeriesIndex({
                     mapping: { properties: {} },
                     template: true,
                     timeseries: true,
                     version: 1,
-                })
+                } as any)
             ).toBeTrue();
         });
     });
@@ -140,8 +133,7 @@ describe('Elasticsearch Store Utils', () => {
         describe('when passed an invalid config object', () => {
             it('should throw an error', () => {
                 expect(() => {
-                    // @ts-ignore
-                    validateIndexConfig();
+                    validateIndexConfig(undefined as any);
                 }).toThrowWithMessage(TSError, /IndexConfig cannot be empty/);
             });
         });
@@ -214,7 +206,6 @@ describe('Elasticsearch Store Utils', () => {
             it('should throw if a string is used for the Index Schema version', () => {
                 expect(() => {
                     validateIndexConfig({
-                        // @ts-ignore
                         index_schema: {
                             mapping: { properties: {} },
                             version: '8',
@@ -245,7 +236,6 @@ describe('Elasticsearch Store Utils', () => {
                             mapping: { properties: {} },
                             version: 8,
                         },
-                        // @ts-ignore
                         version: '8',
                         index: 'hello',
                     });

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/job-components",
-    "version": "0.23.9",
+    "version": "0.23.10",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.7",
-        "@terascope/utils": "^0.20.5",
+        "@terascope/utils": "^0.20.6",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^3.3.3"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.18.0",
-        "@terascope/utils": "^0.20.5",
+        "@terascope/utils": "^0.20.6",
         "@types/is-ci": "^2.0.0",
         "codecov": "^3.5.0",
         "execa": "^3.2.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "terafoundation",
-    "version": "0.14.0",
+    "version": "0.14.1",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.5",
+        "@terascope/utils": "^0.20.6",
         "aws-sdk": "^2.563.0",
         "bluebird": "^3.5.5",
         "bunyan": "^1.8.12",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-cli",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.6.0",
-        "@terascope/utils": "^0.20.5",
+        "@terascope/utils": "^0.20.6",
         "archiver": "^3.0.0",
         "bluebird": "^3.5.5",
         "chalk": "^2.4.2",
@@ -51,7 +51,7 @@
         "request": "^2.88.0",
         "request-promise": "^4.2.5",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.8.7",
+        "teraslice-client-js": "^0.8.8",
         "tmp": "^0.1.0",
         "tty-table": "^2.8.1",
         "yargs": "^14.2.0",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-client-js",
-    "version": "0.8.7",
+    "version": "0.8.8",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -29,7 +29,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.23.9",
+        "@terascope/job-components": "^0.23.10",
         "auto-bind": "^3.0.0",
         "got": "^9.6.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-messaging",
-    "version": "0.4.9",
+    "version": "0.4.10",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.7",
-        "@terascope/utils": "^0.20.5",
+        "@terascope/utils": "^0.20.6",
         "ms": "^2.1.2",
         "nanoid": "^2.1.6",
         "p-event": "^4.1.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
-    "version": "1.7.11",
+    "version": "1.7.12",
     "description": "A testing harness to simplify testing Teraslice processors and operations.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-op-test-harness#readme",
     "bugs": {
@@ -17,7 +17,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.23.9",
+        "@terascope/job-components": "^0.23.10",
         "bluebird": "^3.5.5",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-state-storage",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.2.0",
-        "@terascope/utils": "^0.20.5",
+        "@terascope/elasticsearch-api": "^2.2.1",
+        "@terascope/utils": "^0.20.6",
         "bluebird": "^3.5.5",
         "mnemonist": "^0.30.0"
     },

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-test-harness",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {
@@ -30,8 +30,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.23.9",
-        "@terascope/teraslice-op-test-harness": "^1.7.11",
+        "@terascope/job-components": "^0.23.10",
+        "@terascope/teraslice-op-test-harness": "^1.7.12",
         "lodash": "^4.17.11"
     },
     "devDependencies": {},

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -32,11 +32,11 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.2.0",
-        "@terascope/job-components": "^0.23.9",
+        "@terascope/elasticsearch-api": "^2.2.1",
+        "@terascope/job-components": "^0.23.10",
         "@terascope/queue": "^1.1.7",
-        "@terascope/teraslice-messaging": "^0.4.9",
-        "@terascope/utils": "^0.20.5",
+        "@terascope/teraslice-messaging": "^0.4.10",
+        "@terascope/utils": "^0.20.6",
         "async-mutex": "^0.1.3",
         "barbe": "^3.0.15",
         "bluebird": "^3.5.5",
@@ -60,11 +60,11 @@
         "shortid": "^2.2.14",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.14.0",
+        "terafoundation": "^0.14.1",
         "uuid": "^3.3.3"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.7.11",
+        "@terascope/teraslice-op-test-harness": "^1.7.12",
         "archiver": "^3.0.0",
         "bufferstreams": "^2.0.1",
         "chance": "^1.1.3",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-transforms",
-    "version": "0.25.0",
+    "version": "0.25.0-rc.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -44,7 +44,7 @@
         "shortid": "^2.2.14",
         "valid-url": "^1.0.9",
         "validator": "^11.0.0",
-        "xlucene-evaluator": "^0.12.0",
+        "xlucene-evaluator": "^0.12.0-rc.0",
         "yargs": "^14.2.0"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-transforms",
-    "version": "0.24.13",
+    "version": "0.25.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.5",
+        "@terascope/utils": "^0.20.6",
         "@types/graphlib": "^2.1.5",
         "@types/shortid": "^0.0.29",
         "awesome-phonenumber": "^2.21.0",
@@ -44,7 +44,7 @@
         "shortid": "^2.2.14",
         "valid-url": "^1.0.9",
         "validator": "^11.0.0",
-        "xlucene-evaluator": "^0.11.8",
+        "xlucene-evaluator": "^0.12.0",
         "yargs": "^14.2.0"
     },
     "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/utils",
-    "version": "0.20.5",
+    "version": "0.20.6",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -53,15 +53,9 @@ export function uniq<T>(arr: T[]): T[] {
 /** A native implemation of lodash times */
 export function times(n: number): number[];
 export function times<T>(n: number, fn: (index: number) => T): T[];
-export function times<T>(n: number, fn?: (index: number) => T): T[] {
-    let i = -1;
-    const result = Array(n);
-
-    while (++i < n) {
-        result[i] = fn != null ? fn(i) : i;
-    }
-
-    return result;
+export function times<T>(n: number, fn?: (index: number) => T): (T[])|(number[]) {
+    if (fn) return Array.from({ length: n }, (_, x) => fn(x));
+    return Array.from({ length: n }, (_, x) => x);
 }
 
 /** Map an array faster without sparse array handling */

--- a/packages/utils/src/interfaces.ts
+++ b/packages/utils/src/interfaces.ts
@@ -69,3 +69,13 @@ export interface AnyObject {
 export type PartialDeep<T> = {
     [ P in keyof T ]?: PartialDeep<T[ P ]>;
 }
+
+/**
+ * Remove types from T that are assignable to U
+*/
+export type Diff<T, U> = T extends U ? never : T;
+
+/**
+ * Remove types from T that are NOT assignable to U
+*/
+export type Filter<T, U> = T extends U ? T : never;

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -8,11 +8,12 @@ import {
 } from './strings';
 
 /** Check if an input is empty, similar to lodash.isEmpty */
-export function isEmpty(val?: any): boolean {
-    if (val == null) return true;
-    if (val.size != null) return !val.size;
-    if (typeof val === 'object') return !Object.keys(val).length;
-    if (val.length != null) return !val.length;
+export function isEmpty<T>(val?: T): val is undefined {
+    const _val = val as any;
+    if (!_val) return true;
+    if (typeof _val.size === 'number') return !_val.size;
+    if (typeof _val.length === 'number') return !_val.length;
+    if (typeof val === 'object') return !Object.keys(_val).length;
 
     return true;
 }

--- a/packages/xlucene-evaluator/package.json
+++ b/packages/xlucene-evaluator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xlucene-evaluator",
-    "version": "0.11.8",
+    "version": "0.12.0",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-evaluator#readme",
     "repository": {
@@ -28,7 +28,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.20.5",
+        "@terascope/utils": "^0.20.6",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-point-in-polygon": "^6.0.1",

--- a/packages/xlucene-evaluator/package.json
+++ b/packages/xlucene-evaluator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xlucene-evaluator",
-    "version": "0.12.0",
+    "version": "0.12.0-rc.0",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-evaluator#readme",
     "repository": {

--- a/packages/xlucene-evaluator/src/query-access/interfaces.ts
+++ b/packages/xlucene-evaluator/src/query-access/interfaces.ts
@@ -21,7 +21,7 @@ export interface RestrictSearchQueryOptions extends ElasticsearchDSLOptions {
 export interface QueryAccessConfig<T extends AnyObject = AnyObject> {
     excludes?: (keyof T)[];
     includes?: (keyof T)[];
-    constraint?: string;
+    constraint?: string|string[];
     prevent_prefix_wildcard?: boolean;
     allow_implicit_queries?: boolean;
     allow_empty_queries?: boolean;


### PR DESCRIPTION
**Features:** 

- Add soft delete support
- Add the ability to add extra constraints to Query Access (so multiple constraints can be added without have to worry about correctly joining the together or potentially mutating a user defined constrained).
- Add support for read/write hooks for a records (useful for validation and fixing records before/after storing them).

**Breaking Changes:**

- Changes to some of the base `IndexModel` fields, `id` => `_key`, `created` => `_created`, and `updated` => `_created`.
- Moves more methods from the `IndexModel` to the `IndexStore` since the `IndexStore` should be more generic and would be benefit from those methods.
- Changes the argument order of some the methods on `IndexModel` to be more consistent (for example, `createWithId(doc, id)` is now `createById(id, doc)`).
- Renames some of the methods on `IndexModel` to have a convention different than the ones on `IndexStore`, now there is `createRecord`, `updateRecord`, `fetchRecord`, and `deleteRecord`
- Removes support for the old read/write hook API