### PR TITLE
Allow other workspaces outside of the packages directory and misc ts-scripts fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,18 +70,13 @@ jobs:
       node_js: '12.16'
       # run only on pull-requests and cron
       if: branch = master AND type IN (pull_request, cron) AND fork = false
-      script:
-        - yarn --silent --cwd e2e test
+      script: yarn --silent --cwd e2e test
 
     - stage: "Releases"
       name: 'Publish pre-release packages'
       # Run on pull-request and when the commit message includes a prerelease bump
       if: branch = master AND type IN (pull_request) AND commit_message =~ /bump:.*\((prerelease|preminor|prepatch|prerelease)\).*/
-      script: true
-      deploy:
-          - provider: script
-            skip_cleanup: true
-            script: yarn ts-scripts publish -t dev npm
+      script: yarn ts-scripts publish -t dev npm
 
     - script:
       name: 'Publish packages, docs and expiremental docker image'

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@types/lodash": "^4.14.149",
         "debug": "^4.1.1",
         "ms": "^2.1.2",
-        "typescript": "^3.8.3"
+        "typescript": "~3.8.3"
     },
     "dependencies": {},
     "devDependencies": {
@@ -54,7 +54,7 @@
         "lerna": "^3.20.1",
         "node-notifier": "^7.0.0",
         "ts-jest": "^25.5.1",
-        "typescript": "^3.8.3"
+        "typescript": "~3.8.3"
     },
     "engines": {
         "node": ">=10.16.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "terascope": {
         "root": true,
         "type": "monorepo",
+        "target": "es2018",
         "tests": {
             "suites": {
                 "e2e": [

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.19.0-rc.2",
+    "version": "0.19.0-rc.3",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.19.0-rc.4",
+    "version": "0.19.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.18.2",
+    "version": "0.19.0-rc.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -28,7 +28,7 @@
     },
     "resolutions": {
         "ms": "^2.1.2",
-        "typescript": "^3.8.3"
+        "typescript": "~3.8.3"
     },
     "dependencies": {
         "@lerna/query-graph": "^3.18.5",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.19.0-rc.1",
+    "version": "0.19.0-rc.2",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.19.0-rc.0",
+    "version": "0.19.0-rc.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.19.0-rc.3",
+    "version": "0.19.0-rc.4",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/cmds/sync.ts
+++ b/packages/scripts/src/cmds/sync.ts
@@ -1,17 +1,15 @@
 import { CommandModule } from 'yargs';
 import { isCI } from '@terascope/utils';
-import { syncAll, syncPackages } from '../helpers/sync';
-import { PackageInfo, GlobalCMDOptions } from '../helpers/interfaces';
-import { coercePkgArg } from '../helpers/args';
+import { syncAll } from '../helpers/sync';
+import { GlobalCMDOptions } from '../helpers/interfaces';
 
 type Options = {
     verify: boolean;
     quiet?: boolean;
-    packages?: PackageInfo[];
 }
 
 const cmd: CommandModule<GlobalCMDOptions, Options> = {
-    command: 'sync [packages..]',
+    command: 'sync',
     describe: 'Sync packages to make sure they are up-to-date',
     builder(yargs) {
         return yargs
@@ -25,19 +23,9 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
                 description: 'This will disable out-of-sync warnings',
                 type: 'boolean',
                 default: false,
-            })
-            .positional('packages', {
-                description: 'Run scripts for one or more a package',
-                type: 'string',
-                coerce(arg) {
-                    return coercePkgArg(arg);
-                },
             });
     },
-    handler({ packages, verify, quiet }) {
-        if (packages && packages.length) {
-            return syncPackages(packages, { verify, quiet });
-        }
+    handler({ verify, quiet }) {
         return syncAll({ verify, quiet });
     },
 };

--- a/packages/scripts/src/helpers/docs/index.ts
+++ b/packages/scripts/src/helpers/docs/index.ts
@@ -14,7 +14,7 @@ export async function buildPackages(pkgInfos: PackageInfo[]) {
         writePkgHeader('Building docs', [pkgInfo], runOnce);
 
         if (pkgInfo.terascope.enableTypedoc) {
-            const outputDir = path.join(getRootDir(), 'docs', 'packages', pkgInfo.folderName, 'api');
+            const outputDir = path.join(getRootDir(), 'docs', pkgInfo.relativeDir, 'api');
             await generateTSDocs(pkgInfo, outputDir);
             await build(pkgInfo);
         }

--- a/packages/scripts/src/helpers/docs/sidebar.ts
+++ b/packages/scripts/src/helpers/docs/sidebar.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fse from 'fs-extra';
 import { getRootDir, listMdFiles, writeIfChanged } from '../misc';
 import { PackageInfo } from '../interfaces';
+import { getWorkspaceNames } from '../packages';
 
 function getSubcategories(pkgDocFolder: string): string[] {
     const docsFolder = path.join(getRootDir(), 'docs');
@@ -16,39 +17,44 @@ function getSubcategories(pkgDocFolder: string): string[] {
 }
 
 export async function updateSidebarJSON(pkgInfos: PackageInfo[]) {
-    const docsFilePath = path.join(getRootDir(), 'docs/packages');
     const sidebarFilePath = path.join(getRootDir(), 'website/sidebars.json');
     const sidebarJSON = await fse.readJSON(sidebarFilePath);
-    if (!sidebarJSON.packages) {
-        sidebarJSON.packages = {
-            Overview: ['packages'],
-            Packages: [],
-        };
-    }
-    for (const [key, list] of Object.entries(sidebarJSON.packages)) {
-        if (key === 'Overview' || !Array.isArray(list)) continue;
-        sidebarJSON.packages[key] = list
-            .map(
-                (pkg: Subcategory | string): Subcategory => {
-                    if (typeof pkg === 'string') {
-                        return {
-                            type: 'subcategory',
-                            label: pkg,
-                            ids: [`packages/${pkg}/overview`],
-                        };
+
+    for (const name of getWorkspaceNames()) {
+        const docsFilePath = path.join(getRootDir(), 'docs', name);
+
+        if (!sidebarJSON[name]) {
+            sidebarJSON[name] = {
+                Overview: [name],
+                Packages: [],
+            };
+        }
+
+        for (const [key, list] of Object.entries(sidebarJSON.packages)) {
+            if (key === 'Overview' || !Array.isArray(list)) continue;
+            sidebarJSON[name][key] = list
+                .map(
+                    (pkg: Subcategory | string): Subcategory => {
+                        if (typeof pkg === 'string') {
+                            return {
+                                type: 'subcategory',
+                                label: pkg,
+                                ids: [`${name}/${pkg}/overview`],
+                            };
+                        }
+                        return pkg;
                     }
+                )
+                .filter((pkg) => {
+                    if (!pkg) return false;
+                    const filePath = path.join(docsFilePath, pkg.label);
+                    return fse.existsSync(filePath);
+                })
+                .map((pkg) => {
+                    pkg.ids = getSubcategories(path.join(docsFilePath, pkg.label));
                     return pkg;
-                }
-            )
-            .filter((pkg) => {
-                if (!pkg) return false;
-                const filePath = path.join(docsFilePath, pkg.label);
-                return fse.existsSync(filePath);
-            })
-            .map((pkg) => {
-                pkg.ids = getSubcategories(path.join(docsFilePath, pkg.label));
-                return pkg;
-            });
+                });
+        }
     }
 
     const names = pkgInfos.map(({ name }) => name);

--- a/packages/scripts/src/helpers/docs/typedoc.ts
+++ b/packages/scripts/src/helpers/docs/typedoc.ts
@@ -17,7 +17,7 @@ async function writeDocFile(filePath: string, { title, sidebarLabel }: { title: 
     // remove header
     contents = contents
         .split('\n')
-        .slice(isOverview(filePath) ? 5 : 4)
+        .slice(isOverview(filePath) ? 7 : 6)
         .join('\n')
         .trim();
 

--- a/packages/scripts/src/helpers/docs/typedoc.ts
+++ b/packages/scripts/src/helpers/docs/typedoc.ts
@@ -17,7 +17,7 @@ async function writeDocFile(filePath: string, { title, sidebarLabel }: { title: 
     // remove header
     contents = contents
         .split('\n')
-        .slice(isOverview(filePath) ? 7 : 6)
+        .slice(isOverview(filePath) ? 7 : 4)
         .join('\n')
         .trim();
 

--- a/packages/scripts/src/helpers/interfaces.ts
+++ b/packages/scripts/src/helpers/interfaces.ts
@@ -1,5 +1,6 @@
 export type PackageInfo = {
     dir: string;
+    relativeDir: string;
     folderName: string;
     private?: boolean;
     name: string;
@@ -42,6 +43,7 @@ export type PackageConfig = {
 export type RootPackageInfo = {
     version: string;
     dir: string;
+    relativeDir: string;
     folderName: string;
     name: string;
     displayName: string;

--- a/packages/scripts/src/helpers/interfaces.ts
+++ b/packages/scripts/src/helpers/interfaces.ts
@@ -56,6 +56,7 @@ export type RootPackageInfo = {
     terascope: {
         root: boolean;
         type: 'monorepo';
+        target: string;
         tests: {
             suites: {
                 [suite: string]: Service[];

--- a/packages/scripts/src/helpers/misc.ts
+++ b/packages/scripts/src/helpers/misc.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import pkgUp from 'pkg-up';
 import fse from 'fs-extra';
 import defaultsDeep from 'lodash.defaultsdeep';
-import { isPlainObject, get } from '@terascope/utils';
+import { isPlainObject, get, toTitleCase } from '@terascope/utils';
 import sortPackageJson from 'sort-package-json';
 import { PackageInfo, RootPackageInfo, Service } from './interfaces';
 import { NPM_DEFAULT_REGISTRY, DEV_TAG } from './config';
@@ -94,12 +94,7 @@ export function getDevDockerImage(): string {
 }
 
 export function getName(input: string): string {
-    return input
-        .split(/\W/g)
-        .map((str) => str.trim())
-        .filter((str) => str.length > 0)
-        .map((str: string) => `${str.charAt(0).toUpperCase()}${str.slice(1)}`)
-        .join(' ');
+    return toTitleCase(input);
 }
 
 export function listMdFiles(dir: string, levels = 10): string[] {

--- a/packages/scripts/src/helpers/misc.ts
+++ b/packages/scripts/src/helpers/misc.ts
@@ -50,6 +50,7 @@ function _getRootInfo(pkgJSONPath: string): RootPackageInfo | undefined {
         terascope: {
             root: isRoot,
             type: 'monorepo',
+            target: 'es2018',
             tests: {
                 suites: {}
             },

--- a/packages/scripts/src/helpers/misc.ts
+++ b/packages/scripts/src/helpers/misc.ts
@@ -39,6 +39,7 @@ function _getRootInfo(pkgJSONPath: string): RootPackageInfo | undefined {
 
     return sortPackageJson(defaultsDeep(pkg, {
         dir,
+        relativeDir: '.',
         folderName,
         displayName: getName(pkg.name),
         documentation: '',

--- a/packages/scripts/src/helpers/packages.ts
+++ b/packages/scripts/src/helpers/packages.ts
@@ -83,6 +83,7 @@ export function getWorkspaceNames(): string[] {
         listPackages()
             .filter((pkg) => !('workspaces' in pkg))
             .map((pkg) => path.dirname(path.basename(pkg.dir)))
+            .filter((name) => !name || name === '.')
     );
 }
 
@@ -199,6 +200,7 @@ export function updatePkgJSON(
     const pkgJSON = getSortedPkgJSON(pkgInfo);
     delete pkgJSON.folderName;
     delete pkgJSON.dir;
+    delete pkgJSON.relativeDir;
     return misc.writeIfChanged(path.join(pkgInfo.dir, 'package.json'), pkgJSON, {
         log,
     });
@@ -222,7 +224,7 @@ export function getDocPath(pkgInfo: i.PackageInfo, withFileName: boolean, withEx
         return e2eDevDocs;
     }
 
-    const docPath = path.join(`docs/${pkgInfo.relativeDir}`, pkgInfo.folderName);
+    const docPath = path.join('docs', pkgInfo.relativeDir);
     fse.ensureDirSync(docPath);
     if (withFileName) {
         return path.join(

--- a/packages/scripts/src/helpers/packages.ts
+++ b/packages/scripts/src/helpers/packages.ts
@@ -82,8 +82,8 @@ export function getWorkspaceNames(): string[] {
     return uniq(
         listPackages()
             .filter((pkg) => !('workspaces' in pkg))
-            .map((pkg) => path.dirname(path.basename(pkg.dir)))
-            .filter((name) => !name || name === '.')
+            .map((pkg) => path.basename(path.dirname(pkg.dir)))
+            .filter((name) => name && name !== '.')
     );
 }
 

--- a/packages/scripts/src/helpers/packages.ts
+++ b/packages/scripts/src/helpers/packages.ts
@@ -78,6 +78,14 @@ export function listPackages(): i.PackageInfo[] {
     return _packages;
 }
 
+export function getWorkspaceNames(): string[] {
+    return uniq(
+        listPackages()
+            .filter((pkg) => !('workspaces' in pkg))
+            .map((pkg) => path.dirname(path.basename(pkg.dir)))
+    );
+}
+
 export function getJestAliases() {
     const aliases: Record<string, string> = {};
     listPackages().forEach((pkg) => {
@@ -168,6 +176,7 @@ export function updatePkgInfo(pkgInfo: i.PackageInfo): void {
     }
 
     pkgInfo.folderName = path.basename(pkgInfo.dir);
+    pkgInfo.relativeDir = path.relative(rootInfo.dir, pkgInfo.dir);
     addPackageConfig(pkgInfo);
 
     if (!pkgInfo.displayName) {
@@ -213,7 +222,7 @@ export function getDocPath(pkgInfo: i.PackageInfo, withFileName: boolean, withEx
         return e2eDevDocs;
     }
 
-    const docPath = path.join('docs/packages', pkgInfo.folderName);
+    const docPath = path.join(`docs/${pkgInfo.relativeDir}`, pkgInfo.folderName);
     fse.ensureDirSync(docPath);
     if (withFileName) {
         return path.join(

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -42,12 +42,14 @@ async function publishToNPM(options: PublishOptions) {
     const bumped = result.filter(isString);
 
     if (!bumped.length) {
-        if (options.dryRun) signale.info('No packages published, turn use --no-dry-run to publish');
+        if (options.dryRun) signale.info('No packages to be published');
         else signale.info('No packages published');
         return;
     }
 
-    signale.info(`Published the follow packages:${formatList(bumped)}`);
+    const l = formatList(bumped);
+    if (options.dryRun) signale.info(`\nUse --no-dry-run to publish the follow packages:${l}`);
+    else signale.info(`\nPublished the follow packages:${l}`);
 }
 
 async function npmPublish(
@@ -64,7 +66,7 @@ async function npmPublish(
 
     if (options.dryRun) {
         signale.info(`[DRY RUN] - skipping publish for package ${pkgInfo.name}@v${pkgInfo.version} (${tag})`);
-        return;
+        return pkgInfo.name;
     }
 
     const registry: string|undefined = get(pkgInfo, 'publishConfig.registry');

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -48,8 +48,10 @@ async function publishToNPM(options: PublishOptions) {
     }
 
     const l = formatList(bumped);
-    if (options.dryRun) signale.info(`\nUse --no-dry-run to publish the follow packages:${l}`);
-    else signale.info(`\nPublished the follow packages:${l}`);
+    process.stdout.write('\n');
+
+    if (options.dryRun) signale.info(`Use --no-dry-run to publish the follow packages:${l}`);
+    else signale.info(`Published the follow packages:${l}`);
 }
 
 async function npmPublish(

--- a/packages/scripts/src/helpers/publish/utils.ts
+++ b/packages/scripts/src/helpers/publish/utils.ts
@@ -20,7 +20,7 @@ export async function shouldNPMPublish(pkgInfo: PackageInfo, type?: PublishType)
     const isPrelease = getPublishTag(local) === 'prerelease';
     const options: semver.Options = { includePrerelease: true };
 
-    if (semver.gt(local, remote, options)) {
+    if (semver.gt(local, remote, options) || isPrelease) {
         if (type === PublishType.Tag) {
             if (isMain) {
                 signale.info(`* publishing main package ${pkgInfo.name}@${remote}->${local}`);
@@ -31,7 +31,6 @@ export async function shouldNPMPublish(pkgInfo: PackageInfo, type?: PublishType)
             return false;
         }
 
-        // TODO: This doesn't seem to be work right
         if (type === PublishType.Dev) {
             if (isMain && !isPrelease) {
                 signale.info('* skipping main package until tag release');

--- a/packages/scripts/src/helpers/publish/utils.ts
+++ b/packages/scripts/src/helpers/publish/utils.ts
@@ -91,7 +91,7 @@ export async function buildDevDockerImage(cacheFromPrev?: boolean): Promise<stri
     signale.pending(`building docker image ${devImage}`);
 
     try {
-        await dockerBuild(devImage, cacheFromPrev ? [devImage] : []);
+        await dockerBuild(devImage, cacheFromPrev ? [devImage] : [], undefined);
     } catch (err) {
         throw new TSError(err, {
             message: `Failed to build ${devImage} docker image`,

--- a/packages/scripts/src/helpers/signale.ts
+++ b/packages/scripts/src/helpers/signale.ts
@@ -2,7 +2,6 @@ import { isTest } from '@terascope/utils';
 import { Signale } from 'signale';
 
 export default new Signale({
-    // @ts-ignore because the types are wrong
     logLevel: isTest ? 'error' : 'info',
     stream: process.stderr,
     types: {

--- a/packages/scripts/src/helpers/sync/configs.ts
+++ b/packages/scripts/src/helpers/sync/configs.ts
@@ -1,0 +1,50 @@
+import fse from 'fs-extra';
+import path from 'path';
+import { getRootInfo } from '../misc';
+import { PackageInfo } from '../interfaces';
+
+export async function generateTSConfig(pkgInfos: PackageInfo[]) {
+    const rootInfo = getRootInfo();
+    const references = pkgInfos
+        .filter((pkgInfo) => {
+            if (pkgInfo.terascope?.main) return false;
+            return fse.existsSync(path.join(pkgInfo.dir, 'tsconfig.json'));
+        })
+        .map((pkgInfo) => ({
+            path: pkgInfo.relativeDir.replace(/^\.\//, '')
+        }));
+
+    const tsconfig = {
+        compilerOptions: {
+            baseUrl: '.',
+            module: 'commonjs',
+            moduleResolution: 'node',
+            target: rootInfo.terascope.target,
+            skipLibCheck: true,
+            experimentalDecorators: true,
+            strict: true,
+            noFallthroughCasesInSwitch: true,
+            preserveConstEnums: true,
+            esModuleInterop: true,
+            resolveJsonModule: true,
+            forceConsistentCasingInFileNames: true,
+            suppressImplicitAnyIndexErrors: true,
+            // Require project settings
+            composite: true,
+            declaration: true,
+            declarationMap: true,
+            sourceMap: true,
+            typeRoots: ['./types', './node_modules/@types'],
+            paths: {
+                '*': ['*', './types/*']
+            }
+        },
+        include: [],
+        // these project references should be ordered by dependants first
+        references
+    };
+
+    await fse.writeJSON(path.join(rootInfo.dir, 'tsconfig.json'), tsconfig, {
+        spaces: 4,
+    });
+}

--- a/packages/scripts/src/helpers/sync/index.ts
+++ b/packages/scripts/src/helpers/sync/index.ts
@@ -3,6 +3,7 @@ import { PackageInfo } from '../interfaces';
 import { SyncOptions } from './interfaces';
 import { getRootInfo } from '../misc';
 import * as utils from './utils';
+import { generateTSConfig } from './configs';
 
 export async function syncAll(options: SyncOptions) {
     await utils.verifyCommitted(options);
@@ -15,6 +16,7 @@ export async function syncAll(options: SyncOptions) {
     await updatePkgJSON(rootInfo);
 
     await Promise.all(pkgInfos.map((pkgInfo) => utils.syncPackage(files, pkgInfo)));
+    await generateTSConfig(pkgInfos);
 
     await utils.verify(files, options);
 }

--- a/packages/scripts/src/helpers/sync/index.ts
+++ b/packages/scripts/src/helpers/sync/index.ts
@@ -13,7 +13,7 @@ export async function syncAll(options: SyncOptions) {
     const pkgInfos = listPackages();
     const rootInfo = getRootInfo();
     utils.syncVersions(pkgInfos, rootInfo);
-    await updatePkgJSON(rootInfo);
+    await updatePkgJSON(rootInfo, !options.quiet);
 
     await Promise.all(pkgInfos.map((pkgInfo) => utils.syncPackage(files, pkgInfo)));
     await generateTSConfig(pkgInfos);
@@ -28,7 +28,7 @@ export async function syncPackages(pkgInfos: PackageInfo[], options: SyncOptions
 
     const rootInfo = getRootInfo();
     utils.syncVersions(pkgInfos, rootInfo);
-    await updatePkgJSON(rootInfo);
+    await updatePkgJSON(rootInfo, !options.quiet);
 
     await Promise.all(
         pkgInfos.map(async (pkgInfo) => {

--- a/packages/scripts/src/helpers/sync/index.ts
+++ b/packages/scripts/src/helpers/sync/index.ts
@@ -1,5 +1,5 @@
+import { pMap } from '@terascope/utils';
 import { listPackages, updatePkgJSON } from '../packages';
-import { PackageInfo } from '../interfaces';
 import { SyncOptions } from './interfaces';
 import { getRootInfo } from '../misc';
 import * as utils from './utils';
@@ -12,29 +12,16 @@ export async function syncAll(options: SyncOptions) {
 
     const pkgInfos = listPackages();
     const rootInfo = getRootInfo();
+
     utils.syncVersions(pkgInfos, rootInfo);
+
     await updatePkgJSON(rootInfo, !options.quiet);
 
-    await Promise.all(pkgInfos.map((pkgInfo) => utils.syncPackage(files, pkgInfo)));
+    await pMap(pkgInfos, (pkgInfo) => utils.syncPackage(files, pkgInfo, options), {
+        concurrency: 10
+    });
+
     await generateTSConfig(pkgInfos);
-
-    await utils.verify(files, options);
-}
-
-export async function syncPackages(pkgInfos: PackageInfo[], options: SyncOptions) {
-    await utils.verifyCommitted(options);
-
-    const files: string[] = [];
-
-    const rootInfo = getRootInfo();
-    utils.syncVersions(pkgInfos, rootInfo);
-    await updatePkgJSON(rootInfo, !options.quiet);
-
-    await Promise.all(
-        pkgInfos.map(async (pkgInfo) => {
-            await utils.syncPackage(files, pkgInfo);
-        })
-    );
 
     await utils.verify(files, options);
 }

--- a/packages/scripts/src/helpers/sync/utils.ts
+++ b/packages/scripts/src/helpers/sync/utils.ts
@@ -46,6 +46,8 @@ ${formatList(changed)}
 }
 
 export async function verify(files: string[], options: SyncOptions) {
+    if (options.quiet && !options.verify) return;
+
     const changed = await getChangedFiles(...uniq([
         ...topLevelFiles,
         ...files,
@@ -80,11 +82,13 @@ export function getFiles(pkgInfo: PackageInfo): string[] {
     ];
 }
 
-export async function syncPackage(files: string[], pkgInfo: PackageInfo) {
+export async function syncPackage(
+    files: string[], pkgInfo: PackageInfo, options: SyncOptions
+): Promise<void> {
     await Promise.all([
         updateReadme(pkgInfo),
         ensureOverview(pkgInfo),
-        updatePkgJSON(pkgInfo),
+        updatePkgJSON(pkgInfo, !options.quiet),
     ]);
 
     files.push(...getFiles(pkgInfo));

--- a/packages/scripts/src/helpers/sync/utils.ts
+++ b/packages/scripts/src/helpers/sync/utils.ts
@@ -3,7 +3,9 @@ import semver from 'semver';
 import {
     getFirstChar, uniq, trim, isCI
 } from '@terascope/utils';
-import { getDocPath, updatePkgJSON, fixDepPkgName } from '../packages';
+import {
+    getDocPath, updatePkgJSON, fixDepPkgName, listPackages
+} from '../packages';
 import { updateReadme, ensureOverview } from '../docs/overview';
 import { PackageInfo, RootPackageInfo } from '../interfaces';
 import { formatList, getRootDir } from '../misc';
@@ -15,15 +17,15 @@ const topLevelFiles: readonly string[] = [
     'package.json',
     'yarn.lock'
 ];
-
 let prevChanged: string[] = [];
 
 export async function verifyCommitted(options: SyncOptions) {
+    const pkgDirs: string[] = listPackages().map((pkg) => pkg.relativeDir);
+
     const changed = await getChangedFiles(
         ...topLevelFiles,
+        ...pkgDirs,
         'docs',
-        'packages',
-        'e2e'
     );
     prevChanged = [...changed];
 

--- a/packages/scripts/src/helpers/sync/utils.ts
+++ b/packages/scripts/src/helpers/sync/utils.ts
@@ -14,6 +14,7 @@ import { DepKey, SyncOptions } from './interfaces';
 import signale from '../signale';
 
 const topLevelFiles: readonly string[] = [
+    'tsconfig.json',
     'package.json',
     'yarn.lock'
 ];

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -1,5 +1,4 @@
 import ms from 'ms';
-import path from 'path';
 import {
     debugLogger,
     chunk,
@@ -174,7 +173,7 @@ async function runTestSuite(
         }
 
         const args = utils.getArgs(options);
-        args.projects = pkgs.map((pkgInfo) => path.join('packages', pkgInfo.folderName));
+        args.projects = pkgs.map((pkgInfo) => pkgInfo.relativeDir);
 
         try {
             await runJest(getRootDir(), args, env, options.jestArgs, options.debug);

--- a/packages/scripts/src/helpers/test-runner/interfaces.ts
+++ b/packages/scripts/src/helpers/test-runner/interfaces.ts
@@ -21,7 +21,7 @@ export type GroupedPackages = {
     [suite: string]: PackageInfo[];
 };
 
-export type CleanupFN = () => (Promise<void>|void);
+export type CleanupFN = (...args: any[]) => (Promise<void>|void);
 export type RunSuiteResult = {
     errors: string[];
     cleanup: CleanupFN;

--- a/packages/scripts/src/helpers/test-runner/tracker.ts
+++ b/packages/scripts/src/helpers/test-runner/tracker.ts
@@ -1,0 +1,135 @@
+import ms from 'ms';
+import { getFullErrorStack, isString, isFunction } from '@terascope/utils';
+import { TestOptions, CleanupFN } from './interfaces';
+import signale from '../signale';
+import { formatList } from '../misc';
+
+export class TestTracker {
+    started = 0;
+    ended = 0;
+    expected = 0;
+
+    private cleanups = new Map<string, CleanupFN>();
+    private errors = new Set<string>();
+
+    private onSIGTERM: () => void;
+    private onSIGINT: () => void;
+    private shuttingDown = false;
+
+    constructor(private readonly options: TestOptions) {
+        this.onSIGTERM = () => {
+            process.stderr.write('\n');
+            signale.info('received SIGTERM');
+            this.finish();
+        };
+
+        this.onSIGINT = () => {
+            process.stderr.write('\n');
+            signale.info('received SIGINT');
+            this.finish();
+        };
+
+        process.on('SIGINT', this.onSIGINT);
+        process.on('SIGTERM', this.onSIGTERM);
+    }
+
+    hasErrors() {
+        return this.errors.size > 0;
+    }
+
+    addError(error: string | any) {
+        this.errors.add(
+            isString(error) ? error : getFullErrorStack(error)
+        );
+    }
+
+    addCleanup(key: string, fn: CleanupFN, ...args: any[]) {
+        this.cleanups.set(key, () => fn(...args));
+    }
+
+    async runCleanupByKey(key: string): Promise<void> {
+        if (!this.cleanups.has(key)) return;
+
+        const fn = this.cleanups.get(key);
+        if (!isFunction(fn)) {
+            signale.warn(new Error(`Expected cleanup function for key ${key} got nothing`));
+            this.cleanups.delete(key);
+            return;
+        }
+
+        try {
+            await fn();
+            this.cleanups.delete(key);
+        } catch (err) {
+            signale.warn(err, `cleanup ${key} error`);
+        }
+    }
+
+    async finish() {
+        if (this.shuttingDown) {
+            await this.end(true);
+
+            process.removeListener('SIGINT', this.onSIGINT);
+            process.removeListener('SIGTERM', this.onSIGTERM);
+            return;
+        }
+
+        this.shuttingDown = true;
+
+        if (this.options.keepOpen) {
+            signale.info('keeping the tests open so the services don\'t shutdown, use ctrl-c to exit.');
+            const id = setTimeout(() => {
+                this.end();
+            }, ms('1 hour'));
+            this.addCleanup('keepOpen', (timeoutId) => clearTimeout(timeoutId), id);
+            return;
+        }
+
+        await this.end();
+    }
+
+    private async end(force = false) {
+        if (!force) {
+            const keys = [...this.cleanups.keys()];
+            if (keys.length && this.options.debug) {
+                signale.info('Cleaning up after tests tests');
+            }
+            for (const key of keys) {
+                await this.runCleanupByKey(key);
+            }
+        } else {
+            signale.warn('Skipping cleanup because the SIGTERM and SIGINT was called more than once');
+        }
+
+        let errorMsg = '';
+        const errors = [...this.errors];
+        if (errors.length > 1) {
+            errorMsg = `Multiple Test Failures:${formatList(errors)}`;
+        } else if (errors.length === 1) {
+            ([errorMsg] = errors);
+        }
+
+        if (errors.length) {
+            process.stderr.write('\n');
+            signale.fatal(`${errorMsg}`);
+            process.stderr.write('\n');
+            const exitCode = (process.exitCode || 0) > 0 ? process.exitCode : 1;
+            process.exit(exitCode);
+        }
+
+        if (this.started === 0 || this.expected === 0) {
+            signale.warn('No tests ran');
+            // if not tests are expected to run, it is safe to exit
+            process.exit(this.expected === 0 ? 0 : 1);
+        }
+
+        if (this.ended !== this.expected) {
+            const msg = `started: ${this.started}, completed: ${this.ended}, total: ${this.expected}`;
+            signale.error(`Incomplete tests - ${msg}`);
+            process.exit(1);
+        }
+
+        signale.success('All tests completed');
+        process.exit(0);
+    }
+}

--- a/scripts/link-pkg.sh
+++ b/scripts/link-pkg.sh
@@ -16,6 +16,18 @@ USAGE
     exit 1
 }
 
+link_pkg() {
+    local dir="$1"; shift;
+
+    if [ -d "$dir" ]; then
+        yarn --cwd="$dir" --silent link "$@"
+
+        if [ -d "$dir/node_modules" ]; then
+            rm -rf "$dir/node_modules"
+        fi
+    fi
+}
+
 main() {
     local arg="$1"
 
@@ -26,12 +38,10 @@ main() {
     esac
 
     yarn --silent link "$@"
-    yarn --cwd "e2e" --silent link "$@"
+    link_pkg "e2e" "$@"
 
     for dir in ./packages/*; do
-        if [ -d "$dir" ]; then
-            yarn --cwd "$dir" --silent link "$@"
-        fi
+        link_pkg "$dir" "$@"
     done
 
     echoerr '* running yarn setup'

--- a/scripts/unlink-pkg.sh
+++ b/scripts/unlink-pkg.sh
@@ -16,6 +16,18 @@ USAGE
     exit 1
 }
 
+unlink_pkg() {
+    local dir="$1"; shift;
+
+    if [ -d "$dir" ]; then
+        yarn --cwd="$dir" --silent unlink "$@"
+
+        if [ -d "$dir/node_modules" ]; then
+            rm -rf "$dir/node_modules"
+        fi
+    fi
+}
+
 main() {
     local arg="$1"
 
@@ -26,16 +38,10 @@ main() {
     esac
 
     yarn --silent unlink "$@"
-    yarn --cwd="e2e" --silent unlink "$@"
+    unlink_pkg "e2e" "$@"
 
     for dir in ./packages/*; do
-        if [ -d "$dir" ]; then
-            yarn --cwd="$dir" --silent unlink "$@"
-
-            if [ -d "$dir/node_modules" ]; then
-                rm -rf "$dir/node_modules"
-            fi
-        fi
+        unlink_pkg "$dir" "$@"
     done
 
     echoerr '* reinstalling node modules and running yarn setup'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,19 +13,26 @@
         "resolveJsonModule": true,
         "forceConsistentCasingInFileNames": true,
         "suppressImplicitAnyIndexErrors": true,
-        // Require project settings
         "composite": true,
         "declaration": true,
         "declarationMap": true,
         "sourceMap": true,
-        "typeRoots": ["./types", "./node_modules/@types"],
+        "typeRoots": [
+            "./types",
+            "./node_modules/@types"
+        ],
         "paths": {
-            "*": ["*", "./types/*"]
+            "*": [
+                "*",
+                "./types/*"
+            ]
         }
     },
     "include": [],
-    // these project references should be ordered by dependants first
     "references": [
+        {
+            "path": "packages/docker-compose-js"
+        },
         {
             "path": "packages/types"
         },
@@ -33,19 +40,16 @@
             "path": "packages/utils"
         },
         {
-            "path": "packages/scripts"
-        },
-        {
-            "path": "packages/docker-compose-js"
-        },
-        {
             "path": "packages/data-types"
         },
         {
-            "path": "packages/terafoundation"
+            "path": "packages/job-components"
         },
         {
-            "path": "packages/job-components"
+            "path": "packages/scripts"
+        },
+        {
+            "path": "packages/terafoundation"
         },
         {
             "path": "packages/teraslice-messaging"
@@ -57,25 +61,25 @@
             "path": "packages/data-mate"
         },
         {
-            "path": "packages/xlucene-translator"
-        },
-        {
-            "path": "packages/ts-transforms"
-        },
-        {
             "path": "packages/teraslice-client-js"
-        },
-        {
-            "path": "packages/elasticsearch-store"
-        },
-        {
-            "path": "packages/teraslice-test-harness"
         },
         {
             "path": "packages/teraslice-state-storage"
         },
         {
+            "path": "packages/xlucene-translator"
+        },
+        {
+            "path": "packages/elasticsearch-store"
+        },
+        {
             "path": "packages/teraslice-cli"
+        },
+        {
+            "path": "packages/teraslice-test-harness"
+        },
+        {
+            "path": "packages/ts-transforms"
         }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11821,7 +11821,7 @@ typedoc@^0.17.6:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.10.1"
 
-typescript@^3.8.3:
+typescript@~3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==


### PR DESCRIPTION
- Makes sure it is possible to have workspes outside of the packages directory (like `asset-bundles`)
- Tests output improves, better SIGTERM / SIGINT handling, and making sure to exit with correct status code with tests do not complete fully.
- Fix publish output and prerelease check
- Fix sync command to not output when `--quiet` is used and to better handle failures when there `git` is not available.
- Make sync generate the top level `tsconfig.json` file
- Fix a couple of top level bash scripts to match our internal monorepo (no major updates)