### PR TITLE
Memory leak fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ This monorepo contains sub-packages for various Terascope projects.
     - [Source Code](https://github.com/terascope/teraslice/tree/master/packages/ts-transforms)
     - [Documentation](https://terascope.github.io/teraslice/docs/packages/ts-transforms/overview)
 - xLucene - Extensible Lucene query syntax parser and executor
-    - [Source Code](https://github.com/terascope/teraslice/tree/master/packages/xlucene-evaluator)
-    - [Documentation](https://terascope.github.io/teraslice/docs/packages/xlucene-evaluator/overview)
+    - Source Code: ([Parser](https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser)) - ([Translator](https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator))
+    - Documentation: ([Parser](https://terascope.github.io/teraslice/docs/packages/xlucene-parser/overview)) - ([Translator](https://terascope.github.io/teraslice/docs/packages/xlucene-translator/overview))
 - Other - Various supporting packages
     - [Source Code](https://github.com/terascope/teraslice/tree/master/packages)
     - [Documentation](https://terascope.github.io/teraslice/docs/packages)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "0.64.0",
+    "version": "0.64.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "docs": "ts-scripts docs",
         "lint": "eslint --cache --ext .js,.jsx,.ts,.tsx .",
         "lint:fix": "yarn lint --fix && yarn sync",
-        "setup": "yarn $YARN_SETUP_ARGS && lerna link --force-local && ./scripts/build-cleanup.sh && lerna run prebuild && tsc --build",
+        "setup": "yarn $YARN_SETUP_ARGS && lerna link --force-local && lerna run prebuild && tsc --build --force",
         "start": "node service.js",
         "sync": "ts-scripts sync",
         "test": "ts-scripts test"

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -32,9 +32,9 @@
         "@turf/clean-coords": "^6.0.1"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.14.3",
+        "@terascope/data-types": "^0.14.4",
         "@terascope/types": "^0.1.3",
-        "@terascope/utils": "^0.24.3",
+        "@terascope/utils": "^0.24.4",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-point-in-polygon": "^6.0.1",
@@ -49,7 +49,7 @@
         "jexl": "^2.2.2",
         "valid-url": "^1.0.9",
         "validator": "^12.2.0",
-        "xlucene-parser": "^0.19.3"
+        "xlucene-parser": "^0.19.4"
     },
     "devDependencies": {},
     "engines": {

--- a/packages/data-mate/src/document-matcher/index.ts
+++ b/packages/data-mate/src/document-matcher/index.ts
@@ -9,9 +9,7 @@ export default class DocumentMatcher {
     private filterFn: BooleanCB;
 
     constructor(query: string, options: DocumentMatcherOptions = {}) {
-        const logger = options.logger != null
-            ? options.logger.child({ module: 'document-matcher' })
-            : _logger;
+        const logger = options.logger || _logger;
 
         const parser = new Parser(query, {
             type_config: options.type_config,

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.14.3",
+    "version": "0.14.4",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.1.3",
-        "@terascope/utils": "^0.24.3",
+        "@terascope/utils": "^0.24.4",
         "graphql": "^14.5.8",
         "lodash.defaultsdeep": "^4.6.1",
         "yargs": "^15.3.0"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.6.3",
+    "version": "2.6.4",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.24.3",
+        "@terascope/utils": "^0.24.4",
         "bluebird": "^3.7.2",
         "lodash.isequal": "^4.5.0"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.23.1",
+    "version": "0.23.2",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,13 +24,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.3.3",
-        "@terascope/data-types": "^0.14.3",
+        "@terascope/data-mate": "^0.3.4",
+        "@terascope/data-types": "^0.14.4",
         "@terascope/types": "^0.1.3",
-        "@terascope/utils": "^0.24.3",
+        "@terascope/utils": "^0.24.4",
         "ajv": "^6.12.0",
         "uuid": "^7.0.2",
-        "xlucene-translator": "^0.3.3"
+        "xlucene-translator": "^0.3.4"
     },
     "devDependencies": {
         "@types/uuid": "^7.0.0",

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -43,7 +43,9 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
             },
             default_query_access: new QueryAccess({
                 type_config: modelConfig.data_type.toXlucene(),
-                constraint: '_deleted: false'
+                constraint: '_deleted: false',
+            }, {
+                logger: options.logger,
             })
         };
 

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.24.3",
+        "@terascope/utils": "^0.24.4",
         "chalk": "^3.0.0",
         "lodash.defaultsdeep": "^4.6.1",
         "yeoman-generator": "^4.7.0",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.30.1",
+    "version": "0.30.2",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.24.3",
+        "@terascope/utils": "^0.24.4",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^7.0.2"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.14.3",
+    "version": "0.14.4",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.18.5",
-        "@terascope/utils": "^0.24.3",
+        "@terascope/utils": "^0.24.4",
         "codecov": "^3.6.5",
         "execa": "^4.0.0",
         "fs-extra": "^8.1.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.18.3",
+    "version": "0.18.4",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.24.3",
+        "@terascope/utils": "^0.24.4",
         "aws-sdk": "^2.596.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.12",

--- a/packages/terafoundation/src/connectors/s3.ts
+++ b/packages/terafoundation/src/connectors/s3.ts
@@ -4,7 +4,7 @@ import { Logger } from '@terascope/utils';
 import { defer, promisifyAll } from 'bluebird';
 
 function create(customConfig: any, logger: Logger) {
-    const AWS = require('aws-sdk');
+    const S3 = require('aws-sdk/clients/s3');
 
     logger.info(`Using S3 endpoint: ${customConfig.endpoint}`);
 
@@ -32,14 +32,14 @@ function create(customConfig: any, logger: Logger) {
         });
     }
 
-    const client = new AWS.S3(customConfig);
+    const client = new S3(customConfig);
 
     return {
         client: promisifyAll(client, { suffix: '_Async' })
     };
 }
 
-module.exports = {
+export default {
     create,
     config_schema() {
         return {

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.18.1",
+    "version": "0.18.2",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.6.0",
-        "@terascope/utils": "^0.24.3",
+        "@terascope/utils": "^0.24.4",
         "archiver": "^3.0.0",
         "chalk": "^3.0.0",
         "cli-table3": "^0.5.1",
@@ -49,7 +49,7 @@
         "request": "^2.88.0",
         "request-promise": "^4.2.5",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.16.1",
+        "teraslice-client-js": "^0.16.2",
         "tmp": "^0.1.0",
         "tty-table": "^4.0.0",
         "yargs": "^15.3.0",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.16.1",
+    "version": "0.16.2",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.30.1",
+        "@terascope/job-components": "^0.30.2",
         "auto-bind": "^4.0.0",
         "got": "^9.6.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/utils": "^0.24.3",
+        "@terascope/utils": "^0.24.4",
         "ms": "^2.1.2",
         "nanoid": "^2.1.10",
         "p-event": "^4.1.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
     "displayName": "Teraslice Op Test Harness",
-    "version": "1.14.1",
+    "version": "1.14.2",
     "description": "A testing harness to simplify testing Teraslice processors and operations.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-op-test-harness#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.30.1",
+        "@terascope/job-components": "^0.30.2",
         "bluebird": "^3.7.2"
     },
     "devDependencies": {},

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.12.3",
+    "version": "0.12.4",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.6.3",
-        "@terascope/utils": "^0.24.3",
+        "@terascope/elasticsearch-api": "^2.6.4",
+        "@terascope/utils": "^0.24.4",
         "mnemonist": "^0.32.0"
     },
     "publishConfig": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "0.15.1",
+    "version": "0.15.2",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {
@@ -30,8 +30,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.30.1",
-        "@terascope/teraslice-op-test-harness": "^1.14.1"
+        "@terascope/job-components": "^0.30.2",
+        "@terascope/teraslice-op-test-harness": "^1.14.2"
     },
     "devDependencies": {},
     "engines": {

--- a/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/k8sResource.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/k8sResource.js
@@ -6,7 +6,7 @@ const path = require('path');
 const barbe = require('barbe');
 const _ = require('lodash');
 
-const { safeEncode } = require('../../../../../../lib/utils/encoding_utils');
+const { safeEncode } = require('../../../../../utils/encoding_utils');
 const { addEnvToContainerEnv } = require('./utils');
 
 class K8sResource {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.6.3",
-        "@terascope/job-components": "^0.30.1",
-        "@terascope/teraslice-messaging": "^0.8.3",
-        "@terascope/utils": "^0.24.3",
+        "@terascope/elasticsearch-api": "^2.6.4",
+        "@terascope/job-components": "^0.30.2",
+        "@terascope/teraslice-messaging": "^0.8.4",
+        "@terascope/utils": "^0.24.4",
         "async-mutex": "^0.1.3",
         "barbe": "^3.0.15",
         "body-parser": "^1.19.0",
@@ -62,11 +62,11 @@
         "shortid": "^2.2.14",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.18.3",
+        "terafoundation": "^0.18.4",
         "uuid": "^7.0.2"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.14.1",
+        "@terascope/teraslice-op-test-harness": "^1.14.2",
         "archiver": "^3.0.0",
         "bufferstreams": "^3.0.0",
         "chance": "^1.1.4",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "0.64.0",
+    "version": "0.64.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.32.3",
+    "version": "0.32.4",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.3.3",
+        "@terascope/data-mate": "^0.3.4",
         "@terascope/types": "^0.1.3",
-        "@terascope/utils": "^0.24.3",
+        "@terascope/utils": "^0.24.4",
         "awesome-phonenumber": "^2.26.0",
         "graphlib": "^2.1.8",
         "jexl": "^2.2.2",

--- a/packages/utils/bench/once.js
+++ b/packages/utils/bench/once.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const { Suite } = require('./helpers');
+const { once } = require('../dist/src');
+
+let hi = 1;
+let hello = 1;
+const sameFn = () => {
+    hello += 1;
+    return hello;
+};
+const run = async () => Suite('fn')
+    .add('once (new fn everytime)', {
+        fn() {
+            const fn = once(() => {
+                hi += 1;
+                return hi;
+            });
+            fn();
+        }
+    })
+    .add('once (same fn everytime)', {
+        fn() {
+            const fn = once(sameFn);
+            fn();
+        }
+    })
+    .run({
+        async: true,
+        minSamples: 10,
+        initCount: 2,
+        maxTime: 60
+    });
+
+if (require.main === module) {
+    run().then((suite) => {
+        suite.on('complete', () => {});
+    });
+} else {
+    module.exports = run;
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.24.3",
+    "version": "0.24.4",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/functions.ts
+++ b/packages/utils/src/functions.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-param-reassign */
+
 import { toString } from './strings';
 
 type ArgType<T> = T extends (...args: infer A) => any ? A : any;
@@ -8,7 +10,11 @@ type ArgType<T> = T extends (...args: infer A) => any ? A : any;
 export function once<T extends((...args: any[]) => any)>(fn: T) {
     let called = false;
     function _fn(...args: ArgType<T>): ReturnType<T>|undefined {
-        if (called) return undefined;
+        if (called) {
+            // @ts-ignore
+            fn = undefined;
+            return undefined;
+        }
         called = true;
         return fn(...args);
     }

--- a/packages/utils/src/promises.ts
+++ b/packages/utils/src/promises.ts
@@ -1,4 +1,3 @@
-import { isEmpty } from './empty';
 import { debugLogger } from './logger';
 import { toHumanTime, trackTimeout } from './dates';
 import {
@@ -115,7 +114,7 @@ export async function pRetry<T = any>(
     } catch (_err) {
         let matches = true;
 
-        if (!isEmpty(config.matches)) {
+        if (config.matches?.length) {
             const rawErr = parseError(_err);
             matches = config.matches.some((match) => {
                 const reg = new RegExp(match);

--- a/packages/utils/src/promises.ts
+++ b/packages/utils/src/promises.ts
@@ -92,7 +92,6 @@ export async function pRetry<T = any>(
             maxDelay: 60000,
             backoff: 2,
             matches: [],
-            logError: logger.warn,
             _currentDelay: 0,
             // @ts-ignore
             _context: undefined as PRetryContext,
@@ -156,10 +155,12 @@ export async function pRetry<T = any>(
 
             await pDelay(config._currentDelay);
 
-            config.logError(err, 'retry error, retrying...', {
-                ...config,
-                _context: null,
-            });
+            if (config.logError) {
+                config.logError(err, 'retry error, retrying...', {
+                    ...config,
+                    _context: null,
+                });
+            }
             return pRetry(fn, config);
         }
 

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.19.3",
+    "version": "0.19.4",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.1.3",
-        "@terascope/utils": "^0.24.3",
+        "@terascope/utils": "^0.24.4",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-contains": "^6.0.1",

--- a/packages/xlucene-parser/src/parser.ts
+++ b/packages/xlucene-parser/src/parser.ts
@@ -18,9 +18,7 @@ export class Parser {
     logger: Logger;
 
     constructor(query: string, options: i.ParserOptions = {}) {
-        this.logger = options.logger != null
-            ? options.logger.child({ module: 'xlucene-parser' })
-            : _logger;
+        this.logger = options.logger || _logger;
 
         this.query = trim(query || '');
 

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,8 +29,8 @@
     },
     "dependencies": {
         "@terascope/types": "^0.1.3",
-        "@terascope/utils": "^0.24.3",
-        "xlucene-parser": "^0.19.3"
+        "@terascope/utils": "^0.24.4",
+        "xlucene-parser": "^0.19.4"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xlucene-translator/src/query-access/query-access.ts
+++ b/packages/xlucene-translator/src/query-access/query-access.ts
@@ -45,9 +45,7 @@ export class QueryAccess<T extends ts.AnyObject = ts.AnyObject> {
         if (ts.isEmpty(typeConfig)) throw new Error('Configuration for type_config must be provided');
         this.typeConfig = { ...typeConfig };
 
-        this.logger = options.logger != null
-            ? options.logger.child({ module: 'xlucene-query-access' })
-            : _logger;
+        this.logger = options.logger || _logger;
 
         this.excludes = excludes?.slice();
         this.includes = includes?.slice();

--- a/packages/xlucene-translator/src/translator/translator.ts
+++ b/packages/xlucene-translator/src/translator/translator.ts
@@ -26,9 +26,7 @@ export class Translator {
 
     constructor(input: string | Parser, options: i.TranslatorOptions = {}) {
         this.variables = options.variables;
-        this.logger = options.logger != null
-            ? options.logger.child({ module: 'xlucene-translator' })
-            : _logger;
+        this.logger = options.logger || _logger;
 
         this.typeConfig = options.type_config || {};
         if (isString(input)) {


### PR DESCRIPTION
Memory leak fixes:

- Avoid creating child loggers too often (this causes memory leaks)
- Make sure to properly dereference the function in the once util

Other fixes:

- fix s3 connector in `terafoundation`
- fix xlucene reference in `README`
- improve setup script to tsc --build --force
- Slight improvement to matches check in pRetry
- Fix reference to file in `k8Resource.js`
