### PR TITLE
ts-scripts test improvements

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -2,9 +2,8 @@
 
 const fs = require('fs');
 const path = require('path');
-const { jest: lernaAliases } = require('lerna-alias');
-
-const isCI = process.env.CI === 'true';
+const { isCI } = require('@terascope/utils');
+const { getJestAliases } = require('@terascope/scripts');
 
 module.exports = (projectDir) => {
     let parentFolder;
@@ -53,7 +52,7 @@ module.exports = (projectDir) => {
             `<rootDir>/${parentFolder}/teraslice-cli/test/fixtures/`
         ],
         transformIgnorePatterns: ['^.+\\.js$'],
-        moduleNameMapper: lernaAliases({ mainFields: ['srcMain', 'main'] }),
+        moduleNameMapper: getJestAliases(),
         moduleFileExtensions: ['ts', 'js', 'json', 'node', 'pegjs'],
         collectCoverage: true,
         coveragePathIgnorePatterns: ['/node_modules/', '/test/'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,8 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-
-const isCI = process.env.CI === 'true';
+const { isCI } = require('@terascope/utils');
 
 const packagesPath = path.join(__dirname, 'packages');
 const projects = fs

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "url": "https://github.com/terascope/teraslice/issues"
     },
     "workspaces": [
-        "packages/*"
+        "packages/*",
+        "e2e"
     ],
     "scripts": {
         "benchmark": "lerna run --concurrency=1 --no-prefix --stream benchmark",
@@ -51,7 +52,6 @@
         "jest-extended": "^0.11.5",
         "jest-watch-typeahead": "^0.4.0",
         "lerna": "^3.20.1",
-        "lerna-alias": "^3.0.2",
         "node-notifier": "^6.0.0",
         "ts-jest": "^25.0.0",
         "typescript": "^3.8.3"

--- a/packages/docker-compose-js/package.json
+++ b/packages/docker-compose-js/package.json
@@ -42,6 +42,7 @@
         "access": "public",
         "registry": "https://registry.npmjs.org/"
     },
+    "srcMain": "src/index.ts",
     "terascope": {
         "testSuite": "disabled",
         "enableTypedoc": true

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -36,6 +36,7 @@
         "codecov": "^3.6.5",
         "execa": "^4.0.0",
         "fs-extra": "^8.1.0",
+        "globby": "^11.0.0",
         "got": "^9.6.0",
         "ip": "^1.1.5",
         "lodash.defaultsdeep": "^4.6.1",
@@ -51,6 +52,7 @@
         "yargs": "^15.3.1"
     },
     "devDependencies": {
+        "@types/globby": "^9.1.0",
         "@types/got": "^9.6.8",
         "@types/ip": "^1.1.0",
         "@types/lodash.defaultsdeep": "^4.6.6",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.14.4",
+    "version": "0.15.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/cmds/publish.ts
+++ b/packages/scripts/src/cmds/publish.ts
@@ -1,9 +1,9 @@
 import { CommandModule } from 'yargs';
+import { isCI } from '@terascope/utils';
 import { GlobalCMDOptions } from '../helpers/interfaces';
 import { PublishAction, PublishType } from '../helpers/publish/interfaces';
 import { publish } from '../helpers/publish';
 import { syncAll } from '../helpers/sync';
-import { isCI } from '../helpers/config';
 
 type Options = {
     type: PublishType;

--- a/packages/scripts/src/cmds/sync.ts
+++ b/packages/scripts/src/cmds/sync.ts
@@ -1,8 +1,8 @@
 import { CommandModule } from 'yargs';
+import { isCI } from '@terascope/utils';
 import { syncAll, syncPackages } from '../helpers/sync';
 import { PackageInfo, GlobalCMDOptions } from '../helpers/interfaces';
 import { coercePkgArg } from '../helpers/args';
-import { isCI } from '../helpers/config';
 
 type Options = {
     verify: boolean;

--- a/packages/scripts/src/helpers/bump/utils.ts
+++ b/packages/scripts/src/helpers/bump/utils.ts
@@ -54,6 +54,8 @@ export async function getPackagesToBump(
     }
 
     async function _bumpPackage(pkgInfo: PackageInfo) {
+        if (pkgInfo.private) return;
+
         await _resetVersion(pkgInfo);
 
         const from = pkgInfo.version;

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -1,7 +1,5 @@
 import { address } from 'ip';
-import { toBoolean, toSafeString } from '@terascope/utils';
-
-export const isCI = toBoolean(process.env.CI);
+import { toBoolean, toSafeString, isCI } from '@terascope/utils';
 
 const forceColor = process.env.FORCE_COLOR || '1';
 export const FORCE_COLOR = toBoolean(forceColor)

--- a/packages/scripts/src/helpers/interfaces.ts
+++ b/packages/scripts/src/helpers/interfaces.ts
@@ -3,6 +3,8 @@ export type PackageInfo = {
     folderName: string;
     private?: boolean;
     name: string;
+    main: string;
+    srcMain?: string;
     displayName: string;
     version: string;
     description: string;
@@ -48,6 +50,7 @@ export type RootPackageInfo = {
     };
     documentation: string;
     homepage: string;
+    workspaces: string[]|{ packages: string[] };
     terascope: {
         root: boolean;
         type: 'monorepo';

--- a/packages/scripts/src/helpers/sync/utils.ts
+++ b/packages/scripts/src/helpers/sync/utils.ts
@@ -1,13 +1,14 @@
 import path from 'path';
 import semver from 'semver';
-import { getFirstChar, uniq, trim } from '@terascope/utils';
+import {
+    getFirstChar, uniq, trim, isCI
+} from '@terascope/utils';
 import { getDocPath, updatePkgJSON, fixDepPkgName } from '../packages';
 import { updateReadme, ensureOverview } from '../docs/overview';
 import { PackageInfo, RootPackageInfo } from '../interfaces';
 import { formatList, getRootDir } from '../misc';
 import { getChangedFiles, gitDiff } from '../scripts';
 import { DepKey, SyncOptions } from './interfaces';
-import { isCI } from '../config';
 import signale from '../signale';
 
 const topLevelFiles: readonly string[] = [

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -5,6 +5,7 @@ import {
     chunk,
     TSError,
     getFullErrorStack,
+    isCI
 } from '@terascope/utils';
 import {
     writePkgHeader,
@@ -25,7 +26,6 @@ import * as utils from './utils';
 import signale from '../signale';
 import { getE2EDir } from '../packages';
 import { buildDevDockerImage } from '../publish/utils';
-import { isCI } from '../config';
 
 const logger = debugLogger('ts-scripts:cmd:test');
 

--- a/packages/scripts/src/helpers/test-runner/utils.ts
+++ b/packages/scripts/src/helpers/test-runner/utils.ts
@@ -6,7 +6,8 @@ import {
     TSError,
     isFunction,
     flatten,
-    toBoolean
+    toBoolean,
+    isCI
 } from '@terascope/utils';
 import {
     ArgsMap,
@@ -46,7 +47,7 @@ export function getArgs(options: TestOptions): ArgsMap {
         }
     }
 
-    if (config.isCI) {
+    if (isCI) {
         args.verbose = 'false';
     }
 
@@ -239,8 +240,8 @@ export async function logE2E(dir: string, failed: boolean): Promise<void> {
 
     const errLogs = await getE2ELogs(dir, {
         LOG_LEVEL: 'INFO',
-        RAW_LOGS: config.isCI ? 'true' : 'false',
-        FORCE_COLOR: config.isCI ? '0' : '1',
+        RAW_LOGS: isCI ? 'true' : 'false',
+        FORCE_COLOR: isCI ? '0' : '1',
     });
     process.stderr.write(`${errLogs}\n`);
 }

--- a/packages/scripts/src/index.ts
+++ b/packages/scripts/src/index.ts
@@ -1,1 +1,3 @@
-export {};
+export * from './helpers/packages';
+export * from './helpers/misc';
+export * from './helpers/scripts';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1706,6 +1706,13 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/globby@^9.1.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@types/globby/-/globby-9.1.0.tgz#08e2cf99c64f8e45c6cfbe05e9d8ac763aca6482"
+  integrity sha512-9du/HCA71EBz7syHRnM4Q/u4Fbx3SyN/Uu+4Of9lyPX4A6Xi+A8VMxvx8j5/CMTfrae2Zwdwg0fAaKvKXfRbAw==
+  dependencies:
+    globby "*"
+
 "@types/got@^9.6.8":
   version "9.6.9"
   resolved "https://registry.yarnpkg.com/@types/got/-/got-9.6.9.tgz#b3192188b96c871b9c67dc80d1b0336441432a38"
@@ -4952,7 +4959,7 @@ fast-glob@^2.0.2, fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.0.3:
+fast-glob@^3.0.3, fast-glob@^3.1.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.2.tgz#ade1a9d91148965d4bf7c51f72e1ca662d32e63d"
   integrity sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==
@@ -5386,13 +5393,6 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-lerna-packages@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/get-lerna-packages/-/get-lerna-packages-0.1.1.tgz#37aaaac36fd14f00082f17b1096dd6c69290cef9"
-  integrity sha512-venxkvga57gOUZoTmXZlJ0zHc8cmvsx7Y0GTMcoEK/7OCEK3PLpG5gVTbUUMJaLxbzK13AWQdKPf1LSkuEfWqA==
-  dependencies:
-    glob "^7.1.2"
-
 get-pkg-repo@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz#c73b489c06d80cc5536c2c853f9e05232056972d"
@@ -5613,6 +5613,18 @@ globalthis@^1.0.1:
   integrity sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==
   dependencies:
     define-properties "^1.1.3"
+
+globby@*, globby@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.0.tgz#56fd0e9f0d4f8fb0c456f1ab0dee96e1380bc154"
+  integrity sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
 
 globby@10.0.1:
   version "10.0.1"
@@ -6040,7 +6052,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1:
+ignore@^5.1.1, ignore@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
@@ -7476,13 +7488,6 @@ lazystream@^1.0.0:
   integrity sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=
   dependencies:
     readable-stream "^2.0.5"
-
-lerna-alias@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lerna-alias/-/lerna-alias-3.0.2.tgz#61d7d79b182849e98ee4cdca0127f714f8712d4d"
-  integrity sha512-3Ly21S1gn+j+yt2zMN0mB5ull1U46HYHb1ksjCznuuac/YWI4gf3EYNwxHNz7W4MdezTF4SClHRbJsmfu/8wyQ==
-  dependencies:
-    get-lerna-packages "^0.1.0"
 
 lerna@^3.20.1:
   version "3.20.2"


### PR DESCRIPTION
- Don't bump private packages
- Fail if elasticsearch service is not up
- Expost helper functions from `@terascope/scripts` and add `getJestAliases`