### PR TITLE
v0.62.1 - Fix services references

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-workspace",
-    "version": "0.62.0",
+    "version": "0.62.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/lib/cluster/services/api.js
+++ b/packages/teraslice/lib/cluster/services/api.js
@@ -257,7 +257,7 @@ module.exports = function apiService(context, { assetsUrl, app }) {
                 query += ` AND (${statusTerms})`;
             }
 
-            return exStore.searchExecutionContexts(query, from, size, sort);
+            return exStore.search(query, from, size, sort);
         });
     });
 
@@ -318,7 +318,7 @@ module.exports = function apiService(context, { assetsUrl, app }) {
         requestHandler(async () => {
             const nodes = await clusterService.getClusterState();
 
-            const transform = Object.values(nodes).forEach((node) => Object.assign(
+            const transform = Object.values(nodes).map((node) => Object.assign(
                 {},
                 node,
                 { active: node.active.length }
@@ -348,7 +348,7 @@ module.exports = function apiService(context, { assetsUrl, app }) {
 
         const requestHandler = handleRequest(req, res, 'Could not get all executions');
         requestHandler(async () => {
-            const exs = await executionService.search(query, from, size, sort);
+            const exs = await exStore.search(query, from, size, sort);
             return makeTable(req, defaults, exs);
         });
     });

--- a/packages/teraslice/lib/cluster/services/execution.js
+++ b/packages/teraslice/lib/cluster/services/execution.js
@@ -106,7 +106,7 @@ module.exports = function executionService(context, { clusterMasterServer }) {
     }
 
     function findAllWorkers() {
-        return flatten(clusterService.getClusterState()
+        return flatten(Object.values(clusterService.getClusterState())
             .filter((node) => node.state === 'connected')
             .map((node) => {
                 const workers = node.active.filter(Boolean);

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice",
-    "version": "0.62.0",
+    "version": "0.62.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
Fixes the following issues:


```sh
curl -Ss localhost:5678/txt/workers
{
    "error": 500,
    "message": "clusterService.getClusterState(...).filter is not a function"
}
curl -Ss localhost:5678/txt/ex
{
    "error": 500,
    "message": "executionService.search is not a function"
}
curl -Ss localhost:5678/txt/nodes
{
    "error": 500,
    "message": "Cannot read property 'length' of undefined"
}
curl -Ss localhost:5678/ex
{
    "error": 500,
    "message": "exStore.searchExecutionContexts is not a function"
}
```