### PR TITLE
ESlint Fixes / Improvements

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -25,6 +25,7 @@ e2e/.config
 /packages/*/dist
 /packages/*/build
 /packages/teraslice-cli/generator-templates
+/packages/generator-teraslice/generators/*/templates/**/*.ts
 /packages/xlucene-evaluator/src/parser/peg-engine.ts
 
 website

--- a/e2e/test/cases/data/id-reader-spec.js
+++ b/e2e/test/cases/data/id-reader-spec.js
@@ -10,6 +10,7 @@ const { resetState, testJobLifeCycle, runEsJob } = require('../../helpers');
  *  - https://github.com/terascope/teraslice/issues/68
  *  - https://github.com/terascope/elasticsearch-assets/issues/12
  */
+// eslint-disable-next-line jest/no-disabled-tests
 xdescribe('id reader', () => {
     beforeAll(() => resetState());
 

--- a/e2e/test/cases/validation/job-spec.js
+++ b/e2e/test/cases/validation/job-spec.js
@@ -12,9 +12,7 @@ describe('job validation', () => {
 
         return misc.teraslice()
             .jobs.submit(jobSpec)
-            .then(() => {
-                fail('Submission should not succeed when no index is specified.');
-            }) // This should throw a validation error.
+            .then(() => Promise.reject(new Error('Submission should not succeed when no index is specified.'))) // This should throw a validation error.
             .catch((err) => {
                 expect(err.error).toBe(500);
             });
@@ -37,9 +35,7 @@ describe('job validation', () => {
 
         return misc.teraslice()
             .jobs.submit(jobSpec)
-            .then(() => {
-                fail('Submission should not succeed when slicers == 0');
-            }) // This should throw a validation error.
+            .then(() => Promise.reject(new Error('Submission should not succeed when slicers == 0'))) // This should throw a validation error.
             .catch((err) => {
                 expect(err.error).toBe(500);
             });
@@ -51,9 +47,7 @@ describe('job validation', () => {
 
         return misc.teraslice()
             .jobs.submit(jobSpec)
-            .then(() => {
-                fail('Submission should not succeed when slicers == -1');
-            }) // This should throw a validation error.
+            .then(() => new Promise(new Error('Submission should not succeed when slicers == -1'))) // This should throw a validation error.
             .catch((err) => {
                 expect(err.error).toBe(500);
             });
@@ -65,9 +59,7 @@ describe('job validation', () => {
 
         return misc.teraslice()
             .jobs.submit(jobSpec)
-            .then(() => {
-                fail('Submission should not succeed when workers == 0');
-            }) // This should throw a validation error.
+            .then(() => Promise.reject(new Error('Submission should not succeed when workers == 0'))) // This should throw a validation error.
             .catch((err) => {
                 expect(err.error).toBe(500);
             });
@@ -79,9 +71,7 @@ describe('job validation', () => {
 
         return misc.teraslice()
             .jobs.submit(jobSpec)
-            .then(() => {
-                fail('Submission should not succeed when lifecycle is invalid');
-            }) // This should throw a validation error.
+            .then(() => Promise.reject(new Error('Submission should not succeed when lifecycle is invalid'))) // This should throw a validation error.
             .catch((err) => {
                 expect(err.error).toBe(500);
             });
@@ -92,9 +82,7 @@ describe('job validation', () => {
 
         return misc.teraslice()
             .jobs.submit(jobSpec)
-            .then(() => {
-                fail('Submission should not succeed when job is empty');
-            }) // This should throw a validation error.
+            .then(() => Promise.reject(new Error('Submission should not succeed when job is empty'))) // This should throw a validation error.
             .catch((err) => {
                 expect(err.error).toBe(400);
             });

--- a/examples/k8s/asset/asset/example-op.js
+++ b/examples/k8s/asset/asset/example-op.js
@@ -9,7 +9,6 @@ function schema() {
     };
 }
 
-
 module.exports = {
     newProcessor,
     schema

--- a/packages/chunked-file-reader/lib/formatters.js
+++ b/packages/chunked-file-reader/lib/formatters.js
@@ -31,7 +31,6 @@ function _toRecords(rawData, delimiter, slice) {
     return outputData.split(delimiter).splice(1);
 }
 
-
 // No parsing, leaving to reader or a downstream op.
 function raw(incomingData, logger, opConfig, metadata, slice) {
     const data = _toRecords(incomingData, opConfig.line_delimiter, slice);

--- a/packages/chunked-file-reader/lib/index.js
+++ b/packages/chunked-file-reader/lib/index.js
@@ -2,7 +2,6 @@
 
 const chunkFormatter = require('./formatters');
 
-
 function _averageRecordSize(array) {
     return Math.floor(array.reduce((accum, str) => accum + str.length, 0) / array.length);
 }
@@ -31,7 +30,6 @@ function getOffsets(size, total, delimiter) {
     }
     return chunks;
 }
-
 
 // This function will grab the chunk of data specified by the slice plus an
 // extra margin if the slice does not end with the delimiter.

--- a/packages/data-types/src/types/versions/v1/object.ts
+++ b/packages/data-types/src/types/versions/v1/object.ts
@@ -1,4 +1,3 @@
-
 import { FieldType } from 'xlucene-evaluator';
 import BaseType from '../base-type';
 import { ElasticSearchTypes } from '../../../interfaces';

--- a/packages/elasticsearch-api/index.js
+++ b/packages/elasticsearch-api/index.js
@@ -764,7 +764,6 @@ module.exports = function elasticsearchApi(client = {}, logger, _opConfig) {
         return Object.assign({}, defaultParams, params);
     }
 
-
     function _migrate(index, migrantIndexName, mapping, recordType, clusterName) {
         const reindexQuery = {
             slices: 4,

--- a/packages/elasticsearch-api/test/api-spec.js
+++ b/packages/elasticsearch-api/test/api-spec.js
@@ -521,13 +521,6 @@ describe('elasticsearch-api', () => {
         return expect(results).toBeTruthy();
     });
 
-    it('can call nodeStats', async () => {
-        const api = esApi(client, logger);
-
-        const results = await api.nodeStats();
-        return expect(results).toBeTruthy();
-    });
-
     it('can warn window size with version', () => {
         const api = esApi(client, logger, { index: 'some_index' });
 

--- a/packages/elasticsearch-store/test/index-store-spec.ts
+++ b/packages/elasticsearch-store/test/index-store-spec.ts
@@ -335,6 +335,7 @@ describe('IndexStore', () => {
                 }
             });
 
+            // eslint-disable-next-line
             xit('compare xlucene query', async () => {
                 const q = '_exists_:test_number OR test_number:<0 OR test_number:100000 NOT test_keyword:other-keyword';
                 const realResult = await indexStore.searchRequest({
@@ -407,6 +408,7 @@ describe('IndexStore', () => {
                 console.dir(xluceneResult);
             });
 
+            // eslint-disable-next-line
             xit('test lucene query', async () => {
                 const result = await indexStore.searchRequest({
                     q: '*rec?rd',

--- a/packages/elasticsearch-store/test/utils-spec.ts
+++ b/packages/elasticsearch-store/test/utils-spec.ts
@@ -138,7 +138,7 @@ describe('Elasticsearch Store Utils', () => {
             });
         });
 
-        describe('when passed an empty name', () => {
+        describe('when passed no name', () => {
             it('should throw an error', () => {
                 expect(() => {
                     validateIndexConfig({});

--- a/packages/eslint-config/lib/overrides.js
+++ b/packages/eslint-config/lib/overrides.js
@@ -69,6 +69,15 @@ if (hasTypescript) {
             rules: rules.react,
         },
         {
+            // overrides just for spec files
+            files: ['*-spec.js', '*-spec.ts', '*-spec.tsx', '*-spec.jsx'],
+            plugins: ['jest'],
+            env: {
+                'jest/globals': true
+            },
+            rules: rules.jest,
+        },
+        {
             // overrides just for typescript files
             files: ['*.ts'],
             extends: ['plugin:@typescript-eslint/recommended', 'airbnb-base'],

--- a/packages/eslint-config/lib/overrides.js
+++ b/packages/eslint-config/lib/overrides.js
@@ -69,15 +69,6 @@ if (hasTypescript) {
             rules: rules.react,
         },
         {
-            // overrides just for spec files
-            files: ['*-spec.js', '*-spec.ts', '*-spec.tsx', '*-spec.jsx'],
-            plugins: ['jest'],
-            env: {
-                'jest/globals': true
-            },
-            rules: rules.jest,
-        },
-        {
             // overrides just for typescript files
             files: ['*.ts'],
             extends: ['plugin:@typescript-eslint/recommended', 'airbnb-base'],
@@ -93,7 +84,16 @@ if (hasTypescript) {
                 },
             },
             rules: rules.typescript,
-        }
+        },
+        {
+            // overrides just for spec files
+            files: ['*-spec.js', '*-spec.ts', '*-spec.tsx', '*-spec.jsx'],
+            plugins: ['jest'],
+            env: {
+                'jest/globals': true
+            },
+            rules: rules.jest,
+        },
     );
 }
 

--- a/packages/eslint-config/lib/overrides.js
+++ b/packages/eslint-config/lib/overrides.js
@@ -46,7 +46,7 @@ if (hasTypescript) {
     overrides.push(
         {
             // overrides just for react files
-            files: ['.jsx', '*.tsx'],
+            files: ['*.jsx', '*.tsx'],
             extends: ['plugin:@typescript-eslint/recommended', 'airbnb'],
             plugins: ['@typescript-eslint'],
             parser: '@typescript-eslint/parser',
@@ -91,19 +91,17 @@ if (hasTypescript) {
 function getTSProjects(workspace) {
     const folderPath = workspace.replace(/\*$/, '');
     if (!fs.existsSync(folderPath)) return [];
+    const tsconfigPath = path.join(folderPath, 'tsconfig.json');
+    if (fs.existsSync(tsconfigPath)) {
+        return [tsconfigPath];
+    }
     if (fs.existsSync(path.join(folderPath, 'package.json'))) {
-        const tsconfigPath = path.join(folderPath, 'tsconfig.json');
-        if (fs.existsSync(tsconfigPath)) {
-            return [tsconfigPath];
-        }
         return [];
     }
     return fs
         .readdirSync(folderPath)
         .filter((pkgName) => {
             const pkgDir = path.join(folderPath, pkgName);
-
-            if (!fs.statSync(pkgDir).isDirectory()) return false;
             const tsConfigPath = path.join(pkgDir, 'tsconfig.json');
             return fs.existsSync(tsConfigPath);
         })

--- a/packages/eslint-config/lib/rules/index.js
+++ b/packages/eslint-config/lib/rules/index.js
@@ -3,9 +3,11 @@
 const javascript = require('./javascript');
 const typescript = require('./typescript');
 const react = require('./react');
+const jest = require('./jest');
 
 module.exports = {
     javascript,
     typescript,
     react,
+    jest,
 };

--- a/packages/eslint-config/lib/rules/index.js
+++ b/packages/eslint-config/lib/rules/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const javascript = require('./javascript');
-const typescript = require('./typescript');
-const react = require('./react');
-const jest = require('./jest');
+const javascriptRules = require('./javascript');
+const typescriptRules = require('./typescript');
+const reactRules = require('./react');
+const jestRules = require('./jest');
 
 module.exports = {
-    javascript,
-    typescript,
-    react,
-    jest,
+    javascript: javascriptRules,
+    typescript: typescriptRules,
+    react: reactRules,
+    jest: jestRules,
 };

--- a/packages/eslint-config/lib/rules/javascript.js
+++ b/packages/eslint-config/lib/rules/javascript.js
@@ -39,6 +39,14 @@ module.exports = {
         'error',
         { allowTernary: true, allowShortCircuit: true },
     ],
+    'no-multiple-empty-lines': [
+        'error',
+        {
+            max: 1,
+            maxBOF: 0,
+            maxEOF: 0
+        }
+    ],
     'import/prefer-default-export': 'off',
     'no-empty-function': 'off',
     'prefer-object-spread': 'off',

--- a/packages/eslint-config/lib/rules/jest.js
+++ b/packages/eslint-config/lib/rules/jest.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+    'jest/no-commented-out-tests': 'warn',
+    'jest/no-disabled-tests': 'warn',
+    'jest/no-focused-tests': 'warn',
+    'jest/no-identical-title': 'warn',
+    'jest/no-jasmine-globals': 'error',
+    'jest/no-jest-import': 'error',
+    'jest/no-standalone-expect': 'error',
+    'jest/prefer-to-contain': 'warn',
+    'jest/prefer-todo': 'warn',
+    'jest/require-top-level-describe': 'warn',
+    'jest/valid-describe': 'error',
+    'jest/valid-expect-in-promise': 'error',
+    'jest/valid-expect': 'error',
+    'jest/valid-title': 'error',
+};

--- a/packages/eslint-config/lib/rules/typescript.js
+++ b/packages/eslint-config/lib/rules/typescript.js
@@ -28,7 +28,9 @@ module.exports = Object.assign({}, jsRules, {
     'lines-between-class-members': 'off',
 
     // better miss handling of promises linting
-    '@typescript-eslint/no-misused-promises': ['error', {}],
+    '@typescript-eslint/no-misused-promises': ['error', {
+        checksVoidReturn: false
+    }],
 
     // The following rules make compatibility between eslint rules and typescript rules
     'consistent-return': 'off',

--- a/packages/eslint-config/lib/rules/typescript.js
+++ b/packages/eslint-config/lib/rules/typescript.js
@@ -27,11 +27,6 @@ module.exports = Object.assign({}, jsRules, {
     'no-dupe-class-members': 'off',
     'lines-between-class-members': 'off',
 
-    // better miss handling of promises linting
-    '@typescript-eslint/no-misused-promises': ['error', {
-        checksVoidReturn: false
-    }],
-
     // The following rules make compatibility between eslint rules and typescript rules
     'consistent-return': 'off',
     'brace-style': 'off',

--- a/packages/eslint-config/lib/rules/typescript.js
+++ b/packages/eslint-config/lib/rules/typescript.js
@@ -19,6 +19,7 @@ module.exports = Object.assign({}, jsRules, {
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/no-empty-function': 'off',
+
     // we SHOULD really have this but we've become depedent on it
     '@typescript-eslint/ban-ts-ignore': 'off',
 
@@ -26,15 +27,45 @@ module.exports = Object.assign({}, jsRules, {
     'no-dupe-class-members': 'off',
     'lines-between-class-members': 'off',
 
+    // better miss handling of promises linting
+    '@typescript-eslint/no-misused-promises': ['error', {}],
+
     // The following rules make compatibility between eslint rules and typescript rules
     'consistent-return': 'off',
+    'brace-style': 'off',
+    '@typescript-eslint/brace-style': [
+        'error',
+        '1tbs',
+        {
+            allowSingleLine: true
+        }
+    ],
+    'no-extra-parens': 'off',
+    '@typescript-eslint/no-extra-parens': [
+        'off',
+        'all',
+        {
+            conditionalAssign: true,
+            nestedBinaryExpressions: false,
+            returnAssign: false,
+            ignoreJSX: 'all',
+            enforceForArrowConditionals: false
+        }
+    ],
+    'func-call-spacing': 'off',
+    '@typescript-eslint/func-call-spacing': ['error', 'never'],
     indent: 'off',
     '@typescript-eslint/indent': ['error', INDENT],
     'no-underscore-dangle': 'off',
     'no-useless-constructor': 'off',
     '@typescript-eslint/prefer-for-of': ['error'],
     camelcase: 'off',
-    '@typescript-eslint/camelcase': ['error', { properties: 'never' }],
+    '@typescript-eslint/camelcase': ['error', {
+        properties: 'never'
+    }],
+    '@typescript-eslint/class-name-casing': ['error', {
+        allowUnderscorePrefix: true
+    }],
     'no-use-before-define': 'off',
     '@typescript-eslint/no-use-before-define': ['error', {
         functions: false,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/eslint-config",
-    "version": "0.1.8",
+    "version": "0.2.0",
     "description": "A shared eslint config based on eslint-config-airbnb",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/eslint-config#readme",
     "bugs": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -21,6 +21,7 @@
         "eslint-config-airbnb": "^18.0.1",
         "eslint-config-airbnb-base": "^14.0.0",
         "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-jest": "^23.1.1",
         "eslint-plugin-jsx-a11y": "^6.2.3",
         "eslint-plugin-react": "^7.14.3",
         "eslint-plugin-react-hooks": "^2.3.0"

--- a/packages/eslint-config/test/index-spec.js
+++ b/packages/eslint-config/test/index-spec.js
@@ -27,7 +27,7 @@ describe('ESLint Config Index', () => {
         expect(Index).toHaveProperty('overrides');
         expect(Index.overrides).toBeArray();
         expect(Index.overrides[0]).toMatchObject({
-            files: ['.jsx', '*.tsx'],
+            files: ['*.jsx', '*.tsx'],
             extends: ['plugin:@typescript-eslint/recommended', 'airbnb'],
             parser: '@typescript-eslint/parser',
             env: {

--- a/packages/job-components/src/formats.ts
+++ b/packages/job-components/src/formats.ts
@@ -1,4 +1,3 @@
-
 import { addFormat, Format } from 'convict';
 // @ts-ignore
 import dateMath from 'datemath-parser';

--- a/packages/job-components/src/job-schemas.ts
+++ b/packages/job-components/src/job-schemas.ts
@@ -1,4 +1,3 @@
-
 import os from 'os';
 import convict from 'convict';
 import {

--- a/packages/job-components/src/job-validator.ts
+++ b/packages/job-components/src/job-validator.ts
@@ -1,4 +1,3 @@
-
 import convict from 'convict';
 import { cloneDeep } from '@terascope/utils';
 import {

--- a/packages/job-components/test/execution-context/worker-spec.ts
+++ b/packages/job-components/test/execution-context/worker-spec.ts
@@ -57,15 +57,12 @@ describe('WorkerExecutionContext', () => {
                 terasliceOpPath,
             });
 
-            expect(executionContext).toHaveProperty('status', 'initializing');
             await executionContext.initialize();
-            expect(executionContext).toHaveProperty('status', 'idle');
         });
 
         afterAll(async () => {
             events.removeAllListeners();
             await executionContext.shutdown();
-            expect(executionContext).toHaveProperty('status', 'shutdown');
         });
 
         it('should have correct properties', () => {

--- a/packages/job-components/test/index-spec.ts
+++ b/packages/job-components/test/index-spec.ts
@@ -1,30 +1,32 @@
 import 'jest-extended'; // require for type definitions
 import * as index from '../src/index';
 
-it('should be truthy', () => {
-    expect(index).toBeTruthy();
-});
+describe('Job Components Exports', () => {
+    it('should be truthy', () => {
+        expect(index).toBeTruthy();
+    });
 
-it('should have a OperationLoader class', () => {
-    expect(index.OperationLoader).toBeFunction();
-});
+    it('should have a OperationLoader class', () => {
+        expect(index.OperationLoader).toBeFunction();
+    });
 
-it('should have a registerApis function', () => {
-    expect(index.registerApis).toBeFunction();
-});
+    it('should have a registerApis function', () => {
+        expect(index.registerApis).toBeFunction();
+    });
 
-it('should have a getOpConfig function', () => {
-    expect(index.getOpConfig).toBeFunction();
-});
+    it('should have a getOpConfig function', () => {
+        expect(index.getOpConfig).toBeFunction();
+    });
 
-it('should have a getClient function', () => {
-    expect(index.getClient).toBeFunction();
-});
+    it('should have a getClient function', () => {
+        expect(index.getClient).toBeFunction();
+    });
 
-it('should have a formats array', () => {
-    expect(index.formats).toBeArray();
-});
+    it('should have a formats array', () => {
+        expect(index.formats).toBeArray();
+    });
 
-it('should have a addFormats function', () => {
-    expect(index.addFormats).toBeFunction();
+    it('should have a addFormats function', () => {
+        expect(index.addFormats).toBeFunction();
+    });
 });

--- a/packages/job-components/test/job-validator-spec.ts
+++ b/packages/job-components/test/job-validator-spec.ts
@@ -38,25 +38,6 @@ describe('JobValidator', () => {
             expect(validJob.assets).toBeDefined();
         });
 
-        it('throws an error with faulty operation configuration', () => {
-            const jobSpec: JobConfig = {
-                name: 'test',
-                // @ts-ignore
-                operations: [
-                    {
-                        something: 'else',
-                    },
-                    {
-                        _op: 'noop',
-                    },
-                ],
-            };
-
-            expect(() => {
-                api.validateConfig(jobSpec);
-            }).toThrowError();
-        });
-
         it('will properly read an operation', () => {
             const jobSpec: JobConfig = {
                 name: 'test',
@@ -91,27 +72,6 @@ describe('JobValidator', () => {
                         _op: 'noop',
                     },
                 ],
-            };
-
-            expect(() => {
-                api.validateConfig(jobSpec);
-            }).toThrowError();
-        });
-
-        it('will throw based off crossValidation errors', () => {
-            const jobSpec: JobConfig = {
-                name: 'test',
-                lifecycle: 'persistent',
-                assets: ['fixtures'],
-                operations: [
-                    {
-                        _op: 'example-reader'
-                    },
-                    {
-                        _op: 'noop',
-                        failCrossValidation: true
-                    },
-                ]
             };
 
             expect(() => {

--- a/packages/job-components/test/job-validator-spec.ts
+++ b/packages/job-components/test/job-validator-spec.ts
@@ -38,25 +38,6 @@ describe('JobValidator', () => {
             expect(validJob.assets).toBeDefined();
         });
 
-        it('will properly read an operation', () => {
-            const jobSpec: JobConfig = {
-                name: 'test',
-                assets: ['fixtures'],
-                operations: [
-                    {
-                        _op: 'example-reader',
-                    },
-                    {
-                        _op: 'noop',
-                    },
-                ],
-            };
-
-            expect(() => {
-                api.validateConfig(jobSpec);
-            }).not.toThrowError();
-        });
-
         it('will throw based off op validation errors', () => {
         // if subslice_by_key, then it needs type specified or it will error
             const jobSpec: JobConfig = {

--- a/packages/scripts/src/helpers/publish/utils.ts
+++ b/packages/scripts/src/helpers/publish/utils.ts
@@ -66,7 +66,6 @@ export async function shouldNPMPublish(pkgInfo: PackageInfo, type?: PublishType)
     return false;
 }
 
-
 function padNumber(n: number): string {
     if (n < 10) return `0${n}`;
     return `${n}`;

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
 import path from 'path';
 import execa from 'execa';
 import fse from 'fs-extra';

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-misused-promises */
 import path from 'path';
 import execa from 'execa';
 import fse from 'fs-extra';

--- a/packages/terafoundation/src/api/index.ts
+++ b/packages/terafoundation/src/api/index.ts
@@ -135,7 +135,6 @@ export default function registerApis(context: i.FoundationContext) {
         }
     }
 
-
     // This exposes the registerAPI function to the rest of the system.
     context.apis = {
         registerAPI

--- a/packages/terafoundation/src/core-context.ts
+++ b/packages/terafoundation/src/core-context.ts
@@ -2,7 +2,6 @@ import * as ts from '@terascope/utils';
 import registerApis from './api';
 import * as i from './interfaces';
 
-
 /**
  * CoreContext
 */

--- a/packages/terafoundation/src/process-context.ts
+++ b/packages/terafoundation/src/process-context.ts
@@ -4,7 +4,6 @@ import { CoreContext } from './core-context';
 import { getArgs } from './sysconfig';
 import * as i from './interfaces';
 
-
 /**
  * A Single Process Context, this should be used when running
  * in a single process instance/container. This context doesn't

--- a/packages/terafoundation/test/apis/get-connection-spec.ts
+++ b/packages/terafoundation/test/apis/get-connection-spec.ts
@@ -134,14 +134,7 @@ describe('getConnection foundation API', () => {
         expect(mongodb.connect).toHaveBeenCalledTimes(1);
     });
 
-    it.todo('should return the default s3 connection', () => {
-        // const { foundation } = context.apis;
-        // const config = { type: 's3' };
-        // const { client } = foundation.getConnection(config);
-
-        // expect(client).toEqual(awsClient);
-        // expect(aws.S3).toHaveBeenCalledTimes(1);
-    });
+    it.todo('should return the default s3 connection');
 
     it('should return the default redis connection', () => {
         const { foundation } = context.apis;

--- a/packages/terafoundation/test/apis/get-connection-spec.ts
+++ b/packages/terafoundation/test/apis/get-connection-spec.ts
@@ -80,7 +80,6 @@ describe('getConnection foundation API', () => {
         name: 'terafoundation'
     } as any;
 
-
     beforeEach(() => {
         jest.clearAllMocks();
         // This sets up the API endpoints in the context.
@@ -135,14 +134,14 @@ describe('getConnection foundation API', () => {
         expect(mongodb.connect).toHaveBeenCalledTimes(1);
     });
 
-    // it('should return the default s3 connection', () => {
-    //     const { foundation } = context.apis;
-    //     const config = { type: 's3' };
-    //     const { client } = foundation.getConnection(config);
+    it.todo('should return the default s3 connection', () => {
+        // const { foundation } = context.apis;
+        // const config = { type: 's3' };
+        // const { client } = foundation.getConnection(config);
 
-    //     expect(client).toEqual(awsClient);
-    //     expect(aws.S3).toHaveBeenCalledTimes(1);
-    // });
+        // expect(client).toEqual(awsClient);
+        // expect(aws.S3).toHaveBeenCalledTimes(1);
+    });
 
     it('should return the default redis connection', () => {
         const { foundation } = context.apis;

--- a/packages/terafoundation/test/apis/get-system-events-spec.ts
+++ b/packages/terafoundation/test/apis/get-system-events-spec.ts
@@ -24,7 +24,7 @@ describe('getSystemEvents foundation API', () => {
 
     it('should emit and receive events', () => {
         const { foundation } = context.apis;
-        const spy = jasmine.createSpy('testevent');
+        const spy = jest.fn();
         const events = foundation.getSystemEvents();
 
         events.on('testevent', spy);

--- a/packages/terafoundation/test/sysconfig-spec.ts
+++ b/packages/terafoundation/test/sysconfig-spec.ts
@@ -23,11 +23,6 @@ describe('sysconfig helpers', () => {
             const filePath = getTestFile('test-config.yaml');
             expect(() => parseConfigFile(filePath)).not.toThrow();
         });
-
-        it('should work with a yaml file', () => {
-            const filePath = getTestFile('test-config.yml');
-            expect(() => parseConfigFile(filePath)).not.toThrow();
-        });
     });
 });
 

--- a/packages/terafoundation/test/validate-configs-spec.ts
+++ b/packages/terafoundation/test/validate-configs-spec.ts
@@ -168,7 +168,6 @@ describe('Validate Configs', () => {
         });
     });
 
-
     describe("when using using a connector that doesn't exist", () => {
         const configFile = {
             terafoundation: {

--- a/packages/teraslice-cli/src/cmds/aliases/add.ts
+++ b/packages/teraslice-cli/src/cmds/aliases/add.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 import Reply from '../lib/reply';
 import Config from '../../helpers/config';

--- a/packages/teraslice-cli/src/cmds/aliases/index.ts
+++ b/packages/teraslice-cli/src/cmds/aliases/index.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 
 export = {

--- a/packages/teraslice-cli/src/cmds/aliases/list.ts
+++ b/packages/teraslice-cli/src/cmds/aliases/list.ts
@@ -1,4 +1,3 @@
-
 import Config from '../../helpers/config';
 import YargsOptions from '../../helpers/yargs-options';
 import { CMD } from '../../interfaces';

--- a/packages/teraslice-cli/src/cmds/aliases/remove.ts
+++ b/packages/teraslice-cli/src/cmds/aliases/remove.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 import Reply from '../lib/reply';
 import Config from '../../helpers/config';

--- a/packages/teraslice-cli/src/cmds/aliases/update.ts
+++ b/packages/teraslice-cli/src/cmds/aliases/update.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 import Reply from '../lib/reply';
 import Config from '../../helpers/config';

--- a/packages/teraslice-cli/src/cmds/assets/delete.ts
+++ b/packages/teraslice-cli/src/cmds/assets/delete.ts
@@ -1,4 +1,3 @@
-
 import _ from 'lodash';
 import { CMD } from '../../interfaces';
 import Reply from '../lib/reply';

--- a/packages/teraslice-cli/src/cmds/assets/index.ts
+++ b/packages/teraslice-cli/src/cmds/assets/index.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 
 export = {

--- a/packages/teraslice-cli/src/cmds/assets/init.ts
+++ b/packages/teraslice-cli/src/cmds/assets/init.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import fs from 'fs-extra';
 import yeoman from 'yeoman-environment';

--- a/packages/teraslice-cli/src/cmds/assets/list.ts
+++ b/packages/teraslice-cli/src/cmds/assets/list.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 import Reply from '../lib/reply';
 import Config from '../../helpers/config';

--- a/packages/teraslice-cli/src/cmds/controllers/index.ts
+++ b/packages/teraslice-cli/src/cmds/controllers/index.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 
 export = {

--- a/packages/teraslice-cli/src/cmds/controllers/stats.ts
+++ b/packages/teraslice-cli/src/cmds/controllers/stats.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 import Config from '../../helpers/config';
 import TerasliceUtil from '../../helpers/teraslice-util';

--- a/packages/teraslice-cli/src/cmds/ex/errors.ts
+++ b/packages/teraslice-cli/src/cmds/ex/errors.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 import Config from '../../helpers/config';
 import TerasliceUtil from '../../helpers/teraslice-util';

--- a/packages/teraslice-cli/src/cmds/ex/index.ts
+++ b/packages/teraslice-cli/src/cmds/ex/index.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 
 export = {

--- a/packages/teraslice-cli/src/cmds/ex/list.ts
+++ b/packages/teraslice-cli/src/cmds/ex/list.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 import Config from '../../helpers/config';
 import TerasliceUtil from '../../helpers/teraslice-util';

--- a/packages/teraslice-cli/src/cmds/jobs/index.ts
+++ b/packages/teraslice-cli/src/cmds/jobs/index.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 
 export = {

--- a/packages/teraslice-cli/src/cmds/lib/annotation.ts
+++ b/packages/teraslice-cli/src/cmds/lib/annotation.ts
@@ -1,4 +1,3 @@
-
 // @ts-ignore
 import request from 'request-promise';
 import Reply from './reply';

--- a/packages/teraslice-cli/src/cmds/lib/app-cli.ts
+++ b/packages/teraslice-cli/src/cmds/lib/app-cli.ts
@@ -1,4 +1,3 @@
-
 import os from 'os';
 
 const homeDir = os.homedir();

--- a/packages/teraslice-cli/src/cmds/lib/cli/all.ts
+++ b/packages/teraslice-cli/src/cmds/lib/cli/all.ts
@@ -1,4 +1,3 @@
-
 export = {
     args: (yargs: any) => {
         yargs

--- a/packages/teraslice-cli/src/cmds/lib/cli/base-dir.ts
+++ b/packages/teraslice-cli/src/cmds/lib/cli/base-dir.ts
@@ -1,4 +1,3 @@
-
 export = {
     args: (yargs: any) => {
         yargs

--- a/packages/teraslice-cli/src/cmds/lib/cli/cluster-url.ts
+++ b/packages/teraslice-cli/src/cmds/lib/cli/cluster-url.ts
@@ -1,4 +1,3 @@
-
 export = {
     args: (yargs: any) => {
         yargs

--- a/packages/teraslice-cli/src/cmds/lib/reply.ts
+++ b/packages/teraslice-cli/src/cmds/lib/reply.ts
@@ -1,4 +1,3 @@
-
 import chalk from 'chalk';
 import { toString, get } from '@terascope/utils';
 

--- a/packages/teraslice-cli/src/cmds/nodes/index.ts
+++ b/packages/teraslice-cli/src/cmds/nodes/index.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 
 export = {

--- a/packages/teraslice-cli/src/cmds/tjm/index.ts
+++ b/packages/teraslice-cli/src/cmds/tjm/index.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 
 export = {

--- a/packages/teraslice-cli/src/cmds/tjm/update.ts
+++ b/packages/teraslice-cli/src/cmds/tjm/update.ts
@@ -1,4 +1,3 @@
-
 import _ from 'lodash';
 import TjmUtil from '../../helpers/tjm-util';
 import JobSrc from '../../helpers/job-src';

--- a/packages/teraslice-cli/src/cmds/workers/index.ts
+++ b/packages/teraslice-cli/src/cmds/workers/index.ts
@@ -1,4 +1,3 @@
-
 import { CMD } from '../../interfaces';
 
 export = {

--- a/packages/teraslice-cli/src/generators/new-asset/index.ts
+++ b/packages/teraslice-cli/src/generators/new-asset/index.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import Generator from 'yeoman-generator';
 import ProcessorGenerator from '../new-processor';

--- a/packages/teraslice-cli/src/generators/new-processor/index.ts
+++ b/packages/teraslice-cli/src/generators/new-processor/index.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import Generator from 'yeoman-generator';
 import { getTemplatePath } from '../utils';

--- a/packages/teraslice-cli/src/helpers/aliases.ts
+++ b/packages/teraslice-cli/src/helpers/aliases.ts
@@ -1,4 +1,3 @@
-
 import fs from 'fs';
 import _ from 'lodash';
 // @ts-ignore

--- a/packages/teraslice-cli/src/helpers/asset-src.ts
+++ b/packages/teraslice-cli/src/helpers/asset-src.ts
@@ -1,4 +1,3 @@
-
 import { spawnSync } from 'child_process';
 import _ from 'lodash';
 import fs from 'fs-extra';

--- a/packages/teraslice-cli/src/helpers/config.ts
+++ b/packages/teraslice-cli/src/helpers/config.ts
@@ -1,4 +1,3 @@
-
 import fs from 'fs';
 import _ from 'lodash';
 import { has } from '@terascope/utils';

--- a/packages/teraslice-cli/src/helpers/github-asset.ts
+++ b/packages/teraslice-cli/src/helpers/github-asset.ts
@@ -1,4 +1,3 @@
-
 import fs from 'fs-extra';
 import { TSError } from '@terascope/utils';
 import downloadRelease from '@terascope/fetch-github-release';

--- a/packages/teraslice-cli/src/helpers/job-src.ts
+++ b/packages/teraslice-cli/src/helpers/job-src.ts
@@ -1,4 +1,3 @@
-
 import fs from 'fs-extra';
 import path from 'path';
 import _ from 'lodash';

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -1,4 +1,3 @@
-
 import _ from 'lodash';
 import fs from 'fs-extra';
 import TerasliceUtil from './teraslice-util';

--- a/packages/teraslice-cli/src/helpers/tjm-util.ts
+++ b/packages/teraslice-cli/src/helpers/tjm-util.ts
@@ -1,4 +1,3 @@
-
 import Reply from '../cmds/lib/reply';
 
 const reply = new Reply();

--- a/packages/teraslice-cli/src/helpers/url.ts
+++ b/packages/teraslice-cli/src/helpers/url.ts
@@ -1,4 +1,3 @@
-
 import { startsWith, TSError } from '@terascope/utils';
 
 export default class Url {

--- a/packages/teraslice-cli/src/helpers/utils.ts
+++ b/packages/teraslice-cli/src/helpers/utils.ts
@@ -1,4 +1,3 @@
-
 import signale from 'signale';
 import { has, parseErrorInfo } from '@terascope/utils';
 import TerasliceClient from 'teraslice-client-js';

--- a/packages/teraslice-cli/src/helpers/yargs-options.ts
+++ b/packages/teraslice-cli/src/helpers/yargs-options.ts
@@ -1,4 +1,3 @@
-
 import os from 'os';
 import Url from './url';
 

--- a/packages/teraslice-cli/src/interfaces.ts
+++ b/packages/teraslice-cli/src/interfaces.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 
 export type CMD = yargs.CommandModule;

--- a/packages/teraslice-cli/test/cmds/ex/errors-spec.ts
+++ b/packages/teraslice-cli/test/cmds/ex/errors-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import errors from '../../../src/cmds/ex/errors';
 

--- a/packages/teraslice-cli/test/cmds/ex/list-spec.ts
+++ b/packages/teraslice-cli/test/cmds/ex/list-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import list from '../../../src/cmds/ex/list';
 

--- a/packages/teraslice-cli/test/cmds/ex/status-spec.ts
+++ b/packages/teraslice-cli/test/cmds/ex/status-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import status from '../../../src/cmds/ex/status';
 

--- a/packages/teraslice-cli/test/cmds/ex/stop-spec.ts
+++ b/packages/teraslice-cli/test/cmds/ex/stop-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import stop from '../../../src/cmds/ex/stop';
 

--- a/packages/teraslice-cli/test/cmds/jobs/errors-spec.ts
+++ b/packages/teraslice-cli/test/cmds/jobs/errors-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import errors from '../../../src/cmds/jobs/errors';
 

--- a/packages/teraslice-cli/test/cmds/jobs/list-spec.ts
+++ b/packages/teraslice-cli/test/cmds/jobs/list-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import list from '../../../src/cmds/jobs/list';
 

--- a/packages/teraslice-cli/test/cmds/jobs/pause-spec.ts
+++ b/packages/teraslice-cli/test/cmds/jobs/pause-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import pause from '../../../src/cmds/jobs/pause';
 

--- a/packages/teraslice-cli/test/cmds/jobs/recover-spec.ts
+++ b/packages/teraslice-cli/test/cmds/jobs/recover-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import recover from '../../../src/cmds/jobs/recover';
 

--- a/packages/teraslice-cli/test/cmds/jobs/restart-spec.ts
+++ b/packages/teraslice-cli/test/cmds/jobs/restart-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import restart from '../../../src/cmds/jobs/restart';
 

--- a/packages/teraslice-cli/test/cmds/jobs/resume-spec.ts
+++ b/packages/teraslice-cli/test/cmds/jobs/resume-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import resume from '../../../src/cmds/jobs/resume';
 

--- a/packages/teraslice-cli/test/cmds/jobs/run-spec.ts
+++ b/packages/teraslice-cli/test/cmds/jobs/run-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import run from '../../../src/cmds/jobs/run';
 

--- a/packages/teraslice-cli/test/cmds/jobs/save-spec.ts
+++ b/packages/teraslice-cli/test/cmds/jobs/save-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import save from '../../../src/cmds/jobs/save';
 

--- a/packages/teraslice-cli/test/cmds/jobs/start-spec.ts
+++ b/packages/teraslice-cli/test/cmds/jobs/start-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import start from '../../../src/cmds/jobs/start';
 

--- a/packages/teraslice-cli/test/cmds/jobs/status-spec.ts
+++ b/packages/teraslice-cli/test/cmds/jobs/status-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import status from '../../../src/cmds/jobs/status';
 

--- a/packages/teraslice-cli/test/cmds/jobs/stop-spec.ts
+++ b/packages/teraslice-cli/test/cmds/jobs/stop-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import stop from '../../../src/cmds/jobs/stop';
 

--- a/packages/teraslice-cli/test/cmds/jobs/view-spec.ts
+++ b/packages/teraslice-cli/test/cmds/jobs/view-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import view from '../../../src/cmds/jobs/view';
 

--- a/packages/teraslice-cli/test/cmds/jobs/workers-spec.ts
+++ b/packages/teraslice-cli/test/cmds/jobs/workers-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import workers from '../../../src/cmds/jobs/workers';
 

--- a/packages/teraslice-cli/test/cmds/nodes/list-spec.ts
+++ b/packages/teraslice-cli/test/cmds/nodes/list-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import list from '../../../src/cmds/nodes/list';
 

--- a/packages/teraslice-cli/test/cmds/workers/list-spec.ts
+++ b/packages/teraslice-cli/test/cmds/workers/list-spec.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import list from '../../../src/cmds/workers/list';
 

--- a/packages/teraslice-cli/test/generators/new-asset-spec.ts
+++ b/packages/teraslice-cli/test/generators/new-asset-spec.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import fs from 'fs-extra';
 import assert from 'yeoman-assert';

--- a/packages/teraslice-cli/test/generators/new-processor-spec.ts
+++ b/packages/teraslice-cli/test/generators/new-processor-spec.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import fs from 'fs-extra';
 import assert from 'yeoman-assert';

--- a/packages/teraslice-cli/test/lib/aliases-spec.ts
+++ b/packages/teraslice-cli/test/lib/aliases-spec.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import fs from 'fs';
 // @ts-ignore
@@ -7,101 +6,103 @@ import { createTempDirSync } from 'jest-fixtures';
 
 import Aliases from '../../src/helpers/aliases';
 
-let aliases: Aliases;
+describe('Aliases', () => {
+    let aliases: Aliases;
 
-beforeEach(() => {
-    const tmpDir = createTempDirSync();
-    aliases = new Aliases(path.join(tmpDir, 'aliases-test.yaml'));
-});
-
-afterEach(() => {
-    // @ts-ignore
-    aliases = null;
-});
-
-describe('aliases', () => {
-    test('should return a defined object', () => {
-        expect(aliases).toBeDefined();
-        expect(aliases.config).toBeDefined();
+    beforeEach(() => {
+        const tmpDir = createTempDirSync();
+        aliases = new Aliases(path.join(tmpDir, 'aliases-test.yaml'));
     });
 
-    describe('-> add', () => {
-        test('should add new alias to file', () => {
-            aliases.add('test1', 'test1.net');
-            const aliasesOutput = yaml.readSync(aliases.aliasesFile);
-            expect(fs.existsSync(aliases.aliasesFile)).toBeTruthy();
-            expect(aliasesOutput.clusters.test1.host).toBe('test1.net');
+    afterEach(() => {
+        // @ts-ignore
+        aliases = null;
+    });
+
+    describe('aliases', () => {
+        test('should return a defined object', () => {
+            expect(aliases).toBeDefined();
+            expect(aliases.config).toBeDefined();
         });
 
-        test('should throw an error when existing alias added', () => {
-            aliases.add('test1', 'test1.net');
-            function aliasAdd() {
+        describe('-> add', () => {
+            test('should add new alias to file', () => {
                 aliases.add('test1', 'test1.net');
-            }
-            expect(aliasAdd).toThrow('test1 already exists');
-        });
-    });
+                const aliasesOutput = yaml.readSync(aliases.aliasesFile);
+                expect(fs.existsSync(aliases.aliasesFile)).toBeTruthy();
+                expect(aliasesOutput.clusters.test1.host).toBe('test1.net');
+            });
 
-    describe('-> list', () => {
-        test('should display txt table', () => {
-            expect(aliases.list('txt')).toBe(undefined);
-        });
-
-        test('should display pretty table', () => {
-            expect(aliases.list('pretty')).toBe(undefined);
-        });
-    });
-
-    describe('-> present', () => {
-        test('should return true if alias is present in file', () => {
-            aliases.add('test1', 'test1.net');
-            expect(aliases.present('test1')).toBeTruthy();
+            test('should throw an error when existing alias added', () => {
+                aliases.add('test1', 'test1.net');
+                function aliasAdd() {
+                    aliases.add('test1', 'test1.net');
+                }
+                expect(aliasAdd).toThrow('test1 already exists');
+            });
         });
 
-        test('should return false if alias is not present in file', () => {
-            aliases.add('test1', 'test1.net');
-            expect(aliases.present('test2')).toBeFalsy();
-        });
-    });
+        describe('-> list', () => {
+            test('should display txt table', () => {
+                expect(aliases.list('txt')).toBe(undefined);
+            });
 
-    describe('-> remove', () => {
-        test('should remove an alias from the file', () => {
-            const tmpDir = createTempDirSync();
-            const aliasesFile = path.join(tmpDir, 'aliases-test1.yaml');
-            fs.copyFileSync(path.join(__dirname, '../fixtures', 'aliases-test1.yaml'), aliasesFile);
-            aliases = new Aliases(aliasesFile);
-            aliases.remove('test1');
-            const aliasesOutput = yaml.readSync(aliases.aliasesFile);
-
-            expect(fs.existsSync(aliases.aliasesFile)).toBeTruthy();
-            expect(aliasesOutput.clusters.test1).toBe(undefined);
-            expect(aliasesOutput.clusters.localhost.host).toBe('http://localhost:5678');
+            test('should display pretty table', () => {
+                expect(aliases.list('pretty')).toBe(undefined);
+            });
         });
 
-        test('should throw an error when existing alias added', () => {
-            function aliasRemove() {
-                aliases.remove('test2');
-            }
-            expect(aliasRemove).toThrow('test2 not in aliases list');
-        });
-    });
+        describe('-> present', () => {
+            test('should return true if alias is present in file', () => {
+                aliases.add('test1', 'test1.net');
+                expect(aliases.present('test1')).toBeTruthy();
+            });
 
-    describe('-> update', () => {
-        test('should update an alias from the file', () => {
-            const tmpDir = createTempDirSync();
-            const aliasesFile = path.join(tmpDir, 'aliases-test1.yaml');
-            fs.copyFileSync(path.join(__dirname, '../fixtures', 'aliases-test1.yaml'), aliasesFile);
-            aliases = new Aliases(aliasesFile);
-            aliases.update('test1', 'http://test1.net:9999');
-            const aliasesOutput = yaml.readSync(aliases.aliasesFile);
-            expect(aliasesOutput.clusters.test1.host).toBe('http://test1.net:9999');
+            test('should return false if alias is not present in file', () => {
+                aliases.add('test1', 'test1.net');
+                expect(aliases.present('test2')).toBeFalsy();
+            });
         });
 
-        test('should throw an error when updating a missing alias', () => {
-            function aliasUpdate() {
-                aliases.update('test2', 'http://test2.net');
-            }
-            expect(aliasUpdate).toThrow('test2 not in aliases list');
+        describe('-> remove', () => {
+            test('should remove an alias from the file', () => {
+                const tmpDir = createTempDirSync();
+                const aliasesFile = path.join(tmpDir, 'aliases-test1.yaml');
+                fs.copyFileSync(path.join(__dirname, '../fixtures', 'aliases-test1.yaml'), aliasesFile);
+                aliases = new Aliases(aliasesFile);
+                aliases.remove('test1');
+                const aliasesOutput = yaml.readSync(aliases.aliasesFile);
+
+                expect(fs.existsSync(aliases.aliasesFile)).toBeTruthy();
+                expect(aliasesOutput.clusters.test1).toBe(undefined);
+                expect(aliasesOutput.clusters.localhost.host).toBe('http://localhost:5678');
+            });
+
+            test('should throw an error when existing alias added', () => {
+                function aliasRemove() {
+                    aliases.remove('test2');
+                }
+                expect(aliasRemove).toThrow('test2 not in aliases list');
+            });
+        });
+
+        describe('-> update', () => {
+            test('should update an alias from the file', () => {
+                const tmpDir = createTempDirSync();
+                const aliasesFile = path.join(tmpDir, 'aliases-test1.yaml');
+                fs.copyFileSync(path.join(__dirname, '../fixtures', 'aliases-test1.yaml'), aliasesFile);
+                aliases = new Aliases(aliasesFile);
+                aliases.update('test1', 'http://test1.net:9999');
+                const aliasesOutput = yaml.readSync(aliases.aliasesFile);
+                expect(aliasesOutput.clusters.test1.host).toBe('http://test1.net:9999');
+            });
+
+            test('should throw an error when updating a missing alias', () => {
+                function aliasUpdate() {
+                    aliases.update('test2', 'http://test2.net');
+                }
+                expect(aliasUpdate).toThrow('test2 not in aliases list');
+            });
         });
     });
 });

--- a/packages/teraslice-cli/test/lib/assetsrc-spec.ts
+++ b/packages/teraslice-cli/test/lib/assetsrc-spec.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import fs from 'fs-extra';
 import tmp from 'tmp';

--- a/packages/teraslice-cli/test/lib/config-spec.ts
+++ b/packages/teraslice-cli/test/lib/config-spec.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import fs from 'fs';
 import { createTempDirSync } from 'jest-fixtures';

--- a/packages/teraslice-cli/test/lib/display-spec.ts
+++ b/packages/teraslice-cli/test/lib/display-spec.ts
@@ -1,4 +1,3 @@
-
 import 'jest-extended';
 import displayModule from '../../src/cmds/lib/display';
 

--- a/packages/teraslice-cli/test/lib/job-src-spec.ts
+++ b/packages/teraslice-cli/test/lib/job-src-spec.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import fs from 'fs-extra';
 import { createTempDirSync } from 'jest-fixtures';
@@ -67,12 +66,8 @@ describe('JobSrc', () => {
     });
 
     it('should return correct version', () => {
-        try {
-            const job = new JobSrc(args);
-            expect(job.version).toBe(version);
-        } catch (e) {
-            fail(e);
-        }
+        const job = new JobSrc(args);
+        expect(job.version).toBe(version);
     });
 
     it('should add metaData to job contents', () => {
@@ -87,18 +82,14 @@ describe('JobSrc', () => {
             }
         ];
         writeJob();
-        try {
-            const job = new JobSrc(args);
-            job.readFile();
-            job.addMetaData('1234', 'localhost');
-            const { content } = job;
-            expect(content.__metadata.cli.version).toBe(version);
-            expect(content.__metadata.cli.job_id).toBe('1234');
-            expect(content.__metadata.cli.cluster).toBe('localhost');
-            expect(content.__metadata.cli.updated).toBeDefined();
-        } catch (e) {
-            fail(e);
-        }
+        const job = new JobSrc(args);
+        job.readFile();
+        job.addMetaData('1234', 'localhost');
+        const { content } = job;
+        expect(content.__metadata.cli.version).toBe(version);
+        expect(content.__metadata.cli.job_id).toBe('1234');
+        expect(content.__metadata.cli.cluster).toBe('localhost');
+        expect(content.__metadata.cli.updated).toBeDefined();
     });
 
     it('should check presence of metadataCheck false', () => {
@@ -113,13 +104,9 @@ describe('JobSrc', () => {
             }
         ];
         writeJob();
-        try {
-            const job = new JobSrc(args);
-            job.readFile();
-            expect(job.hasMetaData).toBe(false);
-        } catch (e) {
-            fail(e);
-        }
+        const job = new JobSrc(args);
+        job.readFile();
+        expect(job.hasMetaData).toBe(false);
     });
 
     it('should check presence of metadataCheck true', () => {
@@ -134,14 +121,10 @@ describe('JobSrc', () => {
             }
         ];
         writeJob();
-        try {
-            const job = new JobSrc(args);
-            job.readFile();
-            job.addMetaData('1234', 'localhost');
-            expect(job.hasMetaData).toBe(true);
-        } catch (e) {
-            fail(e);
-        }
+        const job = new JobSrc(args);
+        job.readFile();
+        job.addMetaData('1234', 'localhost');
+        expect(job.hasMetaData).toBe(true);
     });
 
     it('should overwrite old job file', () => {
@@ -211,13 +194,9 @@ describe('JobSrc', () => {
 
         writeJob();
         const job = new JobSrc(args);
-        try {
-            job.init();
-            expect(job.clusterUrl).toBe('localhost:5678');
-            expect(job.jobId).toBe('some-job-id');
-            expect(job.name).toBe('goodJob');
-        } catch (e) {
-            fail(e);
-        }
+        job.init();
+        expect(job.clusterUrl).toBe('localhost:5678');
+        expect(job.jobId).toBe('some-job-id');
+        expect(job.name).toBe('goodJob');
     });
 });

--- a/packages/teraslice-cli/test/lib/jobs-spec.ts
+++ b/packages/teraslice-cli/test/lib/jobs-spec.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import Jobs from '../../src/helpers/jobs';
 

--- a/packages/teraslice-cli/test/lib/teraslice-util-spec.ts
+++ b/packages/teraslice-cli/test/lib/teraslice-util-spec.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import TerasliceUtil from '../../src/helpers/teraslice-util';
 

--- a/packages/teraslice-cli/test/lib/tjm-util-spec.ts
+++ b/packages/teraslice-cli/test/lib/tjm-util-spec.ts
@@ -1,4 +1,3 @@
-
 import Promise from 'bluebird';
 import TjmUtil from '../../src/helpers/tjm-util';
 // @ts-ignore

--- a/packages/teraslice-cli/test/lib/url-spec.ts
+++ b/packages/teraslice-cli/test/lib/url-spec.ts
@@ -1,45 +1,45 @@
-
 import Url from '../../src/helpers/url';
 
-let url: any;
-
-beforeEach(() => {
-    url = new Url();
-});
-
-afterEach(() => {
-    url = null;
-});
-
-describe('url', () => {
-    test('should return a defined object', () => {
-        expect(url).toBeDefined();
+describe('Url', () => {
+    let url: any;
+    beforeEach(() => {
+        url = new Url();
     });
 
-    describe('-> check ', () => {
-        test('should return true for valid url with http', () => {
-            expect(url.check('http://test1.net')).toBe(true);
-        });
-        test('should return true for valid url with https', () => {
-            expect(url.check('https://test1.net')).toBe(true);
-        });
-        test('should return false for valid url without http', () => {
-            expect(url.check('test1.net')).toBe(false);
-        });
+    afterEach(() => {
+        url = null;
     });
 
-    describe(' -> build', () => {
-        test('should return url with http and default port of 5678', () => {
-            expect(url.build('test1.net')).toBe('http://test1.net:5678');
+    describe('url', () => {
+        test('should return a defined object', () => {
+            expect(url).toBeDefined();
         });
-        test('should return url with http and not change port', () => {
-            expect(url.build('test1.net:80')).toBe('http://test1.net:80');
+
+        describe('-> check', () => {
+            test('should return true for valid url with http', () => {
+                expect(url.check('http://test1.net')).toBe(true);
+            });
+            test('should return true for valid url with https', () => {
+                expect(url.check('https://test1.net')).toBe(true);
+            });
+            test('should return false for valid url without http', () => {
+                expect(url.check('test1.net')).toBe(false);
+            });
         });
-        test('should throw an error when given an empty url', () => {
-            function urlBuild() {
-                url.build('');
-            }
-            expect(urlBuild).toThrow('empty url');
+
+        describe('-> build', () => {
+            test('should return url with http and default port of 5678', () => {
+                expect(url.build('test1.net')).toBe('http://test1.net:5678');
+            });
+            test('should return url with http and not change port', () => {
+                expect(url.build('test1.net:80')).toBe('http://test1.net:80');
+            });
+            test('should throw an error when given an empty url', () => {
+                function urlBuild() {
+                    url.build('');
+                }
+                expect(urlBuild).toThrow('empty url');
+            });
         });
     });
 });

--- a/packages/teraslice-cli/test/lib/yargs-options-spec.ts
+++ b/packages/teraslice-cli/test/lib/yargs-options-spec.ts
@@ -1,4 +1,3 @@
-
 import _ from 'lodash';
 import Options from '../../src/helpers/yargs-options';
 

--- a/packages/teraslice-cli/test/servers/github-server.ts
+++ b/packages/teraslice-cli/test/servers/github-server.ts
@@ -1,4 +1,3 @@
-
 import fs from 'fs';
 import path from 'path';
 import nock from 'nock';

--- a/packages/teraslice-cli/test/servers/index.ts
+++ b/packages/teraslice-cli/test/servers/index.ts
@@ -1,4 +1,3 @@
-
 import GithubServer from './github-server';
 import TerasliceServer from './teraslice-server';
 

--- a/packages/teraslice-cli/test/servers/teraslice-server.ts
+++ b/packages/teraslice-cli/test/servers/teraslice-server.ts
@@ -1,4 +1,3 @@
-
 import nock from 'nock';
 import { RootResponse, AssetIDResponse } from 'teraslice-client-js';
 

--- a/packages/teraslice-client-js/src/index.ts
+++ b/packages/teraslice-client-js/src/index.ts
@@ -1,4 +1,3 @@
-
 import Jobs from './jobs';
 import Cluster from './cluster';
 import Assets from './assets';

--- a/packages/teraslice-client-js/src/job.ts
+++ b/packages/teraslice-client-js/src/job.ts
@@ -1,4 +1,3 @@
-
 import util from 'util';
 import autoBind from 'auto-bind';
 import {

--- a/packages/teraslice-client-js/test/assets-spec.ts
+++ b/packages/teraslice-client-js/test/assets-spec.ts
@@ -1,4 +1,3 @@
-
 import nock from 'nock';
 import path from 'path';
 import fs from 'fs';

--- a/packages/teraslice-client-js/test/client-spec.ts
+++ b/packages/teraslice-client-js/test/client-spec.ts
@@ -1,4 +1,3 @@
-
 import nock from 'nock';
 import TerasliceClient from '../src';
 import Client from '../src/client';

--- a/packages/teraslice-client-js/test/cluster-spec.ts
+++ b/packages/teraslice-client-js/test/cluster-spec.ts
@@ -1,4 +1,3 @@
-
 import nock from 'nock';
 import Cluster from '../src/cluster';
 

--- a/packages/teraslice-client-js/test/ex-spec.ts
+++ b/packages/teraslice-client-js/test/ex-spec.ts
@@ -1,4 +1,3 @@
-
 import nock from 'nock';
 import Ex from '../src/ex';
 import {

--- a/packages/teraslice-client-js/test/executions-spec.ts
+++ b/packages/teraslice-client-js/test/executions-spec.ts
@@ -1,4 +1,3 @@
-
 import nock from 'nock';
 import Ex from '../src/ex';
 import Executions from '../src/executions';

--- a/packages/teraslice-client-js/test/job-spec.ts
+++ b/packages/teraslice-client-js/test/job-spec.ts
@@ -456,7 +456,7 @@ describe('Teraslice Job', () => {
             });
         });
 
-        describe('when called and the state has workers', () => {
+        describe('when called and the state has workers (with headers)', () => {
             beforeEach(() => {
                 scope.get('/cluster/state')
                     .matchHeader('Some-Header', 'yes')
@@ -577,7 +577,7 @@ describe('Teraslice Job', () => {
             });
         });
 
-        describe('when called and it matches on the first try', () => {
+        describe('when called and it matches on the first try (with headers)', () => {
             const searchOptions = { headers: { 'Some-Header': 'yes' } };
 
             beforeEach(() => {

--- a/packages/teraslice-client-js/test/job-spec.ts
+++ b/packages/teraslice-client-js/test/job-spec.ts
@@ -1,4 +1,3 @@
-
 import nock from 'nock';
 import Job from '../src/job';
 import {

--- a/packages/teraslice-client-js/test/jobs-spec.ts
+++ b/packages/teraslice-client-js/test/jobs-spec.ts
@@ -1,4 +1,3 @@
-
 import 'jest-extended';
 import nock from 'nock';
 import Job from '../src/job';

--- a/packages/teraslice-messaging/src/index.ts
+++ b/packages/teraslice-messaging/src/index.ts
@@ -1,4 +1,3 @@
-
 import * as ClusterMaster from './cluster-master';
 import * as ExecutionController from './execution-controller';
 import * as Messenger from './messenger';

--- a/packages/teraslice-messaging/test/index-spec.ts
+++ b/packages/teraslice-messaging/test/index-spec.ts
@@ -1,18 +1,20 @@
 import 'jest-extended'; // require for type definitions
 import * as index from '../src/index';
 
-it('should be truthy', () => {
-    expect(index).toBeTruthy();
-});
+describe('Messaging Export', () => {
+    it('should be truthy', () => {
+        expect(index).toBeTruthy();
+    });
 
-it('should have a Messenger', () => {
-    expect(index.Messenger).toBeTruthy();
-});
+    it('should have a Messenger', () => {
+        expect(index.Messenger).toBeTruthy();
+    });
 
-it('should have a ExecutionController', () => {
-    expect(index.ExecutionController).toBeTruthy();
-});
+    it('should have a ExecutionController', () => {
+        expect(index.ExecutionController).toBeTruthy();
+    });
 
-it('should have a ClusterMaster', () => {
-    expect(index.ClusterMaster).toBeTruthy();
+    it('should have a ClusterMaster', () => {
+        expect(index.ClusterMaster).toBeTruthy();
+    });
 });

--- a/packages/teraslice-messaging/test/messenger-spec.ts
+++ b/packages/teraslice-messaging/test/messenger-spec.ts
@@ -405,6 +405,7 @@ describe('Messenger', () => {
             });
         });
 
+        // eslint-disable-next-line jest/no-disabled-tests
         xdescribe('when the client responds with an error', () => {
             let responseMsg: Message | object | undefined;
             let responseErr: Error | undefined;

--- a/packages/teraslice-state-storage/src/index.ts
+++ b/packages/teraslice-state-storage/src/index.ts
@@ -1,4 +1,3 @@
-
 import ESCachedStateStorage from './elasticsearch-state-storage';
 import CachedStateStorage from './cached-state-storage';
 

--- a/packages/teraslice-test-harness/test/fixtures/asset/recoverable-reader.ts/fetcher.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/recoverable-reader.ts/fetcher.ts
@@ -1,4 +1,3 @@
-
 import { Fetcher, SliceRequest, AnyObject } from '@terascope/job-components';
 
 export default class TestFetcher extends Fetcher<AnyObject> {

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-flush/interfaces.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-flush/interfaces.ts
@@ -1,4 +1,3 @@
-
 import { OpConfig } from '@terascope/job-components';
 
 export interface FlusherConfig extends OpConfig {

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-flush/processor.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-flush/processor.ts
@@ -1,4 +1,3 @@
-
 import { BatchProcessor, DataEntity } from '@terascope/job-components';
 import { FlusherConfig } from './interfaces';
 

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-flush/schema.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-flush/schema.ts
@@ -1,4 +1,3 @@
-
 import { ConvictSchema } from '@terascope/job-components';
 import { FlusherConfig } from './interfaces';
 

--- a/packages/teraslice/lib/cluster/services/assets.js
+++ b/packages/teraslice/lib/cluster/services/assets.js
@@ -158,7 +158,6 @@ module.exports = function assetsService(context) {
         });
     }
 
-
     const { port } = process.env;
     return {
         async initialize() {

--- a/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/index.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/index.js
@@ -80,7 +80,6 @@ module.exports = function kubernetesClusterBackend(context, clusterMasterServer)
         return true;
     }
 
-
     /**
      * Creates k8s Service and Job for the Teraslice Execution Controller
      * (formerly slicer).  This currently works by creating a service with a
@@ -151,7 +150,6 @@ module.exports = function kubernetesClusterBackend(context, clusterMasterServer)
             });
     }
 
-
     // FIXME: These functions should probably do something with the response
     // NOTE: I find is strange that the expected return value here is
     //        effectively the same as the function inputs
@@ -160,14 +158,12 @@ module.exports = function kubernetesClusterBackend(context, clusterMasterServer)
         return { action: 'add', ex_id: executionContext.ex_id, workerNum: numWorkers };
     }
 
-
     // NOTE: This is passed exId instead of executionContext like addWorkers and
     // removeWorkers.  I don't know why, just dealing with it.
     async function removeWorkers(exId, numWorkers) {
         await k8s.scaleExecution(exId, numWorkers, 'remove');
         return { action: 'remove', ex_id: exId, workerNum: numWorkers };
     }
-
 
     async function setWorkers(executionContext, numWorkers) {
         await k8s.scaleExecution(executionContext.ex_id, numWorkers, 'set');

--- a/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/k8s.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/k8s.js
@@ -36,7 +36,6 @@ class K8s {
         }
     }
 
-
     /**
      * Returns the k8s NamespaceList object
      * @return {Promise} [description]
@@ -53,7 +52,6 @@ class K8s {
         }
         return namespaces.body;
     }
-
 
     /**
     * returns list of k8s objects matching provided selector
@@ -100,7 +98,6 @@ class K8s {
 
         return response.body;
     }
-
 
     /**
      * posts manifest to k8s
@@ -171,7 +168,6 @@ class K8s {
         return response.body;
     }
 
-
     /**
      * Deletes k8s object of specified objType
      * @param  {String} name     Name of the deployment to delete
@@ -219,7 +215,6 @@ class K8s {
         return response.body;
     }
 
-
     /**
      * Delete all of the deployments and services related to the specified exId
      * @param  {String}  exId ID of the execution
@@ -236,7 +231,6 @@ class K8s {
             this._deleteObjByExId(exId, 'execution_controller', 'services')
         ]);
     }
-
 
     /**
      * Finds the k8s object by nodeType and exId and then deletes it

--- a/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/k8sResource.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/k8sResource.js
@@ -70,7 +70,6 @@ class K8sResource {
         const shutdownTimeoutMs = _.get(this.terasliceConfig, 'shutdown_timeout', 60000);
         const shutdownTimeoutSeconds = Math.round(shutdownTimeoutMs / 1000);
 
-
         const config = {
             // assetsDirectory: _.get(this.terasliceConfig, 'assets_directory', ''),
             // assetsVolume: _.get(this.terasliceConfig, 'assets_volume', ''),

--- a/packages/teraslice/lib/cluster/services/cluster/backends/native/index.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/native/index.js
@@ -390,7 +390,6 @@ module.exports = function nativeClustering(context, clusterMasterServer, executi
             });
     }
 
-
     function allocateSlicer(job) {
         let retryCount = 0;
         const errorNodes = {};

--- a/packages/teraslice/lib/cluster/services/cluster/backends/native/messaging.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/native/messaging.js
@@ -493,7 +493,6 @@ module.exports = function messaging(context, logger) {
         return emitIpcMessage(emitFn);
     }
 
-
     // all child processes need to set up a process listener on the 'message' event
     if (config.clients.ipcClient) {
         process.on('message', handleIpcMessages());

--- a/packages/teraslice/lib/cluster/services/execution.js
+++ b/packages/teraslice/lib/cluster/services/execution.js
@@ -107,7 +107,6 @@ module.exports = function executionService(context, { clusterMasterServer }) {
             });
     }
 
-
     function _iterateState(cb) {
         return _.chain(getClusterState())
             .filter((node) => node.state === 'connected')
@@ -509,7 +508,6 @@ module.exports = function executionService(context, { clusterMasterServer }) {
                 return Promise.reject(error);
             });
     }
-
 
     return makeExStore(context)
         .then((ex) => {

--- a/packages/teraslice/lib/cluster/storage/assets.js
+++ b/packages/teraslice/lib/cluster/storage/assets.js
@@ -10,7 +10,6 @@ const elasticsearchBackend = require('./backends/elasticsearch_store');
 const { makeLogger } = require('../../workers/helpers/terafoundation');
 const { saveAsset } = require('../../utils/file_utils');
 
-
 // Module to manager job states in Elasticsearch.
 // All functions in this module return promises that must be resolved to
 // get the final result.

--- a/packages/teraslice/lib/cluster/storage/backends/elasticsearch_store.js
+++ b/packages/teraslice/lib/cluster/storage/backends/elasticsearch_store.js
@@ -82,7 +82,6 @@ module.exports = function elasticsearchStorage(backendConfig) {
             esQuery.body = query;
         }
 
-
         if (fields) {
             const esVersion = elasticsearch.getESVersion();
             if (esVersion > 6) {

--- a/packages/teraslice/lib/cluster/storage/execution.js
+++ b/packages/teraslice/lib/cluster/storage/execution.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const { TSError, pRetry, includes } = require('@terascope/utils');
 const uuid = require('uuid');
 const Promise = require('bluebird');

--- a/packages/teraslice/lib/utils/date_utils.js
+++ b/packages/teraslice/lib/utils/date_utils.js
@@ -43,7 +43,6 @@ function dateOptions(value) {
     throw new Error(`the time descriptor of "${value}" for the interval is malformed`);
 }
 
-
 function timeseriesIndex(timeseriesFormat, index, dateStr) {
     const timestamp = new Date().toISOString();
     const formatter = { daily: 10, monthly: 7, yearly: 4 };

--- a/packages/teraslice/test/processors/script/script-spec.js
+++ b/packages/teraslice/test/processors/script/script-spec.js
@@ -188,8 +188,7 @@ xdescribe(processorName, () => {
             asset: 'test_script'
         };
         try {
-            const checkData = await harness.runAsync(data, opConfig, context);
-            fail(checkData);
+            await expect(harness.runAsync(data, opConfig, context)).toReject();
         } catch (error) {
             const errorLines = error.toString().split('\n');
             expect(errorLines[0].trim()).toEqual('Traceback (most recent call last):');
@@ -211,8 +210,7 @@ xdescribe(processorName, () => {
             asset: 'test_script'
         };
         try {
-            const checkData = await harness.runAsync(data, opConfig, context);
-            fail(checkData);
+            await expect(harness.runAsync(data, opConfig, context)).toReject();
         } catch (error) {
             expect(error.code).toEqual('ENOENT');
             expect(error.errno).toEqual('ENOENT');

--- a/packages/teraslice/test/processors/script/script-spec.js
+++ b/packages/teraslice/test/processors/script/script-spec.js
@@ -8,6 +8,7 @@ const harness = opHarness(processor);
 
 const processorName = 'script processor';
 
+// eslint-disable-next-line
 xdescribe(processorName, () => {
     const assetPath = path.relative(process.cwd(), path.join(__dirname, './test_scripts'));
 

--- a/packages/teraslice/test/services/messaging-spec.js
+++ b/packages/teraslice/test/services/messaging-spec.js
@@ -321,7 +321,7 @@ describe('messaging module', () => {
         testContext.cleanup();
     });
 
-    xit('can send transactional and non-transactional messages', async () => {
+    it.todo('can send transactional and non-transactional messages', async () => {
         const testContext = getContext({ env: { assignment: 'cluster_master' } });
         const eventEmitter = testContext.apis.foundation.getSystemEvents();
         const messaging = messagingModule(testContext, logger);

--- a/packages/teraslice/test/services/messaging-spec.js
+++ b/packages/teraslice/test/services/messaging-spec.js
@@ -321,7 +321,11 @@ describe('messaging module', () => {
         testContext.cleanup();
     });
 
-    it.todo('can send transactional and non-transactional messages', async () => {
+    // This test is broken but it works.
+    // We may not need a test for this because this messaging service
+    // should be replaced with @terascope/teraslice-messaging.
+    // eslint-disable-next-line jest/no-disabled-tests
+    xit('can send transactional and non-transactional messages', async () => {
         const testContext = getContext({ env: { assignment: 'cluster_master' } });
         const eventEmitter = testContext.apis.foundation.getSystemEvents();
         const messaging = messagingModule(testContext, logger);

--- a/packages/teraslice/test/utils/elastic_utils-spec.js
+++ b/packages/teraslice/test/utils/elastic_utils-spec.js
@@ -2,7 +2,6 @@
 
 const utils = require('../../lib/utils/date_utils');
 
-
 describe('elastic_utils', () => {
     it('has methods dateOptions and processInterval', () => {
         const { dateOptions } = utils;

--- a/packages/teraslice/test/workers/execution-controller/slice-analytics-spec.js
+++ b/packages/teraslice/test/workers/execution-controller/slice-analytics-spec.js
@@ -126,8 +126,8 @@ describe('slice_analytics', () => {
     it('analyzeStats will log results', () => {
         analytics.analyzeStats();
         expect(logMessages.shift()).toEqual('calculating statistics');
-        expect(logMessages.shift().includes('operation config1')).toEqual(true);
-        expect(logMessages.shift().includes('operation config2')).toEqual(true);
-        expect(logMessages.shift().includes('operation config3')).toEqual(true);
+        expect(logMessages.shift()).toContain('operation config1');
+        expect(logMessages.shift()).toContain('operation config2');
+        expect(logMessages.shift()).toContain('operation config3');
     });
 });

--- a/packages/ts-transforms/src/command.ts
+++ b/packages/ts-transforms/src/command.ts
@@ -1,4 +1,3 @@
-
 import yargs from 'yargs';
 import path from 'path';
 import fs from 'fs';
@@ -187,7 +186,6 @@ async function transformIO(manager: PhaseManager) {
                 process.stderr.write('\n');
                 console.time('execution-time');
             }
-
 
             rl.on('line', (str: string) => {
                 const obj = parseLine(str);

--- a/packages/ts-transforms/src/index.ts
+++ b/packages/ts-transforms/src/index.ts
@@ -1,4 +1,3 @@
-
 import {
     OperationsManager, OperationBase, TransformOpBase, ValidationOpBase
 } from './operations';

--- a/packages/ts-transforms/src/interfaces.ts
+++ b/packages/ts-transforms/src/interfaces.ts
@@ -1,4 +1,3 @@
-
 import { TypeConfig } from 'xlucene-evaluator';
 import { DataEntity } from '@terascope/utils';
 import { Extraction } from '../src/operations';
@@ -57,7 +56,6 @@ export interface SelectorConfig {
     __id: string;
     selector: string;
 }
-
 
 export interface ExtractionConfig {
     __id: string;

--- a/packages/ts-transforms/src/loader/index.ts
+++ b/packages/ts-transforms/src/loader/index.ts
@@ -1,4 +1,3 @@
-
 import Loader from './loader';
 import RulesLoader from './rules-loader';
 import RulesParser from './rules-parser';

--- a/packages/ts-transforms/src/loader/loader.ts
+++ b/packages/ts-transforms/src/loader/loader.ts
@@ -1,4 +1,3 @@
-
 import { Logger } from '@terascope/utils';
 import RulesLoader from './rules-loader';
 import RulesParser from './rules-parser';

--- a/packages/ts-transforms/src/loader/rules-loader.ts
+++ b/packages/ts-transforms/src/loader/rules-loader.ts
@@ -1,4 +1,3 @@
-
 import fs from 'fs';
 import readline from 'readline';
 import { Readable } from 'stream';

--- a/packages/ts-transforms/src/loader/rules-parser.ts
+++ b/packages/ts-transforms/src/loader/rules-parser.ts
@@ -1,4 +1,3 @@
-
 import shortid from 'shortid';
 import { Logger, set } from '@terascope/utils';
 import { OperationConfigInput, OperationConfig } from '../interfaces';

--- a/packages/ts-transforms/src/loader/utils.ts
+++ b/packages/ts-transforms/src/loader/utils.ts
@@ -1,4 +1,3 @@
-
 import graphlib from 'graphlib';
 import { Logger, cloneDeep, has } from '@terascope/utils';
 import shortid from 'shortid';

--- a/packages/ts-transforms/src/matcher.ts
+++ b/packages/ts-transforms/src/matcher.ts
@@ -1,4 +1,3 @@
-
 import { Logger, debugLogger } from '@terascope/utils';
 import { PhaseManager } from './phases';
 import { WatcherConfig } from './interfaces';

--- a/packages/ts-transforms/src/operations/lib/base.ts
+++ b/packages/ts-transforms/src/operations/lib/base.ts
@@ -1,4 +1,3 @@
-
 import {
     DataEntity, set, unset, isString
 } from '@terascope/utils';

--- a/packages/ts-transforms/src/operations/lib/transforms/array.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/array.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity, get, set } from '@terascope/utils';
 import { PostProcessConfig, InputOutputCardinality } from '../../../interfaces';
 import TransformOpBase from './base';

--- a/packages/ts-transforms/src/operations/lib/transforms/base.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/base.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity, get } from '@terascope/utils';
 import OperationBase from '../base';
 

--- a/packages/ts-transforms/src/operations/lib/transforms/base64decode.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/base64decode.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { PostProcessConfig } from '../../../interfaces';
 import TransformOpBase from './base';

--- a/packages/ts-transforms/src/operations/lib/transforms/base64encode.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/base64encode.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { PostProcessConfig } from '../../../interfaces';
 import TransformOpBase from './base';

--- a/packages/ts-transforms/src/operations/lib/transforms/dedup.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/dedup.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity, get, uniq } from '@terascope/utils';
 import TransformOpBase from './base';
 import { PostProcessConfig } from '../../../interfaces';

--- a/packages/ts-transforms/src/operations/lib/transforms/extraction.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/extraction.ts
@@ -1,4 +1,3 @@
-
 import {
     DataEntity, matchAll, get, set, AnyObject, TSError
 } from '@terascope/utils';

--- a/packages/ts-transforms/src/operations/lib/transforms/hexdecode.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/hexdecode.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { PostProcessConfig } from '../../../interfaces';
 import TransformOpBase from './base';

--- a/packages/ts-transforms/src/operations/lib/transforms/hexencode.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/hexencode.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { PostProcessConfig } from '../../../interfaces';
 import TransformOpBase from './base';

--- a/packages/ts-transforms/src/operations/lib/transforms/join.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/join.ts
@@ -1,4 +1,3 @@
-
 import {
     DataEntity, set, get, flattenDeep
 } from '@terascope/utils';

--- a/packages/ts-transforms/src/operations/lib/transforms/jsonparse.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/jsonparse.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity, get } from '@terascope/utils';
 import TransformOpBase from './base';
 import { PostProcessConfig } from '../../../interfaces';

--- a/packages/ts-transforms/src/operations/lib/transforms/lowercase.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/lowercase.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity, get } from '@terascope/utils';
 import { PostProcessConfig } from '../../../interfaces';
 import TransformOpBase from './base';

--- a/packages/ts-transforms/src/operations/lib/transforms/md5encode.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/md5encode.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import crypto from 'crypto';
 import { PostProcessConfig } from '../../../interfaces';

--- a/packages/ts-transforms/src/operations/lib/transforms/selector.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/selector.ts
@@ -1,4 +1,3 @@
-
 import { DocumentMatcher, TypeConfig } from 'xlucene-evaluator';
 import { DataEntity } from '@terascope/utils';
 import { InputOutputCardinality, SelectorConfig } from '../../../interfaces';

--- a/packages/ts-transforms/src/operations/lib/transforms/sha1encode.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/sha1encode.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import crypto from 'crypto';
 import { PostProcessConfig } from '../../../interfaces';

--- a/packages/ts-transforms/src/operations/lib/transforms/sha2encode.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/sha2encode.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import crypto from 'crypto';
 import { PostProcessConfig } from '../../../interfaces';

--- a/packages/ts-transforms/src/operations/lib/transforms/trim.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/trim.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity, get } from '@terascope/utils';
 import { PostProcessConfig } from '../../../interfaces';
 import TransformOpBase from './base';

--- a/packages/ts-transforms/src/operations/lib/transforms/uppercase.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/uppercase.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity, get } from '@terascope/utils';
 import { PostProcessConfig } from '../../../interfaces';
 import TransformOpBase from './base';

--- a/packages/ts-transforms/src/operations/lib/transforms/urldecode.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/urldecode.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import TransformOpBase from './base';
 import { PostProcessConfig } from '../../../interfaces';

--- a/packages/ts-transforms/src/operations/lib/transforms/urlencode.ts
+++ b/packages/ts-transforms/src/operations/lib/transforms/urlencode.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { PostProcessConfig } from '../../../interfaces';
 import TransformOpBase from './base';

--- a/packages/ts-transforms/src/operations/lib/validations/base.ts
+++ b/packages/ts-transforms/src/operations/lib/validations/base.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity, get, isFunction } from '@terascope/utils';
 import OperationBase from '../base';
 

--- a/packages/ts-transforms/src/operations/lib/validations/boolean.ts
+++ b/packages/ts-transforms/src/operations/lib/validations/boolean.ts
@@ -1,4 +1,3 @@
-
 import { isBoolean } from '@terascope/utils';
 import { PostProcessConfig, BoolValidationResult } from '../../../interfaces';
 import ValidationOpBase from './base';

--- a/packages/ts-transforms/src/operations/lib/validations/number.ts
+++ b/packages/ts-transforms/src/operations/lib/validations/number.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity, toNumber } from '@terascope/utils';
 import { PostProcessConfig } from '../../../interfaces';
 import ValidationOpBase from './base';

--- a/packages/ts-transforms/src/phases/extraction-phase.ts
+++ b/packages/ts-transforms/src/phases/extraction-phase.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { hasKeys } from './utils';
 import {

--- a/packages/ts-transforms/src/phases/selector-phase.ts
+++ b/packages/ts-transforms/src/phases/selector-phase.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { WatcherConfig, Operation, SelectorConfig } from '../interfaces';
 import PhaseBase from './base';

--- a/packages/ts-transforms/src/phases/utils.ts
+++ b/packages/ts-transforms/src/phases/utils.ts
@@ -1,4 +1,3 @@
-
 export function hasKeys(doc: object) {
     return Object.keys(doc).length > 0;
 }

--- a/packages/ts-transforms/src/transform.ts
+++ b/packages/ts-transforms/src/transform.ts
@@ -1,4 +1,3 @@
-
 import { Logger, debugLogger } from '@terascope/utils';
 import { PhaseManager } from './phases';
 import { WatcherConfig } from './interfaces';

--- a/packages/ts-transforms/test/command-spec.ts
+++ b/packages/ts-transforms/test/command-spec.ts
@@ -1,4 +1,3 @@
-
 import execa from 'execa';
 import path from 'path';
 import { pWhile } from '@terascope/utils';

--- a/packages/ts-transforms/test/fixtures/plugins/double.ts
+++ b/packages/ts-transforms/test/fixtures/plugins/double.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { OperationConfig, TransformOpBase, InputOutputCardinality } from '../../../src';
 

--- a/packages/ts-transforms/test/fixtures/plugins/index.ts
+++ b/packages/ts-transforms/test/fixtures/plugins/index.ts
@@ -1,4 +1,3 @@
-
 import NoOp from './noop';
 import Double from './double';
 

--- a/packages/ts-transforms/test/fixtures/plugins/noop.ts
+++ b/packages/ts-transforms/test/fixtures/plugins/noop.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { OperationConfig, InputOutputCardinality } from '../../../src';
 

--- a/packages/ts-transforms/test/loader/rules-loader-spec.ts
+++ b/packages/ts-transforms/test/loader/rules-loader-spec.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import { debugLogger, isPlainObject, has } from '@terascope/utils';
 import { RulesLoader, OperationConfigInput } from '../../src';

--- a/packages/ts-transforms/test/loader/rules-parsing-spec.ts
+++ b/packages/ts-transforms/test/loader/rules-parsing-spec.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import {
     debugLogger, has, isPlainObject, get

--- a/packages/ts-transforms/test/loader/rules-validator-spec.ts
+++ b/packages/ts-transforms/test/loader/rules-validator-spec.ts
@@ -1,4 +1,3 @@
-
 import 'jest-extended';
 import { debugLogger, cloneDeep } from '@terascope/utils';
 import { isPrimaryConfig } from '../../src/loader/utils';

--- a/packages/ts-transforms/test/operations/transforms/base64decode-spec.ts
+++ b/packages/ts-transforms/test/operations/transforms/base64decode-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { Base64Decode } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/operations/transforms/base64encode-spec.ts
+++ b/packages/ts-transforms/test/operations/transforms/base64encode-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { Base64Encode } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/operations/transforms/extraction-spec.ts
+++ b/packages/ts-transforms/test/operations/transforms/extraction-spec.ts
@@ -86,7 +86,7 @@ describe('transform operator', () => {
         expect(results10).toEqual({ otherField: ['data', 'otherData'] });
     });
 
-    it('can transform data end = ', () => {
+    it('can transform data end =', () => {
         const opConfig = {
             source: 'someField',
             target: 'otherField',
@@ -401,7 +401,6 @@ describe('transform operator', () => {
         const results = test.run(data);
         expect(results).toEqual({ my_key: 20 });
     });
-
 
     it('can use expr to manipulate data', () => {
         const opConfig = {

--- a/packages/ts-transforms/test/operations/transforms/hexdecode-spec.ts
+++ b/packages/ts-transforms/test/operations/transforms/hexdecode-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { HexDecode } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/operations/transforms/hexencode-spec.ts
+++ b/packages/ts-transforms/test/operations/transforms/hexencode-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { HexEncode } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/operations/transforms/jsonparse-spec.ts
+++ b/packages/ts-transforms/test/operations/transforms/jsonparse-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { JsonParse } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/operations/transforms/lowercase-spec.ts
+++ b/packages/ts-transforms/test/operations/transforms/lowercase-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { Lowercase } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/operations/transforms/md5encode-spec.ts
+++ b/packages/ts-transforms/test/operations/transforms/md5encode-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import crypto from 'crypto';
 import { Md5Encode } from '../../../src/operations';

--- a/packages/ts-transforms/test/operations/transforms/selector-spec.ts
+++ b/packages/ts-transforms/test/operations/transforms/selector-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { Selector } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/operations/transforms/sha1encode-spec.ts
+++ b/packages/ts-transforms/test/operations/transforms/sha1encode-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import crypto from 'crypto';
 import { Sha1Encode } from '../../../src/operations';

--- a/packages/ts-transforms/test/operations/transforms/trim-spec.ts
+++ b/packages/ts-transforms/test/operations/transforms/trim-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { Trim } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/operations/transforms/uppercase-spec.ts
+++ b/packages/ts-transforms/test/operations/transforms/uppercase-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { Uppercase } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/operations/transforms/urlencode-spec.ts
+++ b/packages/ts-transforms/test/operations/transforms/urlencode-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { UrlEncode } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/operations/validations/boolean-spec.ts
+++ b/packages/ts-transforms/test/operations/validations/boolean-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { BooleanValidation } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/operations/validations/ip-spec.ts
+++ b/packages/ts-transforms/test/operations/validations/ip-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { Ip } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/operations/validations/isdn-spec.ts
+++ b/packages/ts-transforms/test/operations/validations/isdn-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { ISDN } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/operations/validations/mac-address-spec.ts
+++ b/packages/ts-transforms/test/operations/validations/mac-address-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { MacAddress } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/operations/validations/number-spec.ts
+++ b/packages/ts-transforms/test/operations/validations/number-spec.ts
@@ -1,4 +1,3 @@
-
 import { DataEntity } from '@terascope/utils';
 import { NumberValidation } from '../../../src/operations';
 

--- a/packages/ts-transforms/test/phases/output-phase-spec.ts
+++ b/packages/ts-transforms/test/phases/output-phase-spec.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import { DataEntity, debugLogger } from '@terascope/utils';
 import {

--- a/packages/ts-transforms/test/phases/selector-phase-spec.ts
+++ b/packages/ts-transforms/test/phases/selector-phase-spec.ts
@@ -1,4 +1,3 @@
-
 import path from 'path';
 import { DataEntity, debugLogger } from '@terascope/utils';
 import {

--- a/packages/ts-transforms/test/test-harness.ts
+++ b/packages/ts-transforms/test/test-harness.ts
@@ -1,4 +1,3 @@
-
 import { debugLogger, DataEntity } from '@terascope/utils';
 import {
     Matcher, Transform, PhaseManager, WatcherConfig, PluginList

--- a/packages/ts-transforms/test/transform-spec.ts
+++ b/packages/ts-transforms/test/transform-spec.ts
@@ -1,4 +1,3 @@
-
 import 'jest-extended';
 import path from 'path';
 import { DataEntity, get, cloneDeep } from '@terascope/utils';
@@ -944,7 +943,7 @@ describe('can transform matches', () => {
         });
     });
 
-    it('can catch all selector extractions', async () => {
+    it('can catch all selector extractions for transformRules31', async () => {
         const config: WatcherConfig = {
             rules: [getPath('transformRules31.txt')],
         };
@@ -987,7 +986,7 @@ describe('can transform matches', () => {
         });
     });
 
-    it('can catch all selector extractions', async () => {
+    it('can catch all selector extractions for sameSourceDifferentSelector', async () => {
         const config: WatcherConfig = {
             rules: [getPath('sameSourceDifferentSelector.txt')],
         };

--- a/packages/utils/src/entities/data-entity.ts
+++ b/packages/utils/src/entities/data-entity.ts
@@ -85,7 +85,6 @@ export class DataEntity<
         return DataEntity.make({}, input.getMetadata()) as T;
     }
 
-
     /**
      * A utility for converting a `Buffer` to a `DataEntity`,
      * using the DataEntity encoding.

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -108,5 +108,4 @@ export function debugLogger(testName: string, param?: debugParam, otherName?: st
     return logger;
 }
 
-
 export { Logger };

--- a/packages/utils/test/utils-spec.ts
+++ b/packages/utils/test/utils-spec.ts
@@ -51,6 +51,7 @@ describe('Utils', () => {
         });
 
         // TODO: We may need to add support for this?
+        // eslint-disable-next-line jest/no-disabled-tests
         xit('should handle a json base64 encoded Buffer', () => {
             const input = Buffer.from(JSON.stringify({ foo: 'bar' }), 'base64');
             expect(parseJSON(input)).toEqual({ foo: 'bar' });

--- a/packages/xlucene-evaluator/src/document-matcher/index.ts
+++ b/packages/xlucene-evaluator/src/document-matcher/index.ts
@@ -1,4 +1,3 @@
-
 import { debugLogger } from '@terascope/utils';
 import { BooleanCB, DocumentMatcherOptions } from './interfaces';
 import logicBuilder from './logic-builder';

--- a/packages/xlucene-evaluator/src/document-matcher/logic-builder/geo.ts
+++ b/packages/xlucene-evaluator/src/document-matcher/logic-builder/geo.ts
@@ -1,4 +1,3 @@
-
 import pointInPolygon from '@turf/boolean-point-in-polygon';
 // @ts-ignore
 import createCircle from '@turf/circle';

--- a/packages/xlucene-evaluator/src/document-matcher/logic-builder/index.ts
+++ b/packages/xlucene-evaluator/src/document-matcher/logic-builder/index.ts
@@ -1,4 +1,3 @@
-
 import _ from 'lodash';
 import fp from 'lodash/fp';
 import { geoDistance, geoBoundingBox } from './geo';

--- a/packages/xlucene-evaluator/src/document-matcher/logic-builder/string.ts
+++ b/packages/xlucene-evaluator/src/document-matcher/logic-builder/string.ts
@@ -1,4 +1,3 @@
-
 import _ from 'lodash';
 import { BooleanCB } from '../interfaces';
 

--- a/packages/xlucene-evaluator/src/interfaces.ts
+++ b/packages/xlucene-evaluator/src/interfaces.ts
@@ -1,4 +1,3 @@
-
 type GeoPointArr = [number, number];
 type GeoPointStr = string;
 type GeoObjShort = {lat: string | number; lon: string | number};

--- a/packages/xlucene-evaluator/src/parser/functions/geo/box.ts
+++ b/packages/xlucene-evaluator/src/parser/functions/geo/box.ts
@@ -1,4 +1,3 @@
-
 import { polyHasPoint, makeBBox } from './helpers';
 import * as i from '../../interfaces';
 import { parseGeoPoint } from '../../../utils';

--- a/packages/xlucene-evaluator/src/parser/functions/geo/contains-point.ts
+++ b/packages/xlucene-evaluator/src/parser/functions/geo/contains-point.ts
@@ -1,4 +1,3 @@
-
 import { point } from '@turf/helpers';
 import { pointInGeoShape } from './helpers';
 import { parseGeoPoint } from '../../../utils';

--- a/packages/xlucene-evaluator/src/parser/functions/geo/distance.ts
+++ b/packages/xlucene-evaluator/src/parser/functions/geo/distance.ts
@@ -1,4 +1,3 @@
-
 import { polyHasPoint, makeCircle } from './helpers';
 import { parseGeoPoint, parseGeoDistance } from '../../../utils';
 import * as i from '../../interfaces';

--- a/packages/xlucene-evaluator/src/parser/functions/geo/helpers.ts
+++ b/packages/xlucene-evaluator/src/parser/functions/geo/helpers.ts
@@ -1,4 +1,3 @@
-
 import bbox from '@turf/bbox';
 import bboxPolygon from '@turf/bbox-polygon';
 // @ts-ignore

--- a/packages/xlucene-evaluator/src/parser/functions/geo/polygon.ts
+++ b/packages/xlucene-evaluator/src/parser/functions/geo/polygon.ts
@@ -1,4 +1,3 @@
-
 import { TSError } from '@terascope/utils';
 import {
     polyHasPoint, makePolygon, polyHasShape, makeCoordinatesFromGeoPoint

--- a/packages/xlucene-evaluator/src/parser/functions/index.ts
+++ b/packages/xlucene-evaluator/src/parser/functions/index.ts
@@ -1,4 +1,3 @@
-
 import geoBox from './geo/box';
 import geoDistance from './geo/distance';
 import geoPolygon from './geo/polygon';

--- a/packages/xlucene-evaluator/src/parser/interfaces.ts
+++ b/packages/xlucene-evaluator/src/parser/interfaces.ts
@@ -1,4 +1,3 @@
-
 import { Logger } from '@terascope/utils';
 import { UtilsTranslateQueryOptions, AnyQuery, AnyQuerySort } from '../translator/interfaces';
 import {

--- a/packages/xlucene-evaluator/src/utils.ts
+++ b/packages/xlucene-evaluator/src/utils.ts
@@ -29,7 +29,6 @@ import {
     isGeoShapePoint
 } from './parser/functions/geo/helpers';
 
-
 export function isInfiniteValue(input?: number|string) {
     return input === '*' || input === Number.NEGATIVE_INFINITY || input === Number.POSITIVE_INFINITY;
 }

--- a/packages/xlucene-evaluator/test/cases/document-matcher/range.ts
+++ b/packages/xlucene-evaluator/test/cases/document-matcher/range.ts
@@ -1,4 +1,3 @@
-
 const ageData = [
     { age: 33 },
     { age: 8 },

--- a/packages/xlucene-evaluator/test/cases/document-matcher/wildcard.ts
+++ b/packages/xlucene-evaluator/test/cases/document-matcher/wildcard.ts
@@ -1,4 +1,3 @@
-
 const keyData = [
     { key: 'abcde' },
     { key: 'field' },

--- a/packages/xlucene-evaluator/test/cases/parser/index.ts
+++ b/packages/xlucene-evaluator/test/cases/parser/index.ts
@@ -1,4 +1,3 @@
-
 import empty from './empty';
 import exists from './exists';
 import fieldGroup from './field-group';

--- a/packages/xlucene-evaluator/test/document-matcher-spec.ts
+++ b/packages/xlucene-evaluator/test/document-matcher-spec.ts
@@ -1,4 +1,3 @@
-
 import 'jest-extended';
 import _ from 'lodash';
 import { DocumentMatcher, TypeConfig, FieldType } from '../src';

--- a/packages/xlucene-evaluator/test/query-access-spec.ts
+++ b/packages/xlucene-evaluator/test/query-access-spec.ts
@@ -138,7 +138,7 @@ describe('QueryAccess', () => {
             expect(result).toEqual(query);
         });
 
-        it('should throw if field is not included', () => {
+        it('should throw if field is not included with other term', () => {
             const query = 'hello:world AND bar:foo';
 
             expect(() => queryAccess.restrict(query)).toThrow();
@@ -173,7 +173,7 @@ describe('QueryAccess', () => {
             expect(queryAccess.restrict(query)).toEqual(query);
         });
 
-        it('should allow field listed if included', () => {
+        it('should allow field listed if included with range query', () => {
             const query = 'bar:[0 TO *] OR star:(0 OR 2)';
 
             expect(queryAccess.restrict(query)).toEqual(query);

--- a/packages/xlucene-evaluator/test/utils-spec.ts
+++ b/packages/xlucene-evaluator/test/utils-spec.ts
@@ -10,7 +10,6 @@ import {
     GeoShapeRelation
 } from '../src/interfaces';
 
-
 describe('Utils', () => {
     it('should have GEO_DISTANCE_UNITS', () => {
         expect(utils.GEO_DISTANCE_UNITS).toBeObject();
@@ -82,7 +81,7 @@ describe('Utils', () => {
             expect(results).toEqual('location:geoDistance(point:"60,90" distance:"100m")');
         });
 
-        it('can add additional fieldParams for geoDistance ', () => {
+        it('can add additional fieldParams for geoDistance', () => {
             const input = { location: '60,90' };
             const options: utils.CreateJoinQueryOptions = {
                 fieldParams: { location: '50km' },

--- a/packages/xlucene-evaluator/test/xlucene-functions/geo-box-spec.ts
+++ b/packages/xlucene-evaluator/test/xlucene-functions/geo-box-spec.ts
@@ -1,4 +1,3 @@
-
 import 'jest-extended';
 import { debugLogger } from '@terascope/utils';
 import { Parser, } from '../../src';

--- a/packages/xlucene-evaluator/test/xlucene-functions/geo-distance-spec.ts
+++ b/packages/xlucene-evaluator/test/xlucene-functions/geo-distance-spec.ts
@@ -1,4 +1,3 @@
-
 import 'jest-extended';
 import { debugLogger } from '@terascope/utils';
 import { Parser } from '../../src';

--- a/packages/xlucene-evaluator/test/xlucene-functions/geo-polygon-spec.ts
+++ b/packages/xlucene-evaluator/test/xlucene-functions/geo-polygon-spec.ts
@@ -1,4 +1,3 @@
-
 import 'jest-extended';
 import { debugLogger } from '@terascope/utils';
 import { Parser } from '../../src';
@@ -313,7 +312,6 @@ describe('geoPolygon', () => {
                     ]
                 ]
             };
-
 
             it('poly v poly default relations matches within', () => {
                 const query = `location: geoPolygon(points:${JSON.stringify(queryPoints)})`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3664,42 +3664,7 @@ datemath-parser@^1.0.6:
   dependencies:
     moment "^2.22.2"
 
-debug@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
-  integrity sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=
-  dependencies:
-    ms "0.7.1"
-
-debug@2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
-  integrity sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=
-  dependencies:
-    ms "0.7.2"
-
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
-debug@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
-debug@^3.1.0, debug@^3.2.6:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@2.2.0, debug@2.3.3, debug@2.6.9, debug@3.1.0, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9, debug@^3.1.0, debug@^3.2.6, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -7838,27 +7803,7 @@ mquery@3.2.2:
     safe-buffer "5.1.2"
     sliced "1.0.1"
 
-ms@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
-  integrity sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=
-
-ms@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
-  integrity sha1-riXPJRKziFodldfwN4aNhDESR2U=
-
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
-
-ms@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
-  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
-
-ms@2.1.2, ms@^2.0.0, ms@^2.1.1, ms@^2.1.2:
+ms@2.1.1, ms@2.1.2, ms@^2.0.0, ms@^2.1.1, ms@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,6 +1833,15 @@
     "@typescript-eslint/typescript-estree" "2.9.0"
     eslint-scope "^5.0.0"
 
+"@typescript-eslint/experimental-utils@^2.5.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.10.0.tgz#8db1656cdfd3d9dcbdbf360b8274dea76f0b2c2c"
+  integrity sha512-FZhWq6hWWZBP76aZ7bkrfzTMP31CCefVIImrwP3giPLcoXocmLTmr92NLZxuIcTL4GTEOE33jQMWy9PwelL+yQ==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.10.0"
+    eslint-scope "^5.0.0"
+
 "@typescript-eslint/parser@^2.9.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.9.0.tgz#2e9cf438de119b143f642a3a406e1e27eb70b7cd"
@@ -1842,6 +1851,19 @@
     "@typescript-eslint/experimental-utils" "2.9.0"
     "@typescript-eslint/typescript-estree" "2.9.0"
     eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/typescript-estree@2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.10.0.tgz#89cdabd5e8c774e9d590588cb42fb9afd14dcbd9"
+  integrity sha512-oOYnplddQNm/LGVkqbkAwx4TIBuuZ36cAQq9v3nFIU9FmhemHuVzAesMSXNQDdAzCa5bFgCrfD3JWhYVKlRN2g==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash.unescape "4.0.1"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@2.9.0":
   version "2.9.0"
@@ -3642,7 +3664,42 @@ datemath-parser@^1.0.6:
   dependencies:
     moment "^2.22.2"
 
-debug@2.2.0, debug@2.3.3, debug@2.6.9, debug@3.1.0, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9, debug@^3.1.0, debug@^3.2.6, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
+  integrity sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=
+  dependencies:
+    ms "0.7.1"
+
+debug@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
+  integrity sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=
+  dependencies:
+    ms "0.7.2"
+
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
+debug@^3.1.0, debug@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -4258,6 +4315,13 @@ eslint-plugin-import@^2.18.2:
     object.values "^1.1.0"
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
+
+eslint-plugin-jest@^23.1.1:
+  version "23.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.1.1.tgz#1220ab53d5a4bf5c3c4cd07c0dabc6199d4064dd"
+  integrity sha512-2oPxHKNh4j1zmJ6GaCBuGcb8FVZU7YjFUOJzGOPnl9ic7VA/MGAskArLJiRIlnFUmi1EUxY+UiATAy8dv8s5JA==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^2.5.0"
 
 eslint-plugin-jsx-a11y@^6.2.3:
   version "6.2.3"
@@ -7774,7 +7838,27 @@ mquery@3.2.2:
     safe-buffer "5.1.2"
     sliced "1.0.1"
 
-ms@2.1.1, ms@2.1.2, ms@^2.0.0, ms@^2.1.1, ms@^2.1.2:
+ms@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
+  integrity sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=
+
+ms@0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
+  integrity sha1-riXPJRKziFodldfwN4aNhDESR2U=
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
+ms@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
+ms@2.1.2, ms@^2.0.0, ms@^2.1.1, ms@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==


### PR DESCRIPTION
- fix inconsistencies in with line spaces in typescript and javascript files.
- enable `@typescript-eslint/brace-style` for consistency between js and ts
- enable `@typescript-eslint/no-extra-parens` for consistency between js and ts
- enable `@typescript-eslint/func-call-spacing` for consistency between js and ts
- enforce more naming conventions for typescript
- add [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest) support to catch things like:
   - Invalid `expect` / `it` / `describe` 
   - Duplicate test titles (to avoid auto-grouping them)
   - Committed disabled or focused tests
   - Using `jasmine` globals

These linting changes have already caught a variety of problems (mainly in the tests)

**NOTE:** Ignore the file changed file count (it just fixes the multiple empty lines)