### PR TITLE
v0.63.2 - Fix updating _updated date on execution / job

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "0.63.1",
+    "version": "0.63.2",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.11.1",
+    "version": "0.12.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {

--- a/packages/data-types/src/data-type.ts
+++ b/packages/data-types/src/data-type.ts
@@ -4,7 +4,7 @@ import { formatSchema, formatGQLComment } from './graphql-helper';
 import * as i from './interfaces';
 import BaseType from './types/base-type';
 import * as utils from './utils';
-import { getTypes, LATEST_VERSION } from './types';
+import { getTypes, LATEST_VERSION, getGroupedFields } from './types';
 
 /**
  * A DataType is used to define the structure of data with version support
@@ -19,8 +19,8 @@ export class DataType {
     readonly description?: string;
     readonly fields: i.TypeConfigFields;
     readonly version: i.AvailableVersion;
-    /** Excludes the nested fields (useful testing) */
-    readonly baseFields: i.TypeConfigFields = {};
+    /** An object of base fields with their child fields */
+    readonly groupedFields: i.GroupedFields;
 
     private readonly _types: BaseType[];
 
@@ -94,7 +94,8 @@ export class DataType {
         this.fields = fields;
         this.version = version;
 
-        this._types = getTypes(fields, version);
+        this.groupedFields = getGroupedFields(fields);
+        this._types = getTypes(fields, this.groupedFields, version);
     }
 
     /**

--- a/packages/data-types/src/interfaces.ts
+++ b/packages/data-types/src/interfaces.ts
@@ -12,6 +12,7 @@ export type GraphQLOptions = {
     description?: string;
     customTypes?: string[];
     references?: string[];
+    useSnakeCase?: boolean;
     createInputType?: boolean;
     includeAllInputFields?: boolean;
 };
@@ -21,6 +22,7 @@ export type MergeGraphQLOptions = {
     references?: GraphQLTypeReferences;
     customTypes?: string[];
     createInputTypes?: boolean;
+    useSnakeCase?: boolean;
     includeAllInputFields?: boolean;
 };
 

--- a/packages/data-types/src/interfaces.ts
+++ b/packages/data-types/src/interfaces.ts
@@ -1,6 +1,9 @@
 import { AnyObject } from '@terascope/utils';
 import BaseType from './types/base-type';
 
+/** An object of base fields with their child fields */
+export type GroupedFields = Record<string, string[]>;
+
 export type GraphQLTypesResult = {
     baseType: string;
     inputType?: string;

--- a/packages/data-types/src/types/base-type.ts
+++ b/packages/data-types/src/types/base-type.ts
@@ -10,20 +10,29 @@ export interface IBaseType {
     new(field: string, config: FieldTypeConfig): BaseType;
 }
 
+export type ToGraphQLOptions = {
+    typeName?: string;
+    isInput?: boolean;
+    includePrivate?: boolean;
+    useSnakeCase?: boolean;
+};
+
 export default abstract class BaseType {
     readonly field: string;
     readonly config: FieldTypeConfig;
+    readonly version: number;
 
-    constructor(field: string, config: FieldTypeConfig) {
+    constructor(field: string, config: FieldTypeConfig, version = 1) {
         if (!field || !ts.isString(field)) {
             throw new ts.TSError('A field must be provided and must be of type string');
         }
+        this.version = version;
         this.field = field;
         this.config = config;
     }
 
     abstract toESMapping(version?: number): TypeESMapping;
-    abstract toGraphQL(typeName?: string, isInput?: boolean, includePrivate?: boolean): GraphQLType;
+    abstract toGraphQL(options?: ToGraphQLOptions): GraphQLType;
     abstract toXlucene(): TypeConfig;
 
     protected _formatGql(
@@ -43,19 +52,13 @@ export default abstract class BaseType {
         };
     }
 
-    _formatGQLTypeName(
-        typeName: string,
-        isInput?: boolean,
-        includeField?: boolean,
-        version?: number
-    ): string {
+    _formatGQLTypeName(typeName: string, isInput?: boolean, inputSuffix = 'Input'): string {
         return [
             'DT',
-            (typeName),
-            includeField ? ts.firstToUpper(this.field) : '',
-            isInput ? 'Input' : '',
-            `V${version ?? 1}`
-        ].filter(Boolean).join('');
+            typeName,
+            isInput ? inputSuffix : '',
+            `V${this.version}`
+        ].join('');
     }
 }
 

--- a/packages/data-types/src/types/group-type.ts
+++ b/packages/data-types/src/types/group-type.ts
@@ -1,16 +1,15 @@
 import { TypeConfig } from 'xlucene-evaluator';
+import { firstToUpper } from '@terascope/utils';
 import * as i from '../interfaces';
-import BaseType from './base-type';
+import BaseType, { ToGraphQLOptions } from './base-type';
 
 export type NestedTypes = { [field: string]: BaseType };
 
 export default class GroupType extends BaseType {
     readonly types: NestedTypes;
-    readonly version: number;
 
     constructor(field: string, version: number, types: NestedTypes) {
-        super(field, types[field].config);
-        this.version = version;
+        super(field, types[field].config, version);
         this.types = types;
     }
 
@@ -47,12 +46,15 @@ export default class GroupType extends BaseType {
         };
     }
 
-    toGraphQL(typeName?: string, isInput?: boolean, includePrivate?: boolean) {
-        const customTypeName: string = this._formatGQLTypeName(
-            typeName || 'Object',
-            isInput,
-            true,
-            this.version,
+    toGraphQL(options: ToGraphQLOptions = {}) {
+        const { typeName = 'Object', isInput, includePrivate } = options;
+
+        const customTypeName = this._formatGQLTypeName(
+            options.useSnakeCase
+                ? `_${typeName}_${this.field}_`
+                : `${typeName}${firstToUpper(this.field)}`,
+            options.isInput,
+            options.useSnakeCase ? 'input_' : undefined
         );
 
         const properties: string[] = [];
@@ -67,7 +69,7 @@ export default class GroupType extends BaseType {
                 continue;
             }
 
-            const result = type.toGraphQL(typeName, isInput, includePrivate);
+            const result = type.toGraphQL(options);
 
             properties.push(this._removeBase(result.type));
 

--- a/packages/data-types/src/types/v1/boundary.ts
+++ b/packages/data-types/src/types/v1/boundary.ts
@@ -1,5 +1,5 @@
 import { FieldType } from 'xlucene-evaluator';
-import BaseType from '../base-type';
+import BaseType, { ToGraphQLOptions } from '../base-type';
 import { ElasticSearchTypes } from '../../interfaces';
 
 export default class Boundary extends BaseType {
@@ -16,7 +16,7 @@ export default class Boundary extends BaseType {
         };
     }
 
-    toGraphQL(_typeName?: string, isInput?: boolean) {
+    toGraphQL({ isInput }: ToGraphQLOptions = {}) {
         const defType = isInput ? 'input' : 'type';
         const name = this._formatGQLTypeName('GeoBoundary', isInput);
         const customType = `

--- a/packages/data-types/src/types/v1/geo-point.ts
+++ b/packages/data-types/src/types/v1/geo-point.ts
@@ -1,5 +1,5 @@
 import { FieldType } from 'xlucene-evaluator';
-import BaseType from '../base-type';
+import BaseType, { ToGraphQLOptions } from '../base-type';
 import { ElasticSearchTypes } from '../../interfaces';
 
 export default class GeoPointType extends BaseType {
@@ -7,7 +7,7 @@ export default class GeoPointType extends BaseType {
         return { mapping: { [this.field]: { type: 'geo_point' as ElasticSearchTypes } } };
     }
 
-    toGraphQL(_typeName?: string, isInput?: boolean) {
+    toGraphQL({ isInput }: ToGraphQLOptions = {}) {
         const defType = isInput ? 'input' : 'type';
         const name = this._formatGQLTypeName('GeoPoint', isInput);
         const customType = `

--- a/packages/data-types/src/types/v1/geo.ts
+++ b/packages/data-types/src/types/v1/geo.ts
@@ -1,5 +1,5 @@
 import { FieldType } from 'xlucene-evaluator';
-import BaseType from '../base-type';
+import BaseType, { ToGraphQLOptions } from '../base-type';
 import { ElasticSearchTypes } from '../../interfaces';
 
 // TODO: This type is deprecated, not sure how to properly indicate it.
@@ -8,7 +8,7 @@ export default class GeoType extends BaseType {
         return { mapping: { [this.field]: { type: 'geo_point' as ElasticSearchTypes } } };
     }
 
-    toGraphQL(_typeName?: string, isInput?: boolean) {
+    toGraphQL({ isInput }: ToGraphQLOptions = {}) {
         const defType = isInput ? 'input' : 'type';
         const name = this._formatGQLTypeName('GeoPoint', isInput);
         const customType = `

--- a/packages/data-types/test/data-type-spec.ts
+++ b/packages/data-types/test/data-type-spec.ts
@@ -85,7 +85,7 @@ describe('DataType', () => {
         expect(() => new DataType(typeConfig)).not.toThrow();
     });
 
-    it('should persist config, name and description', () => {
+    it('should persist name, version, fields and description', () => {
         const typeConfig: DataTypeConfig = {
             version: LATEST_VERSION,
             fields: { hello: { type: 'Keyword' } },
@@ -96,5 +96,26 @@ describe('DataType', () => {
         expect(dataType).toHaveProperty('description', 'hello there');
         expect(dataType).toHaveProperty('fields', typeConfig.fields);
         expect(dataType).toHaveProperty('version', typeConfig.version);
+        expect(dataType).toHaveProperty('groupedFields', {
+            hello: ['hello']
+        });
+    });
+
+    it('should have correctly grouped fields list', () => {
+        const typeConfig: DataTypeConfig = {
+            version: LATEST_VERSION,
+            fields: {
+                hello: { type: 'Keyword' },
+                foo: { type: 'Object' },
+                'foo.bar': { type: 'Keyword' },
+                'foo.baz': { type: 'Keyword' },
+            },
+        };
+
+        const dataType = new DataType(typeConfig, 'Test', 'hello there');
+        expect(dataType).toHaveProperty('groupedFields', {
+            hello: ['hello'],
+            foo: ['foo', 'foo.bar', 'foo.baz']
+        });
     });
 });

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.18.2",
+    "version": "0.19.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.11.1",
+        "@terascope/data-types": "^0.12.0",
         "@terascope/utils": "^0.22.0",
         "ajv": "^6.11.0",
         "nanoid": "^2.1.10",

--- a/packages/teraslice-messaging/src/messenger/server.ts
+++ b/packages/teraslice-messaging/src/messenger/server.ts
@@ -103,7 +103,7 @@ export class Server extends Core {
             retries: isTest ? 1 : 5,
             endWithFatal: true,
             logError: (err: any, ...args) => {
-                this.logger.error(err, ...args);
+                this.logger.warn(err, ...args);
             }
         });
 

--- a/packages/teraslice/lib/storage/execution.js
+++ b/packages/teraslice/lib/storage/execution.js
@@ -112,7 +112,10 @@ module.exports = async function executionStorage(context) {
     }
 
     async function updateMetadata(exId, metadata = {}) {
-        await backend.update(exId, { metadata });
+        await backend.update(exId, {
+            metadata,
+            _updated: makeISODate()
+        });
     }
 
     function _addMetadataFns() {
@@ -185,7 +188,8 @@ module.exports = async function executionStorage(context) {
             return await updatePartial(exId, (existing) => {
                 _verifyStatus(existing._status, status);
                 return Object.assign(existing, body, {
-                    _status: status
+                    _status: status,
+                    _updated: makeISODate()
                 });
             });
         } catch (err) {

--- a/packages/teraslice/lib/workers/execution-controller/index.js
+++ b/packages/teraslice/lib/workers/execution-controller/index.js
@@ -4,7 +4,7 @@ const ms = require('ms');
 const _ = require('lodash');
 const Messaging = require('@terascope/teraslice-messaging');
 const {
-    TSError, get, pDelay, getFullErrorStack, logError, pWhile
+    TSError, includes, get, pDelay, getFullErrorStack, logError, pWhile, makeISODate
 } = require('@terascope/utils');
 const { waitForWorkerShutdown } = require('../helpers/worker-shutdown');
 const { makeStateStore, makeExStore, SliceState } = require('../../storage');
@@ -634,7 +634,9 @@ class ExecutionController {
                 this.logger.debug(`execution is set to ${status}, status will not be updated`);
                 await exStore.updatePartial(this.exId, (existing) => {
                     const metaData = exStore.executionMetaData(executionStats);
-                    return Object.assign(existing, metaData);
+                    return Object.assign(existing, metaData, {
+                        _updated: makeISODate()
+                    });
                 });
                 return;
             }
@@ -818,9 +820,9 @@ class ExecutionController {
             return `${prefix} sending execution:finished event to cluster master`;
         };
 
-        if (_.includes(terminalStatuses, status)) {
+        if (includes(terminalStatuses, status)) {
             error = new Error(invalidStateMsg('terminal'));
-        } else if (_.includes(runningStatuses, status)) {
+        } else if (includes(runningStatuses, status)) {
             error = new Error(invalidStateMsg('running'));
         } else {
             return true;

--- a/packages/teraslice/lib/workers/helpers/job.js
+++ b/packages/teraslice/lib/workers/helpers/job.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { get } = require('@terascope/utils');
+const { get, makeISODate } = require('@terascope/utils');
 const { JobValidator } = require('@terascope/job-components');
 const { terasliceOpPath } = require('../../config');
 const { makeJobStore, makeExStore, makeStateStore } = require('../../storage');
@@ -69,6 +69,7 @@ async function initializeTestExecution({
         ex = await stores.exStore.updatePartial(ex.ex_id, (existing) => Object.assign(existing, {
             slicer_hostname: slicerHostname,
             slicer_port: slicerPort,
+            _updated: makeISODate()
         }));
     }
 

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "0.63.1",
+    "version": "0.63.2",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
- Add optional support for snake casing type names for` dataType->toGraphQL` (this will make it look more consistent if snake case is used for other types)
- Add `groupedFields` to data type instance to make easier to do look if a base field exists in a `DataType` (and what any nested fields too)
- Make sure to update `_updated` date on execution and job more often

Resolves #1660 