### PR TITLE
v0.63.6 - Fix/slicer stats on stopped jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "0.63.5",
+    "version": "0.63.6",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/lib/storage/execution.js
+++ b/packages/teraslice/lib/storage/execution.js
@@ -104,7 +104,11 @@ module.exports = async function executionStorage(context) {
      */
 
     /**
-     * Format the execution error stats
+     * Format the execution error stats, primarly used for updating the
+     * status.
+     *
+     * If no error message is passed, it will reset the _has_errors and _failureReason.
+     * If execution stats is provided it will set the _slicer_stats
      *
      * @param stats {import(
      *  '../workers/execution-controller/execution-analytics.js'
@@ -114,7 +118,7 @@ module.exports = async function executionStorage(context) {
     */
     function executionMetaData(stats, errMsg) {
         const errMetadata = {
-            _has_errors: true,
+            _has_errors: false,
             _failureReason: ''
         };
         const statsMetadata = {};

--- a/packages/teraslice/lib/storage/execution.js
+++ b/packages/teraslice/lib/storage/execution.js
@@ -94,16 +94,41 @@ module.exports = async function executionStorage(context) {
         return backend.updatePartial(exId, applyChanges);
     }
 
+    /**
+     * @typedef ExErrorMetadata
+     * @property _has_errors {boolean}
+     * @property _failureReason {string}
+     * @property _slicer_stats {import(
+     *  '../workers/execution-controller/execution-analytics.js'
+     * ).ExecutionStats}
+     */
+
+    /**
+     * Format the execution error stats
+     *
+     * @param stats {import(
+     *  '../workers/execution-controller/execution-analytics.js'
+     * ).ExecutionStats=}
+     * @param errMsg {string=}
+     * @return {ExErrorMetadata}
+    */
     function executionMetaData(stats, errMsg) {
-        let hasErrors = false;
-        if (errMsg) hasErrors = true;
-        const metaData = { _has_errors: hasErrors, _slicer_stats: stats };
+        const errMetadata = {
+            _has_errors: true,
+            _failureReason: ''
+        };
+        const statsMetadata = {};
+
         if (errMsg) {
-            metaData._failureReason = errMsg;
-        } else {
-            metaData._failureReason = '';
+            errMetadata._has_errors = true;
+            errMetadata._failureReason = errMsg;
         }
-        return metaData;
+
+        if (stats) {
+            statsMetadata._slicer_stats = Object.assign({}, stats);
+        }
+
+        return Object.assign({}, errMetadata, statsMetadata);
     }
 
     async function getMetadata(exId) {

--- a/packages/teraslice/lib/workers/execution-controller/execution-analytics.js
+++ b/packages/teraslice/lib/workers/execution-controller/execution-analytics.js
@@ -3,6 +3,25 @@
 const { makeISODate, get, has } = require('@terascope/utils');
 const { makeLogger } = require('../helpers/terafoundation');
 
+/**
+ * @typedef ExecutionStats
+ * @property workers_available {number}
+ * @property workers_active {number}
+ * @property workers_joined {number}
+ * @property workers_reconnected {number}
+ * @property workers_disconnected {number}
+ * @property job_duration {number}
+ * @property failed {number}
+ * @property subslices {number}
+ * @property queued {number}
+ * @property slice_range_expansion {number}
+ * @property processed {number}
+ * @property slicers {number}
+ * @property subslice_by_key {number}
+ * @property started {String} a date string
+ * @property queuing_complete {String} a date string
+*/
+
 class ExecutionAnalytics {
     constructor(context, executionContext, client) {
         this.logger = makeLogger(context, 'execution_analytics');
@@ -13,6 +32,7 @@ class ExecutionAnalytics {
         this._handlers = {};
         this._pushing = false;
 
+        /** @property {ExecutionStats} */
         this.executionAnalytics = {
             workers_available: 0,
             workers_active: 0,

--- a/packages/teraslice/lib/workers/execution-controller/scheduler.js
+++ b/packages/teraslice/lib/workers/execution-controller/scheduler.js
@@ -411,12 +411,15 @@ class Scheduler {
             || makeExecutionRecovery(this.context, this.stateStore, this.executionContext);
 
         await this.recover.initialize();
-        this.events.emit('slicers:registered', 1);
+
+        const { slicers: prevSlicers } = await this.exStore.get(this.recoverFromExId);
+        this.events.emit('slicers:registered', prevSlicers);
     }
 
     async _initializeExecution() {
         await this.executionContext.initialize(this.startingPoints);
-        this.events.emit('slicers:registered', this.executionContext.slicer().slicers);
+        const slicers = this.executionContext.slicer().slicers();
+        this.events.emit('slicers:registered', slicers);
     }
 
     async _waitForRecovery() {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "0.63.5",
+    "version": "0.63.6",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/test/workers/execution-controller/execution-special-test-cases-spec.js
+++ b/packages/teraslice/test/workers/execution-controller/execution-special-test-cases-spec.js
@@ -567,7 +567,9 @@ describe('ExecutionController Special Tests', () => {
         it('should have the correct execution status', () => {
             const { exId } = testContext.executionContext;
             expect(exStatus).toBeObject();
-            expect(exStatus).toHaveProperty('_slicer_stats');
+            expect(exStatus).toHaveProperty('_slicer_stats.processed');
+            expect(exStatus).toHaveProperty('_slicer_stats.queued');
+            expect(exStatus).toHaveProperty('_slicer_stats.slicers');
 
             if (shutdownEarly) {
                 expect(exStatus).toHaveProperty(

--- a/packages/teraslice/test/workers/execution-controller/execution-test-cases-spec.js
+++ b/packages/teraslice/test/workers/execution-controller/execution-test-cases-spec.js
@@ -360,7 +360,9 @@ describe('ExecutionController Test Cases', () => {
             const { exId } = testContext.executionContext;
 
             expect(exStatus).toBeObject();
-            expect(exStatus).toHaveProperty('_slicer_stats');
+            expect(exStatus).toHaveProperty('_slicer_stats.processed');
+            expect(exStatus).toHaveProperty('_slicer_stats.queued');
+            expect(exStatus).toHaveProperty('_slicer_stats.slicers');
 
             if (sliceFails || slicerFails) {
                 if (sliceFails) {


### PR DESCRIPTION
- Fix `_slicer_stats.slicers`, which was previously returning a function
- Fix updating the `executionMetaData` function to not set `_slicer_stats` to `null` and effectively remove the `_slicer_stats` when updating the execution.
- Improves the code documentation around `executionMetaData` functionality

Resolves https://github.com/terascope/teraslice/issues/1701