### PR TITLE
v0.60.1 - Update kafka connector 2.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN npm init --yes > /dev/null \
     && npm install \
     --quiet \
     --no-package-lock \
-    'terafoundation_kafka_connector@~0.5.2'
+    'terafoundation_kafka_connector@~0.5.3'
 
 RUN apk del .build-deps
 
@@ -90,8 +90,8 @@ RUN yarn quick:setup
 # [BUILD THE PRODUCTION IMAGE]
 ENV NODE_ENV production
 
-# verify @terascope/node-rdkafka is installed right
-RUN node -e "require('@terascope/node-rdkafka')"
+# verify node-rdkafka is installed right
+RUN node -e "require('node-rdkafka')"
 
 COPY service.js /app/source/
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-workspace",
-    "version": "0.60.0",
+    "version": "0.60.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.60.0",
+    "version": "0.60.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
Update docker image to use `terafoundation_kafka_connector@2.5.3` which switching back to using the official `node-rdkafka` npm package.

Ref #1500 