### PR TITLE
Breaking changes to elasticsearch-store

### DIFF
--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.21.3",
+    "version": "0.22.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -29,10 +29,11 @@
         "@terascope/types": "^0.1.3",
         "@terascope/utils": "^0.24.3",
         "ajv": "^6.12.0",
-        "nanoid": "^2.1.10",
+        "uuid": "^7.0.1",
         "xlucene-translator": "^0.3.3"
     },
     "devDependencies": {
+        "@types/uuid": "^7.0.0",
         "elasticsearch": "^15.4.1"
     },
     "publishConfig": {

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -200,7 +200,9 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
             }
             if (existing && existing[field] === record[field]) continue;
 
-            let query = `${field}:${utils.uniqueFieldQuery(String(record[field]))}`;
+            const fieldKey = this._hasTextAnalyzer(field) ? `${field}.text` : field;
+
+            let query = `${fieldKey}:${utils.uniqueFieldQuery(String(record[field]))}`;
             if (record.client_id && record.client_id > 0) {
                 query += ` AND client_id: ${record.client_id}`;
             }
@@ -213,5 +215,13 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
                 });
             }
         }
+    }
+
+    private _hasTextAnalyzer(field: keyof T): boolean {
+        const fieldConfig = this.config.data_type.fields[field as string];
+        if (!fieldConfig) return false;
+        if (fieldConfig.type !== 'KeywordCaseInsensitive') return false;
+        if (!fieldConfig.use_fields_hack) return false;
+        return true;
     }
 }

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -2,6 +2,7 @@ import * as es from 'elasticsearch';
 import * as ts from '@terascope/utils';
 import { JoinBy } from '@terascope/data-mate';
 import { QueryAccess, RestrictOptions } from 'xlucene-translator';
+import { v4 as uuid } from 'uuid';
 import IndexStore, { AnyInput } from './index-store';
 import * as utils from './utils';
 import * as i from './interfaces';
@@ -94,7 +95,7 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
             _updated: ts.makeISODate(),
         } as T;
 
-        const id = await utils.makeId();
+        const id = uuid();
         docInput._key = id;
 
         const doc = this._sanitizeRecord(docInput);

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -200,9 +200,12 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
             }
             if (existing && existing[field] === record[field]) continue;
 
-            const count = await this.countRecords({
-                [field]: record[field],
-            } as AnyInput<T>, record.client_id);
+            let query = `${field}:${utils.uniqueFieldQuery(String(record[field]))}`;
+            if (record.client_id && record.client_id > 0) {
+                query += ` AND client_id: ${record.client_id}`;
+            }
+            query += ' AND _deleted:false';
+            const count = await this.count(query);
 
             if (count > 0) {
                 throw new ts.TSError(`${this.name} requires ${field} to be unique`, {

--- a/packages/elasticsearch-store/src/interfaces.ts
+++ b/packages/elasticsearch-store/src/interfaces.ts
@@ -277,3 +277,9 @@ export interface MigrateIndexOptions {
 }
 
 export type MigrateIndexStoreOptions = Omit<MigrateIndexOptions, 'config'>;
+
+export type SearchResult<T> = {
+    _total: number;
+    _fetched: number;
+    results: T[];
+};

--- a/packages/elasticsearch-store/src/utils/model.ts
+++ b/packages/elasticsearch-store/src/utils/model.ts
@@ -78,6 +78,5 @@ export function toInstanceName(name: string): string {
 
 const _wildcardRegex = /[^A-Za-z0-9]/gm;
 export function uniqueFieldQuery(field: string): string {
-    if (!_wildcardRegex.test(field)) return `"${field}"`;
-    return field.replace(_wildcardRegex, '?');
+    return `/${field.replace(_wildcardRegex, '.')}/`;
 }

--- a/packages/elasticsearch-store/src/utils/model.ts
+++ b/packages/elasticsearch-store/src/utils/model.ts
@@ -75,3 +75,9 @@ export function mergeDefaults<T>(source: T, from: Partial<T>): T {
 export function toInstanceName(name: string): string {
     return ts.getWordParts(name).map(ts.firstToUpper).join('');
 }
+
+const _wildcardRegex = /[^A-Za-z0-9]/gm;
+export function uniqueFieldQuery(field: string): string {
+    if (!_wildcardRegex.test(field)) return `"${field}"`;
+    return field.replace(_wildcardRegex, '?');
+}

--- a/packages/elasticsearch-store/src/utils/model.ts
+++ b/packages/elasticsearch-store/src/utils/model.ts
@@ -1,7 +1,5 @@
 import * as dt from '@terascope/data-types';
 import * as ts from '@terascope/utils';
-import generate from 'nanoid/generate';
-import nanoid from 'nanoid/async';
 
 /** JSON Schema */
 export const schema = {
@@ -50,21 +48,6 @@ export function makeRecordDataType(arg: {
 
 export function addDefaultSchema(input: object) {
     return mergeDefaults(input, schema);
-}
-
-const badIdRegex = new RegExp(/^[-_]+/);
-
-/**
- * Make unique URL friendly id
- */
-export async function makeId(len = 12): Promise<string> {
-    const id = await nanoid(len);
-    const result = badIdRegex.exec(id);
-    if (result && result[0].length) {
-        const chars = generate('1234567890abcdef', result[0].length);
-        return id.replace(badIdRegex, chars);
-    }
-    return id;
 }
 
 /**

--- a/packages/elasticsearch-store/test/index-model-spec.ts
+++ b/packages/elasticsearch-store/test/index-model-spec.ts
@@ -175,6 +175,20 @@ describe('IndexModel', () => {
                     expect(err.statusCode).toEqual(409);
                 }
             });
+            it('should NOT be able to create a record with a similar lowercased name and client', async () => {
+                try {
+                    await expect(indexModel.createRecord({
+                        client_id: 5,
+                        name: name.toLowerCase(),
+                        type: name,
+                        config: {},
+                    })).toReject();
+                } catch (err) {
+                    expect(err.message).toEqual('ExampleModel requires name to be unique');
+                    expect(err).toBeInstanceOf(TSError);
+                    expect(err.statusCode).toEqual(409);
+                }
+            });
 
             it('should be able to create the same name in different client', async () => {
                 await expect(indexModel.createRecord({

--- a/packages/elasticsearch-store/test/index-search-compatability-spec.ts
+++ b/packages/elasticsearch-store/test/index-search-compatability-spec.ts
@@ -203,7 +203,8 @@ describe('IndexSearchCompatability', () => {
     });
 
     async function search(q: string) {
-        return indexModel.search(q, { sort: 'id:asc' }, queryAccess);
+        const { results } = await indexModel.search(q, { sort: 'id:asc' }, queryAccess);
+        return results;
     }
 
     describe('search compatability', () => {

--- a/packages/elasticsearch-store/test/index-store-spec.ts
+++ b/packages/elasticsearch-store/test/index-store-spec.ts
@@ -188,8 +188,8 @@ describe('IndexStore', () => {
 
                 await indexStore.indexById(testRecord.test_id, testRecord);
 
-                const [results] = await indexStore.search('test_keyword:$word', { variables });
-                expect(results).toEqual(testRecord);
+                const { results } = await indexStore.search('test_keyword:$word', { variables });
+                expect(results).toEqual([testRecord]);
             });
 
             it('can use findBy with variables', async () => {
@@ -361,12 +361,24 @@ describe('IndexStore', () => {
             });
 
             it('should be able to search the records', async () => {
-                const result = await indexStore.search(`test_keyword: ${keyword}`, {
+                const {
+                    results,
+                } = await indexStore.search(`test_keyword: ${keyword}`, {
                     sort: 'test_id',
                 });
 
-                expect(DataEntity.isDataEntityArray(result)).toBeTrue();
-                expect(result).toEqual(records);
+                expect(DataEntity.isDataEntityArray(results)).toBeTrue();
+                expect(results).toEqual(records);
+            });
+
+            it('should be able to search the records and get the total', async () => {
+                const {
+                    results
+                } = await indexStore.search(`test_keyword: ${keyword}`, {
+                    sort: 'test_id',
+                });
+
+                expect(results).toEqual(records);
             });
         });
 
@@ -420,7 +432,9 @@ describe('IndexStore', () => {
                     sort: 'test_number:asc',
                     size: 200,
                 });
-                const xluceneResult = await indexStore.search(q, {
+                const {
+                    results: xluceneResult
+                } = await indexStore.search(q, {
                     size: 200,
                     includes: ['test_id', 'test_boolean'],
                     sort: 'test_number:asc',
@@ -499,33 +513,39 @@ describe('IndexStore', () => {
             });
 
             it('should be able to search the records', async () => {
-                const result = await indexStore.search(`test_keyword: ${keyword}`, {
+                const {
+                    results
+                } = await indexStore.search(`test_keyword: ${keyword}`, {
                     sort: 'test_number',
                     size: records.length + 1,
                 });
 
-                expect(result).toBeArrayOfSize(records.length);
-                expect(DataEntity.isDataEntityArray(result)).toBeTrue();
+                expect(results).toBeArrayOfSize(records.length);
+                expect(DataEntity.isDataEntityArray(results)).toBeTrue();
             });
 
             it('should be able use exists and range xlucene syntax', async () => {
-                const result = await indexStore.search('_exists_:test_number AND test_number: <100', {
+                const {
+                    results
+                } = await indexStore.search('_exists_:test_number AND test_number: <100', {
                     sort: 'test_number',
                     size: 5,
                 });
 
-                expect(result).toBeArrayOfSize(5);
-                expect(DataEntity.isDataEntityArray(result)).toBeTrue();
+                expect(results).toBeArrayOfSize(5);
+                expect(DataEntity.isDataEntityArray(results)).toBeTrue();
             });
 
             it('should be able use multi-term xlucene syntax', async () => {
                 const query = 'test_id:/bulk-.*/ AND test_number:(20 OR 22 OR 26)';
-                const result = await indexStore.search(query, {
+                const {
+                    results
+                } = await indexStore.search(query, {
                     sort: 'test_number',
                 });
 
-                expect(result).toBeArrayOfSize(3);
-                expect(DataEntity.isDataEntityArray(result)).toBeTrue();
+                expect(results).toBeArrayOfSize(3);
+                expect(DataEntity.isDataEntityArray(results)).toBeTrue();
             });
 
             it('should be able to bulk update the records', async () => {
@@ -544,12 +564,14 @@ describe('IndexStore', () => {
                 await indexStore.flush(true);
                 await indexStore.refresh();
 
-                const result = await indexStore.search(`test_keyword: ${keyword}`, {
+                const {
+                    results
+                } = await indexStore.search(`test_keyword: ${keyword}`, {
                     sort: 'test_id',
                     size: records.length + 1,
                 });
 
-                expect(result[0]).toHaveProperty('test_object', {
+                expect(results[0]).toHaveProperty('test_object', {
                     updated: true,
                 });
             });
@@ -563,12 +585,14 @@ describe('IndexStore', () => {
 
                 await indexStore.refresh();
 
-                const result = await indexStore.search(`test_keyword: ${keyword}`, {
+                const {
+                    results
+                } = await indexStore.search(`test_keyword: ${keyword}`, {
                     sort: 'test_id',
                     size: records.length + 1,
                 });
 
-                expect(result).toBeArrayOfSize(0);
+                expect(results).toBeArrayOfSize(0);
             });
         });
     });
@@ -694,12 +718,14 @@ describe('IndexStore', () => {
             });
 
             it('should have created all of the records', async () => {
-                const result = await indexStore.search(`test_keyword: ${keyword}`, {
+                const {
+                    results,
+                } = await indexStore.search(`test_keyword: ${keyword}`, {
                     sort: 'test_id',
                 });
 
-                expect(DataEntity.isDataEntityArray(result)).toBeTrue();
-                expect(result).toEqual(expected);
+                expect(DataEntity.isDataEntityArray(results)).toBeTrue();
+                expect(results).toEqual(expected);
 
                 const record = await indexStore.get(expected[0].test_id);
 

--- a/packages/elasticsearch-store/test/utils-spec.ts
+++ b/packages/elasticsearch-store/test/utils-spec.ts
@@ -4,9 +4,36 @@ import {
     isTemplatedIndex,
     isTimeSeriesIndex,
     validateIndexConfig,
+    uniqueFieldQuery,
 } from '../src/utils';
 
 describe('Elasticsearch Store Utils', () => {
+    describe('uniqueFieldQuery', () => {
+        it('should return a quouted value when there are no special characters', () => {
+            expect(
+                uniqueFieldQuery('fooBar')
+            ).toEqual('"fooBar"');
+        });
+
+        it('should return a wildcard with a ? for dashes', () => {
+            expect(
+                uniqueFieldQuery('test-a-b-c')
+            ).toEqual('test?a?b?c');
+        });
+
+        it('should return a wildcard with a ? for underscores', () => {
+            expect(
+                uniqueFieldQuery('test_a_b_c')
+            ).toEqual('test?a?b?c');
+        });
+
+        it('should return a wildcard with a ? for other misc characters', () => {
+            expect(
+                uniqueFieldQuery('h*ll@^[]{})"\'`hih/\\ AND (')
+            ).toEqual('h?ll??????????hih???AND??');
+        });
+    });
+
     describe('#isTemplatedIndex', () => {
         it('should return false when given a simple index', () => {
             expect(

--- a/packages/elasticsearch-store/test/utils-spec.ts
+++ b/packages/elasticsearch-store/test/utils-spec.ts
@@ -9,28 +9,28 @@ import {
 
 describe('Elasticsearch Store Utils', () => {
     describe('uniqueFieldQuery', () => {
-        it('should return a quouted value when there are no special characters', () => {
+        it('should return not return an dots for a valid string', () => {
             expect(
-                uniqueFieldQuery('fooBar')
-            ).toEqual('"fooBar"');
+                uniqueFieldQuery('fooBar0123')
+            ).toEqual('/fooBar0123/');
         });
 
-        it('should return a wildcard with a ? for dashes', () => {
+        it('should return . for each dashe', () => {
             expect(
                 uniqueFieldQuery('test-a-b-c')
-            ).toEqual('test?a?b?c');
+            ).toEqual('/test.a.b.c/');
         });
 
-        it('should return a wildcard with a ? for underscores', () => {
+        it('should return . for each underscore', () => {
             expect(
                 uniqueFieldQuery('test_a_b_c')
-            ).toEqual('test?a?b?c');
+            ).toEqual('/test.a.b.c/');
         });
 
-        it('should return a wildcard with a ? for other misc characters', () => {
+        it('should return . for each special characters', () => {
             expect(
-                uniqueFieldQuery('h*ll@^[]{})"\'`hih/\\ AND (')
-            ).toEqual('h?ll??????????hih???AND??');
+                uniqueFieldQuery('h*ll.?@^[]{})"\'`hih/\\ AND (')
+            ).toEqual('/h.ll............hih...AND../');
         });
     });
 


### PR DESCRIPTION
**BREAKING CHANGES:**

- Change `IndexStore` to use the UUID v4 id generator instead of nanoid
- Change `IndexModel` behavior when counting unique values like name to ignore special characters and case insenstive.
- Change `IndexStore->search` to return a `{ _total: number; _fetched: number; results: any[] }` instead of just the results so we can get the total record count.
