### PR TITLE
Harness and Parallel-Slicer fixes

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -32,9 +32,9 @@
         "@turf/clean-coords": "^6.0.1"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.18.2",
+        "@terascope/data-types": "^0.18.3",
         "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.27.2",
+        "@terascope/utils": "^0.27.3",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-point-in-polygon": "^6.0.1",
@@ -49,7 +49,7 @@
         "jexl": "^2.2.2",
         "valid-url": "^1.0.9",
         "validator": "^13.0.0",
-        "xlucene-parser": "^0.22.3"
+        "xlucene-parser": "^0.22.4"
     },
     "devDependencies": {},
     "engines": {

--- a/packages/data-mate/src/aggregations/record-aggregation.ts
+++ b/packages/data-mate/src/aggregations/record-aggregation.ts
@@ -121,7 +121,8 @@ function batchByKeys(input: any, config: ValidatedBatchConfig, filterFn: FilterF
     const batch: Batch = new Map<string, AggregationResults>();
     const keys = config.keys || [];
     const hasKeys = keys.length !== 0;
-    const filterConfig = { excludes: [source], includes: keys };
+    const excludes = keys.includes(source) ? [] : [source];
+    const filterConfig = { excludes, includes: keys };
     // we batch based of target key since it will be collapsed
 
     for (const record of data) {
@@ -159,11 +160,16 @@ export function unique(input: any, _parentContext: any, batchConfig: BatchConfig
 }
 
 export function count(input: any, _parentContext: any, batchConfig: BatchConfig) {
+    console.log('count input', input, batchConfig);
     const config = validateConfig(batchConfig);
     if (ts.isNil(input)) return null;
 
     const batchData = batchByKeys(input, config, _filterValues);
-    return _iterateBatch(batchData, _length);
+    console.log('what is batchData', batchData, batchData.get('count-3:field-value1'));
+    const results = _iterateBatch(batchData, _length);
+    console.log('what is results i here', results);
+
+    return results;
 }
 
 function _length(val: any[]) {

--- a/packages/data-mate/src/aggregations/record-aggregation.ts
+++ b/packages/data-mate/src/aggregations/record-aggregation.ts
@@ -160,14 +160,11 @@ export function unique(input: any, _parentContext: any, batchConfig: BatchConfig
 }
 
 export function count(input: any, _parentContext: any, batchConfig: BatchConfig) {
-    console.log('count input', input, batchConfig);
     const config = validateConfig(batchConfig);
     if (ts.isNil(input)) return null;
 
     const batchData = batchByKeys(input, config, _filterValues);
-    console.log('what is batchData', batchData, batchData.get('count-3:field-value1'));
     const results = _iterateBatch(batchData, _length);
-    console.log('what is results i here', results);
 
     return results;
 }

--- a/packages/data-mate/test/record-aggregator-spec.ts
+++ b/packages/data-mate/test/record-aggregator-spec.ts
@@ -273,6 +273,25 @@ describe('RecordAggregator', () => {
 
             expect(RecordAggregator.count(mixedData, mixedData, config)).toEqual(expectedResults);
         });
+
+        it('should not mutate input if source is keyed and target is a different value', () => {
+            const config: BatchConfig = { source: 'count', target: 'myCount', keys: ['field', 'count'] };
+
+            const input = [
+                { count: 3, field: 'value1' },
+                { count: 13, field: 'value2' },
+                { count: 3, field: 'value1' },
+                { count: 2, field: 'value3' }
+            ];
+
+            const expectedResults = [
+                { count: 3, field: 'value1', myCount: 2 },
+                { count: 13, field: 'value2', myCount: 1 },
+                { count: 2, field: 'value3', myCount: 1 }
+            ];
+
+            expect(RecordAggregator.count(input, input, config)).toEqual(expectedResults);
+        });
     });
 
     describe('sum should', () => {

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.18.2",
+    "version": "0.18.3",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.27.2",
+        "@terascope/utils": "^0.27.3",
         "graphql": "^14.5.8",
         "lodash.defaultsdeep": "^4.6.1",
         "yargs": "^15.3.1"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.9.3",
+    "version": "2.9.4",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.27.2",
+        "@terascope/utils": "^0.27.3",
         "bluebird": "^3.7.2",
         "lodash.isequal": "^4.5.0"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.30.3",
+    "version": "0.30.4",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,13 +24,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.10.3",
-        "@terascope/data-types": "^0.18.2",
+        "@terascope/data-mate": "^0.10.4",
+        "@terascope/data-types": "^0.18.3",
         "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.27.2",
+        "@terascope/utils": "^0.27.3",
         "ajv": "^6.12.2",
         "uuid": "^8.1.0",
-        "xlucene-translator": "^0.6.3"
+        "xlucene-translator": "^0.6.4"
     },
     "devDependencies": {
         "@types/uuid": "^8.0.0",

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.27.2",
+        "@terascope/utils": "^0.27.3",
         "chalk": "^4.0.0",
         "lodash.defaultsdeep": "^4.6.1",
         "yeoman-generator": "^4.8.2",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.34.2",
+    "version": "0.34.3",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.27.2",
+        "@terascope/utils": "^0.27.3",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^8.1.0"

--- a/packages/job-components/src/operations/parallel-slicer.ts
+++ b/packages/job-components/src/operations/parallel-slicer.ts
@@ -84,8 +84,6 @@ export default abstract class ParallelSlicer<T = OpConfig> extends SlicerCore<T>
     }
 
     private async processSlicer(slicer: SlicerObj) {
-        this.logger.info('slicer', slicer);
-
         slicer.processing = true;
         let result: SlicerResult;
 
@@ -114,7 +112,6 @@ export default abstract class ParallelSlicer<T = OpConfig> extends SlicerCore<T>
                 }
             }
         } finally {
-            this.logger.info(`slicer ${slicer.id} has finished processing`);
             slicer.processing = false;
         }
     }

--- a/packages/job-components/src/operations/parallel-slicer.ts
+++ b/packages/job-components/src/operations/parallel-slicer.ts
@@ -65,12 +65,12 @@ export default abstract class ParallelSlicer<T = OpConfig> extends SlicerCore<T>
         // they will return undefined which will always win race
         // which will prevent other from calling
 
-        const promises = this._slicers
+        const slicers = this._slicers
             .filter((slicer) => !slicer.processing && !slicer.done);
 
         // calling race on an empty array will be forever pending
-        if (promises.length > 0) {
-            await Promise.race(promises.map((slicer) => this.processSlicer(slicer)));
+        if (slicers.length > 0) {
+            await Promise.race(slicers.map((slicer) => this.processSlicer(slicer)));
         } else {
             // promises are a microtask, if no action then we need to delay
             await pDelay(10);

--- a/packages/job-components/src/operations/parallel-slicer.ts
+++ b/packages/job-components/src/operations/parallel-slicer.ts
@@ -64,7 +64,6 @@ export default abstract class ParallelSlicer<T = OpConfig> extends SlicerCore<T>
         // must filter out done slicers, if they are done
         // they will return undefined which will always win race
         // which will prevent other from calling
-
         const slicers = this._slicers
             .filter((slicer) => !slicer.processing && !slicer.done);
 

--- a/packages/job-components/src/operations/slicer.ts
+++ b/packages/job-components/src/operations/slicer.ts
@@ -21,7 +21,7 @@ export default abstract class Slicer<T = OpConfig> extends SlicerCore<T> {
      */
     abstract async slice(): Promise<SlicerResult>;
 
-    slicers() {
+    slicers(): number {
         return 1;
     }
 

--- a/packages/job-components/test/operations/parallel-slicer-spec.ts
+++ b/packages/job-components/test/operations/parallel-slicer-spec.ts
@@ -187,7 +187,7 @@ describe('ParallelSlicer', () => {
         });
     });
 
-    describe('when returning a sub-slices', () => {
+    describe('when returning a multiple slicers', () => {
         let slicer: ExampleParallelSlicer;
         const onSlicerSubslice = jest.fn();
 
@@ -340,6 +340,47 @@ describe('ParallelSlicer', () => {
                     expect(onSlicerSubslice).toHaveBeenCalledTimes(4);
                     expect(slicer.getSlice()).toBeNil();
                 });
+            });
+        });
+    });
+
+    describe('edge cases of calling multiple slicers', () => {
+        let slicer: ExampleParallelSlicer;
+        const onSlicerSubslice = jest.fn();
+
+        beforeAll(async () => {
+            const context = new TestContext('teraslice-operations');
+            const events = context.apis.foundation.getSystemEvents();
+
+            events.on('slicer:subslice', onSlicerSubslice);
+
+            const exConfig = newTestExecutionConfig();
+
+            exConfig.operations.push({
+                _op: 'example-op',
+            });
+
+            exConfig.slicers = 2;
+
+            const opConfig = exConfig.operations[0];
+
+            slicer = new ExampleParallelSlicer(context as WorkerContext, opConfig, exConfig);
+            slicer.subslice = true;
+
+            await slicer.initialize([]);
+        });
+
+        afterAll(() => slicer.shutdown());
+
+        describe('->handle', () => {
+            it('should not emit slicer:subslice yet', () => {
+                expect(onSlicerSubslice).not.toHaveBeenCalled();
+            });
+
+            it('calling handle multiple times does not hang process with race', async () => {
+                await Promise.all([slicer.handle(), slicer.handle()]);
+                const slices = slicer.getSlices(3);
+                expect(slices).toBeArrayOfSize(2);
             });
         });
     });

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.20.2",
+    "version": "0.20.3",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.18.5",
-        "@terascope/utils": "^0.27.2",
+        "@terascope/utils": "^0.27.3",
         "codecov": "^3.6.5",
         "execa": "^4.0.2",
         "fs-extra": "^9.0.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.21.3",
+    "version": "0.21.4",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.27.2",
+        "@terascope/utils": "^0.27.3",
         "aws-sdk": "^2.685.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.12",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.23.2",
+    "version": "0.23.3",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.6.0",
-        "@terascope/utils": "^0.27.2",
+        "@terascope/utils": "^0.27.3",
         "archiver": "^4.0.1",
         "chalk": "^4.0.0",
         "cli-table3": "^0.6.0",
@@ -48,7 +48,7 @@
         "node-yaml": "^4.0.0",
         "prompts": "^2.3.2",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.21.2",
+        "teraslice-client-js": "^0.21.3",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.3",
         "yargs": "^15.3.1",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.21.2",
+    "version": "0.21.3",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.34.2",
+        "@terascope/job-components": "^0.34.3",
         "auto-bind": "^4.0.0",
         "got": "^11.2.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.11.3",
+    "version": "0.11.4",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/utils": "^0.27.2",
+        "@terascope/utils": "^0.27.3",
         "ms": "^2.1.2",
         "nanoid": "^3.1.9",
         "p-event": "^4.1.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
     "displayName": "Teraslice Op Test Harness",
-    "version": "1.18.2",
+    "version": "1.18.3",
     "description": "A testing harness to simplify testing Teraslice processors and operations.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-op-test-harness#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.34.2",
+        "@terascope/job-components": "^0.34.3",
         "bluebird": "^3.7.2"
     },
     "devDependencies": {},

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.16.3",
+    "version": "0.16.4",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.9.3",
-        "@terascope/utils": "^0.27.2",
+        "@terascope/elasticsearch-api": "^2.9.4",
+        "@terascope/utils": "^0.27.3",
         "mnemonist": "^0.36.1"
     },
     "publishConfig": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "0.19.3",
+    "version": "0.20.0",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {
@@ -30,8 +30,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.34.2",
-        "@terascope/teraslice-op-test-harness": "^1.18.2"
+        "@terascope/job-components": "^0.34.3",
+        "@terascope/teraslice-op-test-harness": "^1.18.3"
     },
     "devDependencies": {},
     "engines": {

--- a/packages/teraslice-test-harness/src/interfaces.ts
+++ b/packages/teraslice-test-harness/src/interfaces.ts
@@ -5,6 +5,8 @@ import {
     TestClientConfig,
     ProcessorConstructor,
     SlicerConstructor,
+    Slice,
+    DataEntity
 } from '@terascope/job-components';
 
 export type ExecutionContext = WorkerExecutionContext|SlicerExecutionContext;
@@ -20,3 +22,8 @@ export interface OpTestHarnessOptions {
 }
 
 export type AnyOperationConstructor = ProcessorConstructor|SlicerConstructor;
+
+export interface SliceResults {
+    slice: Slice;
+    data: DataEntity[]
+}

--- a/packages/teraslice-test-harness/src/job-test-harness.ts
+++ b/packages/teraslice-test-harness/src/job-test-harness.ts
@@ -42,11 +42,11 @@ export default class JobTestHarness {
         return this.workerHarness.fetcher<T>();
     }
 
-    get processors() {
+    get processors(): WorkerTestHarness['processors'] {
         return this.workerHarness.processors;
     }
 
-    get apis() {
+    get apis(): WorkerTestHarness['apis'] {
         return this.workerHarness.apis;
     }
 
@@ -135,6 +135,7 @@ export default class JobTestHarness {
     */
     async runToCompletion(): Promise<SliceResults[]> {
         const results: SliceResults[] = [];
+
         const allSlices = (await this.slicerHarness.getAllSlices({ fullResponse: true }))
             .filter(Boolean) as Slice[];
 

--- a/packages/teraslice-test-harness/src/job-test-harness.ts
+++ b/packages/teraslice-test-harness/src/job-test-harness.ts
@@ -14,7 +14,7 @@ import {
 } from '@terascope/job-components';
 import SlicerTestHarness from './slicer-test-harness';
 import WorkerTestHarness from './worker-test-harness';
-import { JobHarnessOptions } from './interfaces';
+import { JobHarnessOptions, SliceResults } from './interfaces';
 
 /**
  * A test harness for both the Slicer and Fetcher,
@@ -24,11 +24,6 @@ import { JobHarnessOptions } from './interfaces';
  *
  * @todo Handle more than one worker?
 */
-
-interface SliceResults {
-    slice: Slice;
-    data: DataList
-}
 
 export default class JobTestHarness {
     private workerHarness: WorkerTestHarness;

--- a/packages/teraslice-test-harness/src/job-test-harness.ts
+++ b/packages/teraslice-test-harness/src/job-test-harness.ts
@@ -8,9 +8,9 @@ import {
     FetcherCore,
     SlicerCore,
     SlicerRecoveryData,
-    AnyObject,
     pDelay,
-    flatten
+    flatten,
+    APICore
 } from '@terascope/job-components';
 import SlicerTestHarness from './slicer-test-harness';
 import WorkerTestHarness from './worker-test-harness';
@@ -53,6 +53,10 @@ export default class JobTestHarness {
 
     get apis() {
         return this.workerHarness.apis;
+    }
+
+    getOperationAPI<T extends APICore = APICore>(apiName: string): T {
+        return this.workerHarness.getOperationAPI<T>(apiName);
     }
 
     /**

--- a/packages/teraslice-test-harness/src/job-test-harness.ts
+++ b/packages/teraslice-test-harness/src/job-test-harness.ts
@@ -7,7 +7,10 @@ import {
     TestClientConfig,
     FetcherCore,
     SlicerCore,
-    SlicerRecoveryData
+    SlicerRecoveryData,
+    AnyObject,
+    pDelay,
+    flatten
 } from '@terascope/job-components';
 import SlicerTestHarness from './slicer-test-harness';
 import WorkerTestHarness from './worker-test-harness';
@@ -22,7 +25,11 @@ import { JobHarnessOptions } from './interfaces';
  * @todo Handle more than one worker?
 */
 
-type CB = (results: BatchedResults) => void;
+interface SliceResults {
+    slice: Slice;
+    data: DataList
+}
+
 export default class JobTestHarness {
     private workerHarness: WorkerTestHarness;
     private slicerHarness: SlicerTestHarness;
@@ -52,7 +59,7 @@ export default class JobTestHarness {
      * Set the Terafoundation Clients on both
      * the Slicer and Worker contexts
     */
-    async setClients(clients: TestClientConfig[]) {
+    async setClients(clients: TestClientConfig[]): Promise<void> {
         this.workerHarness.setClients(clients);
         this.slicerHarness.setClients(clients);
     }
@@ -63,7 +70,7 @@ export default class JobTestHarness {
      * @param recoveryData is an array of starting points to recover from
      * the retry data is only passed to slicer
     */
-    async initialize(recoveryData?: SlicerRecoveryData[]) {
+    async initialize(recoveryData?: SlicerRecoveryData[]): Promise<void> {
         await this.slicerHarness.initialize(recoveryData);
         await this.workerHarness.initialize();
     }
@@ -76,53 +83,72 @@ export default class JobTestHarness {
     */
     async run(): Promise<BatchedResults> {
         const rawSlices = await this.slicerHarness.createSlices({ fullResponse: true }) as Slice[];
-
         const results: BatchedResults = [];
 
         for (const slice of rawSlices) {
-            if (slice == null) continue;
-            this.slicerHarness.onSliceDispatch(slice);
-
-            let analytics: SliceAnalyticsData = {
-                time: [],
-                size: [],
-                memory: [],
-            };
-
-            try {
-                const result = await this.workerHarness.runSlice(
-                    slice,
-                    { fullResponse: true }
-                ) as RunSliceResult;
-                if (result.analytics) {
-                    analytics = result.analytics;
-                }
-                // @ts-ignore
-                results.push(result.results as DataList);
-                this.slicerHarness.stats.slices.processed++;
-            } catch (err) {
-                this.slicerHarness.stats.slices.failed++;
-                throw err;
-            } finally {
-                this.slicerHarness.onSliceComplete({
-                    slice,
-                    analytics
-                });
-            }
+            const sliceData = await this.processSlice(slice);
+            results.push(...sliceData);
         }
 
         return results;
     }
 
-    async runAllSlices(cb: CB): Promise<void> {
-        // @ts-ignore
-        const bool = this.slicerHarness.slicer().isFinished;
+    private async processSlice(slice: Slice): Promise<BatchedResults> {
+        const results: BatchedResults = [];
+
+        if (slice == null) return [null];
+        this.slicerHarness.onSliceDispatch(slice);
+
+        let analytics: SliceAnalyticsData = {
+            time: [],
+            size: [],
+            memory: [],
+        };
+
+        try {
+            const result = await this.workerHarness.runSlice(
+                slice,
+                { fullResponse: true }
+            ) as RunSliceResult;
+            if (result.analytics) {
+                analytics = result.analytics;
+            }
+            // @ts-ignore
+            results.push(result.results as DataList);
+            this.slicerHarness.stats.slices.processed++;
+        } catch (err) {
+            this.slicerHarness.stats.slices.failed++;
+            throw err;
+        } finally {
+            this.slicerHarness.onSliceComplete({
+                slice,
+                analytics
+            });
+        }
+
+        return results;
+    }
+
+    async runToCompletion(): Promise<SliceResults[]> {
+        const results: SliceResults[] = [];
+        const allSlices = (await this.slicerHarness.getAllSlices({ fullResponse: true }))
+            .filter(Boolean) as Slice[];
+
+        for (const slice of allSlices) {
+            const sliceData = await this.processSlice(slice);
+            await pDelay(1);
+            const dataLists = [...sliceData].filter(Boolean) as DataList[];
+            const data = flatten<DataEntity>(dataLists);
+            results.push({ slice, data });
+        }
+
+        return results;
     }
 
     /**
      * Shutdown both the Worker and Slicer test harness
     */
-    async shutdown() {
+    async shutdown(): Promise<void> {
         await Promise.all([
             this.slicerHarness.shutdown(),
             this.workerHarness.shutdown(),
@@ -131,4 +157,4 @@ export default class JobTestHarness {
 }
 
 type DataList = DataEntity[];
-export type BatchedResults = (DataList & null)[];
+export type BatchedResults = (DataList | null)[];

--- a/packages/teraslice-test-harness/src/job-test-harness.ts
+++ b/packages/teraslice-test-harness/src/job-test-harness.ts
@@ -110,10 +110,10 @@ export default class JobTestHarness {
                 slice,
                 { fullResponse: true }
             ) as RunSliceResult;
+
             if (result.analytics) {
                 analytics = result.analytics;
             }
-            // @ts-ignore
             results.push(result.results as DataList);
             this.slicerHarness.stats.slices.processed++;
         } catch (err) {
@@ -129,6 +129,11 @@ export default class JobTestHarness {
         return results;
     }
 
+    /**
+     * Gathers all slices from slicer and run them,
+     *
+     * @returns an array of objects containing the slice and the data the reader generated
+    */
     async runToCompletion(): Promise<SliceResults[]> {
         const results: SliceResults[] = [];
         const allSlices = (await this.slicerHarness.getAllSlices({ fullResponse: true }))

--- a/packages/teraslice-test-harness/src/slicer-test-harness.ts
+++ b/packages/teraslice-test-harness/src/slicer-test-harness.ts
@@ -131,7 +131,6 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
     async getAllSlices(options: { fullResponse: true }): Promise<SliceResults>;
     async getAllSlices({ fullResponse = false } = {}): Promise<SliceResults> {
         const results = [];
-        this.executionContext.logger.info('starting test');
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         while (!this.slicer().isFinished) {
@@ -139,9 +138,7 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
             if (fullResponse) {
                 sliceResults = await this.createSlices({ fullResponse });
             } else {
-                this.executionContext.logger.info('making createSlices in test')
                 sliceResults = await this.createSlices();
-                this.executionContext.logger.info('making createSlices in test all done', sliceResults)
             }
             results.push(...sliceResults);
         }

--- a/packages/teraslice-test-harness/src/slicer-test-harness.ts
+++ b/packages/teraslice-test-harness/src/slicer-test-harness.ts
@@ -10,7 +10,7 @@ import {
     SlicerRecoveryData,
     times,
     isPlainObject,
-=} from '@terascope/job-components';
+} from '@terascope/job-components';
 import BaseTestHarness from './base-test-harness';
 import { JobHarnessOptions } from './interfaces';
 

--- a/packages/teraslice-test-harness/src/slicer-test-harness.ts
+++ b/packages/teraslice-test-harness/src/slicer-test-harness.ts
@@ -10,6 +10,7 @@ import {
     SlicerRecoveryData,
     times,
     isPlainObject,
+    AnyObject
 } from '@terascope/job-components';
 import BaseTestHarness from './base-test-harness';
 import { JobHarnessOptions } from './interfaces';
@@ -19,6 +20,9 @@ import { JobHarnessOptions } from './interfaces';
  * the Execution Controller, mainly the Slicer.
  * This is useful for testing Slicers.
 */
+
+type SliceResults = (AnyObject|SliceRequest|Slice|null)[];
+
 export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionContext> {
     readonly stats: ExecutionStats = {
         workers: {
@@ -50,7 +54,7 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
      * Initialize the Operations on the ExecutionContext
      * @param recoveryData is an array of starting points to recover from
     */
-    async initialize(recoveryData: SlicerRecoveryData[] = []) {
+    async initialize(recoveryData: SlicerRecoveryData[] = []): Promise<void> {
         await super.initialize();
         // teraslice checks to see if slicer is recoverable
         // should throw test recoveryData if slicer is not recoverable
@@ -65,7 +69,6 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
             this.executionContext.onExecutionStats(this.stats);
         }, 100);
     }
-
     /**
      * Create Slices, always returns an Array of slices or slice requests.
      * To adjust the number of slicers change the job configuration
@@ -79,15 +82,16 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
      *
      * @returns an array of Slices including the metadata or the just the Slice Request.
     */
-    async createSlices(): Promise<SliceRequest[]>;
-    async createSlices(options: { fullResponse: false }): Promise<SliceRequest[]>;
-    async createSlices(options: { fullResponse: true }): Promise<Slice[]>;
-    async createSlices({ fullResponse = false } = {}): Promise<SliceRequest[]|Slice[]> {
+    async createSlices(): Promise<SliceResults>;
+    async createSlices(): Promise<SliceResults>;
+    async createSlices(options: { fullResponse: false }): Promise<SliceResults>;
+    async createSlices(options: { fullResponse: true }): Promise<SliceResults>;
+    async createSlices({ fullResponse = false } = {}): Promise<SliceResults> {
         const slicers = this.slicer().slicers();
         await this.slicer().handle();
 
         const slices = this.slicer().getSlices(10000);
-        const sliceRequests = [];
+        const sliceRequests: (Slice | SliceRequest|null)[] = [];
         const slicesBySlicers: (Slice[])[] = [];
 
         for (const slice of slices) {
@@ -98,6 +102,8 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
         }
 
         for (const perSlicer of slicesBySlicers) {
+            if (perSlicer == null) continue;
+
             const sorted = perSlicer.sort((a, b) => a.slicer_order - b.slicer_order);
             sorted.forEach((slice) => {
                 this.executionContext.onSliceEnqueued(slice);
@@ -120,24 +126,47 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
         return sliceRequests;
     }
 
-    setWorkers(count: number) {
+    async getAllSlices(): Promise<SliceResults>;
+    async getAllSlices(options: { fullResponse: false }): Promise<SliceResults>;
+    async getAllSlices(options: { fullResponse: true }): Promise<SliceResults>;
+    async getAllSlices({ fullResponse = false } = {}): Promise<SliceResults> {
+        const results = [];
+        this.executionContext.logger.info('starting test');
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        while (!this.slicer().isFinished) {
+            let sliceResults: SliceResults;
+            if (fullResponse) {
+                sliceResults = await this.createSlices({ fullResponse });
+            } else {
+                this.executionContext.logger.info('making createSlices in test')
+                sliceResults = await this.createSlices();
+                this.executionContext.logger.info('making createSlices in test all done', sliceResults)
+            }
+            results.push(...sliceResults);
+        }
+
+        return results;
+    }
+
+    setWorkers(count: number): void {
         this.stats.workers.connected = count;
         this.stats.workers.available = count;
         this.executionContext.onExecutionStats(this.stats);
     }
 
-    onSliceDispatch(slice: Slice) {
+    onSliceDispatch(slice: Slice): void {
         this.executionContext.onSliceDispatch(slice);
     }
 
-    onSliceComplete(result: SliceResult) {
+    onSliceComplete(result: SliceResult): void {
         this.executionContext.onSliceComplete(result);
     }
 
     /**
      * Shutdown the Operations on the ExecutionContext
     */
-    async shutdown() {
+    async shutdown(): Promise<void> {
         if (this._emitInterval) {
             clearInterval(this._emitInterval);
         }

--- a/packages/teraslice-test-harness/src/slicer-test-harness.ts
+++ b/packages/teraslice-test-harness/src/slicer-test-harness.ts
@@ -10,8 +10,7 @@ import {
     SlicerRecoveryData,
     times,
     isPlainObject,
-    AnyObject
-} from '@terascope/job-components';
+=} from '@terascope/job-components';
 import BaseTestHarness from './base-test-harness';
 import { JobHarnessOptions } from './interfaces';
 
@@ -21,7 +20,7 @@ import { JobHarnessOptions } from './interfaces';
  * This is useful for testing Slicers.
 */
 
-type SliceResults = (AnyObject|SliceRequest|Slice|null)[];
+type SliceResults = (SliceRequest|Slice|null)[];
 
 export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionContext> {
     readonly stats: ExecutionStats = {
@@ -82,11 +81,10 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
      *
      * @returns an array of Slices including the metadata or the just the Slice Request.
     */
-    async createSlices(): Promise<SliceResults>;
-    async createSlices(): Promise<SliceResults>;
-    async createSlices(options: { fullResponse: false }): Promise<SliceResults>;
-    async createSlices(options: { fullResponse: true }): Promise<SliceResults>;
-    async createSlices({ fullResponse = false } = {}): Promise<SliceResults> {
+    async createSlices(): Promise<(SliceRequest|null)[]>;
+    async createSlices(options: { fullResponse: false }): Promise<(SliceRequest|null)[]>;
+    async createSlices(options: { fullResponse: true }): Promise<(Slice|null)[]>;
+    async createSlices({ fullResponse = false } = {}): Promise<(SliceRequest|Slice|null)[]> {
         const slicers = this.slicer().slicers();
         await this.slicer().handle();
 
@@ -127,12 +125,12 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
     }
 
     async getAllSlices(): Promise<SliceResults>;
-    async getAllSlices(options: { fullResponse: false }): Promise<SliceResults>;
-    async getAllSlices(options: { fullResponse: true }): Promise<SliceResults>;
+    async getAllSlices(options: { fullResponse: false }): Promise<(Slice|null)[]>;
+    async getAllSlices(options: { fullResponse: true }): Promise<(SliceRequest|null)[]>;
     async getAllSlices({ fullResponse = false } = {}): Promise<SliceResults> {
+        if (this.executionContext.config.lifecycle !== 'once') throw new Error('This method can only be used when lifecycle is set to "once"');
         const results = [];
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
+        // @ts-expect-error
         while (!this.slicer().isFinished) {
             let sliceResults: SliceResults;
             if (fullResponse) {

--- a/packages/teraslice-test-harness/src/worker-test-harness.ts
+++ b/packages/teraslice-test-harness/src/worker-test-harness.ts
@@ -28,7 +28,7 @@ export default class WorkerTestHarness extends BaseTestHarness<WorkerExecutionCo
         super(job, options, 'worker');
     }
 
-    static testProcessor(opConfig: OpConfig, options?: JobHarnessOptions) {
+    static testProcessor(opConfig: OpConfig, options?: JobHarnessOptions): WorkerTestHarness {
         const job = newTestJobConfig({
             max_retries: 0,
             operations: [
@@ -42,7 +42,7 @@ export default class WorkerTestHarness extends BaseTestHarness<WorkerExecutionCo
         return new WorkerTestHarness(job, options);
     }
 
-    static testFetcher(opConfig: OpConfig, options?: JobHarnessOptions) {
+    static testFetcher(opConfig: OpConfig, options?: JobHarnessOptions): WorkerTestHarness {
         const job = newTestJobConfig({
             max_retries: 0,
             operations: [
@@ -59,11 +59,11 @@ export default class WorkerTestHarness extends BaseTestHarness<WorkerExecutionCo
         return this.executionContext.fetcher<T>();
     }
 
-    get processors() {
+    get processors(): WorkerExecutionContext['processors'] {
         return this.executionContext.processors;
     }
 
-    get apis() {
+    get apis(): WorkerExecutionContext['apis'] {
         return this.executionContext.apis;
     }
 
@@ -78,7 +78,7 @@ export default class WorkerTestHarness extends BaseTestHarness<WorkerExecutionCo
     /**
      * Initialize the Operations on the ExecutionContext
      */
-    async initialize() {
+    async initialize(): Promise<void> {
         await super.initialize();
         await this.executionContext.initialize();
     }
@@ -153,7 +153,7 @@ export default class WorkerTestHarness extends BaseTestHarness<WorkerExecutionCo
         return response;
     }
 
-    async shutdown() {
+    async shutdown(): Promise<void> {
         await super.shutdown();
         await this.executionContext.shutdown();
     }

--- a/packages/teraslice-test-harness/src/worker-test-harness.ts
+++ b/packages/teraslice-test-harness/src/worker-test-harness.ts
@@ -8,6 +8,7 @@ import {
     newTestSlice,
     FetcherCore,
     OperationCore,
+    APICore,
     OpConfig,
     newTestJobConfig,
 } from '@terascope/job-components';
@@ -68,6 +69,10 @@ export default class WorkerTestHarness extends BaseTestHarness<WorkerExecutionCo
 
     getOperation<T extends OperationCore = OperationCore>(findBy: string | number): T {
         return this.executionContext.getOperation<T>(findBy);
+    }
+
+    getOperationAPI<T extends APICore = APICore>(apiName: string): T {
+        return this.executionContext.api.getAPI<T>(apiName);
     }
 
     /**

--- a/packages/teraslice-test-harness/test/example-asset-spec.ts
+++ b/packages/teraslice-test-harness/test/example-asset-spec.ts
@@ -113,8 +113,10 @@ describe('Example Asset', () => {
         let harness: SlicerTestHarness;
 
         beforeEach(async () => {
-            // @ts-expect-error
-            simpleClient.sliceRequest.mockImplementation((count: number) => ({ count, super: 'man' }));
+            const mockedSliceRequest = jest.fn()
+                .mockImplementation((count: number) => ({ count, super: 'man' }))
+
+            simpleClient.sliceRequest = mockedSliceRequest;
 
             harness = new SlicerTestHarness(job, {
                 clients: [clientConfig],
@@ -132,14 +134,14 @@ describe('Example Asset', () => {
             expect(clientConfig.create).toHaveBeenCalledTimes(1);
         });
 
-        it('should return a list of records', async () => {
-            const results = await harness.createSlices();
+        fit('should return a list of records', async () => {
+            const results = await harness.createSlices() as any[];
             expect(results).toBeArrayOfSize(10);
 
             for (const result of results) {
                 expect(DataEntity.isDataEntity(result)).toBe(false);
-                expect(result.count).toEqual(10);
-                expect(result.super).toEqual('man');
+                expect(result?.count).toEqual(10);
+                expect(result?.super).toEqual('man');
             }
         });
     });
@@ -196,7 +198,7 @@ describe('Example Asset', () => {
 
             for (const results of batches) {
                 expect(results).toBeArrayOfSize(10);
-
+                // @ts-ignore
                 for (const result of results) {
                     expect(DataEntity.isDataEntity(result)).toBe(true);
                     expect(result.scale).toBe(6);
@@ -218,7 +220,7 @@ describe('Example Asset', () => {
 
             for (const results of batches) {
                 expect(results).toBeArrayOfSize(10);
-
+                // @ts-ignore
                 for (const result of results) {
                     expect(DataEntity.isDataEntity(result)).toBe(true);
                     expect(result.scale).toBe(6);

--- a/packages/teraslice-test-harness/test/example-asset-spec.ts
+++ b/packages/teraslice-test-harness/test/example-asset-spec.ts
@@ -134,7 +134,7 @@ describe('Example Asset', () => {
             expect(clientConfig.create).toHaveBeenCalledTimes(1);
         });
 
-        fit('should return a list of records', async () => {
+        it('should return a list of records', async () => {
             const results = await harness.createSlices() as any[];
             expect(results).toBeArrayOfSize(10);
 
@@ -197,9 +197,10 @@ describe('Example Asset', () => {
             expect(batches).toBeArrayOfSize(10);
 
             for (const results of batches) {
+                expect(results).not.toBeNull();
                 expect(results).toBeArrayOfSize(10);
-                // @ts-ignore
-                for (const result of results) {
+
+                for (const result of results as any) {
                     expect(DataEntity.isDataEntity(result)).toBe(true);
                     expect(result.scale).toBe(6);
                 }
@@ -219,9 +220,10 @@ describe('Example Asset', () => {
             expect(batches).toBeArrayOfSize(10);
 
             for (const results of batches) {
+                expect(results).not.toBeNull();
                 expect(results).toBeArrayOfSize(10);
-                // @ts-ignore
-                for (const result of results) {
+
+                for (const result of results as any) {
                     expect(DataEntity.isDataEntity(result)).toBe(true);
                     expect(result.scale).toBe(6);
                 }

--- a/packages/teraslice-test-harness/test/example-asset-spec.ts
+++ b/packages/teraslice-test-harness/test/example-asset-spec.ts
@@ -124,7 +124,7 @@ describe('Example Asset', () => {
 
         beforeEach(async () => {
             const mockedSliceRequest = jest.fn()
-                .mockImplementation((count: number) => ({ count, super: 'man' }))
+                .mockImplementation((count: number) => ({ count, super: 'man' }));
 
             simpleClient.sliceRequest = mockedSliceRequest;
 

--- a/packages/teraslice-test-harness/test/example-asset-spec.ts
+++ b/packages/teraslice-test-harness/test/example-asset-spec.ts
@@ -11,6 +11,7 @@ jest.mock('./fixtures/asset/simple-connector/client');
 
 describe('Example Asset', () => {
     const assetDir = path.join(__dirname, 'fixtures');
+    const apiName = 'simple-api';
     const simpleClient = new SimpleClient();
     const clientConfig: TestClientConfig = {
         type: 'simple-client',
@@ -27,7 +28,7 @@ describe('Example Asset', () => {
         job.analytics = true;
         job.apis = [
             {
-                _name: 'simple-api',
+                _name: apiName,
             },
         ];
         job.operations = [
@@ -95,6 +96,15 @@ describe('Example Asset', () => {
             const api = harness.apis['simple-api'].opAPI as SimpleAPI;
 
             expect(api).toHaveProperty('count', 0);
+        });
+
+        it('can get apis using getOperationAPI', async () => {
+            const api = harness.getOperationAPI<SimpleAPI>(apiName);
+
+            expect(api).toBeDefined();
+            expect(api.count).toBeNumber();
+            expect(api.add).toBeFunction();
+            expect(api.sub).toBeFunction();
         });
     });
 
@@ -228,6 +238,15 @@ describe('Example Asset', () => {
                     expect(result.scale).toBe(6);
                 }
             }
+        });
+
+        it('can get apis using getOperationAPI', async () => {
+            const api = harness.getOperationAPI<SimpleAPI>(apiName);
+
+            expect(api).toBeDefined();
+            expect(api.count).toBeNumber();
+            expect(api.add).toBeFunction();
+            expect(api.sub).toBeFunction();
         });
     });
 });

--- a/packages/teraslice-test-harness/test/fixtures/asset/parallel-reader/fetcher.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/parallel-reader/fetcher.ts
@@ -1,0 +1,7 @@
+import { Fetcher, SliceRequest, AnyObject } from '@terascope/job-components';
+
+export default class TestFetcher extends Fetcher<AnyObject> {
+    async fetch(request: SliceRequest) {
+        return request;
+    }
+}

--- a/packages/teraslice-test-harness/test/fixtures/asset/parallel-reader/schema.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/parallel-reader/schema.ts
@@ -1,0 +1,7 @@
+import { ConvictSchema, AnyObject } from '@terascope/job-components';
+
+export default class Schema extends ConvictSchema<AnyObject> {
+    build() {
+        return {};
+    }
+}

--- a/packages/teraslice-test-harness/test/fixtures/asset/parallel-reader/slicer.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/parallel-reader/slicer.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { ParallelSlicer, AnyObject, pDelay } from '@terascope/job-components';
+
+export default class Counter extends ParallelSlicer<AnyObject> {
+    count = 0;
+
+    async newSlicer(id: number) {
+        let count = 3;
+        return async () => {
+            const delay = Math.round(100 * Math.random());
+            await pDelay(delay);
+            count -= 1;
+            if (count <= 0) return null;
+            return { count, id };
+        };
+    }
+}

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-api/interfaces.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-api/interfaces.ts
@@ -1,9 +1,11 @@
+import { APICore } from '@terascope/job-components';
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SimpleAPIConfig {
 
 }
 
-export interface SimpleAPI {
+export interface SimpleAPI extends APICore {
     count: number;
     add(n?: number): void;
     sub(n?: number): void;

--- a/packages/teraslice-test-harness/test/fixtures/asset/test-processor/processor.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/test-processor/processor.ts
@@ -1,0 +1,7 @@
+import { DataEntity, AnyObject, BatchProcessor } from '@terascope/job-components';
+
+export default class TestProcessor extends BatchProcessor<AnyObject> {
+    async onBatch(data: DataEntity[]): Promise<DataEntity<Record<string, any>>[]> {
+        return data.map((obj) => obj.getMetadata('test'));
+    }
+}

--- a/packages/teraslice-test-harness/test/fixtures/asset/test-processor/schema.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/test-processor/schema.ts
@@ -1,0 +1,7 @@
+import { ConvictSchema, AnyObject } from '@terascope/job-components';
+
+export default class Schema extends ConvictSchema<AnyObject> {
+    build(): AnyObject {
+        return {};
+    }
+}

--- a/packages/teraslice-test-harness/test/slicer-test-harness-spec.ts
+++ b/packages/teraslice-test-harness/test/slicer-test-harness-spec.ts
@@ -4,7 +4,8 @@ import {
     newTestJobConfig,
     Slicer,
     uniq,
-    AnyObject
+    AnyObject,
+    LifeCycle
 } from '@terascope/job-components';
 import { SlicerTestHarness } from '../src';
 import ParallelSlicer from './fixtures/asset/parallel-reader/slicer';
@@ -149,9 +150,10 @@ describe('SlicerTestHarness', () => {
             if (slicerHarness) await slicerHarness.shutdown();
         });
 
-        async function makeTest(numOfSlicers = 1): Promise<SlicerTestHarness> {
+        async function makeTest(numOfSlicers = 1, mode = 'once' as LifeCycle): Promise<SlicerTestHarness> {
             const job = newTestJobConfig();
             job.analytics = true;
+            job.lifecycle = mode;
             job.slicers = numOfSlicers;
             job.operations = [
                 {
@@ -213,6 +215,10 @@ describe('SlicerTestHarness', () => {
                 expect(result.slicer_order).toEqual(index + 1);
                 expect(result.request).toEqual(slicerTwoResults[index]);
             });
+        });
+
+        it('getAllSlices will throw if not in once mode', async () => {
+            expect(makeTest(2, 'persistent')).toReject();
         });
     });
 });

--- a/packages/teraslice-test-harness/test/slicer-test-harness-spec.ts
+++ b/packages/teraslice-test-harness/test/slicer-test-harness-spec.ts
@@ -191,38 +191,6 @@ describe('SlicerTestHarness', () => {
             const results = await test.getAllSlices();
             console.log('results', results)
             expect(results).toEqual('hello')
-            // const slices1 = await test.createSlices();
-            // const slices2 = await test.createSlices();
-            // const slices3 = await test.createSlices();
-            // const slices4 = await test.createSlices();
-            // const slices5 = await test.createSlices();
-            // const slices6 = await test.createSlices();
-            // const slices7 = await test.createSlices();
-            // const slices8 = await test.createSlices();
-            // const slices9 = await test.createSlices();
-            // const slices10 = await test.createSlices();
-            // const slices11 = await test.createSlices();
-            // const slices12 = await test.createSlices();
-            // const slices13 = await test.createSlices();
-
-            // console.log('slices1', slices1);
-            // console.log('slices2', slices2);
-            // console.log('slices3', slices3);
-            // console.log('slices4', slices4);
-            // console.log('slices5', slices5);
-            // console.log('slices6', slices6);
-            // console.log('slices7', slices7);
-            // console.log('slices8', slices8);
-            // console.log('slices9', slices9);
-            // console.log('slices10', slices10);
-            // console.log('slices11', slices11);
-            // console.log('slices12', slices12);
-            // console.log('slices13', slices13);
-            // expect(slices2).toEqual('hello')
-
-            // expect(slices13).toEqual('hello')
-
-            // expect(slices).toEqual('hello')
         });
     });
 });

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.9.3",
-        "@terascope/job-components": "^0.34.2",
-        "@terascope/teraslice-messaging": "^0.11.3",
-        "@terascope/utils": "^0.27.2",
+        "@terascope/elasticsearch-api": "^2.9.4",
+        "@terascope/job-components": "^0.34.3",
+        "@terascope/teraslice-messaging": "^0.11.4",
+        "@terascope/utils": "^0.27.3",
         "async-mutex": "^0.2.1",
         "barbe": "^3.0.15",
         "body-parser": "^1.19.0",
@@ -61,11 +61,11 @@
         "porty": "^3.1.1",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.21.3",
+        "terafoundation": "^0.21.4",
         "uuid": "^8.1.0"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.18.2",
+        "@terascope/teraslice-op-test-harness": "^1.18.3",
         "archiver": "^4.0.1",
         "bufferstreams": "^3.0.0",
         "chance": "^1.1.6",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.39.3",
+    "version": "0.39.4",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.10.3",
+        "@terascope/data-mate": "^0.10.4",
         "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.27.2",
+        "@terascope/utils": "^0.27.3",
         "awesome-phonenumber": "^2.33.0",
         "graphlib": "^2.1.8",
         "jexl": "^2.2.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.27.2",
+    "version": "0.27.3",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -36,9 +36,9 @@ export function fastCloneDeep<T>(input: T): T {
 }
 
 /** Perform a shallow clone of an object to another, in the fastest way possible */
-export function fastAssign<T, U>(target: T, source: U): T & U {
-    if (!isPlainObject(source)) {
-        return target as T & U;
+export function fastAssign<T, U>(target: T, source: U) {
+    if (!isObjectEntity(source)) {
+        return target;
     }
 
     for (const [key, val] of Object.entries(source)) {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.22.3",
+    "version": "0.22.4",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.27.2",
+        "@terascope/utils": "^0.27.3",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-contains": "^6.0.1",

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,8 +29,8 @@
     },
     "dependencies": {
         "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.27.2",
-        "xlucene-parser": "^0.22.3"
+        "@terascope/utils": "^0.27.3",
+        "xlucene-parser": "^0.22.4"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"


### PR DESCRIPTION
- fixed parallel-slicer issues around Promise.race, it would forever be stuck in pending if no slicer was available. Also, some slicer would not correctly call.

- Updated test harness to work better with parallel-slicers, added methods to get all slices, as well as process all slices

- Added getOperationAPI to WorkerTestHarness and JobTestHarness

- fixed a case in utils to check if its an object or dataentity