### PR TITLE
Fix process.env usage in @terascope/utils for webpack

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -32,9 +32,9 @@
         "@turf/clean-coords": "^6.0.1"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.17.1",
+        "@terascope/data-types": "^0.17.2",
         "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.26.1",
+        "@terascope/utils": "^0.26.2",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-point-in-polygon": "^6.0.1",
@@ -49,7 +49,7 @@
         "jexl": "^2.2.2",
         "valid-url": "^1.0.9",
         "validator": "^13.0.0",
-        "xlucene-parser": "^0.21.2"
+        "xlucene-parser": "^0.21.3"
     },
     "devDependencies": {},
     "engines": {

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.17.1",
+    "version": "0.17.2",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.26.1",
+        "@terascope/utils": "^0.26.2",
         "graphql": "^14.5.8",
         "lodash.defaultsdeep": "^4.6.1",
         "yargs": "^15.3.1"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.8.1",
+    "version": "2.8.2",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.26.1",
+        "@terascope/utils": "^0.26.2",
         "bluebird": "^3.7.2",
         "lodash.isequal": "^4.5.0"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.28.1",
+    "version": "0.28.2",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,13 +24,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.8.1",
-        "@terascope/data-types": "^0.17.1",
+        "@terascope/data-mate": "^0.8.2",
+        "@terascope/data-types": "^0.17.2",
         "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.26.1",
+        "@terascope/utils": "^0.26.2",
         "ajv": "^6.12.0",
         "uuid": "^7.0.2",
-        "xlucene-translator": "^0.5.2"
+        "xlucene-translator": "^0.5.3"
     },
     "devDependencies": {
         "@types/uuid": "^7.0.0",

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.26.1",
+        "@terascope/utils": "^0.26.2",
         "chalk": "^4.0.0",
         "lodash.defaultsdeep": "^4.6.1",
         "yeoman-generator": "^4.8.2",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.32.2",
+    "version": "0.32.3",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.26.1",
+        "@terascope/utils": "^0.26.2",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^7.0.2"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.17.3",
+    "version": "0.17.4",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.18.5",
-        "@terascope/utils": "^0.26.1",
+        "@terascope/utils": "^0.26.2",
         "codecov": "^3.6.5",
         "execa": "^4.0.0",
         "fs-extra": "^9.0.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.20.1",
+    "version": "0.20.2",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.26.1",
+        "@terascope/utils": "^0.26.2",
         "aws-sdk": "^2.596.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.12",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.20.2",
+    "version": "0.20.3",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.6.0",
-        "@terascope/utils": "^0.26.1",
+        "@terascope/utils": "^0.26.2",
         "archiver": "^3.0.0",
         "chalk": "^4.0.0",
         "cli-table3": "^0.6.0",
@@ -49,7 +49,7 @@
         "request": "^2.88.0",
         "request-promise": "^4.2.5",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.18.2",
+        "teraslice-client-js": "^0.18.3",
         "tmp": "^0.1.0",
         "tty-table": "^4.1.1",
         "yargs": "^15.3.1",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.18.2",
+    "version": "0.18.3",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.32.2",
+        "@terascope/job-components": "^0.32.3",
         "auto-bind": "^4.0.0",
         "got": "^9.6.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/utils": "^0.26.1",
+        "@terascope/utils": "^0.26.2",
         "ms": "^2.1.2",
         "nanoid": "^2.1.10",
         "p-event": "^4.1.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
     "displayName": "Teraslice Op Test Harness",
-    "version": "1.16.2",
+    "version": "1.16.3",
     "description": "A testing harness to simplify testing Teraslice processors and operations.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-op-test-harness#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.32.2",
+        "@terascope/job-components": "^0.32.3",
         "bluebird": "^3.7.2"
     },
     "devDependencies": {},

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.14.1",
+    "version": "0.14.2",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.8.1",
-        "@terascope/utils": "^0.26.1",
+        "@terascope/elasticsearch-api": "^2.8.2",
+        "@terascope/utils": "^0.26.2",
         "mnemonist": "^0.36.0"
     },
     "publishConfig": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "0.17.2",
+    "version": "0.17.3",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {
@@ -30,8 +30,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.32.2",
-        "@terascope/teraslice-op-test-harness": "^1.16.2"
+        "@terascope/job-components": "^0.32.3",
+        "@terascope/teraslice-op-test-harness": "^1.16.3"
     },
     "devDependencies": {},
     "engines": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.8.1",
-        "@terascope/job-components": "^0.32.2",
-        "@terascope/teraslice-messaging": "^0.10.2",
-        "@terascope/utils": "^0.26.1",
+        "@terascope/elasticsearch-api": "^2.8.2",
+        "@terascope/job-components": "^0.32.3",
+        "@terascope/teraslice-messaging": "^0.10.3",
+        "@terascope/utils": "^0.26.2",
         "async-mutex": "^0.2.1",
         "barbe": "^3.0.15",
         "body-parser": "^1.19.0",
@@ -62,11 +62,11 @@
         "shortid": "^2.2.14",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.20.1",
+        "terafoundation": "^0.20.2",
         "uuid": "^7.0.2"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.16.2",
+        "@terascope/teraslice-op-test-harness": "^1.16.3",
         "archiver": "^3.0.0",
         "bufferstreams": "^3.0.0",
         "chance": "^1.1.4",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.37.1",
+    "version": "0.37.2",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.8.1",
+        "@terascope/data-mate": "^0.8.2",
         "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.26.1",
+        "@terascope/utils": "^0.26.2",
         "awesome-phonenumber": "^2.29.0",
         "graphlib": "^2.1.8",
         "jexl": "^2.2.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.26.1",
+    "version": "0.26.2",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -1,6 +1,4 @@
-const { NODE_ENV = 'production' } = process.env;
-
-export const isProd = NODE_ENV === 'production';
-export const isTest = NODE_ENV === 'test';
-export const isDev = NODE_ENV === 'development';
+export const isProd = !process.env.NODE_ENV || process.env.NODE_ENV === 'production';
+export const isTest = process.env.NODE_ENV === 'test';
+export const isDev = process.env.NODE_ENV === 'development';
 export const isCI = process.env.CI === 'true';

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.21.2",
+    "version": "0.21.3",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.26.1",
+        "@terascope/utils": "^0.26.2",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-contains": "^6.0.1",

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,8 +29,8 @@
     },
     "dependencies": {
         "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.26.1",
-        "xlucene-parser": "^0.21.2"
+        "@terascope/utils": "^0.26.2",
+        "xlucene-parser": "^0.21.3"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"


### PR DESCRIPTION
The [`webpack.DefinePlugin`](https://webpack.js.org/plugins/define-plugin/) only allows getting the `NODE_ENV` environment variable using `process.env.NODE_ENV` and doesn't work with destructuring.