### PR TITLE
v0.64.5 - Update base docker image to fix node-rdkafka

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM terascope/node-base:10.19.0-1
+FROM terascope/node-base:10.19.0-2
 
 ENV NODE_ENV production
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "0.64.4",
+    "version": "0.64.5",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "0.64.4",
+    "version": "0.64.5",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
Updates docker base image to `terascope/node-base:10.19.0-2`, fixes node-rdkafka ssl issues.
The base image switches back to using alpine

Closes https://github.com/terascope/teraslice/issues/1868
