### PR TITLE
Fix regex queries in xlucene

### DIFF
--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -35,7 +35,7 @@
     "devDependencies": {
         "@types/lodash.defaultsdeep": "^4.6.6",
         "@types/yargs": "^13.0.3",
-        "xlucene-evaluator": "^0.14.0"
+        "xlucene-evaluator": "^0.14.1"
     },
     "engines": {
         "node": ">=8.0.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "elasticsearch-store",
-    "version": "0.15.0",
+    "version": "0.15.1",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "ajv": "^6.10.0",
         "nanoid": "^2.1.6",
         "rambda": "~3.0.1",
-        "xlucene-evaluator": "^0.14.0"
+        "xlucene-evaluator": "^0.14.1"
     },
     "devDependencies": {
         "@terascope/data-types": "^0.8.0",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-transforms",
-    "version": "0.27.0",
+    "version": "0.27.1",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -44,7 +44,7 @@
         "shortid": "^2.2.14",
         "valid-url": "^1.0.9",
         "validator": "^12.1.0",
-        "xlucene-evaluator": "^0.14.0",
+        "xlucene-evaluator": "^0.14.1",
         "yargs": "^15.0.2"
     },
     "devDependencies": {

--- a/packages/xlucene-evaluator/package.json
+++ b/packages/xlucene-evaluator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xlucene-evaluator",
-    "version": "0.14.0",
+    "version": "0.14.1",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-evaluator#readme",
     "repository": {

--- a/packages/xlucene-evaluator/src/parser/context.ts
+++ b/packages/xlucene-evaluator/src/parser/context.ts
@@ -98,6 +98,15 @@ export default function makeContext(args: any) {
             `coercing field "${field}":${node.value} type of ${node.field_type} to ${fieldType}`
         );
 
+        // in the case of tokenized fields we should update the
+        // node to indicate so non-term level queries can be performed
+        if (utils.isTermType(node) && field.includes('.') && !typeConfig[field]) {
+            const parentField = field.split('.').slice(0, -1);
+            if (typeConfig[parentField] && typeConfig[parentField] !== FieldType.Object) {
+                node.tokenizer = parentField;
+            }
+        }
+
         if (fieldType === FieldType.Boolean) {
             node.field_type = fieldType;
             delete node.quoted;

--- a/packages/xlucene-evaluator/src/parser/interfaces.ts
+++ b/packages/xlucene-evaluator/src/parser/interfaces.ts
@@ -43,6 +43,7 @@ export type TermLikeType =
 export interface TermLikeAST {
     type: TermLikeType;
     field: Field;
+    tokenizer?: boolean;
 }
 
 export enum ASTType {

--- a/packages/xlucene-evaluator/src/parser/parser.ts
+++ b/packages/xlucene-evaluator/src/parser/parser.ts
@@ -38,7 +38,6 @@ export class Parser {
             const astJSON = JSON.stringify(this.ast, null, 4);
             this.logger.trace(`parsed ${this.query ? this.query : "''"} to `, astJSON);
         } catch (err) {
-            console.error(err);
             if (err && err.message.includes('Expected ,')) {
                 err.message = err.message.replace('Expected ,', 'Expected');
             }

--- a/packages/xlucene-evaluator/src/translator/interfaces.ts
+++ b/packages/xlucene-evaluator/src/translator/interfaces.ts
@@ -54,6 +54,7 @@ export type AnyQuery =
     | WildcardQuery
     | ExistsQuery
     | RegExprQuery
+    | QueryStringQuery
     | RangeQuery
     | MultiMatchQuery
 
@@ -113,6 +114,13 @@ export interface GeoQuery {
 export interface RegExprQuery {
     regexp: {
         [field: string]: string;
+    };
+}
+
+export interface QueryStringQuery {
+    query_string: {
+        fields: string[];
+        query: string;
     };
 }
 

--- a/packages/xlucene-evaluator/src/translator/utils.ts
+++ b/packages/xlucene-evaluator/src/translator/utils.ts
@@ -257,13 +257,25 @@ export function translateQuery(
         return wildcardQuery;
     }
 
-    function buildRegExprQuery(node: p.Regexp): i.RegExprQuery | i.MultiMatchQuery {
+    function buildRegExprQuery(
+        node: p.Regexp
+    ): i.RegExprQuery | i.MultiMatchQuery | i.QueryStringQuery {
         if (isMultiMatch(node)) {
             const query = `${node.value}`;
             return buildMultiMatchQuery(node, query);
         }
 
         const field = getTermField(node);
+
+        if (node.tokenizer) {
+            return {
+                query_string: {
+                    fields: [field],
+                    query: `/${node.value}/`
+                }
+            };
+        }
+
         const regexQuery: i.RegExprQuery = {
             regexp: {
                 [field]: node.value,

--- a/packages/xlucene-evaluator/test/cases/translator/term.ts
+++ b/packages/xlucene-evaluator/test/cases/translator/term.ts
@@ -43,6 +43,36 @@ export default [
         },
     ],
     [
+        'firstname.text:/[A-Z]+/',
+        'query.constant_score.filter',
+        {
+            query_string: {
+                fields: ['firstname.text'],
+                query: '/[A-Z]+/',
+            },
+        },
+        {
+            type_config: {
+                firstname: FieldType.String
+            }
+        }
+    ],
+    [
+        'other.value:/[a-z]{1,3}/',
+        'query.constant_score.filter',
+        {
+            regexp: {
+                'other.value': '[a-z]{1,3}',
+            },
+        },
+        {
+            type_config: {
+                other: FieldType.String,
+                'other.value': FieldType.String
+            }
+        }
+    ],
+    [
         '_exists_:hello',
         'query.constant_score.filter',
         {


### PR DESCRIPTION
Fixes regex queries on tokenized fields by switching use a `query_string` for tokenized fields since that is the only way I can see how to fix it.

>  The regexp query allows you to use regular expression term queries. See Regular expression syntax for details of the supported regular expression language. The "term queries" in that first sentence means that Elasticsearch will apply the regexp to the terms produced by the tokenizer for that field, and not to the original text of the field.

From [elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-regexp-query.html#query-dsl-regexp-query)