### PR TITLE
Misc fixes/improvements to elasticsearch-store, data-types, utils

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -29,7 +29,7 @@
     "devDependencies": {
         "@terascope/docker-compose-js": "^1.1.3",
         "@terascope/fetch-github-release": "^0.6.0",
-        "@terascope/utils": "^0.21.0",
+        "@terascope/utils": "^0.22.0",
         "bunyan": "^1.8.12",
         "elasticsearch": "^15.4.1",
         "fs-extra": "^8.1.0",
@@ -37,7 +37,7 @@
         "nanoid": "^2.1.8",
         "semver": "^7.1.1",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.12.1",
+        "teraslice-client-js": "^0.13.0",
         "uuid": "^3.3.3"
     },
     "resolutions": {

--- a/packages/chunked-file-reader/package.json
+++ b/packages/chunked-file-reader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/chunked-file-reader",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "This module is an abstracted reader for use in various Teraslice readers. It uses an externally-defined reader to read data and the packages up the data in a DataEntity for use with other Teraslice processors.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/chunked-file-reader#readme",
     "bugs": {
@@ -20,7 +20,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.21.0",
+        "@terascope/utils": "^0.22.0",
         "bluebird": "^3.7.2",
         "csvtojson": "^2.0.8",
         "lodash": "^4.17.11"

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/data-types",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.21.0",
+        "@terascope/utils": "^0.22.0",
         "graphql": "^14.3.1",
         "lodash.defaultsdeep": "^4.6.1",
         "yargs": "^15.1.0"
@@ -35,7 +35,7 @@
     "devDependencies": {
         "@types/lodash.defaultsdeep": "^4.6.6",
         "@types/yargs": "^13.0.4",
-        "xlucene-evaluator": "^0.16.3"
+        "xlucene-evaluator": "^0.17.0"
     },
     "engines": {
         "node": ">=8.0.0"

--- a/packages/data-types/src/data-type.ts
+++ b/packages/data-types/src/data-type.ts
@@ -4,7 +4,7 @@ import { formatSchema, formatGQLComment } from './graphql-helper';
 import * as i from './interfaces';
 import BaseType from './types/versions/base-type';
 import * as utils from './utils';
-import { getTypes } from './types';
+import { getTypes, LATEST_VERSION } from './types';
 
 /**
  * A DataType is used to define the structure of data with version support
@@ -78,11 +78,15 @@ export class DataType {
         return formatSchema(strSchema, removeScalars);
     }
 
-    constructor(config: i.DataTypeConfig, typeName?: string, description?: string) {
+    constructor(config: Partial<i.DataTypeConfig>, typeName?: string, description?: string) {
         if (typeName) this.name = typeName;
         if (description) this.description = description;
 
-        const { version, fields } = utils.validateDataTypeConfig(config);
+        const { version, fields } = utils.validateDataTypeConfig({
+            version: LATEST_VERSION,
+            fields: {},
+            ...config,
+        });
         this.fields = fields;
         this.version = version;
 

--- a/packages/data-types/src/data-type.ts
+++ b/packages/data-types/src/data-type.ts
@@ -163,15 +163,20 @@ export class DataType {
         this._types.forEach((typeClass) => {
             const result = typeClass.toGraphQL(typeName);
             baseProperties.push(result.type);
+            customTypes.push(...result.customTypes);
 
             if (createInputType) {
                 if (args.includeAllInputFields
                     || !ts.startsWith(typeClass.field, '_')) {
-                    inputProperties.push(result.type);
+                    const inputResult = typeClass.toGraphQL(
+                        typeName,
+                        true,
+                        args.includeAllInputFields
+                    );
+                    inputProperties.push(inputResult.type);
+                    customTypes.push(...inputResult.customTypes);
                 }
             }
-
-            customTypes.push(...result.customTypes);
         });
 
         if (references.length) {

--- a/packages/data-types/src/graphql-helper.ts
+++ b/packages/data-types/src/graphql-helper.ts
@@ -43,7 +43,7 @@ function parseLiteral(ast: ASTNode) {
                 }
             }
 
-            if (keyName === 'array') {
+            if (keyName === 'array' || keyName === 'indexed') {
                 if (valueNode.kind !== Kind.BOOLEAN && valueNode.kind !== Kind.NULL) {
                     throw new Error(`${keyName}: ${keyValue} is not a valid boolean`);
                 }

--- a/packages/data-types/src/interfaces.ts
+++ b/packages/data-types/src/interfaces.ts
@@ -114,10 +114,17 @@ export type FieldTypeConfig = {
     description?: string;
     /**
      * Specifies whether the field is index in elasticsearch
-     * (Not all fields support this)
-     * @default false
+     *
+     * (Only type Object currently support this)
+     * @default true
     */
     indexed?: boolean;
+
+    /**
+     * A temporary flag to fix KeywordCaseInsensitive to be
+     * a type keyword with case insenstive .text fields
+    */
+    use_fields_hack?: boolean;
 };
 
 type ActualType = {

--- a/packages/data-types/src/types/versions/base-type.ts
+++ b/packages/data-types/src/types/versions/base-type.ts
@@ -23,7 +23,7 @@ export default abstract class BaseType {
     }
 
     abstract toESMapping(version?: number): TypeESMapping;
-    abstract toGraphQL(typeName?: string): GraphQLType;
+    abstract toGraphQL(typeName?: string, isInput?: boolean, includePrivate?: boolean): GraphQLType;
     abstract toXlucene(): TypeConfig;
 
     protected _formatGql(
@@ -41,6 +41,21 @@ export default abstract class BaseType {
             type: formatGQLType(`${this.field}: ${type}`, desc),
             customTypes: makeCustomTypes(customType)
         };
+    }
+
+    _formatGQLTypeName(
+        typeName: string,
+        isInput?: boolean,
+        includeField?: boolean,
+        version?: number
+    ): string {
+        return [
+            'DT',
+            (typeName),
+            includeField ? ts.firstToUpper(this.field) : '',
+            isInput ? 'Input' : '',
+            `V${version ?? 1}`
+        ].filter(Boolean).join('');
     }
 }
 

--- a/packages/data-types/src/types/versions/v1/boundary.ts
+++ b/packages/data-types/src/types/versions/v1/boundary.ts
@@ -16,14 +16,16 @@ export default class Boundary extends BaseType {
         };
     }
 
-    toGraphQL() {
+    toGraphQL(_typeName?: string, isInput?: boolean) {
+        const defType = isInput ? 'input' : 'type';
+        const name = this._formatGQLTypeName('GeoBoundary', isInput);
         const customType = `
-            type GeoBoundaryType {
+            ${defType} ${name} {
                 lat: Int!
                 lon: Int!
             }
         `;
-        return this._formatGql('GeoBoundaryType', customType);
+        return this._formatGql(name, customType);
     }
 
     toXlucene() {

--- a/packages/data-types/src/types/versions/v1/geo-point.ts
+++ b/packages/data-types/src/types/versions/v1/geo-point.ts
@@ -7,15 +7,16 @@ export default class GeoPointType extends BaseType {
         return { mapping: { [this.field]: { type: 'geo_point' as ElasticSearchTypes } } };
     }
 
-    // TODO: need notion of injecting custom types, what about duplicates
-    toGraphQL() {
+    toGraphQL(_typeName?: string, isInput?: boolean) {
+        const defType = isInput ? 'input' : 'type';
+        const name = this._formatGQLTypeName('GeoPoint', isInput);
         const customType = `
-            type DTGeoPointV1 {
+            ${defType} ${name} {
                 lat: String!
                 lon: String!
             }
         `;
-        return this._formatGql('DTGeoPointV1', customType);
+        return this._formatGql(name, customType);
     }
 
     toXlucene() {

--- a/packages/data-types/src/types/versions/v1/geo.ts
+++ b/packages/data-types/src/types/versions/v1/geo.ts
@@ -8,15 +8,16 @@ export default class GeoType extends BaseType {
         return { mapping: { [this.field]: { type: 'geo_point' as ElasticSearchTypes } } };
     }
 
-    // TODO: need notion of injecting custom types, what about duplicates
-    toGraphQL() {
+    toGraphQL(_typeName?: string, isInput?: boolean) {
+        const defType = isInput ? 'input' : 'type';
+        const name = this._formatGQLTypeName('GeoPoint', isInput);
         const customType = `
-            type GeoPointType {
+            ${defType} ${name} {
                 lat: String!
                 lon: String!
             }
         `;
-        return this._formatGql('GeoPointType', customType);
+        return this._formatGql(name, customType);
     }
 
     toXlucene() {

--- a/packages/data-types/src/types/versions/v1/keyword-case-insensitive.ts
+++ b/packages/data-types/src/types/versions/v1/keyword-case-insensitive.ts
@@ -6,8 +6,15 @@ export default class KeywordCaseInsensitive extends BaseType {
     toESMapping(_version?: number) {
         return {
             mapping: {
-                [this.field]: {
-                    // TODO: this is wrong, I dont think analyzer can be at this level
+                [this.field]: this.config.use_fields_hack ? {
+                    type: 'keyword',
+                    fields: {
+                        text: {
+                            type: 'text',
+                            analyzer: 'lowercase_keyword_analyzer',
+                        },
+                    },
+                } : {
                     type: 'text' as ElasticSearchTypes,
                     analyzer: 'lowercase_keyword_analyzer',
                 },

--- a/packages/data-types/src/types/versions/v1/keyword-tokens-case-insensitive.ts
+++ b/packages/data-types/src/types/versions/v1/keyword-tokens-case-insensitive.ts
@@ -7,7 +7,6 @@ export default class KeywordTokensCaseInsensitive extends BaseType {
         return {
             mapping: {
                 [this.field]: {
-                    // TODO: this is wrong, I dont think analyzer can be at this level
                     type: 'text' as ElasticSearchTypes,
                     analyzer: 'lowercase_keyword_analyzer',
                     fields: {

--- a/packages/data-types/test/data-type-graphql-spec.ts
+++ b/packages/data-types/test/data-type-graphql-spec.ts
@@ -65,7 +65,7 @@ describe('DataType (graphql)', () => {
             };
 
             const dataType = new DataType(typeConfig, 'ObjType', 'nested field test description');
-            expect(dataType.toGraphQL()).toEqual(
+            expect(dataType.toGraphQL({ createInputType: true })).toEqual(
                 formatSchema(`
                         type DTObjTypeExampleV1 {
                             a: String
@@ -76,6 +76,17 @@ describe('DataType (graphql)', () => {
                         # nested field test description
                         type ObjType {
                             example: DTObjTypeExampleV1
+                        }
+
+                        input DTObjTypeExampleInputV1 {
+                            a: String
+                            bar: String
+                            foo: String
+                        }
+
+                        # Input for ObjType - nested field test description
+                        input ObjTypeInput {
+                            example: DTObjTypeExampleInputV1
                         }
                     `)
             );

--- a/packages/data-types/test/data-type-spec.ts
+++ b/packages/data-types/test/data-type-spec.ts
@@ -5,15 +5,8 @@ import {
 } from '../src';
 
 describe('DataType', () => {
-    it('should throw when given an empty object', () => {
-        expect.hasAssertions();
-        try {
-            // @ts-ignore
-            new DataType({});
-        } catch (err) {
-            expect(err).toBeInstanceOf(TSError);
-            expect(err.message).toInclude('Missing data type config');
-        }
+    it('should not throw when given an empty object', () => {
+        expect(() => new DataType({})).not.toThrow();
     });
 
     it('should throw when given no version', () => {
@@ -64,9 +57,8 @@ describe('DataType', () => {
             new DataType({
                 version: 1,
                 fields: {
-                    // @ts-ignore
                     blah: true,
-                },
+                } as any,
             });
         } catch (err) {
             expect(err).toBeInstanceOf(TSError);

--- a/packages/data-types/test/types/v1/boundry-spec.ts
+++ b/packages/data-types/test/types/v1/boundry-spec.ts
@@ -44,11 +44,11 @@ describe('Boundary V1', () => {
             type: graphQlTypes,
             customTypes
         } = new Boundary(field, typeConfig).toGraphQL();
-        const results = `${field}: GeoBoundaryType`;
+        const results = `${field}: DTGeoBoundaryV1`;
         const [customType] = customTypes;
 
         expect(graphQlTypes).toEqual(results);
-        expect(customType).toInclude('type GeoBoundaryType {');
+        expect(customType).toInclude('type DTGeoBoundaryV1 {');
         expect(customType).toInclude('lat: Int!');
         expect(customType).toInclude('lon: Int!');
     });

--- a/packages/data-types/test/types/v1/geo-spec.ts
+++ b/packages/data-types/test/types/v1/geo-spec.ts
@@ -38,7 +38,7 @@ describe('Geo V1', () => {
         const results = `${field}: GeoPointType`;
         const [customType] = customTypes;
         expect(graphQlTypes).toEqual(results);
-        expect(customType).toInclude('type GeoPointType {');
+        expect(customType).toInclude('type DTGeoPointTypeV1 {');
         expect(customType).toInclude('lat: String!');
         expect(customType).toInclude('lon: String!');
     });

--- a/packages/data-types/test/types/v1/geo-spec.ts
+++ b/packages/data-types/test/types/v1/geo-spec.ts
@@ -35,10 +35,10 @@ describe('Geo V1', () => {
             type: graphQlTypes,
             customTypes
         } = new GeoType(field, typeConfig).toGraphQL();
-        const results = `${field}: DTGeoPointTypeV1`;
+        const results = `${field}: DTGeoPointV1`;
         const [customType] = customTypes;
         expect(graphQlTypes).toEqual(results);
-        expect(customType).toInclude('type DTGeoPointTypeV1 {');
+        expect(customType).toInclude('type DTGeoPointV1 {');
         expect(customType).toInclude('lat: String!');
         expect(customType).toInclude('lon: String!');
     });

--- a/packages/data-types/test/types/v1/geo-spec.ts
+++ b/packages/data-types/test/types/v1/geo-spec.ts
@@ -35,7 +35,7 @@ describe('Geo V1', () => {
             type: graphQlTypes,
             customTypes
         } = new GeoType(field, typeConfig).toGraphQL();
-        const results = `${field}: GeoPointType`;
+        const results = `${field}: DTGeoPointTypeV1`;
         const [customType] = customTypes;
         expect(graphQlTypes).toEqual(results);
         expect(customType).toInclude('type DTGeoPointTypeV1 {');

--- a/packages/data-types/test/types/v1/keyword-case-insensitive-spec.ts
+++ b/packages/data-types/test/types/v1/keyword-case-insensitive-spec.ts
@@ -44,6 +44,35 @@ describe('KeywordCaseInsensitive V1', () => {
         expect(esMapping).toEqual(results);
     });
 
+    it('can get proper ES Mappings with a fields hack', () => {
+        const esMapping = new KeywordCaseInsensitive(field, {
+            ...typeConfig,
+            use_fields_hack: true
+        }).toESMapping();
+
+        const results = {
+            mapping: {
+                [field]: {
+                    type: 'keyword',
+                    fields: {
+                        text: {
+                            type: 'text' as ElasticSearchTypes,
+                            analyzer: 'lowercase_keyword_analyzer',
+                        }
+                    }
+                },
+            },
+            analyzer: {
+                lowercase_keyword_analyzer: {
+                    tokenizer: 'keyword',
+                    filter: 'lowercase',
+                },
+            },
+        };
+
+        expect(esMapping).toEqual(results);
+    });
+
     it('can get proper graphql types', () => {
         const graphQlTypes = new KeywordCaseInsensitive(field, typeConfig).toGraphQL();
         const results = { type: `${field}: String`, customTypes: [] };

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/elasticsearch-api",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -17,7 +17,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.21.0",
+        "@terascope/utils": "^0.22.0",
         "bluebird": "^3.7.2",
         "lodash": "^4.17.11"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -26,7 +26,6 @@
         "@terascope/utils": "^0.21.0",
         "ajv": "^6.10.0",
         "nanoid": "^2.1.8",
-        "rambda": "~3.0.1",
         "xlucene-evaluator": "^0.16.3"
     },
     "devDependencies": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "elasticsearch-store",
-    "version": "0.17.3",
+    "version": "0.18.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -23,13 +23,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.21.0",
+        "@terascope/utils": "^0.22.0",
         "ajv": "^6.10.0",
         "nanoid": "^2.1.8",
-        "xlucene-evaluator": "^0.16.3"
+        "xlucene-evaluator": "^0.17.0"
     },
     "devDependencies": {
-        "@terascope/data-types": "^0.10.0",
+        "@terascope/data-types": "^0.11.0",
         "elasticsearch": "^15.4.1"
     },
     "publishConfig": {

--- a/packages/elasticsearch-store/src/index-manager.ts
+++ b/packages/elasticsearch-store/src/index-manager.ts
@@ -80,14 +80,13 @@ export default class IndexManager {
         const esVersion = utils.getESVersion(this.client);
         logger.trace(`Using elasticsearch version ${esVersion}`);
 
-        const mapping: any = utils.getIndexMapping(config);
-
-        const body: any = {
-            settings,
-            mappings: {
-                [config.name]: mapping,
-            },
-        };
+        const body: any = config.data_type.toESMapping({
+            typeName: config.name,
+            version: esVersion,
+            overrides: {
+                settings,
+            }
+        });
 
         if (utils.isTemplatedIndex(config.index_schema)) {
             const templateName = this.formatTemplateName(config);

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -25,9 +25,9 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
             version: 1,
             name: modelConfig.name,
             namespace: options.namespace,
+            data_type: modelConfig.data_type,
             index_schema: {
                 version: modelConfig.version,
-                mapping: utils.addDefaultMapping(modelConfig.mapping),
             },
             data_schema: {
                 schema: utils.addDefaultSchema(modelConfig.schema),
@@ -37,14 +37,6 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
             index_settings: {
                 'index.number_of_shards': ts.isTest ? 1 : 5,
                 'index.number_of_replicas': ts.isTest ? 0 : 2,
-                analysis: {
-                    analyzer: {
-                        lowercase_keyword_analyzer: {
-                            tokenizer: 'keyword',
-                            filter: 'lowercase',
-                        },
-                    },
-                },
             },
         };
 

--- a/packages/elasticsearch-store/src/index-store.ts
+++ b/packages/elasticsearch-store/src/index-store.ts
@@ -68,9 +68,7 @@ export default class IndexStore<T extends Record<string, any>> {
             wait: this._bulkMaxWait,
         });
 
-        if (config.index_schema != null) {
-            this.xluceneTypeConfig = utils.getXLuceneTypesFromMapping(config.index_schema.mapping);
-        }
+        this.xluceneTypeConfig = config.data_type.toXlucene();
 
         if (config.data_schema != null) {
             const validator = utils.makeDataValidator(config.data_schema, this._logger);

--- a/packages/elasticsearch-store/src/interfaces.ts
+++ b/packages/elasticsearch-store/src/interfaces.ts
@@ -1,6 +1,6 @@
 import { Logger, Omit } from '@terascope/utils';
 import { Variables } from 'xlucene-evaluator';
-import { ESTypeMappings, ESIndexSettings } from '@terascope/data-types';
+import { ESIndexSettings, DataType } from '@terascope/data-types';
 
 /** A versioned Index Configuration */
 export interface IndexConfig<T = any> {
@@ -19,6 +19,11 @@ export interface IndexConfig<T = any> {
      * Data Version, this allows multiple versions of an index to exist with the same Schema
      */
     version?: number;
+
+    /**
+     * The DataType of the index (used for generating the mappings)
+     */
+    data_type: DataType;
 
     /**
      * Elasticsearch Index Settings
@@ -80,11 +85,6 @@ export interface IndexConfig<T = any> {
 
 /** Elasticsearch Index Schema, Mapping and Version */
 export interface IndexSchema {
-    /**
-     * The ElasticSearch index mapping
-     */
-    mapping: ESTypeMappings;
-
     /**
      * The version of this particular Schema definition
      */
@@ -219,8 +219,8 @@ export interface IndexModelConfig<T extends IndexModelRecord> {
     /** Name of the Model/Data Type */
     name: string;
 
-    /** the elasticsearch type mappings */
-    mapping: ESTypeMappings;
+    /** The DataType of the model */
+    data_type: DataType;
 
     /** JSON Schema */
     schema: any;

--- a/packages/elasticsearch-store/src/utils/errors.ts
+++ b/packages/elasticsearch-store/src/utils/errors.ts
@@ -1,11 +1,9 @@
-import * as R from 'rambda';
 import * as ts from '@terascope/utils';
 import ajv from 'ajv';
 
-export const getErrorMessages: (errors: ErrorLike[]) => string = R.pipe(
-    R.map(getErrorMessage),
-    R.join(', ')
-);
+export function getErrorMessages(errors: ErrorLike[]): string {
+    return errors.filter(Boolean).map(getErrorMessage).join(',');
+}
 
 export function throwValidationError(errors: ErrorLike[] | null | undefined): string | null {
     if (errors == null) return null;
@@ -27,18 +25,15 @@ export function getErrorMessage(err: ErrorLike): string {
         return err;
     }
 
-    const message: string = R.path(['message'], err) || R.pathOr(defaultErrorMsg, ['msg'], err);
-    const prefix = R.path(['dataPath'], err);
+    const message: string = ts.get(err, ['message']) || ts.get(err, ['msg'], defaultErrorMsg);
+    const prefix = ts.get(err, ['dataPath']);
 
     return `${prefix ? `${prefix} ` : ''}${message}`;
 }
 
-export const getErrorType = R.pathOr('', ['error', 'type']);
-
-export const getStatusCode: (error: ErrorLike) => number = R.pipe(
-    R.ifElse(R.has('statusCode'), R.path(['statusCode']), R.path(['status'])),
-    R.defaultTo(500)
-);
+export function getErrorType(err: any): string {
+    return ts.get(err, ['error', 'type'], '');
+}
 
 export type ErrorLike =
     | {

--- a/packages/elasticsearch-store/src/utils/misc.ts
+++ b/packages/elasticsearch-store/src/utils/misc.ts
@@ -1,40 +1,26 @@
-import * as R from 'rambda';
+import * as ts from '@terascope/utils';
+import { TimeSeriesFormat } from '../interfaces';
 
-export const isNotNil = (input: any) => input != null;
-
-export function getFirstValue<T>(input: { [key: string]: T }): T | undefined {
-    return Object.values(input)[0];
-}
-export function getFirstKey<T>(input: T): (keyof T) | undefined {
-    return Object.keys(input)[0] as keyof T;
+export function getRolloverFrequency(config: any): TimeSeriesFormat {
+    return ts.get(config, ['index_schema', 'rollover_frequency'], 'monthly');
 }
 
-export const getIndexMapping = R.path(['index_schema', 'mapping']);
+export function getSchemaVersion(config: any): number {
+    return ts.get(config, ['index_schema', 'version'], 1);
+}
 
-export const getRolloverFrequency = R.pathOr('monthly', ['index_schema', 'rollover_frequency']);
+export function getSchemaVersionStr(config: any): string {
+    return `s${getSchemaVersion(config)}`;
+}
 
-export const getSchemaVersion = R.pathOr(1, ['index_schema', 'version']);
-export const getSchemaVersionStr: (config: any) => string = R.pipe(
-    getSchemaVersion,
-    R.toString as any,
-    R.prepend('s')
-) as any;
+export function getDataVersion(config: any): number {
+    return ts.get(config, ['version'], 1);
+}
 
-export const getDataVersion = R.pathOr(1, ['version']);
-export const getDataVersionStr: (config: any) => string = R.pipe(
-    getDataVersion,
-    R.toString as any,
-    R.prepend('v')
-) as any;
+export function getDataVersionStr(config: any): string {
+    return `v${getDataVersion(config)}`;
+}
 
-export const formatIndexName: (strs: (string | undefined)[]) => string = R.pipe(
-    R.reject((v: string) => !v) as any,
-    R.map(R.trim),
-    R.join('-')
-);
-
-export const buildNestPath: (paths: (string | undefined)[]) => string = R.pipe(
-    R.reject((v: string) => !v) as any,
-    R.map(R.trim),
-    R.join('.')
-);
+export function formatIndexName(strs: (string | undefined)[]): string {
+    return strs.map(ts.trim).filter(Boolean).join('-');
+}

--- a/packages/elasticsearch-store/src/utils/model.ts
+++ b/packages/elasticsearch-store/src/utils/model.ts
@@ -3,31 +3,6 @@ import * as ts from '@terascope/utils';
 import generate from 'nanoid/generate';
 import nanoid from 'nanoid/async';
 
-/** ElasticSearch Mapping */
-export const mapping: dt.ESTypeMappings = {
-    _all: {
-        enabled: false,
-    },
-    dynamic: false,
-    properties: {
-        _key: {
-            type: 'keyword',
-        },
-        client_id: {
-            type: 'integer',
-        },
-        _deleted: {
-            type: 'boolean',
-        },
-        _created: {
-            type: 'date',
-        },
-        _updated: {
-            type: 'date',
-        },
-    },
-};
-
 /** JSON Schema */
 export const schema = {
     additionalProperties: false,
@@ -57,7 +32,7 @@ export const schema = {
 
 export function makeRecordDataType(arg: {
     name: string;
-    description: string;
+    description?: string;
     fields: dt.TypeConfigFields;
 }): dt.DataType {
     return new dt.DataType({
@@ -71,10 +46,6 @@ export function makeRecordDataType(arg: {
         },
         version: dt.LATEST_VERSION
     }, arg.name, arg.description);
-}
-
-export function addDefaultMapping(input: dt.ESTypeMappings): dt.ESTypeMappings {
-    return mergeDefaults(input, mapping);
 }
 
 export function addDefaultSchema(input: object) {
@@ -119,11 +90,5 @@ export function mergeDefaults<T>(source: T, from: Partial<T>): T {
 }
 
 export function toInstanceName(name: string): string {
-    let s = ts.trim(name);
-    s = s.replace(/[_-\s]+/g, ' ');
-    s = s.replace(/s$/, '');
-    return s
-        .split(' ')
-        .map(ts.firstToUpper)
-        .join('');
+    return ts.getWordParts(name).map(ts.firstToUpper).join('');
 }

--- a/packages/elasticsearch-store/src/utils/validation.ts
+++ b/packages/elasticsearch-store/src/utils/validation.ts
@@ -1,8 +1,6 @@
 import Ajv from 'ajv';
-import * as R from 'rambda';
 import * as es from 'elasticsearch';
 import * as ts from '@terascope/utils';
-import { isNotNil } from './misc';
 import { IndexConfig, IndexSchema, DataSchema } from '../interfaces';
 import { throwValidationError, getErrorMessages } from './errors';
 
@@ -112,19 +110,10 @@ export function isValidClient(input: any): input is es.Client {
     return reqKeys.every((key) => input[key] != null);
 }
 
-type indexFn = (config?: IndexSchema) => boolean;
+export function isTemplatedIndex(config?: IndexSchema): boolean {
+    return ts.has(config, 'mapping') || ts.get(config, 'template') === true;
+}
 
-export const isSimpleIndex: indexFn = R.both(
-    isNotNil,
-    R.both(
-        R.has('mapping'),
-        R.pipe(
-            R.path(['template']),
-            R.isNil
-        )
-    )
-);
-
-export const isTemplatedIndex: indexFn = R.both(isNotNil, R.both(R.has('mapping'), R.propEq('template', true)));
-
-export const isTimeSeriesIndex: indexFn = R.both(isTemplatedIndex, R.propEq('timeseries', true));
+export function isTimeSeriesIndex(config?: IndexSchema): boolean {
+    return isTemplatedIndex(config) && ts.get(config, 'timeseries') === true;
+}

--- a/packages/elasticsearch-store/test/helpers/simple-index.ts
+++ b/packages/elasticsearch-store/test/helpers/simple-index.ts
@@ -1,5 +1,5 @@
 import { Overwrite } from '@terascope/utils';
-import { ESTypeMappings } from '@terascope/data-types';
+import { DataType } from '@terascope/data-types';
 
 export interface SimpleRecord {
     test_id: string;
@@ -20,6 +20,18 @@ SimpleRecord,
     _updated?: Date | string;
 }
 >;
+
+export const dataType = new DataType({
+    fields: {
+        test_id: { type: 'Keyword' },
+        test_keyword: { type: 'Keyword' },
+        test_object: { type: 'Object', indexed: false },
+        test_number: { type: 'Integer' },
+        test_boolean: { type: 'Boolean' },
+        _created: { type: 'Keyword' },
+        _updated: { type: 'Keyword' },
+    }
+});
 
 export const schema = {
     additionalProperties: false,
@@ -51,35 +63,4 @@ export const schema = {
         },
     },
     required: ['test_id', 'test_keyword'],
-};
-
-export const mapping: ESTypeMappings = {
-    _all: {
-        enabled: false,
-    },
-    dynamic: false,
-    properties: {
-        test_id: {
-            type: 'keyword',
-        },
-        test_keyword: {
-            type: 'keyword',
-        },
-        test_object: {
-            type: 'object',
-            enabled: false,
-        },
-        test_boolean: {
-            type: 'boolean',
-        },
-        test_number: {
-            type: 'integer',
-        },
-        _created: {
-            type: 'date',
-        },
-        _updated: {
-            type: 'date',
-        },
-    },
 };

--- a/packages/elasticsearch-store/test/helpers/template-index.ts
+++ b/packages/elasticsearch-store/test/helpers/template-index.ts
@@ -1,5 +1,5 @@
 import { Overwrite } from '@terascope/utils';
-import { ESTypeMappings } from '@terascope/data-types';
+import { DataType } from '@terascope/data-types';
 
 export interface TemplateRecord {
     some_id: string;
@@ -17,6 +17,16 @@ TemplateRecord,
     _updated?: Date | string;
 }
 >;
+
+export const dataType = new DataType({
+    fields: {
+        some_id: { type: 'Keyword' },
+        search_keyword: { type: 'Keyword' },
+        random_number: { type: 'Integer' },
+        _created: { type: 'Keyword' },
+        _updated: { type: 'Keyword' },
+    }
+});
 
 export const schema = {
     additionalProperties: false,
@@ -39,28 +49,4 @@ export const schema = {
         },
     },
     required: ['some_id', 'search_keyword'],
-};
-
-export const mapping: ESTypeMappings = {
-    _all: {
-        enabled: false,
-    },
-    dynamic: false,
-    properties: {
-        some_id: {
-            type: 'keyword',
-        },
-        search_keyword: {
-            type: 'keyword',
-        },
-        random_number: {
-            type: 'integer',
-        },
-        _created: {
-            type: 'date',
-        },
-        _updated: {
-            type: 'date',
-        },
-    },
 };

--- a/packages/elasticsearch-store/test/index-manager-migrate-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-migrate-spec.ts
@@ -14,9 +14,9 @@ describe('IndexManager->migrateIndex()', () => {
         const previousConfig: IndexConfig = {
             namespace: TEST_INDEX_PREFIX,
             name: 'migrate',
+            data_type: simple.dataType,
             index_schema: {
                 version: 1,
-                mapping: simple.mapping,
                 strict: true,
             },
             version: 1,
@@ -30,9 +30,9 @@ describe('IndexManager->migrateIndex()', () => {
         const newConfig: IndexConfig = {
             namespace: TEST_INDEX_PREFIX,
             name: 'migrate',
+            data_type: simple.dataType,
             index_schema: {
                 version: 2,
-                mapping: simple.mapping,
                 strict: true,
             },
             version: 1,

--- a/packages/elasticsearch-store/test/index-manager-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-spec.ts
@@ -1,7 +1,10 @@
 import 'jest-extended';
 import { TSError, debugLogger } from '@terascope/utils';
+import { DataType } from '@terascope/data-types';
 import { IndexManager, IndexConfig } from '../src';
 import { makeClient } from './helpers/elasticsearch';
+
+const dataType = new DataType({}, 'hello');
 
 describe('IndexManager', () => {
     const client = makeClient();
@@ -70,6 +73,7 @@ describe('IndexManager', () => {
                 it('should return a correctly formatted index name', () => {
                     const indexName = indexManager.formatIndexName({
                         name: 'hello',
+                        data_type: dataType,
                     });
 
                     expect(indexName).toEqual('hello-v1-s1');
@@ -81,6 +85,7 @@ describe('IndexManager', () => {
                     const indexName = indexManager.formatIndexName({
                         name: 'hello',
                         namespace: 'test',
+                        data_type: dataType,
                     });
 
                     expect(indexName).toEqual('test-hello-v1-s1');
@@ -92,9 +97,9 @@ describe('IndexManager', () => {
                     const indexName = indexManager.formatIndexName(
                         {
                             name: 'hello',
+                            data_type: dataType,
                             index_schema: {
                                 version: 1,
-                                mapping: { properties: {} },
                                 template: true,
                                 timeseries: true,
                             },
@@ -112,11 +117,9 @@ describe('IndexManager', () => {
                 it('should return a correctly formatted index name', () => {
                     const indexName = indexManager.formatIndexName({
                         name: 'hello',
+                        data_type: dataType,
                         index_schema: {
                             version: 1,
-                            mapping: {
-                                properties: {},
-                            },
                             template: true,
                             timeseries: true,
                         },
@@ -131,11 +134,9 @@ describe('IndexManager', () => {
                     const indexName = indexManager.formatIndexName({
                         name: 'hello',
                         version: 3,
+                        data_type: dataType,
                         index_schema: {
                             version: 2,
-                            mapping: {
-                                properties: {},
-                            },
                         },
                     });
 
@@ -149,6 +150,7 @@ describe('IndexManager', () => {
                 it('should return a correctly formatted template name', () => {
                     const templateName = indexManager.formatTemplateName({
                         name: 'hello',
+                        data_type: dataType,
                     });
 
                     expect(templateName).toEqual('hello-v1');
@@ -160,6 +162,7 @@ describe('IndexManager', () => {
                     const templateName = indexManager.formatTemplateName({
                         name: 'hello',
                         namespace: 'test',
+                        data_type: dataType,
                     });
 
                     expect(templateName).toEqual('test-hello-v1');
@@ -171,6 +174,7 @@ describe('IndexManager', () => {
                     const templateName = indexManager.formatTemplateName({
                         name: 'hello',
                         version: 2,
+                        data_type: dataType,
                     });
 
                     expect(templateName).toEqual('hello-v2');

--- a/packages/elasticsearch-store/test/index-model-spec.ts
+++ b/packages/elasticsearch-store/test/index-model-spec.ts
@@ -18,7 +18,10 @@ describe('IndexModel', () => {
     const dataType = makeRecordDataType({
         name: 'ExampleModel',
         fields: {
-            name: { type: 'KeywordCaseInsensitive' },
+            name: {
+                type: 'KeywordCaseInsensitive',
+                use_fields_hack: true
+            },
             type: { type: 'Keyword' },
             config: { type: 'Object', indexed: false },
         }

--- a/packages/elasticsearch-store/test/index-model-spec.ts
+++ b/packages/elasticsearch-store/test/index-model-spec.ts
@@ -3,7 +3,7 @@ import { Client } from 'elasticsearch';
 import { QueryAccess } from 'xlucene-evaluator';
 import { times, TSError, AnyObject } from '@terascope/utils';
 import {
-    IndexModel, IndexModelRecord, IndexModelConfig, IndexModelOptions
+    IndexModel, IndexModelRecord, IndexModelConfig, IndexModelOptions, makeRecordDataType
 } from '../src';
 import { makeClient, cleanupIndexStore } from './helpers/elasticsearch';
 import { TEST_INDEX_PREFIX } from './helpers/config';
@@ -15,29 +15,19 @@ describe('IndexModel', () => {
         config: AnyObject;
     }
 
+    const dataType = makeRecordDataType({
+        name: 'ExampleModel',
+        fields: {
+            name: { type: 'KeywordCaseInsensitive' },
+            type: { type: 'Keyword' },
+            config: { type: 'Object', indexed: false },
+        }
+    });
+
     const client = makeClient();
     const exampleConfig: IndexModelConfig<ExampleRecord> = {
         name: 'example_model',
-        mapping: {
-            properties: {
-                name: {
-                    type: 'keyword',
-                    fields: {
-                        text: {
-                            type: 'text',
-                            analyzer: 'lowercase_keyword_analyzer',
-                        },
-                    },
-                },
-                type: {
-                    type: 'keyword',
-                },
-                config: {
-                    type: 'object',
-                    enabled: false,
-                },
-            },
-        },
+        data_type: dataType,
         schema: {
             properties: {
                 name: {

--- a/packages/elasticsearch-store/test/index-store-spec.ts
+++ b/packages/elasticsearch-store/test/index-store-spec.ts
@@ -4,7 +4,7 @@ import {
 } from '@terascope/utils';
 import { Translator } from 'xlucene-evaluator';
 import {
-    SimpleRecord, SimpleRecordInput, mapping, schema
+    SimpleRecord, SimpleRecordInput, dataType, schema
 } from './helpers/simple-index';
 import { makeClient, cleanupIndexStore } from './helpers/elasticsearch';
 import { TEST_INDEX_PREFIX } from './helpers/config';
@@ -33,9 +33,9 @@ describe('IndexStore', () => {
     const index = `${TEST_INDEX_PREFIX}store-v1-s1`;
     const config: IndexConfig = {
         name: `${TEST_INDEX_PREFIX}store`,
+        data_type: dataType,
         index_schema: {
             version: 1,
-            mapping,
             strict: true,
         },
         version: 1,

--- a/packages/elasticsearch-store/test/utils-spec.ts
+++ b/packages/elasticsearch-store/test/utils-spec.ts
@@ -1,50 +1,16 @@
 import 'jest-extended';
 import { TSError } from '@terascope/utils';
 import {
-    isSimpleIndex,
     isTemplatedIndex,
     isTimeSeriesIndex,
     validateIndexConfig,
-    getFirstValue,
-    getFirstKey,
-    getXLuceneTypesFromMapping,
 } from '../src/utils';
 
 describe('Elasticsearch Store Utils', () => {
-    describe('#isSimpleIndex', () => {
-        it('should return true when given a simple index', () => {
-            expect(
-                isSimpleIndex({
-                    mapping: { properties: {} },
-                    version: 1,
-                })
-            ).toBeTrue();
-        });
-
-        it('should return false when given missing map', () => {
-            expect(
-                isSimpleIndex({
-                    version: 'v1',
-                } as any)
-            ).toBeFalse();
-        });
-
-        it('should return false when given a templated index', () => {
-            expect(
-                isSimpleIndex({
-                    mapping: { properties: {} },
-                    template: true,
-                    version: 1,
-                })
-            ).toBeFalse();
-        });
-    });
-
     describe('#isTemplatedIndex', () => {
         it('should return false when given a simple index', () => {
             expect(
                 isTemplatedIndex({
-                    mapping: { properties: {} },
                     template: false,
                     version: 1,
                 })
@@ -62,7 +28,6 @@ describe('Elasticsearch Store Utils', () => {
         it('should return true when given a templated index', () => {
             expect(
                 isTemplatedIndex({
-                    mapping: { properties: {} },
                     template: true,
                     version: 1,
                 })
@@ -72,9 +37,6 @@ describe('Elasticsearch Store Utils', () => {
         it('should return true when given a timeseries index', () => {
             expect(
                 isTemplatedIndex({
-                    mapping: {
-                        properties: {},
-                    },
                     template: true,
                     timeseries: true,
                     version: 1,
@@ -87,9 +49,6 @@ describe('Elasticsearch Store Utils', () => {
         it('should return false when given a simple index', () => {
             expect(
                 isTimeSeriesIndex({
-                    mapping: {
-                        properties: {},
-                    },
                     template: false,
                     version: 1,
                 })
@@ -107,7 +66,6 @@ describe('Elasticsearch Store Utils', () => {
         it('should return false when given a templated index', () => {
             expect(
                 isTimeSeriesIndex({
-                    mapping: { properties: {} },
                     template: true,
                     version: 1,
                 })
@@ -253,106 +211,6 @@ describe('Elasticsearch Store Utils', () => {
                         index: 'hello',
                     });
                 }).toThrowWithMessage(TSError, /Data Version must be greater than 0, got "-8"/);
-            });
-        });
-    });
-
-    describe('#getFirstValue', () => {
-        describe('when given an object', () => {
-            it('should return the first value', () => {
-                const obj = { key1: 1, key2: 2 };
-                expect(getFirstValue(obj)).toEqual(1);
-            });
-        });
-
-        describe('when given an empty object', () => {
-            it('should return nil', () => {
-                expect(getFirstValue({})).toBeNil();
-            });
-        });
-    });
-
-    describe('#getFirstKey', () => {
-        describe('when given an object', () => {
-            it('should return the first value', () => {
-                const obj = { key1: 1, key2: 2 };
-                expect(getFirstKey(obj)).toEqual('key1');
-            });
-        });
-
-        describe('when given an empty object', () => {
-            it('should return nil', () => {
-                expect(getFirstKey({})).toBeNil();
-            });
-        });
-    });
-
-    describe('#getXLuceneTypesFromMapping', () => {
-        describe('when given a mapping', () => {
-            const mapping = {
-                _all: {
-                    enabled: false,
-                },
-                dynamic: false,
-                properties: {
-                    test_keyword: {
-                        type: 'keyword',
-                    },
-                    test_text: {
-                        type: 'text',
-                    },
-                    test_numeric: {
-                        type: 'integer',
-                    },
-                    test_boolean: {
-                        type: 'boolean',
-                    },
-                    test_integer_range: {
-                        type: 'integer_range',
-                    },
-                    test_date: {
-                        type: 'date',
-                    },
-                    test_object: {
-                        properties: {
-                            nested_ip: {
-                                type: 'ip',
-                            },
-                            nested_geo: {
-                                properties: {
-                                    test_location: {
-                                        type: 'geo_point',
-                                    },
-                                },
-                            },
-                        },
-                    },
-                    test_ip: {
-                        type: 'ip',
-                    },
-                    test_geo_point: {
-                        type: 'geo_point',
-                    },
-                    test_geo_shape: {
-                        type: 'geo_shape',
-                    },
-                },
-            };
-
-            it('should return test_keyword:term', () => {
-                const result = getXLuceneTypesFromMapping(mapping);
-                expect(result).toEqual({
-                    test_boolean: 'boolean',
-                    test_date: 'date',
-                    'test_object.nested_ip': 'ip',
-                    'test_object.nested_geo.test_location': 'geo',
-                    test_keyword: 'string',
-                    test_numeric: 'integer',
-                    test_ip: 'ip',
-                    test_geo_point: 'geo',
-                    test_geo_shape: 'geo',
-                    test_text: 'string'
-                });
             });
         });
     });

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/job-components",
-    "version": "0.26.0",
+    "version": "0.27.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.7",
-        "@terascope/utils": "^0.21.0",
+        "@terascope/utils": "^0.22.0",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^3.3.3"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/scripts",
-    "version": "0.10.1",
+    "version": "0.11.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.18.5",
-        "@terascope/utils": "^0.21.0",
+        "@terascope/utils": "^0.22.0",
         "@types/is-ci": "^2.0.0",
         "codecov": "^3.5.0",
         "execa": "^4.0.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "terafoundation",
-    "version": "0.15.1",
+    "version": "0.16.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.21.0",
+        "@terascope/utils": "^0.22.0",
         "aws-sdk": "^2.596.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.12",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-cli",
-    "version": "0.13.0",
+    "version": "0.14.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.6.0",
-        "@terascope/utils": "^0.21.0",
+        "@terascope/utils": "^0.22.0",
         "archiver": "^3.0.0",
         "bluebird": "^3.7.2",
         "chalk": "^3.0.0",
@@ -51,7 +51,7 @@
         "request": "^2.88.0",
         "request-promise": "^4.2.5",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.12.1",
+        "teraslice-client-js": "^0.13.0",
         "tmp": "^0.1.0",
         "tty-table": "^2.8.4",
         "yargs": "^15.1.0",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-client-js",
-    "version": "0.12.1",
+    "version": "0.13.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -29,7 +29,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.26.0",
+        "@terascope/job-components": "^0.27.0",
         "auto-bind": "^4.0.0",
         "got": "^9.6.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-messaging",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/queue": "^1.1.7",
-        "@terascope/utils": "^0.21.0",
+        "@terascope/utils": "^0.22.0",
         "ms": "^2.1.2",
         "nanoid": "^2.1.8",
         "p-event": "^4.1.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "description": "A testing harness to simplify testing Teraslice processors and operations.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-op-test-harness#readme",
     "bugs": {
@@ -17,7 +17,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.26.0",
+        "@terascope/job-components": "^0.27.0",
         "bluebird": "^3.7.2",
         "lodash": "^4.17.11"
     },

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/teraslice-state-storage",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.3.0",
-        "@terascope/utils": "^0.21.0",
+        "@terascope/elasticsearch-api": "^2.4.0",
+        "@terascope/utils": "^0.22.0",
         "bluebird": "^3.7.2",
         "mnemonist": "^0.32.0"
     },

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "teraslice-test-harness",
-    "version": "0.11.0",
+    "version": "0.12.0",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {
@@ -30,8 +30,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.26.0",
-        "@terascope/teraslice-op-test-harness": "^1.10.0",
+        "@terascope/job-components": "^0.27.0",
+        "@terascope/teraslice-op-test-harness": "^1.11.0",
         "lodash": "^4.17.11"
     },
     "devDependencies": {},

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -32,11 +32,11 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.3.0",
-        "@terascope/job-components": "^0.26.0",
+        "@terascope/elasticsearch-api": "^2.4.0",
+        "@terascope/job-components": "^0.27.0",
         "@terascope/queue": "^1.1.7",
-        "@terascope/teraslice-messaging": "^0.5.0",
-        "@terascope/utils": "^0.21.0",
+        "@terascope/teraslice-messaging": "^0.6.0",
+        "@terascope/utils": "^0.22.0",
         "async-mutex": "^0.1.3",
         "barbe": "^3.0.15",
         "body-parser": "^1.19.0",
@@ -58,11 +58,11 @@
         "shortid": "^2.2.14",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.15.1",
+        "terafoundation": "^0.16.0",
         "uuid": "^3.3.3"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.10.0",
+        "@terascope/teraslice-op-test-harness": "^1.11.0",
         "archiver": "^3.0.0",
         "bufferstreams": "^3.0.0",
         "chance": "^1.1.4",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-transforms",
-    "version": "0.29.3",
+    "version": "0.30.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.21.0",
+        "@terascope/utils": "^0.22.0",
         "@types/graphlib": "^2.1.5",
         "@types/shortid": "^0.0.29",
         "awesome-phonenumber": "^2.24.0",
@@ -44,7 +44,7 @@
         "shortid": "^2.2.14",
         "valid-url": "^1.0.9",
         "validator": "^12.1.0",
-        "xlucene-evaluator": "^0.16.3",
+        "xlucene-evaluator": "^0.17.0",
         "yargs": "^15.1.0"
     },
     "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/utils",
-    "version": "0.21.0",
+    "version": "0.22.0",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -16,6 +16,7 @@ export function flattenDeep<T>(val: ListOfRecursiveArraysOrValues<T>): T[] {
 
 /** A simplified implemation of lodash castArray */
 export function castArray<T>(input: T|T[]): T[] {
+    if (input == null) return [];
     if (Array.isArray(input)) return input;
     return [input];
 }
@@ -36,9 +37,9 @@ export function withoutNil<T extends object>(input: T): WithoutNil<T> {
     // @ts-ignore
     const result: WithoutNil<T> = {};
 
-    for (const [key, val] of Object.entries(input)) {
-        if (val != null) {
-            result[key] = val;
+    for (const key of Object.keys(input).sort()) {
+        if (input[key] != null) {
+            result[key] = input[key];
         }
     }
 
@@ -46,7 +47,8 @@ export function withoutNil<T extends object>(input: T): WithoutNil<T> {
 }
 
 /** A native implemation of lodash uniq */
-export function uniq<T>(arr: T[]): T[] {
+export function uniq<T>(arr: T[]|Set<T>): T[] {
+    if (arr instanceof Set) return [...arr];
     return [...new Set(arr)];
 }
 
@@ -95,7 +97,7 @@ export function includes(input: any, key: string): boolean {
     if (Array.isArray(input) || typeof input === 'string') return input.includes(key);
     if (typeof input.has === 'function') return input.has(key);
     if (typeof input === 'object') {
-        return Object.keys(input).includes(key);
+        return key in input;
     }
     return false;
 }
@@ -105,5 +107,5 @@ export function includes(input: any, key: string): boolean {
  * else if it will return the input
  */
 export function getFirst<T>(input: T | T[]): T {
-    return Array.isArray(input) ? input[0] : input;
+    return castArray(input)[0];
 }

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -4,8 +4,15 @@ import unset from 'lodash.unset';
 import cloneDeep from 'lodash.clonedeep';
 import isPlainObject from 'is-plain-object';
 
+export function getFirstValue<T>(input: { [key: string]: T }): T | undefined {
+    return Object.values(input)[0];
+}
+export function getFirstKey<T>(input: T): (keyof T) | undefined {
+    return Object.keys(input)[0] as keyof T;
+}
+
 /** Check in input has a key */
-export function has(data?: object, key: string|number|symbol): boolean {
+export function has(data: object|undefined, key: string|number|symbol): boolean {
     if (data == null || typeof data !== 'object') return false;
     if (data instanceof Set || data instanceof Map) {
         if (key in data) return true;

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -5,7 +5,7 @@ import cloneDeep from 'lodash.clonedeep';
 import isPlainObject from 'is-plain-object';
 
 /** Check in input has a key */
-export function has(data: object, key: string|number|symbol): boolean {
+export function has(data?: object, key: string|number|symbol): boolean {
     if (data == null || typeof data !== 'object') return false;
     if (data instanceof Set || data instanceof Map) {
         if (key in data) return true;

--- a/packages/utils/src/strings.ts
+++ b/packages/utils/src/strings.ts
@@ -198,22 +198,25 @@ export function getWordParts(input: string): string[] {
 }
 
 export function toCamelCase(input: string): string {
-    return getWordParts(input).map((str, i) => {
+    return firstToLower(getWordParts(input).map((str, i) => {
         if (i === 0) return str;
         return firstToUpper(str);
-    }).join('');
+    }).join(''));
 }
 
 export function toPascalCase(input: string): string {
-    return getWordParts(input).map(firstToUpper).join('');
+    return firstToUpper(getWordParts(input).map((str, i) => {
+        if (i === 0) return str;
+        return firstToUpper(str);
+    }).join(''));
 }
 
 export function toKebabCase(input: string): string {
-    return getWordParts(input).map(firstToUpper).join('-').toLowerCase();
+    return getWordParts(input).join('-').toLowerCase();
 }
 
 export function toSnakeCase(input: string): string {
-    return getWordParts(input).map(firstToUpper).join('_').toLowerCase();
+    return getWordParts(input).join('_').toLowerCase();
 }
 
 /**
@@ -237,17 +240,27 @@ export function toSafeString(input: string): string {
 
     return s;
 }
+function _replaceFirstWordChar(str: string, fn: (char: string) => string): string {
+    let found = false;
+    return str.split('').map((s) => {
+        if (!found && wordChars[s]) {
+            found = true;
+            return fn(s);
+        }
+        return s;
+    }).join('');
+}
 
 /** Change first character in string to upper case */
 export function firstToUpper(str: string): string {
     if (!str) return '';
-    return `${getFirstChar(str).toUpperCase()}${str.slice(1)}`;
+    return _replaceFirstWordChar(str, (char) => char.toUpperCase());
 }
 
 /** Change first character in string to lower case */
 export function firstToLower(str: string): string {
     if (!str) return '';
-    return `${getFirstChar(str).toLowerCase()}${str.slice(1)}`;
+    return _replaceFirstWordChar(str, (char) => char.toLowerCase());
 }
 
 export function getFirstChar(input: string): string {

--- a/packages/utils/src/strings.ts
+++ b/packages/utils/src/strings.ts
@@ -67,6 +67,155 @@ export function truncate(str: string, len: number): string {
     return str.length >= len ? `${str.slice(0, sliceLen)} ...` : str;
 }
 
+const lowerChars = {
+    a: true,
+    b: true,
+    c: true,
+    d: true,
+    e: true,
+    f: true,
+    g: true,
+    h: true,
+    i: true,
+    j: true,
+    k: true,
+    l: true,
+    m: true,
+    n: true,
+    o: true,
+    p: true,
+    q: true,
+    r: true,
+    s: true,
+    t: true,
+    u: true,
+    v: true,
+    w: true,
+    x: true,
+    y: true,
+    z: true,
+};
+
+const upperChars = {
+    A: true,
+    B: true,
+    C: true,
+    D: true,
+    E: true,
+    F: true,
+    G: true,
+    H: true,
+    I: true,
+    J: true,
+    K: true,
+    L: true,
+    M: true,
+    N: true,
+    O: true,
+    P: true,
+    Q: true,
+    R: true,
+    S: true,
+    T: true,
+    U: true,
+    V: true,
+    W: true,
+    X: true,
+    Y: true,
+    Z: true,
+};
+
+const numChars = {
+    0: true,
+    1: true,
+    2: true,
+    3: true,
+    4: true,
+    5: true,
+    6: true,
+    7: true,
+    8: true,
+    9: true,
+};
+
+const sepChars = {
+    ' ': true,
+    _: true,
+    '-': true,
+};
+
+const wordChars = {
+    ...lowerChars,
+    ...upperChars,
+    ...numChars,
+};
+
+/**
+ * Split a string and get the word parts
+*/
+export function getWordParts(input: string): string[] {
+    if (!isString(input)) {
+        throw new Error(`Expected string, got "${input}"`);
+    }
+
+    const parts: string[] = [];
+
+    let word = '';
+    let started = false;
+
+    for (let i = 0; i < input.length; i++) {
+        const char = input.charAt(i);
+        const nextChar = input.charAt(i + 1);
+
+        if (!started && char === '_') {
+            if (nextChar === '_' || wordChars[nextChar]) {
+                word += char;
+                continue;
+            }
+        }
+
+        started = true;
+
+        if (char && wordChars[char]) {
+            word += char;
+        }
+
+        if (sepChars[nextChar]) {
+            parts.push(word);
+            word = '';
+        }
+
+        if (upperChars[nextChar]) {
+            const nextNextChar = input.charAt(i + 2);
+            if (lowerChars[nextNextChar]) {
+                parts.push(word);
+                word = '';
+            }
+        }
+    }
+
+    return parts.concat(word).filter(Boolean);
+}
+
+export function toCamelCase(input: string): string {
+    return getWordParts(input).map((str, i) => {
+        if (i === 0) return str;
+        return firstToUpper(str);
+    }).join('');
+}
+
+export function toPascalCase(input: string): string {
+    return getWordParts(input).map(firstToUpper).join('');
+}
+
+export function toKebabCase(input: string): string {
+    return getWordParts(input).map(firstToUpper).join('-').toLowerCase();
+}
+
+export function toSnakeCase(input: string): string {
+    return getWordParts(input).map(firstToUpper).join('_').toLowerCase();
+}
+
 /**
  * Make a string url/elasticsearch safe.
  * safeString converts the string to lower case,
@@ -85,20 +234,24 @@ export function toSafeString(input: string): string {
     s = s.replace(/\s/g, whitespaceChar);
     const reg = new RegExp('[.+#*?"<>|/\\\\]', 'g');
     s = s.replace(reg, '');
+
     return s;
 }
 
 /** Change first character in string to upper case */
 export function firstToUpper(str: string): string {
+    if (!str) return '';
     return `${getFirstChar(str).toUpperCase()}${str.slice(1)}`;
 }
 
 /** Change first character in string to lower case */
 export function firstToLower(str: string): string {
+    if (!str) return '';
     return `${getFirstChar(str).toLowerCase()}${str.slice(1)}`;
 }
 
 export function getFirstChar(input: string): string {
+    if (!input) return '';
     return trim(input).charAt(0);
 }
 

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -7,6 +7,9 @@ import {
     trimAndToLower
 } from './strings';
 
+export const isNil = (input: any) => input == null;
+export const isNotNil = (input: any) => input != null;
+
 /** Check if an input is empty, similar to lodash.isEmpty */
 export function isEmpty<T>(val?: T): val is undefined {
     const _val = val as any;

--- a/packages/utils/test/objects-spec.ts
+++ b/packages/utils/test/objects-spec.ts
@@ -2,7 +2,9 @@ import 'jest-extended';
 import {
     DataEntity,
     isPlainObject,
-    has
+    has,
+    getFirstKey,
+    getFirstValue
 } from '../src';
 
 describe('Objects', () => {
@@ -103,6 +105,36 @@ describe('Objects', () => {
             expect(has({ a: 'b' }, [] as any)).toBeFalse();
             expect(has({ a: 'b' }, NaN)).toBeFalse();
             expect(has({ a: 'b' }, (() => {}) as any)).toBeFalse();
+        });
+    });
+
+    describe('getFirstValue', () => {
+        describe('when given an object', () => {
+            it('should return the first value', () => {
+                const obj = { key1: 1, key2: 2 };
+                expect(getFirstValue(obj)).toEqual(1);
+            });
+        });
+
+        describe('when given an empty object', () => {
+            it('should return nil', () => {
+                expect(getFirstValue({})).toBeNil();
+            });
+        });
+    });
+
+    describe('getFirstKey', () => {
+        describe('when given an object', () => {
+            it('should return the first value', () => {
+                const obj = { key1: 1, key2: 2 };
+                expect(getFirstKey(obj)).toEqual('key1');
+            });
+        });
+
+        describe('when given an empty object', () => {
+            it('should return nil', () => {
+                expect(getFirstKey({})).toBeNil();
+            });
         });
     });
 });

--- a/packages/utils/test/strings-spec.ts
+++ b/packages/utils/test/strings-spec.ts
@@ -7,7 +7,11 @@ import {
     matchAll,
     match,
     formatRegex,
-    FormatRegexResult
+    FormatRegexResult,
+    toCamelCase,
+    toPascalCase,
+    toSnakeCase,
+    toKebabCase
 } from '../src';
 
 describe('String Utils', () => {
@@ -46,6 +50,58 @@ describe('String Utils', () => {
             ['foo _ bar   baz 123', ['foo', 'bar', 'baz', '123']],
         ])('should convert %s to be %s', (input: any, expected: any) => {
             expect(getWordParts(input)).toStrictEqual(expected);
+        });
+    });
+
+    describe('toCamelCase', () => {
+        test.each([
+            ['_key', '_key'],
+            ['hello-there', 'helloThere'],
+            ['helloThere', 'helloThere'],
+            ['HelloThere', 'helloThere'],
+            ['hello_there', 'helloThere'],
+            ['hello there', 'helloThere'],
+        ])('should convert %s to be %s', (input: any, expected: any) => {
+            expect(toCamelCase(input)).toEqual(expected);
+        });
+    });
+
+    describe('toPascalCase', () => {
+        test.each([
+            ['_key', '_Key'],
+            ['hello-there', 'HelloThere'],
+            ['helloThere', 'HelloThere'],
+            ['HelloThere', 'HelloThere'],
+            ['hello_there', 'HelloThere'],
+            ['hello there', 'HelloThere'],
+        ])('should convert %s to be %s', (input: any, expected: any) => {
+            expect(toPascalCase(input)).toEqual(expected);
+        });
+    });
+
+    describe('toKebabCase', () => {
+        test.each([
+            ['_key', '_key'],
+            ['hello-there', 'hello-there'],
+            ['helloThere', 'hello-there'],
+            ['HelloThere', 'hello-there'],
+            ['hello_there', 'hello-there'],
+            ['hello there', 'hello-there'],
+        ])('should convert %s to be %s', (input: any, expected: any) => {
+            expect(toKebabCase(input)).toEqual(expected);
+        });
+    });
+
+    describe('toSnakeCase', () => {
+        test.each([
+            ['_key', '_key'],
+            ['hello-there', 'hello_there'],
+            ['helloThere', 'hello_there'],
+            ['HelloThere', 'hello_there'],
+            ['hello_there', 'hello_there'],
+            ['hello there', 'hello_there'],
+        ])('should convert %s to be %s', (input: any, expected: any) => {
+            expect(toSnakeCase(input)).toEqual(expected);
         });
     });
 

--- a/packages/utils/test/strings-spec.ts
+++ b/packages/utils/test/strings-spec.ts
@@ -1,7 +1,13 @@
 import 'jest-extended';
-// @ts-ignore
 import {
-    toSafeString, unescapeString, escapeString, matchAll, match, formatRegex, FormatRegexResult
+    toSafeString,
+    unescapeString,
+    getWordParts,
+    escapeString,
+    matchAll,
+    match,
+    formatRegex,
+    FormatRegexResult
 } from '../src';
 
 describe('String Utils', () => {
@@ -19,6 +25,27 @@ describe('String Utils', () => {
             // @ts-ignore
         ])('should convert %s to be %s', (input: any, expected: any) => {
             expect(toSafeString(input)).toEqual(expected);
+        });
+    });
+
+    describe('getWordParts', () => {
+        test.each([
+            ['hello-there', ['hello', 'there']],
+            ['++_--hello', ['hello']],
+            ['GraphQL', ['GraphQL']],
+            ['Howdy-Hi?+ you', ['Howdy', 'Hi', 'you']],
+            ['123', ['123']],
+            ['DataTypes', ['Data', 'Types']],
+            ['Data_Type', ['Data', 'Type']],
+            ['Foo Bar', ['Foo', 'Bar']],
+            ['foo_bar', ['foo', 'bar']],
+            ['_key', ['_key']],
+            ['-key', ['key']],
+            ['__example', ['__example']],
+            ['SomeASTNode123', ['SomeAST', 'Node123']],
+            ['foo _ bar   baz 123', ['foo', 'bar', 'baz', '123']],
+        ])('should convert %s to be %s', (input: any, expected: any) => {
+            expect(getWordParts(input)).toStrictEqual(expected);
         });
     });
 

--- a/packages/xlucene-evaluator/package.json
+++ b/packages/xlucene-evaluator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xlucene-evaluator",
-    "version": "0.16.3",
+    "version": "0.17.0",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-evaluator#readme",
     "repository": {
@@ -29,7 +29,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.21.0",
+        "@terascope/utils": "^0.22.0",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-contains": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9393,11 +9393,6 @@ quickselect@^1.0.1:
   resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-1.1.1.tgz#852e412ce418f237ad5b660d70cffac647ae94c2"
   integrity sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==
 
-rambda@~3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/rambda/-/rambda-3.0.1.tgz#d35c6eba5f101510ecf98fc444164c411be6e6a3"
-  integrity sha512-wwH5lCnWHriTYAmyj12gmiVu7AaFZOanBp/iXsyTR8meZ9kaLOrwfSSwAx3dUK6Lk++0z5zh0MHV/HdSvw7gzQ==
-
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"


### PR DESCRIPTION
- Make sure that input types are correctly created in data-types
- Makes `elasticsearch-store` `DataTypes` more heavily
- Adds temporary flag `use_fields_hack` for `KeywordCaseInsenstive` to work with metadata until we have a good solution.
- Add defaults for version and fields when making a data type so its easier to create an empty one
- Fix misc issues in utils
- Add misc utils from `elasticsearch-store` to `@terascope/utils`
- Remove the use of `rambda` 
- Misc fixes

Resolves #1459