### PR TITLE
Fix xLucene searching of tokenized fields with numeric values

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -49,7 +49,7 @@
         "jexl": "^2.2.2",
         "valid-url": "^1.0.9",
         "validator": "^12.2.0",
-        "xlucene-parser": "^0.19.4"
+        "xlucene-parser": "^0.19.5"
     },
     "devDependencies": {},
     "engines": {

--- a/packages/data-types/src/types/v1/ngram-tokens.ts
+++ b/packages/data-types/src/types/v1/ngram-tokens.ts
@@ -6,7 +6,6 @@ export default class NgramTokens extends BaseType {
         return {
             mapping: {
                 [this.field]: {
-                    // TODO: this is wrong, I dont think analyzer can be at this level
                     type: 'keyword' as ESFieldType,
                     fields: {
                         tokens: {

--- a/packages/data-types/test/types/v1/keyword-case-insensitive-spec.ts
+++ b/packages/data-types/test/types/v1/keyword-case-insensitive-spec.ts
@@ -19,7 +19,6 @@ describe('KeywordCaseInsensitive V1', () => {
         const results = {
             mapping: {
                 [field]: {
-                    // TODO: this is wrong, I dont think analyzer can be at this level
                     type: 'text' as ESFieldType,
                     analyzer: 'lowercase_keyword_analyzer',
                 },

--- a/packages/data-types/test/types/v1/keyword-tokens-case-insensitive-spec.ts
+++ b/packages/data-types/test/types/v1/keyword-tokens-case-insensitive-spec.ts
@@ -19,7 +19,6 @@ describe('KeywordTokensCaseInsensitive V1', () => {
         const results = {
             mapping: {
                 [field]: {
-                    // TODO: this is wrong, I dont think analyzer can be at this level
                     type: 'text' as ESFieldType,
                     analyzer: 'lowercase_keyword_analyzer',
                     fields: {

--- a/packages/data-types/test/types/v1/ngram-tokens-spec.ts
+++ b/packages/data-types/test/types/v1/ngram-tokens-spec.ts
@@ -19,7 +19,6 @@ describe('NgramTokens V1', () => {
         const results = {
             mapping: {
                 [field]: {
-                    // TODO: this is wrong, I dont think analyzer can be at this level
                     type: 'keyword' as ESFieldType,
                     fields: {
                         tokens: {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.23.2",
+    "version": "0.23.3",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,13 +24,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.3.4",
+        "@terascope/data-mate": "^0.3.5",
         "@terascope/data-types": "^0.14.4",
         "@terascope/types": "^0.1.3",
         "@terascope/utils": "^0.24.4",
         "ajv": "^6.12.0",
         "uuid": "^7.0.2",
-        "xlucene-translator": "^0.3.4"
+        "xlucene-translator": "^0.3.5"
     },
     "devDependencies": {
         "@types/uuid": "^7.0.0",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.32.4",
+    "version": "0.32.5",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.3.4",
+        "@terascope/data-mate": "^0.3.5",
         "@terascope/types": "^0.1.3",
         "@terascope/utils": "^0.24.4",
         "awesome-phonenumber": "^2.28.0",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.19.4",
+    "version": "0.19.5",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-parser/src/context.ts
+++ b/packages/xlucene-parser/src/context.ts
@@ -127,7 +127,7 @@ export default function makeContext(args: any) {
         const field = node.field || _field;
         if (!field) return;
 
-        const fieldType = getFieldType(field);
+        let fieldType = getFieldType(field);
         if (fieldType === node.field_type) return;
 
         logger.trace(
@@ -136,9 +136,11 @@ export default function makeContext(args: any) {
 
         // in the case of tokenized fields we should update the
         // node to indicate so non-term level queries can be performed
-        if (utils.isTermType(node) && field.includes('.') && !typeConfig[field]) {
-            const parentField = field.split('.').slice(0, -1);
-            if (typeConfig[parentField] && typeConfig[parentField] !== xLuceneFieldType.Object) {
+        if (utils.isTermType(node) && !typeConfig[field] && field.includes('.')) {
+            const parentField = field.split('.').slice(0, -1)[0];
+            const parentType = typeConfig[parentField];
+            if (parentType && parentType !== xLuceneFieldType.Object) {
+                fieldType = parentType;
                 node.tokenizer = parentField;
             }
         }

--- a/packages/xlucene-parser/src/interfaces.ts
+++ b/packages/xlucene-parser/src/interfaces.ts
@@ -38,7 +38,7 @@ export type TermLikeType =
 export interface TermLikeAST {
     type: TermLikeType;
     field: Field;
-    tokenizer?: boolean;
+    tokenizer?: string;
 }
 
 export enum ASTType {

--- a/packages/xlucene-parser/test/cases/parser/term.ts
+++ b/packages/xlucene-parser/test/cases/parser/term.ts
@@ -114,6 +114,21 @@ export default [
         }
     ],
     [
+        'phone.tokens:3848',
+        'an analyzed field',
+        {
+            type: ASTType.Term,
+            field_type: xLuceneFieldType.String,
+            field: 'phone.tokens',
+            quoted: false,
+            tokenizer: 'phone',
+            value: '3848',
+        },
+        {
+            phone: xLuceneFieldType.String
+        }
+    ],
+    [
         'foo:   bar',
         'field with space between string value',
         {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -30,7 +30,7 @@
     "dependencies": {
         "@terascope/types": "^0.1.3",
         "@terascope/utils": "^0.24.4",
-        "xlucene-parser": "^0.19.4"
+        "xlucene-parser": "^0.19.5"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xlucene-translator/test/cases/translator/term.ts
+++ b/packages/xlucene-translator/test/cases/translator/term.ts
@@ -171,6 +171,23 @@ export default [
         },
     ],
     [
+        'phone.tokens:3848',
+        'query.constant_score.filter',
+        {
+            match: {
+                'phone.tokens': {
+                    operator: 'and',
+                    query: '3848'
+                },
+            },
+        },
+        {
+            type_config: {
+                phone: 'string',
+            }
+        }
+    ],
+    [
         `word:"${escapeString('/value\\\\')}"`,
         'query.constant_score.filter',
         {


### PR DESCRIPTION
This change will correctly use a [match](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-match-query.html) instead of [term](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-term-query.html) when querying against `ngram_analyzer` fields that use numeric values.