### PR TITLE
Elasticsearch api fixes

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.10.4",
+    "version": "0.11.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -32,9 +32,9 @@
         "@turf/clean-coords": "^6.0.1"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.18.3",
-        "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.27.3",
+        "@terascope/data-types": "^0.19.0",
+        "@terascope/types": "^0.4.0",
+        "@terascope/utils": "^0.28.0",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-point-in-polygon": "^6.0.1",
@@ -49,7 +49,7 @@
         "jexl": "^2.2.2",
         "valid-url": "^1.0.9",
         "validator": "^13.0.0",
-        "xlucene-parser": "^0.22.4"
+        "xlucene-parser": "^0.23.0"
     },
     "devDependencies": {},
     "engines": {

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.18.3",
+    "version": "0.19.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -28,8 +28,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.27.3",
+        "@terascope/types": "^0.4.0",
+        "@terascope/utils": "^0.28.0",
         "graphql": "^14.5.8",
         "lodash.defaultsdeep": "^4.6.1",
         "yargs": "^15.3.1"

--- a/packages/elasticsearch-api/index.js
+++ b/packages/elasticsearch-api/index.js
@@ -49,7 +49,7 @@ module.exports = function elasticsearchApi(client = {}, logger, _opConfig) {
         return _searchES(query).then((data) => get(data, 'hits.total.value', get(data, 'hits.total')));
     }
 
-    function parseElasticsearchData(doc) {
+    function convertDocToDataEntity(doc) {
         const now = Date.now();
         const metadata = {
             _key: doc._id,
@@ -86,7 +86,7 @@ module.exports = function elasticsearchApi(client = {}, logger, _opConfig) {
                 return data;
             }
             if (!data.hits.hits) return [];
-            return data.hits.hits.map(parseElasticsearchData);
+            return data.hits.hits.map(convertDocToDataEntity);
         });
     }
 
@@ -119,7 +119,7 @@ module.exports = function elasticsearchApi(client = {}, logger, _opConfig) {
                 if (fullResponse) return results;
                 return results.docs
                     .filter((doc) => doc.found)
-                    .map(parseElasticsearchData);
+                    .map(convertDocToDataEntity);
             });
     }
 
@@ -128,7 +128,7 @@ module.exports = function elasticsearchApi(client = {}, logger, _opConfig) {
             return _clientRequest('get', query);
         }
         return _clientRequest('get', query)
-            .then(parseElasticsearchData);
+            .then(convertDocToDataEntity);
     }
 
     function indexFn(query) {

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.9.4",
+    "version": "2.10.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.27.3",
+        "@terascope/utils": "^0.28.0",
         "bluebird": "^3.7.2",
         "lodash.isequal": "^4.5.0"
     },

--- a/packages/elasticsearch-api/types/index.d.ts
+++ b/packages/elasticsearch-api/types/index.d.ts
@@ -39,5 +39,6 @@ declare namespace elasticsearchAPI {
         indexSetup: (clusterName, newIndex, migrantIndexName, mapping, recordType, clientName) => Promise<boolean>;
         verifyClient: () => boolean;
         validateGeoParameters: (opConfig: any) => any;
+        getESVersion: () => number;
     }
 }

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.30.4",
+    "version": "0.31.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,13 +24,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.10.4",
-        "@terascope/data-types": "^0.18.3",
-        "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.27.3",
+        "@terascope/data-mate": "^0.11.0",
+        "@terascope/data-types": "^0.19.0",
+        "@terascope/types": "^0.4.0",
+        "@terascope/utils": "^0.28.0",
         "ajv": "^6.12.2",
         "uuid": "^8.1.0",
-        "xlucene-translator": "^0.6.4"
+        "xlucene-translator": "^0.7.0"
     },
     "devDependencies": {
         "@types/uuid": "^8.0.0",

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.7.3",
+    "version": "0.8.0",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.27.3",
+        "@terascope/utils": "^0.28.0",
         "chalk": "^4.0.0",
         "lodash.defaultsdeep": "^4.6.1",
         "yeoman-generator": "^4.8.2",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.34.3",
+    "version": "0.35.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.27.3",
+        "@terascope/utils": "^0.28.0",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^8.1.0"

--- a/packages/job-components/src/interfaces/index.ts
+++ b/packages/job-components/src/interfaces/index.ts
@@ -2,3 +2,4 @@ export * from './context';
 export * from './jobs';
 export * from './operation-lifecycle';
 export * from './operations';
+export * from './misc';

--- a/packages/job-components/src/interfaces/misc.ts
+++ b/packages/job-components/src/interfaces/misc.ts
@@ -1,0 +1,4 @@
+export interface SenderApi {
+    send(...params: any[]): Promise<void>;
+    verifyRoute(...params: any[]): Promise<void>
+}

--- a/packages/job-components/src/interfaces/misc.ts
+++ b/packages/job-components/src/interfaces/misc.ts
@@ -1,4 +1,4 @@
-export interface SenderApi {
+export interface RouteSenderAPI {
     send(...params: any[]): Promise<void>;
     verifyRoute(...params: any[]): Promise<void>
 }

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.20.3",
+    "version": "0.21.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.18.5",
-        "@terascope/utils": "^0.27.3",
+        "@terascope/utils": "^0.28.0",
         "codecov": "^3.6.5",
         "execa": "^4.0.2",
         "fs-extra": "^9.0.1",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.21.4",
+    "version": "0.22.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.27.3",
+        "@terascope/utils": "^0.28.0",
         "aws-sdk": "^2.689.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.12",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.23.3",
+    "version": "0.24.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.6.0",
-        "@terascope/utils": "^0.27.3",
+        "@terascope/utils": "^0.28.0",
         "archiver": "^4.0.1",
         "chalk": "^4.0.0",
         "cli-table3": "^0.6.0",
@@ -48,7 +48,7 @@
         "node-yaml": "^4.0.0",
         "prompts": "^2.3.2",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.21.3",
+        "teraslice-client-js": "^0.22.0",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.3",
         "yargs": "^15.3.1",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.21.3",
+    "version": "0.22.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.34.3",
+        "@terascope/job-components": "^0.35.0",
         "auto-bind": "^4.0.0",
         "got": "^11.2.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.11.4",
+    "version": "0.12.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/utils": "^0.27.3",
+        "@terascope/utils": "^0.28.0",
         "ms": "^2.1.2",
         "nanoid": "^3.1.9",
         "p-event": "^4.2.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
     "displayName": "Teraslice Op Test Harness",
-    "version": "1.18.3",
+    "version": "1.19.0",
     "description": "A testing harness to simplify testing Teraslice processors and operations.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-op-test-harness#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.34.3",
+        "@terascope/job-components": "^0.35.0",
         "bluebird": "^3.7.2"
     },
     "devDependencies": {},

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.16.4",
+    "version": "0.17.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.9.4",
-        "@terascope/utils": "^0.27.3",
+        "@terascope/elasticsearch-api": "^2.10.0",
+        "@terascope/utils": "^0.28.0",
         "mnemonist": "^0.36.1"
     },
     "publishConfig": {

--- a/packages/teraslice-state-storage/test/elasticsearch-state-storage-spec.ts
+++ b/packages/teraslice-state-storage/test/elasticsearch-state-storage-spec.ts
@@ -9,6 +9,7 @@ import {
     ESMGetParams,
 } from '../src/elasticsearch-state-storage';
 
+// TODO: this should search against elasticsearch
 describe('elasticsearch-state-storage', () => {
     const logger = debugLogger('elasticsearch-state-storage');
     let client: TestClient;

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "0.20.0",
+    "version": "0.21.0",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {
@@ -30,8 +30,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.34.3",
-        "@terascope/teraslice-op-test-harness": "^1.18.3"
+        "@terascope/job-components": "^0.35.0",
+        "@terascope/teraslice-op-test-harness": "^1.19.0"
     },
     "devDependencies": {},
     "engines": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.9.4",
-        "@terascope/job-components": "^0.34.3",
-        "@terascope/teraslice-messaging": "^0.11.4",
-        "@terascope/utils": "^0.27.3",
+        "@terascope/elasticsearch-api": "^2.10.0",
+        "@terascope/job-components": "^0.35.0",
+        "@terascope/teraslice-messaging": "^0.12.0",
+        "@terascope/utils": "^0.28.0",
         "async-mutex": "^0.2.1",
         "barbe": "^3.0.15",
         "body-parser": "^1.19.0",
@@ -61,11 +61,11 @@
         "porty": "^3.1.1",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.21.4",
+        "terafoundation": "^0.22.0",
         "uuid": "^8.1.0"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.18.3",
+        "@terascope/teraslice-op-test-harness": "^1.19.0",
         "archiver": "^4.0.1",
         "bufferstreams": "^3.0.0",
         "chance": "^1.1.6",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.39.5",
+    "version": "0.40.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.10.4",
-        "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.27.3",
+        "@terascope/data-mate": "^0.11.0",
+        "@terascope/types": "^0.4.0",
+        "@terascope/utils": "^0.28.0",
         "awesome-phonenumber": "^2.33.0",
         "graphlib": "^2.1.8",
         "jexl": "^2.2.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/types",
     "displayName": "Types",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "A collection of typescript interfaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/types#readme",
     "bugs": {

--- a/packages/types/src/misc.ts
+++ b/packages/types/src/misc.ts
@@ -3,3 +3,8 @@ export type MACDelimiter = 'space' | 'colon' | 'dash' | 'dot' | 'none' | 'any';
 export interface MACAddress {
     delimiter: MACDelimiter | MACDelimiter[];
 }
+
+export interface SenderApi {
+    send(...params: any[]): Promise<void>;
+    verifyRoute(...params: any[]): Promise<void>
+}

--- a/packages/types/src/misc.ts
+++ b/packages/types/src/misc.ts
@@ -3,8 +3,3 @@ export type MACDelimiter = 'space' | 'colon' | 'dash' | 'dot' | 'none' | 'any';
 export interface MACAddress {
     delimiter: MACDelimiter | MACDelimiter[];
 }
-
-export interface SenderApi {
-    send(...params: any[]): Promise<void>;
-    verifyRoute(...params: any[]): Promise<void>
-}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.27.3",
+    "version": "0.28.0",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {
@@ -28,7 +28,7 @@
         "debug": "^4.1.1"
     },
     "dependencies": {
-        "@terascope/types": "^0.3.0",
+        "@terascope/types": "^0.4.0",
         "debug": "^4.1.1",
         "is-plain-object": "^3.0.0",
         "js-string-escape": "^1.0.1",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.22.4",
+    "version": "0.23.0",
     "description": "Flexible Lucene-like evalutor and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -33,8 +33,8 @@
         "@turf/clean-coords": "^6.0.1"
     },
     "dependencies": {
-        "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.27.3",
+        "@terascope/types": "^0.4.0",
+        "@terascope/utils": "^0.28.0",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/boolean-contains": "^6.0.1",

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.6.4",
+    "version": "0.7.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -28,9 +28,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.3.0",
-        "@terascope/utils": "^0.27.3",
-        "xlucene-parser": "^0.22.4"
+        "@terascope/types": "^0.4.0",
+        "@terascope/utils": "^0.28.0",
+        "xlucene-parser": "^0.23.0"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"


### PR DESCRIPTION
- fix types in elasticsearch-api
- get/mget/search now return data-entities with metadata
- mget => if full-response is false then it returns an array of data-entities of all found data, it filters out not-found. If you use full response, it returns as normal