### PR TITLE
hotfix for data-mate

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-mate/src/transforms/field-transform.ts
+++ b/packages/data-mate/src/transforms/field-transform.ts
@@ -209,6 +209,7 @@ export function toString(input: any) {
 }
 
 export function toBoolean(input: any) {
+    if (ts.isNil(input)) return null;
     return ts.toBoolean(input);
 }
 

--- a/packages/data-mate/test/field_transform-spec.ts
+++ b/packages/data-mate/test/field_transform-spec.ts
@@ -8,7 +8,7 @@ describe('field transforms', () => {
         });
 
         it('return false for falsy values', () => {
-            [0, false, undefined, null, NaN, '']
+            [0, false, NaN, '']
                 .forEach((v) => expect(transform.toBoolean(v)).toBe(false));
         });
 

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.26.0",
+    "version": "0.26.1",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.6.0",
+        "@terascope/data-mate": "^0.6.1",
         "@terascope/data-types": "^0.16.0",
         "@terascope/types": "^0.2.0",
         "@terascope/utils": "^0.25.0",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.35.0",
+    "version": "0.35.1",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.6.0",
+        "@terascope/data-mate": "^0.6.1",
         "@terascope/types": "^0.2.0",
         "@terascope/utils": "^0.25.0",
         "awesome-phonenumber": "^2.29.0",


### PR DESCRIPTION
- toBoolean in data-mate will now return null when input is null/undefined
- utils toBoolean behaviour is **unchanged**. This will return a bool with null/undefiend.