### PR TITLE
data-mate error fixes and data-type object support for arrays

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -32,9 +32,9 @@
         "@turf/clean-coords": "^6.0.1"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.15.0",
-        "@terascope/types": "^0.1.3",
-        "@terascope/utils": "^0.24.4",
+        "@terascope/data-types": "^0.16.0",
+        "@terascope/types": "^0.2.0",
+        "@terascope/utils": "^0.25.0",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-point-in-polygon": "^6.0.1",
@@ -49,7 +49,7 @@
         "jexl": "^2.2.2",
         "valid-url": "^1.0.9",
         "validator": "^13.0.0",
-        "xlucene-parser": "^0.19.5"
+        "xlucene-parser": "^0.20.0"
     },
     "devDependencies": {},
     "engines": {

--- a/packages/data-mate/src/transforms/field-transform.ts
+++ b/packages/data-mate/src/transforms/field-transform.ts
@@ -12,7 +12,8 @@ import {
 import {
     isString,
     isValidDate,
-    isNumber
+    isNumber,
+    isArray
 } from '../validations/field-validator';
 import { Repository } from '../interfaces';
 
@@ -154,7 +155,45 @@ export const repository: Repository = {
         },
         output_type: 'Any' as AvailableType
     },
+    setDefault: {
+        fn: setDefault,
+        config: {
+            value: {
+                type: 'Any'
+            }
+        },
+        output_type: 'Any' as AvailableType
+    },
+    map: {
+        fn: map,
+        config: {
+            fn: {
+                type: 'String'
+            },
+            args: {
+                type: 'Object'
+            }
+        },
+        output_type: 'Any' as AvailableType
+    },
 };
+
+export function setDefault(input: any, args: { value: any }) {
+    if (input === undefined) {
+        if (args.value === undefined) throw new Error('Parameter value cannot be set to undefined');
+        return args.value;
+    }
+    return input;
+}
+
+export function map(input: any[], args: { fn: string; options?: any }) {
+    if (!isArray(input)) throw new Error('Input must be an array');
+    const { fn, options } = args;
+    const repoConfig = repository[fn];
+    if (!repoConfig) throw new Error(`No function ${fn} was found in the field transform respository`);
+
+    return input.map((data) => repoConfig.fn(data, options));
+}
 
 // TODO: this is currently a hack for directives, this will evolve, do not use it for other purposes
 export function setField(_input: any, args: { field: string; value: any }) {
@@ -372,7 +411,7 @@ export function extract(
     }
 
     const results = extractAndTransferFields();
-    if (results == null) throw new Error('Nothing to extract');
+    if (results == null) return null;
 
     return results;
 }

--- a/packages/data-mate/src/transforms/field-transform.ts
+++ b/packages/data-mate/src/transforms/field-transform.ts
@@ -170,7 +170,7 @@ export const repository: Repository = {
             fn: {
                 type: 'String'
             },
-            args: {
+            options: {
                 type: 'Object'
             }
         },
@@ -179,15 +179,15 @@ export const repository: Repository = {
 };
 
 export function setDefault(input: any, args: { value: any }) {
-    if (input === undefined) {
-        if (args.value === undefined) throw new Error('Parameter value cannot be set to undefined');
+    if (ts.isNil(input)) {
+        if (ts.isNil(args.value)) throw new Error('Parameter value cannot be set to undefined or null');
         return args.value;
     }
     return input;
 }
 
 export function map(input: any[], args: { fn: string; options?: any }) {
-    if (!isArray(input)) throw new Error('Input must be an array');
+    if (!isArray(input)) throw new Error(`Input must be an array, received ${ts.getTypeOf(input)}`);
     const { fn, options } = args;
     const repoConfig = repository[fn];
     if (!repoConfig) throw new Error(`No function ${fn} was found in the field transform respository`);
@@ -196,12 +196,13 @@ export function map(input: any[], args: { fn: string; options?: any }) {
 }
 
 // TODO: this is currently a hack for directives, this will evolve, do not use it for other purposes
-export function setField(_input: any, args: { field: string; value: any }) {
+export function setField(_input: any, args: { value: any }) {
     const { value } = args;
     return value;
 }
 
 export function toString(input: any) {
+    if (ts.isNil(input)) return null;
     return ts.toString(input);
 }
 
@@ -210,36 +211,43 @@ export function toBoolean(input: any) {
 }
 
 export function toUpperCase(input: string) {
-    if (!isString(input)) throw new Error('Input must be a string');
+    if (ts.isNil(input)) return null;
+    if (!isString(input)) throw new Error(`Input must be a string, received ${ts.getTypeOf(input)}`);
     return input.toUpperCase();
 }
 
 export function toLowerCase(input: string) {
-    if (!isString(input)) throw new Error('Input must be a string');
+    if (ts.isNil(input)) return null;
+    if (!isString(input)) throw new Error(`Input must be a string, received ${ts.getTypeOf(input)}`);
     return input.toLowerCase();
 }
 
 export function trim(input: string, args?: { char: string }) {
-    const char = args ? args.char : ' ';
+    if (ts.isNil(input)) return null;
+    const char: string = (args?.char && isString(args.char)) ? args.char : ' ';
+    // @ts-ignore its complaining about passing a string into something thats either string or null
     return trimEnd(trimStart(input, { char }), { char });
 }
 
-export function trimStart(input: string, args?: { char: string }): string {
-    if (!isString(input)) throw new Error('Input must be a string');
-    if (args?.char && !isString(args.char)) throw new Error('Input must be a string');
+export function trimStart(input: string, args?: { char: string }) {
+    if (ts.isNil(input)) return null;
+    if (!isString(input)) throw new Error(`Input must be a string, received ${ts.getTypeOf(input)}`);
+    if (args?.char && !isString(args.char)) throw new Error(`Parameter char must be a string, received ${ts.getTypeOf(input)}`);
 
     return ts.trimStart(input, args?.char);
 }
 
-export function trimEnd(input: string, args?: { char: string }): string {
-    if (!isString(input)) throw new Error('Input must be a string');
-    if (args?.char && !isString(args.char)) throw new Error('Input must be a string');
+export function trimEnd(input: string, args?: { char: string }) {
+    if (ts.isNil(input)) return null;
+    if (!isString(input)) throw new Error(`Input must be a string, received ${ts.getTypeOf(input)}`);
+    if (args?.char && !isString(args.char)) throw new Error(`Parameter char must be a string, received ${ts.getTypeOf(input)}`);
 
     return ts.trimEnd(input, args?.char);
 }
 
 export function truncate(input: string, args: { size: number }) {
-    if (!isString(input)) throw new Error('Input must be a string');
+    if (ts.isNil(input)) return null;
+    if (!isString(input)) throw new Error(`Input must be a string, received ${ts.getTypeOf(input)}`);
     const { size } = args;
 
     if (!size || !ts.isNumber(size) || size <= 0) throw new Error('Invalid size paramter for truncate');
@@ -247,6 +255,7 @@ export function truncate(input: string, args: { size: number }) {
 }
 
 export function toISDN(input: any) {
+    if (ts.isNil(input)) return null;
     let testNumber = ts.toString(input).trim();
     if (testNumber.charAt(0) === '0') testNumber = testNumber.slice(1);
 
@@ -265,43 +274,51 @@ export function toNumber(input: any, args?: { booleanLike?: boolean }) {
     if (args?.booleanLike && ts.isBooleanLike(input)) {
         result = ts.toNumber(toBoolean(result));
     }
-
+    if (ts.isNil(result)) return null;
     result = ts.toNumber(result);
 
-    if (Number.isNaN(result)) throw new Error('could not convert to a number');
+    if (Number.isNaN(result)) throw new Error(`Could not convert input of type ${ts.getTypeOf(input)} to a number`);
     return result;
 }
 
 export function decodeBase64(input: any) {
+    if (ts.isNil(input)) return null;
     return Buffer.from(input, 'base64').toString('utf8');
 }
 
 export function encodeBase64(input: any) {
+    if (ts.isNil(input)) return null;
     return Buffer.from(input).toString('base64');
 }
 
 export function decodeUrl(input: string) {
+    if (ts.isNil(input)) return null;
     return decodeURIComponent(input);
 }
 
 export function encodeUrl(input: string) {
+    if (ts.isNil(input)) return null;
     return encodeURIComponent(input);
 }
 
 export function decodeHex(input: any) {
+    if (ts.isNil(input)) return null;
     return Buffer.from(input, 'hex').toString('utf8');
 }
 
 export function encodeHex(input: any) {
+    if (ts.isNil(input)) return null;
     return Buffer.from(input).toString('hex');
 }
 
 export function encodeMD5(input: any) {
+    if (ts.isNil(input)) return null;
     return crypto.createHash('md5').update(input).digest('hex');
 }
 
 // TODO: better types for this
 export function encodeSHA(input: any, { hash = 'sha256', digest = 'hex' } = {}) {
+    if (ts.isNil(input)) return null;
     // TODO: guard for hash ??
     if (!['ascii', 'utf8', 'utf16le', 'ucs2', 'base64', 'latin1', 'hex', 'binary'].includes(digest)) throw new Error('Parameter digest is misconfigured');
     // @ts-ignore
@@ -309,24 +326,29 @@ export function encodeSHA(input: any, { hash = 'sha256', digest = 'hex' } = {}) 
 }
 
 export function encodeSHA1(input: any) {
+    if (ts.isNil(input)) return null;
     return crypto.createHash('sha1').update(input).digest('hex');
 }
 
 export function decodeSHA1(input: any) {
+    if (ts.isNil(input)) return null;
     return crypto.createHash('sha1').update(input).digest('hex');
 }
 
 export function parseJSON(input: any) {
+    if (ts.isNil(input)) return null;
     return JSON.parse(input);
 }
 
 export function dedupe(input: any[]) {
+    if (ts.isNil(input)) return null;
     // TODO: figure out if we need more than reference equality
-    if (!Array.isArray(input)) throw new Error('Input must be an array');
+    if (!Array.isArray(input)) throw new Error(`Input must be an array, recieved ${ts.getTypeOf(input)}`);
     return ts.uniq(input);
 }
 
 export function toGeoPoint(input: any) {
+    if (ts.isNil(input)) return null;
     return ts.parseGeoPoint(input, true);
 }
 
@@ -336,6 +358,8 @@ export function extract(
         regex, isMultiValue = true, jexlExp, start, end
     }: ExtractFieldConfig
 ) {
+    if (ts.isNil(input)) return null;
+
     function getSubslice() {
         const indexStart = input.indexOf(start);
         if (indexStart !== -1) {
@@ -418,7 +442,8 @@ export function extract(
 
 export function replaceRegex(input: string, {
     regex, replace, ignoreCase, global
-}: ReplaceRegexConfig): string {
+}: ReplaceRegexConfig) {
+    if (ts.isNil(input)) return null;
     let options = '';
 
     if (ignoreCase) options += 'i';
@@ -432,7 +457,8 @@ export function replaceRegex(input: string, {
     }
 }
 
-export function replaceLiteral(input: string, { search, replace }: ReplaceLiteralConfig): string {
+export function replaceLiteral(input: string, { search, replace }: ReplaceLiteralConfig) {
+    if (ts.isNil(input)) return null;
     try {
         return input.replace(search, replace);
     } catch (e) {
@@ -440,14 +466,16 @@ export function replaceLiteral(input: string, { search, replace }: ReplaceLitera
     }
 }
 
-export function toArray(input: string, args?: { delimiter: string }): any[] {
+export function toArray(input: string, args?: { delimiter: string }): string[] | null {
+    if (ts.isNil(input)) return null;
+
     const delimiter = args ? args.delimiter : '';
 
     return input.split(delimiter);
 }
 
 // option to specify, seconds, millisecond, microseconds?
-export function toUnixTime(input: any, { ms = false } = {}): number {
+export function toUnixTime(input: any, { ms = false } = {}) {
     if (!isValidDate(input)) throw new Error('Not a valid date, cannot transform to unix time');
     let time: boolean | number;
 
@@ -460,7 +488,8 @@ export function toUnixTime(input: any, { ms = false } = {}): number {
     return time as number;
 }
 
-export function toISO8601(input: any, args?: { resolution?: 'seconds' | 'milliseconds' }): string {
+export function toISO8601(input: any, args?: { resolution?: 'seconds' | 'milliseconds' }) {
+    if (ts.isNil(input)) return null;
     if (!isValidDate(input)) {
         throw new Error('Not a valid date');
     }
@@ -471,9 +500,10 @@ export function toISO8601(input: any, args?: { resolution?: 'seconds' | 'millise
     return new Date(value).toISOString();
 }
 
-export function formatDate(input: any, args: { format: string; resolution?: 'seconds' | 'milliseconds' }): string {
+export function formatDate(input: any, args: { format: string; resolution?: 'seconds' | 'milliseconds' }) {
+    if (ts.isNil(input)) return null;
     const { format, resolution } = args;
-    if (!isString(format)) throw new Error('Invalid parameter format, must be a string');
+    if (!isString(format)) throw new Error(`Invalid parameter format, must be a string, recieved ${ts.getTypeOf(input)}`);
     // convert string to date
     // validate input as datelike
     if (!isValidDate(input)) {
@@ -489,8 +519,10 @@ export function formatDate(input: any, args: { format: string; resolution?: 'sec
 }
 
 export function parseDate(input: any, args: { format: string }) {
+    if (ts.isNil(input)) return null;
+
     const { format } = args;
-    if (!isString(format)) throw new Error('Invalid parameter format, must be a string');
+    if (!isString(format)) throw new Error(`Invalid parameter format, must be a string, recieved ${ts.getTypeOf(input)}`);
 
     const parsed = parse(input, format, new Date());
 
@@ -501,22 +533,32 @@ export function parseDate(input: any, args: { format: string }) {
     return parsed;
 }
 
-export function toCamelCase(input: string): string {
+export function toCamelCase(input: string) {
+    if (ts.isNil(input)) return null;
+
     return ts.toCamelCase(input);
 }
 
-export function toKebabCase(input: string): string {
+export function toKebabCase(input: string) {
+    if (ts.isNil(input)) return null;
+
     return ts.toKebabCase(input);
 }
 
-export function toPascalCase(input: string): string {
+export function toPascalCase(input: string) {
+    if (ts.isNil(input)) return null;
+
     return ts.toPascalCase(input);
 }
 
-export function toSnakeCase(input: string): string {
+export function toSnakeCase(input: string) {
+    if (ts.isNil(input)) return null;
+
     return ts.toSnakeCase(input);
 }
 
-export function toTitleCase(input: string): string {
+export function toTitleCase(input: string) {
+    if (ts.isNil(input)) return null;
+
     return ts.toTitleCase(input);
 }

--- a/packages/data-mate/src/transforms/field-transform.ts
+++ b/packages/data-mate/src/transforms/field-transform.ts
@@ -187,6 +187,8 @@ export function setDefault(input: any, args: { value: any }) {
 }
 
 export function map(input: any[], args: { fn: string; options?: any }) {
+    if (ts.isNil(input)) return null;
+
     if (!isArray(input)) throw new Error(`Input must be an array, received ${ts.getTypeOf(input)}`);
     const { fn, options } = args;
     const repoConfig = repository[fn];
@@ -274,6 +276,7 @@ export function toNumber(input: any, args?: { booleanLike?: boolean }) {
     if (args?.booleanLike && ts.isBooleanLike(input)) {
         result = ts.toNumber(toBoolean(result));
     }
+
     if (ts.isNil(result)) return null;
     result = ts.toNumber(result);
 

--- a/packages/data-mate/src/validations/field-validator.ts
+++ b/packages/data-mate/src/validations/field-validator.ts
@@ -386,12 +386,12 @@ export function isValidDate(input: any): boolean {
 
 // NOTE: this function will throw compared to all other validations
 export function guard(input: any) {
-    if (input === undefined) throw new Error('input is empty');
+    if (ts.isNil(input)) throw new Error('input is empty');
     return true;
 }
 
 export function exists(input: any): boolean {
-    return input !== undefined;
+    return !ts.isNil(input);
 }
 
 export function isArray(input: any): boolean {

--- a/packages/data-mate/src/validations/field-validator.ts
+++ b/packages/data-mate/src/validations/field-validator.ts
@@ -386,7 +386,7 @@ export function isValidDate(input: any): boolean {
 
 // NOTE: this function will throw compared to all other validations
 export function guard(input: any) {
-    if (ts.isNil(input)) throw new Error('input is empty');
+    if (ts.isNil(input)) throw new Error('Expected value not to be empty');
     return true;
 }
 

--- a/packages/data-mate/src/validations/field-validator.ts
+++ b/packages/data-mate/src/validations/field-validator.ts
@@ -146,8 +146,20 @@ export const repository: i.Repository = {
     exists: { fn: exists, config: {} },
     guard: { fn: guard, config: {} },
     isArray: { fn: isArray, config: {} },
-    some: { fn: some, config: { fn: { type: 'String' } } },
-    every: { fn: every, config: { fn: { type: 'String' } } },
+    some: {
+        fn: some,
+        config: {
+            fn: { type: 'String' },
+            options: { type: 'Object' }
+        }
+    },
+    every: {
+        fn: every,
+        config: {
+            fn: { type: 'String' },
+            options: { type: 'Object' }
+        }
+    },
 };
 
 export function isBoolean(input: any): boolean {
@@ -387,20 +399,20 @@ export function isArray(input: any): boolean {
     return false;
 }
 
-export function some(input: any, { fn }: { fn: string }): boolean {
+export function some(input: any, { fn, options }: { fn: string; options?: any }): boolean {
     if (!isArray(input)) return false;
 
     const repoConfig = repository[fn];
     if (!repoConfig) throw new Error(`No function ${fn} was found in the field validator respository`);
 
-    return input.some(repoConfig.fn);
+    return input.some((data: any) => repoConfig.fn(data, options));
 }
 
-export function every(input: any, { fn }: { fn: string }): boolean {
+export function every(input: any, { fn, options }: { fn: string; options?: any }): boolean {
     if (!isArray(input)) return false;
 
     const repoConfig = repository[fn];
     if (!repoConfig) throw new Error(`No function ${fn} was found in the field validator respository`);
 
-    return input.every(repoConfig.fn);
+    return input.every((data: any) => repoConfig.fn(data, options));
 }

--- a/packages/data-mate/src/validations/field-validator.ts
+++ b/packages/data-mate/src/validations/field-validator.ts
@@ -142,7 +142,12 @@ export const repository: i.Repository = {
         },
 
     },
-    isIPCidr: { fn: isIPCidr, config: {} }
+    isIPCidr: { fn: isIPCidr, config: {} },
+    exists: { fn: exists, config: {} },
+    guard: { fn: guard, config: {} },
+    isArray: { fn: isArray, config: {} },
+    some: { fn: some, config: { fn: { type: 'String' } } },
+    every: { fn: every, config: { fn: { type: 'String' } } },
 };
 
 export function isBoolean(input: any): boolean {
@@ -365,4 +370,37 @@ export function isPostalCode(input: any, { locale }: { locale: 'any' | PostalCod
 
 export function isValidDate(input: any): boolean {
     return !isBoolean(input) && ts.isValidDate(input);
+}
+
+// NOTE: this function will throw compared to all other validations
+export function guard(input: any) {
+    if (input === undefined) throw new Error('input is empty');
+    return true;
+}
+
+export function exists(input: any): boolean {
+    return input !== undefined;
+}
+
+export function isArray(input: any): boolean {
+    if (Array.isArray(input)) return true;
+    return false;
+}
+
+export function some(input: any, { fn }: { fn: string }): boolean {
+    if (!isArray(input)) return false;
+
+    const repoConfig = repository[fn];
+    if (!repoConfig) throw new Error(`No function ${fn} was found in the field validator respository`);
+
+    return input.some(repoConfig.fn);
+}
+
+export function every(input: any, { fn }: { fn: string }): boolean {
+    if (!isArray(input)) return false;
+
+    const repoConfig = repository[fn];
+    if (!repoConfig) throw new Error(`No function ${fn} was found in the field validator respository`);
+
+    return input.every(repoConfig.fn);
 }

--- a/packages/data-mate/test/field_transform-spec.ts
+++ b/packages/data-mate/test/field_transform-spec.ts
@@ -34,6 +34,26 @@ describe('field transforms', () => {
         });
     });
 
+    describe('setDefault should', () => {
+        it('return a value if nothing is provided', () => {
+            expect(transform.setDefault('foo', { value: true })).toEqual('foo');
+            expect(transform.setDefault({ hello: 'world' }, { value: true })).toEqual({ hello: 'world' });
+            expect(transform.setDefault(null, { value: true })).toEqual(null);
+            expect(transform.setDefault(undefined, { value: true })).toEqual(true);
+        });
+    });
+
+    describe('map should', () => {
+        it('map a field transform function to an array', () => {
+            const array = ['hello', 'world', 'goodbye'];
+            const results1 = array.map(transform.toUpperCase);
+            const results2 = array.map((data) => transform.truncate(data, { size: 2 }));
+
+            expect(transform.map(array, { fn: 'toUpperCase' })).toEqual(results1);
+            expect(transform.map(array, { fn: 'truncate', options: { size: 2 } })).toEqual(results2);
+        });
+    });
+
     describe('extract should', () => {
         it('return whats between start and end', () => {
             const results = transform.extract('<hello>', { start: '<', end: '>' });
@@ -53,6 +73,11 @@ describe('field transforms', () => {
         it('can return a singular value', () => {
             const results = transform.extract('hello', { regex: 'he.*', isMultiValue: false });
             expect(results).toEqual('hello');
+        });
+
+        it('should not throw if it cannot extract anything', () => {
+            const results = transform.extract('boo', { regex: 'he.*', isMultiValue: false });
+            expect(results).toEqual(null);
         });
     });
 

--- a/packages/data-mate/test/field_transform-spec.ts
+++ b/packages/data-mate/test/field_transform-spec.ts
@@ -38,7 +38,7 @@ describe('field transforms', () => {
         it('return a value if nothing is provided', () => {
             expect(transform.setDefault('foo', { value: true })).toEqual('foo');
             expect(transform.setDefault({ hello: 'world' }, { value: true })).toEqual({ hello: 'world' });
-            expect(transform.setDefault(null, { value: true })).toEqual(null);
+            expect(transform.setDefault(null, { value: true })).toEqual(true);
             expect(transform.setDefault(undefined, { value: true })).toEqual(true);
         });
     });
@@ -175,15 +175,17 @@ describe('field transforms', () => {
         it('throw an error if input cannot be coerced to a number', () => {
             try {
                 expect(transform.toNumber('bobsyouruncle')).toBe(12321);
-            } catch (e) { expect(e.message).toBe('could not convert to a number'); }
+            } catch (e) { expect(e.message).toBe('Could not convert input of type String to a number'); }
 
             try {
                 expect(transform.toNumber({})).toBe(12321);
-            } catch (e) { expect(e.message).toBe('could not convert to a number'); }
+            } catch (e) { expect(e.message).toBe('Could not convert input of type Object to a number'); }
+        });
 
-            try {
-                expect(transform.toNumber(undefined)).toBe(12321);
-            } catch (e) { expect(e.message).toBe('could not convert to a number'); }
+        it('will return null when given undefined or null', () => {
+            expect(transform.toNumber(undefined)).toBe(null);
+            expect(transform.toNumber(null)).toBe(null);
+
         });
     });
 

--- a/packages/data-mate/test/field_transform-spec.ts
+++ b/packages/data-mate/test/field_transform-spec.ts
@@ -185,7 +185,6 @@ describe('field transforms', () => {
         it('will return null when given undefined or null', () => {
             expect(transform.toNumber(undefined)).toBe(null);
             expect(transform.toNumber(null)).toBe(null);
-
         });
     });
 

--- a/packages/data-mate/test/field_validator-spec.ts
+++ b/packages/data-mate/test/field_validator-spec.ts
@@ -544,7 +544,7 @@ describe('field validators', () => {
             expect(FieldValidator.guard('hello')).toBe(true);
             expect(FieldValidator.guard(23423)).toBe(true);
             expect(FieldValidator.guard({ hello: 'world' })).toBe(true);
-            expect(FieldValidator.guard(null)).toBe(true);
+            expect(() => FieldValidator.guard(null)).toThrow();
             expect(() => FieldValidator.guard(undefined)).toThrow();
         });
     });
@@ -580,7 +580,7 @@ describe('field validators', () => {
             expect(FieldValidator.exists('hello')).toBe(true);
             expect(FieldValidator.exists(23423)).toBe(true);
             expect(FieldValidator.exists({ hello: 'world' })).toBe(true);
-            expect(FieldValidator.exists(null)).toBe(true);
+            expect(FieldValidator.exists(null)).toBe(false);
             expect(FieldValidator.exists(undefined)).toBe(false);
         });
     });

--- a/packages/data-mate/test/field_validator-spec.ts
+++ b/packages/data-mate/test/field_validator-spec.ts
@@ -539,6 +539,52 @@ describe('field validators', () => {
         });
     });
 
+    describe('guard', () => {
+        it('should throw if undefined', () => {
+            expect(FieldValidator.guard('hello')).toBe(true);
+            expect(FieldValidator.guard(23423)).toBe(true);
+            expect(FieldValidator.guard({ hello: 'world' })).toBe(true);
+            expect(FieldValidator.guard(null)).toBe(true);
+            expect(() => FieldValidator.guard(undefined)).toThrow();
+        });
+    });
+
+    describe('some', () => {
+        it('should indicate if some elements of an array pass the validation', () => {
+            expect(FieldValidator.some(['hello', 3, { some: 'obj' }], { fn: 'isString' })).toBe(true);
+            expect(FieldValidator.some(['hello', 3, { some: 'obj' }], { fn: 'isBoolean' })).toBe(false);
+        });
+    });
+
+    describe('every', () => {
+        it('should indicate if every elements of an array pass the validation', () => {
+            expect(FieldValidator.every(['hello', 3, { some: 'obj' }], { fn: 'isString' })).toBe(false);
+            expect(FieldValidator.every(['hello', 'world'], { fn: 'isString' })).toBe(true);
+        });
+    });
+
+    describe('isArray', () => {
+        it('should indicate if an array was given', () => {
+            expect(FieldValidator.isArray('hello')).toBe(false);
+            expect(FieldValidator.isArray(23423)).toBe(false);
+            expect(FieldValidator.isArray({ hello: 'world' })).toBe(false);
+            expect(FieldValidator.isArray(null)).toBe(false);
+            expect(FieldValidator.isArray(undefined)).toBe(false);
+            expect(FieldValidator.isArray([1, 2, 3])).toBe(true);
+            expect(FieldValidator.isArray([])).toBe(true);
+        });
+    });
+
+    describe('exists', () => {
+        it('should indicate if a value was given', () => {
+            expect(FieldValidator.exists('hello')).toBe(true);
+            expect(FieldValidator.exists(23423)).toBe(true);
+            expect(FieldValidator.exists({ hello: 'world' })).toBe(true);
+            expect(FieldValidator.exists(null)).toBe(true);
+            expect(FieldValidator.exists(undefined)).toBe(false);
+        });
+    });
+
     describe('equals', () => {
         it('should return true if string is equal to a value', () => {
             expect(FieldValidator.equals('hello', { value: 'hello' })).toBe(true);

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -28,8 +28,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.1.3",
-        "@terascope/utils": "^0.24.4",
+        "@terascope/types": "^0.2.0",
+        "@terascope/utils": "^0.25.0",
         "graphql": "^14.5.8",
         "lodash.defaultsdeep": "^4.6.1",
         "yargs": "^15.3.1"

--- a/packages/data-types/src/types/base-type.ts
+++ b/packages/data-types/src/types/base-type.ts
@@ -37,7 +37,7 @@ export default abstract class BaseType {
         customType?: string|(string[])
     ): GraphQLType {
         const desc = this.config.description;
-        if (type !== 'JSONObject' && this.config.array) {
+        if (this.config.array) {
             return {
                 type: formatGQLType(`${this.field}: [${type}]`, desc),
                 customTypes: makeCustomTypes(customType),

--- a/packages/data-types/src/types/v1/object.ts
+++ b/packages/data-types/src/types/v1/object.ts
@@ -3,11 +3,12 @@ import BaseType from '../base-type';
 
 export default class ObjectType extends BaseType {
     toESMapping(_version?: number) {
-        const type: ESTypeMapping = { type: 'object' };
+        const type = this.config.array ? 'nested' : 'object';
+        const typeConfig: ESTypeMapping = { type };
         if (this.config.indexed === false) {
-            type.enabled = false;
+            typeConfig.enabled = false;
         }
-        return { mapping: { [this.field]: type } };
+        return { mapping: { [this.field]: typeConfig } };
     }
 
     toGraphQL() {

--- a/packages/data-types/test/types/v1/object-spec.ts
+++ b/packages/data-types/test/types/v1/object-spec.ts
@@ -20,6 +20,14 @@ describe('Object V1', () => {
         expect(esMapping).toEqual(results);
     });
 
+    it('can get proper ES Mappings if given an array', () => {
+        const newTypeConfig = Object.assign({}, { array: true }, typeConfig);
+        const esMapping = new ObejctType(field, newTypeConfig).toESMapping();
+        const results = { mapping: { [field]: { type: 'nested' } } };
+
+        expect(esMapping).toEqual(results);
+    });
+
     it('can get proper ES Mappings when not indexed', () => {
         const esMapping = new ObejctType(field, {
             ...typeConfig,
@@ -39,7 +47,7 @@ describe('Object V1', () => {
 
     it('can get proper graphql types when given an array', () => {
         const graphQlTypes = new ObejctType(field, { ...typeConfig, array: true }).toGraphQL();
-        const results = { type: `${field}: JSONObject`, customTypes: ['scalar JSONObject'] };
+        const results = { type: `${field}: [JSONObject]`, customTypes: ['scalar JSONObject'] };
 
         expect(graphQlTypes).toEqual(results);
     });

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.6.4",
+    "version": "2.7.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.24.4",
+        "@terascope/utils": "^0.25.0",
         "bluebird": "^3.7.2",
         "lodash.isequal": "^4.5.0"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.25.0",
+    "version": "0.26.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,13 +24,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.5.0",
-        "@terascope/data-types": "^0.15.0",
-        "@terascope/types": "^0.1.3",
-        "@terascope/utils": "^0.24.4",
+        "@terascope/data-mate": "^0.6.0",
+        "@terascope/data-types": "^0.16.0",
+        "@terascope/types": "^0.2.0",
+        "@terascope/utils": "^0.25.0",
         "ajv": "^6.12.0",
         "uuid": "^7.0.2",
-        "xlucene-translator": "^0.3.5"
+        "xlucene-translator": "^0.4.0"
     },
     "devDependencies": {
         "@types/uuid": "^7.0.0",

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.4.4",
+    "version": "0.5.0",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.24.4",
+        "@terascope/utils": "^0.25.0",
         "chalk": "^3.0.0",
         "lodash.defaultsdeep": "^4.6.1",
         "yeoman-generator": "^4.7.0",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.30.2",
+    "version": "0.31.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.24.4",
+        "@terascope/utils": "^0.25.0",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^7.0.2"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.15.1",
+    "version": "0.16.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.18.5",
-        "@terascope/utils": "^0.24.4",
+        "@terascope/utils": "^0.25.0",
         "codecov": "^3.6.5",
         "execa": "^4.0.0",
         "fs-extra": "^9.0.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.18.4",
+    "version": "0.19.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.24.4",
+        "@terascope/utils": "^0.25.0",
         "aws-sdk": "^2.596.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.12",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.18.2",
+    "version": "0.19.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.6.0",
-        "@terascope/utils": "^0.24.4",
+        "@terascope/utils": "^0.25.0",
         "archiver": "^3.0.0",
         "chalk": "^3.0.0",
         "cli-table3": "^0.6.0",
@@ -49,7 +49,7 @@
         "request": "^2.88.0",
         "request-promise": "^4.2.5",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.16.2",
+        "teraslice-client-js": "^0.17.0",
         "tmp": "^0.1.0",
         "tty-table": "^4.1.1",
         "yargs": "^15.3.1",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.16.2",
+    "version": "0.17.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.30.2",
+        "@terascope/job-components": "^0.31.0",
         "auto-bind": "^4.0.0",
         "got": "^9.6.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.8.4",
+    "version": "0.9.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/utils": "^0.24.4",
+        "@terascope/utils": "^0.25.0",
         "ms": "^2.1.2",
         "nanoid": "^2.1.10",
         "p-event": "^4.1.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
     "displayName": "Teraslice Op Test Harness",
-    "version": "1.14.2",
+    "version": "1.15.0",
     "description": "A testing harness to simplify testing Teraslice processors and operations.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-op-test-harness#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.30.2",
+        "@terascope/job-components": "^0.31.0",
         "bluebird": "^3.7.2"
     },
     "devDependencies": {},

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.12.4",
+    "version": "0.13.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.6.4",
-        "@terascope/utils": "^0.24.4",
+        "@terascope/elasticsearch-api": "^2.7.0",
+        "@terascope/utils": "^0.25.0",
         "mnemonist": "^0.35.0"
     },
     "publishConfig": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "0.15.2",
+    "version": "0.16.0",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {
@@ -30,8 +30,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.30.2",
-        "@terascope/teraslice-op-test-harness": "^1.14.2"
+        "@terascope/job-components": "^0.31.0",
+        "@terascope/teraslice-op-test-harness": "^1.15.0"
     },
     "devDependencies": {},
     "engines": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.6.4",
-        "@terascope/job-components": "^0.30.2",
-        "@terascope/teraslice-messaging": "^0.8.4",
-        "@terascope/utils": "^0.24.4",
+        "@terascope/elasticsearch-api": "^2.7.0",
+        "@terascope/job-components": "^0.31.0",
+        "@terascope/teraslice-messaging": "^0.9.0",
+        "@terascope/utils": "^0.25.0",
         "async-mutex": "^0.1.3",
         "barbe": "^3.0.15",
         "body-parser": "^1.19.0",
@@ -62,11 +62,11 @@
         "shortid": "^2.2.14",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.18.4",
+        "terafoundation": "^0.19.0",
         "uuid": "^7.0.2"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.14.2",
+        "@terascope/teraslice-op-test-harness": "^1.15.0",
         "archiver": "^3.0.0",
         "bufferstreams": "^3.0.0",
         "chance": "^1.1.4",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.34.0",
+    "version": "0.34.1",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.34.1",
+    "version": "0.35.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.5.0",
-        "@terascope/types": "^0.1.3",
-        "@terascope/utils": "^0.24.4",
+        "@terascope/data-mate": "^0.6.0",
+        "@terascope/types": "^0.2.0",
+        "@terascope/utils": "^0.25.0",
         "awesome-phonenumber": "^2.29.0",
         "graphlib": "^2.1.8",
         "jexl": "^2.2.2",

--- a/packages/ts-transforms/test/phases/selector-phase-spec.ts
+++ b/packages/ts-transforms/test/phases/selector-phase-spec.ts
@@ -33,7 +33,7 @@ describe('selector phase', () => {
 
     it('can run data to match based on selector and types', async () => {
         const configList = await getConfigList('transformRules1.txt');
-        const myOpConfig = Object.assign({}, transformOpconfig, { types: { location: 'geo' } });
+        const myOpConfig = Object.assign({}, transformOpconfig, { type_config: { location: 'geo' } });
         const selectorPhase = new SelectionPhase(myOpConfig, configList, opManager);
         const data = DataEntity.makeArray([
             { some: 'data', isTall: true },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/types",
     "displayName": "Types",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "description": "A collection of typescript interfaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/types#readme",
     "bugs": {

--- a/packages/types/src/elasticsearch-interfaces.ts
+++ b/packages/types/src/elasticsearch-interfaces.ts
@@ -169,7 +169,8 @@ export type ESFieldType =
     | 'date'
     | 'geo_point'
     | 'geo_shape'
-    | 'object';
+    | 'object'
+    | 'nested';
 
 export type ESTypeMapping =
     | PropertyESTypeMapping

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.24.4",
+    "version": "0.25.0",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {
@@ -28,7 +28,7 @@
         "debug": "^4.1.1"
     },
     "dependencies": {
-        "@terascope/types": "^0.1.3",
+        "@terascope/types": "^0.2.0",
         "debug": "^4.1.1",
         "is-plain-object": "^3.0.0",
         "js-string-escape": "^1.0.1",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.19.5",
+    "version": "0.20.0",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -33,8 +33,8 @@
         "@turf/clean-coords": "^6.0.1"
     },
     "dependencies": {
-        "@terascope/types": "^0.1.3",
-        "@terascope/utils": "^0.24.4",
+        "@terascope/types": "^0.2.0",
+        "@terascope/utils": "^0.25.0",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-contains": "^6.0.1",

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.3.5",
+    "version": "0.4.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -28,9 +28,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.1.3",
-        "@terascope/utils": "^0.24.4",
-        "xlucene-parser": "^0.19.5"
+        "@terascope/types": "^0.2.0",
+        "@terascope/utils": "^0.25.0",
+        "xlucene-parser": "^0.20.0"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"


### PR DESCRIPTION
- added support in data-type `Object` for array support
- fixed extract bug so it does not throw on no results
- added `map` and `setDefault` to field transforms
- added `exists`, `guard`,  `isArray`,`every`, `guard` to field validations