### PR TITLE
Fix default index replicas

### DIFF
--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "elasticsearch-store",
-    "version": "0.14.0",
+    "version": "0.14.1",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -35,8 +35,8 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
                 all_formatters: true,
             },
             index_settings: {
-                'index.number_of_shards': ts.isProd ? 5 : 1,
-                'index.number_of_replicas': ts.isProd ? 1 : 0,
+                'index.number_of_shards': ts.isTest ? 1 : 5,
+                'index.number_of_replicas': ts.isTest ? 0 : 2,
                 analysis: {
                     analyzer: {
                         lowercase_keyword_analyzer: {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "terafoundation",
-    "version": "0.14.1",
+    "version": "0.14.2",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -60,7 +60,7 @@
         "shortid": "^2.2.14",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.14.1",
+        "terafoundation": "^0.14.2",
         "uuid": "^3.3.3"
     },
     "devDependencies": {


### PR DESCRIPTION
Change the default production/test index replicas / shards in `elasticsearch-store`. Previously this would default to 1 replica and 5 shards (if `NODE_ENV == null` or `NODE_ENV === 'production'`). Now the default is 2 replica and 5 shards (if `NODE_ENV !== 'test'`). This will prevent accidentally creating indexes with less replicas or shards if NODE_ENV is set to development, like if you are running a migration or running against a production instance.