### PR TITLE
Fix getOperationAPI in teraslice-test-harness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
     - stage: "Verify"
       name: 'Verify Build (node 10)'
       # use node 10 to make sure we don't lose compatibility
-      node_js: '10.19'
+      node_js: '10.21'
       # run on any pull_request
       if: branch = master AND type IN (pull_request)
       # only cache on verify build
@@ -42,7 +42,7 @@ jobs:
     - stage: "Tests"
       name: 'Unit Test Suite (node 10)'
       # use node 10 to make sure we don't lose compatibility
-      node_js: '10.19'
+      node_js: '10.21'
       # run only on pull-requests or cron
       if: branch = master AND type IN (pull_request, cron)
       script: yarn --silent test --suite unit-a

--- a/packages/elasticsearch-store/src/index-store.ts
+++ b/packages/elasticsearch-store/src/index-store.ts
@@ -209,7 +209,7 @@ export default class IndexStore<T extends ts.AnyObject> {
     /**
      * Connect and validate the index configuration.
      */
-    async initialize() {
+    async initialize(): Promise<void> {
         await this.manager.indexSetup(this.config);
 
         const ms = Math.round(this._bulkMaxWait / 2);
@@ -297,7 +297,7 @@ export default class IndexStore<T extends ts.AnyObject> {
     /**
      * Shutdown, flush any pending requests and cleanup
      */
-    async shutdown() {
+    async shutdown(): Promise<void> {
         if (this._interval != null) {
             clearInterval(this._interval);
         }

--- a/packages/elasticsearch-store/test/helpers/elasticsearch.ts
+++ b/packages/elasticsearch-store/test/helpers/elasticsearch.ts
@@ -13,7 +13,9 @@ export function makeClient(): Client {
     });
 }
 
-export async function cleanupIndex(client: Client, index: string, template?: string) {
+export async function cleanupIndex(
+    client: Client, index: string, template?: string
+): Promise<void> {
     await client.indices
         .delete({
             index,
@@ -31,7 +33,9 @@ export async function cleanupIndex(client: Client, index: string, template?: str
     }
 }
 
-export function cleanupIndexStore(store: IndexStore<any>) {
+export function cleanupIndexStore(
+    store: IndexStore<any>
+): Promise<void> {
     const { client, indexQuery } = store;
 
     return cleanupIndex(client, indexQuery);

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.37.0",
+    "version": "0.37.1",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/job-components/src/builtin/collect/processor.ts
+++ b/packages/job-components/src/builtin/collect/processor.ts
@@ -11,13 +11,13 @@ export default class Collect extends BatchProcessor<CollectConfig> {
         this.collector = new Collector(opConfig);
     }
 
-    async onBatch(batch: DataEntity[]) {
+    async onBatch(batch: DataEntity[]): Promise<DataEntity[]> {
         this.collector.add(batch);
 
         return this.collector.getBatch() || [];
     }
 
-    async shutdown() {
+    async shutdown(): Promise<void> {
         await super.shutdown();
         const len = this.collector.flushAll().length;
 

--- a/packages/job-components/src/builtin/collect/schema.ts
+++ b/packages/job-components/src/builtin/collect/schema.ts
@@ -2,7 +2,7 @@ import { CollectConfig } from './interfaces';
 import { ConvictSchema } from '../../operations';
 
 export default class Schema extends ConvictSchema<CollectConfig> {
-    build() {
+    build(): Record<string, any> {
         return {
             size: {
                 default: null,

--- a/packages/job-components/src/builtin/delay/processor.ts
+++ b/packages/job-components/src/builtin/delay/processor.ts
@@ -3,7 +3,7 @@ import { DelayConfig } from './interfaces';
 import { BatchProcessor } from '../../operations';
 
 export default class Delay extends BatchProcessor<DelayConfig> {
-    async onBatch(data: DataEntity[]) {
+    async onBatch(data: DataEntity[]): Promise<DataEntity[]> {
         await pDelay(this.opConfig.ms);
         return data;
     }

--- a/packages/job-components/src/builtin/delay/schema.ts
+++ b/packages/job-components/src/builtin/delay/schema.ts
@@ -2,7 +2,7 @@ import { DelayConfig } from './interfaces';
 import { ConvictSchema } from '../../operations';
 
 export default class Schema extends ConvictSchema<DelayConfig> {
-    build() {
+    build(): Record<string, any> {
         return {
             ms: {
                 default: 100,

--- a/packages/job-components/src/builtin/noop/processor.ts
+++ b/packages/job-components/src/builtin/noop/processor.ts
@@ -2,7 +2,7 @@ import { DataEntity } from '@terascope/utils';
 import { BatchProcessor } from '../../operations';
 
 export default class Noop extends BatchProcessor {
-    async onBatch(data: DataEntity[]) {
+    async onBatch(data: DataEntity[]): Promise<DataEntity[]> {
         return data;
     }
 }

--- a/packages/job-components/src/builtin/test-reader/fetcher.ts
+++ b/packages/job-components/src/builtin/test-reader/fetcher.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { parseJSON, fastCloneDeep } from '@terascope/utils';
+import { parseJSON, fastCloneDeep, DataEntity } from '@terascope/utils';
 import { TestReaderConfig } from './interfaces';
 import { Fetcher } from '../../operations';
 import { SliceRequest } from '../../interfaces';
@@ -10,21 +10,21 @@ export default class TestFetcher extends Fetcher<TestReaderConfig> {
     cachedData: Buffer|null = null;
     lastFilePath = '';
 
-    async initialize() {
+    async initialize(): Promise<void> {
         super.initialize();
     }
 
-    async fetch(slice?: SliceRequest[]) {
+    async fetch(slice?: SliceRequest[]): Promise<DataEntity[]> {
         if (this.opConfig.passthrough_slice) {
             if (!Array.isArray(slice)) {
                 throw new Error('Test, when passthrough_slice is set to true it expects an array');
             }
-            return slice;
+            return slice as any[];
         }
 
         const filePath = this.opConfig.fetcher_data_file_path;
         if (!filePath) {
-            return fastCloneDeep(defaultData);
+            return fastCloneDeep(defaultData) as any[];
         }
 
         if (this.lastFilePath !== filePath) {

--- a/packages/job-components/src/builtin/test-reader/schema.ts
+++ b/packages/job-components/src/builtin/test-reader/schema.ts
@@ -2,7 +2,7 @@ import { TestReaderConfig } from './interfaces';
 import { ConvictSchema } from '../../operations';
 
 export default class Schema extends ConvictSchema<TestReaderConfig> {
-    build() {
+    build(): Record<string, any> {
         return {
             fetcher_data_file_path: {
                 default: null,

--- a/packages/job-components/src/execution-context/index.ts
+++ b/packages/job-components/src/execution-context/index.ts
@@ -17,14 +17,15 @@ export function isSlicerContext(context: Context): context is WorkerContext {
     return context.assignment === 'execution_controller';
 }
 
-export function isWorkerExecutionContext(context: any): context is WorkerExecutionContext {
+export function isWorkerExecutionContext(context: unknown): context is WorkerExecutionContext {
     return context instanceof WorkerExecutionContext;
 }
 
-export function isSlicerExecutionContext(context: any): context is SlicerExecutionContext {
+export function isSlicerExecutionContext(context: unknown): context is SlicerExecutionContext {
     return context instanceof SlicerExecutionContext;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function makeExecutionContext(config: ExecutionContextConfig) {
     if (isSlicerContext(config.context)) {
         return new SlicerExecutionContext(config);

--- a/packages/job-components/src/execution-context/utils.ts
+++ b/packages/job-components/src/execution-context/utils.ts
@@ -7,10 +7,10 @@ export function getMetric(input: number[], i: number): number {
     return 0;
 }
 
-export function isOperationAPI(api: any): api is OperationAPI {
-    return api && isFunction(api.createAPI);
+export function isOperationAPI(api: unknown): api is OperationAPI {
+    return api && typeof api === 'object' && isFunction((api as any).createAPI);
 }
 
-export function getOperationAPIType(api: any): OperationAPIType {
+export function getOperationAPIType(api: unknown): OperationAPIType {
     return isOperationAPI(api) ? 'api' : 'observer';
 }

--- a/packages/job-components/src/formats.ts
+++ b/packages/job-components/src/formats.ts
@@ -11,7 +11,7 @@ import {
 export const formats: Format[] = [
     {
         name: 'required_String',
-        validate(val: any) {
+        validate(val: unknown) {
             if (!val || !isString(val)) {
                 throw new Error('This field is required and must by of type string');
             }
@@ -22,7 +22,7 @@ export const formats: Format[] = [
     } as Format,
     {
         name: 'optional_String',
-        validate(val: any) {
+        validate(val: unknown) {
             if (!val) { return; }
             if (isString(val)) { return; }
             throw new Error('This field is optional but if specified it must be of type string');
@@ -33,7 +33,7 @@ export const formats: Format[] = [
     } as Format,
     {
         name: 'optional_Date',
-        validate(val: any) {
+        validate(val: unknown) {
             if (!val) { return; }
             if (isString(val) || isInteger(val)) {
                 if (isValidDate(val)) { return; }
@@ -55,7 +55,10 @@ export const formats: Format[] = [
     } as Format,
     {
         name: 'elasticsearch_Name',
-        validate(val: any) {
+        validate(val: unknown) {
+            if (typeof val !== 'string') {
+                throw new Error(`value: ${val} must be a string`);
+            }
             if (val.length > 255) {
                 throw new Error(`value: ${val} should not exceed 255 characters`);
             }
@@ -87,7 +90,7 @@ export const formats: Format[] = [
     } as Format,
     {
         name: 'positive_int',
-        validate(val: any) {
+        validate(val: unknown) {
             const int = toInteger(val);
             if (int === false || int < 1) {
                 throw new Error('must be valid integer greater than zero');
@@ -99,7 +102,7 @@ export const formats: Format[] = [
     } as Format,
 ];
 
-export function addFormats() {
+export function addFormats(): void {
     formats.forEach(addFormat);
 }
 

--- a/packages/job-components/src/interfaces/misc.ts
+++ b/packages/job-components/src/interfaces/misc.ts
@@ -7,7 +7,7 @@ export interface RouteSenderAPI {
 export interface APIFactoryRegistry<T, C> {
     get(name: string): T|undefined;
     getConfig(name: string): C|undefined;
-    create(name: string, config: C): Promise<T>;
+    create(name: string, config: Partial<C>): Promise<T>;
     remove(name: string): Promise<void>;
     entries(): IterableIterator<[string, T]>;
     values(): IterableIterator<T>;

--- a/packages/job-components/src/operations/api-factory.ts
+++ b/packages/job-components/src/operations/api-factory.ts
@@ -5,7 +5,11 @@ export default abstract class APIFactory<T, C> extends OperationAPI {
     protected readonly _registry: Map<string, T> = new Map();
     protected readonly _configRegistry: Map<string, C> = new Map();
 
-    abstract async create(name: string, config: C): Promise<{ client: T; config: C }>;
+    abstract async create(name: string, config: Partial<C>): Promise<{
+        client: T;
+        config: C;
+    }>;
+
     abstract async remove(name: string): Promise<void>;
 
     async createAPI(): Promise<APIFactoryRegistry<T, C>> {
@@ -18,8 +22,11 @@ export default abstract class APIFactory<T, C> extends OperationAPI {
             },
             get: (name: string) => registry.get(name),
             getConfig: (name: string) => configRegistry.get(name),
-            create: async (name: string, clientConfig: C) => {
-                // TODO it should throw if it already exists
+            create: async (name: string, clientConfig: Partial<C>) => {
+                if (registry.has(name)) {
+                    throw new Error(`API for "${name}" already exists`);
+                }
+
                 const { client, config } = await this.create(name, clientConfig);
                 registry.set(name, client);
                 configRegistry.set(name, config);

--- a/packages/job-components/src/operations/convict-schema.ts
+++ b/packages/job-components/src/operations/convict-schema.ts
@@ -21,9 +21,9 @@ export default abstract class ConvictSchema<T extends Record<string, any>, S = a
         this.schema = this.build(context);
     }
 
-    validate(inputConfig: any): APIConfig & T;
-    validate(inputConfig: any): OpConfig & T;
-    validate(inputConfig: any): OpConfig|APIConfig & T {
+    validate(inputConfig: Record<string, any>): APIConfig & T;
+    validate(inputConfig: Record<string, any>): OpConfig & T;
+    validate(inputConfig: Record<string, any>): OpConfig|APIConfig & T {
         if (this.opType === 'api') {
             return validateAPIConfig(this.schema, inputConfig);
         }
@@ -31,11 +31,11 @@ export default abstract class ConvictSchema<T extends Record<string, any>, S = a
         return validateOpConfig(this.schema, inputConfig);
     }
 
-    validateJob(_job: ValidatedJobConfig) {
+    validateJob(_job: ValidatedJobConfig): void {
 
     }
 
-    static type() {
+    static type(): string {
         return 'convict';
     }
 

--- a/packages/job-components/src/operations/core/core.ts
+++ b/packages/job-components/src/operations/core/core.ts
@@ -19,7 +19,7 @@ export default abstract class Core<T extends Context> implements OperationLifeCy
         this.events = context.apis.foundation.getSystemEvents();
     }
 
-    abstract async initialize(initConfig?: any): Promise<void>;
+    abstract async initialize(initConfig?: unknown): Promise<void>;
 
     abstract async shutdown(): Promise<void>;
 }

--- a/packages/job-components/src/operations/core/fetcher-core.ts
+++ b/packages/job-components/src/operations/core/fetcher-core.ts
@@ -13,5 +13,5 @@ export default abstract class FetcherCore<T = OpConfig> extends OperationCore<T>
      * A generic method called by the Teraslice framework to a give a "Fetcher"
      * the ability to handle the fetch operation
      */
-    abstract async handle(sliceRequest?: any): Promise<DataEntity[]>;
+    abstract async handle(sliceRequest?: unknown): Promise<DataEntity[]>;
 }

--- a/packages/job-components/src/operations/fetcher.ts
+++ b/packages/job-components/src/operations/fetcher.ts
@@ -11,9 +11,9 @@ export default abstract class Fetcher<T = OpConfig> extends FetcherCore<T> {
      * A method called by {@link Fetcher#handle}
      * @returns a DataEntity compatible array
     */
-    abstract async fetch(sliceRequest?: any): Promise<DataArrayInput>;
+    abstract async fetch(sliceRequest?: unknown): Promise<DataArrayInput>;
 
-    async handle(sliceRequest?: any): Promise<DataEntity[]> {
+    async handle(sliceRequest?: unknown): Promise<DataEntity[]> {
         return DataEntity.makeArray(await this.fetch(sliceRequest));
     }
 }

--- a/packages/job-components/src/operations/job-observer.ts
+++ b/packages/job-components/src/operations/job-observer.ts
@@ -37,7 +37,7 @@ export default class JobObserver extends Observer {
         this._currentIndex = -1;
     }
 
-    async onSliceInitialized(sliceId: string) {
+    async onSliceInitialized(sliceId: string): Promise<void> {
         this._currentSliceId = sliceId;
         this._currentIndex = 0;
 
@@ -48,7 +48,7 @@ export default class JobObserver extends Observer {
         this._initialized = null;
     }
 
-    onOperationStart(sliceId: string, index: number) {
+    onOperationStart(sliceId: string, index: number): void {
         this._currentSliceId = sliceId;
         this._currentIndex = index;
 
@@ -60,7 +60,7 @@ export default class JobObserver extends Observer {
         };
     }
 
-    onOperationComplete(sliceId: string, index: number, processed: number) {
+    onOperationComplete(sliceId: string, index: number, processed: number): void {
         if (!this.collectAnalytics) return;
         if (this._initialized == null || !this.analyticsData) return;
 
@@ -75,7 +75,7 @@ export default class JobObserver extends Observer {
         this._initialized = null;
     }
 
-    getAnalytics() {
+    getAnalytics(): SliceAnalyticsData|undefined {
         if (!this.analyticsData) return;
 
         const { time, memory, size } = this.analyticsData;

--- a/packages/job-components/src/operations/shims/legacy-processor-shim.ts
+++ b/packages/job-components/src/operations/shims/legacy-processor-shim.ts
@@ -16,7 +16,7 @@ import ConvictSchema from '../convict-schema';
 // but it should allow you to write processors using the new way today
 
 export default function legacyProcessorShim(
-    Processor: any,
+    Processor: unknown,
     Schema: SchemaConstructor,
     apis?: APIs
 ): LegacyProcessor {
@@ -48,7 +48,9 @@ export default function legacyProcessorShim(
             }
         },
         async newProcessor(context, opConfig, executionConfig): Promise<ProcessorFn<DataInput[]>> {
-            const processor = new Processor(context as WorkerContext, opConfig, executionConfig);
+            const processor = new (Processor as any)(
+                context as WorkerContext, opConfig, executionConfig
+            );
             await processor.initialize();
 
             legacySliceEventsShim(processor);

--- a/packages/job-components/src/operations/shims/legacy-slice-events-shim.ts
+++ b/packages/job-components/src/operations/shims/legacy-slice-events-shim.ts
@@ -6,7 +6,7 @@ interface SliceOperation extends WorkerOperationLifeCycle {
     shutdown(): Promise<void>;
 }
 
-export default function legacySliceEventsShim(op: SliceOperation) {
+export default function legacySliceEventsShim(op: SliceOperation): void {
     op.events.once('worker:shutdown', async () => {
         await op.shutdown();
     });

--- a/packages/job-components/src/operations/shims/operation-api-shim.ts
+++ b/packages/job-components/src/operations/shims/operation-api-shim.ts
@@ -1,7 +1,7 @@
 import { Context } from '../../interfaces';
 import { OperationAPIConstructor } from '../interfaces';
 
-export default function operationAPIShim(context: Context, apis: APIs = {}) {
+export default function operationAPIShim(context: Context, apis: APIs = {}): void {
     Object.keys(apis).forEach((name) => {
         const api = apis[name];
         context.apis.executionContext.addToRegistry(name, api);

--- a/packages/job-components/src/operations/shims/processor-shim.ts
+++ b/packages/job-components/src/operations/shims/processor-shim.ts
@@ -40,7 +40,7 @@ export default function processorShim<S = any>(legacy: LegacyProcessor): Process
             }
         },
         Schema: class LegacySchemaShim extends ConvictSchema<S> {
-            validate(inputConfig: unknown): any {
+            validate(inputConfig: Record<string, any>): any {
                 const opConfig = super.validate(inputConfig);
                 if (legacy.selfValidation) {
                     // @ts-expect-error

--- a/packages/job-components/src/operations/shims/reader-shim.ts
+++ b/packages/job-components/src/operations/shims/reader-shim.ts
@@ -95,7 +95,7 @@ export default function readerShim<S = any>(legacy: LegacyReader): ReaderModule 
             }
         },
         Schema: class LegacySchemaShim extends ConvictSchema<S> {
-            validate(inputConfig: unknown): any {
+            validate(inputConfig: Record<string, any>): any {
                 const opConfig = super.validate(inputConfig);
                 if (legacy.selfValidation) {
                     // @ts-expect-error

--- a/packages/job-components/src/utils.ts
+++ b/packages/job-components/src/utils.ts
@@ -1,7 +1,7 @@
 import { get, Logger } from '@terascope/utils';
 import { Context, ExecutionConfig } from './interfaces';
 
-export function makeContextLogger(context: Context, moduleName: string, extra = {}) {
+export function makeContextLogger(context: Context, moduleName: string, extra = {}): Logger {
     return context.apis.foundation.makeLogger(
         Object.assign(
             {

--- a/packages/job-components/test/fixtures/empty-api/schema.ts
+++ b/packages/job-components/test/fixtures/empty-api/schema.ts
@@ -1,7 +1,7 @@
 import { ConvictSchema } from '../../../src';
 
 export default class Schema extends ConvictSchema<any, any> {
-    build() {
+    build(): Record<string, any> {
         return {
             example: {
                 default: 'examples are quick and easy',

--- a/packages/job-components/test/fixtures/example-api/api.ts
+++ b/packages/job-components/test/fixtures/example-api/api.ts
@@ -1,19 +1,19 @@
-import { OperationAPI } from '../../../src';
+import { OperationAPI, AnyObject } from '../../../src';
 
 export default class ExampleAPI extends OperationAPI {
     _initialized = false;
     _shutdown = false;
 
-    async initialize() {
+    async initialize(): Promise<void> {
         this._initialized = true;
         return super.initialize();
     }
 
-    async createAPI() {
+    async createAPI(): Promise<AnyObject> {
         return {};
     }
 
-    async shutdown() {
+    async shutdown(): Promise<void> {
         this._shutdown = true;
         return super.shutdown();
     }

--- a/packages/job-components/test/fixtures/example-api/schema.ts
+++ b/packages/job-components/test/fixtures/example-api/schema.ts
@@ -1,7 +1,7 @@
 import { ConvictSchema } from '../../../src';
 
 export default class Schema extends ConvictSchema<any, any> {
-    build() {
+    build(): Record<string, any> {
         return {
             example: {
                 default: 'examples are quick and easy',

--- a/packages/job-components/test/fixtures/example-observer/observer.ts
+++ b/packages/job-components/test/fixtures/example-observer/observer.ts
@@ -4,12 +4,12 @@ export default class ExampleObserver extends Observer {
     _initialized = false;
     _shutdown = false;
 
-    async initialize() {
+    async initialize(): Promise<void> {
         this._initialized = true;
         return super.initialize();
     }
 
-    async shutdown() {
+    async shutdown(): Promise<void> {
         this._shutdown = true;
         return super.shutdown();
     }

--- a/packages/job-components/test/fixtures/example-observer/schema.ts
+++ b/packages/job-components/test/fixtures/example-observer/schema.ts
@@ -1,7 +1,7 @@
 import { ConvictSchema } from '../../../src';
 
 class Schema extends ConvictSchema<any, any> {
-    build() {
+    build(): Record<string, any> {
         return {
             example: {
                 default: 'examples are quick and easy',

--- a/packages/job-components/test/fixtures/example-op/processor.ts
+++ b/packages/job-components/test/fixtures/example-op/processor.ts
@@ -5,17 +5,17 @@ export default class ExampleBatch extends BatchProcessor {
     _shutdown = false;
     _flushing = false;
 
-    async initialize() {
+    async initialize(): Promise<void> {
         this._initialized = true;
         return super.initialize();
     }
 
-    async shutdown() {
+    async shutdown(): Promise<void> {
         this._shutdown = true;
         return super.shutdown();
     }
 
-    async onBatch(input: DataEntity[]) {
+    async onBatch(input: DataEntity[]): Promise<DataEntity[]> {
         if (this.opConfig.test_flush && this._flushing) {
             return times(30, () => DataEntity.make({ flush: true }));
         }
@@ -26,11 +26,11 @@ export default class ExampleBatch extends BatchProcessor {
         }));
     }
 
-    onFlushStart() {
+    onFlushStart(): void {
         this._flushing = true;
     }
 
-    onFlushEnd() {
+    onFlushEnd(): void {
         this._flushing = false;
     }
 }

--- a/packages/job-components/test/fixtures/example-op/schema.ts
+++ b/packages/job-components/test/fixtures/example-op/schema.ts
@@ -1,7 +1,7 @@
 import { ConvictSchema } from '../../../src';
 
 export default class Schema extends ConvictSchema<any, any> {
-    build() {
+    build(): Record<string, any> {
         return {
             example: {
                 default: 'examples are quick and easy',

--- a/packages/job-components/test/fixtures/example-reader/api.ts
+++ b/packages/job-components/test/fixtures/example-reader/api.ts
@@ -1,28 +1,28 @@
-import { OperationAPI } from '../../../src';
+import { OperationAPI, AnyObject } from '../../../src';
 
 export default class ExampleAPI extends OperationAPI {
     _initialized = false;
     _shutdown = false;
 
-    async initialize() {
+    async initialize(): Promise<void> {
         this._initialized = true;
         return super.initialize();
     }
 
-    async shutdown() {
+    async shutdown(): Promise<void> {
         this._shutdown = true;
         return super.shutdown();
     }
 
-    async createAPI() {
+    async createAPI(): Promise<AnyObject> {
         return {};
     }
 
-    name() {
+    name(): string {
         return 'ExampleAPI';
     }
 
-    async handle(config: any) {
+    async handle(config: unknown): Promise<any> {
         return {
             config,
             say() {

--- a/packages/job-components/test/fixtures/example-reader/fetcher.ts
+++ b/packages/job-components/test/fixtures/example-reader/fetcher.ts
@@ -1,20 +1,20 @@
-import { Fetcher } from '../../../src';
+import { Fetcher, DataEntity } from '../../../src';
 
 export default class ExampleFetcher extends Fetcher {
     _initialized = false;
     _shutdown = false;
 
-    async initialize() {
+    async initialize(): Promise<void> {
         this._initialized = true;
         return super.initialize();
     }
 
-    async shutdown() {
+    async shutdown(): Promise<void> {
         this._shutdown = true;
         return super.shutdown();
     }
 
-    async fetch() {
+    async fetch(): Promise<DataEntity[]> {
         const result = [];
         for (let i = 0; i < 10; i++) {
             result.push({
@@ -22,6 +22,6 @@ export default class ExampleFetcher extends Fetcher {
                 data: [Math.random(), Math.random(), Math.random()],
             });
         }
-        return result;
+        return result as any[];
     }
 }

--- a/packages/job-components/test/fixtures/example-reader/schema.ts
+++ b/packages/job-components/test/fixtures/example-reader/schema.ts
@@ -1,14 +1,14 @@
 import { ConvictSchema, ValidatedJobConfig } from '../../../src';
 
 export default class Schema extends ConvictSchema<any, any> {
-    validateJob(job: ValidatedJobConfig) {
+    validateJob(job: ValidatedJobConfig): void {
         const shouldFail = job.operations.find((op) => op.failCrossValidation);
         if (shouldFail) {
             throw new Error('Failing job validation');
         }
     }
 
-    build() {
+    build(): Record<string, any> {
         return {
             example: {
                 default: 'examples are quick and easy',

--- a/packages/job-components/test/fixtures/example-reader/slicer.ts
+++ b/packages/job-components/test/fixtures/example-reader/slicer.ts
@@ -5,17 +5,17 @@ export default class ExampleSlicer extends Slicer {
     _initialized = false;
     _shutdown = false;
 
-    async initialize(recoveryData: SlicerRecoveryData[]) {
+    async initialize(recoveryData: SlicerRecoveryData[]): Promise<void> {
         this._initialized = true;
         return super.initialize(recoveryData);
     }
 
-    async shutdown() {
+    async shutdown(): Promise<void> {
         this._shutdown = true;
         return super.shutdown();
     }
 
-    async slice() {
+    async slice(): Promise<{ id: string; fetchFrom: string }> {
         return {
             id: uuidv4(),
             fetchFrom: 'https://httpstat.us/200',

--- a/packages/job-components/test/fixtures/failing-reader/schema.ts
+++ b/packages/job-components/test/fixtures/failing-reader/schema.ts
@@ -1,7 +1,7 @@
 import { ConvictSchema } from '../../../src';
 
 export default class Schema extends ConvictSchema<any, any> {
-    build() {
+    build(): Record<string, any> {
         return {
             example: {
                 default: 'examples are quick and easy',

--- a/packages/job-components/test/fixtures/failing-reader/slicer.ts
+++ b/packages/job-components/test/fixtures/failing-reader/slicer.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Slicer } from '../../../src';
 
 export default class FailingSlicer extends Slicer {
-    async slice() {
+    async slice(): Promise<{ id: string }> {
         return {
             id: uuidv4(),
         };

--- a/packages/job-components/test/fixtures/invalid-api-observer/api.ts
+++ b/packages/job-components/test/fixtures/invalid-api-observer/api.ts
@@ -5,12 +5,12 @@ export default class ExampleAPI extends OperationAPI {
     _initialized = false;
     _shutdown = false;
 
-    async initialize() {
+    async initialize(): Promise<void> {
         this._initialized = true;
         return super.initialize();
     }
 
-    async shutdown() {
+    async shutdown(): Promise<void> {
         this._shutdown = true;
         return super.shutdown();
     }

--- a/packages/job-components/test/fixtures/invalid-api-observer/observer.ts
+++ b/packages/job-components/test/fixtures/invalid-api-observer/observer.ts
@@ -4,12 +4,12 @@ export default class ExampleObserver extends Observer {
     _initialized = false;
     _shutdown = false;
 
-    async initialize() {
+    async initialize(): Promise<void> {
         this._initialized = true;
         return super.initialize();
     }
 
-    async shutdown() {
+    async shutdown(): Promise<void> {
         this._shutdown = true;
         return super.shutdown();
     }

--- a/packages/job-components/test/fixtures/invalid-api-observer/schema.ts
+++ b/packages/job-components/test/fixtures/invalid-api-observer/schema.ts
@@ -1,7 +1,7 @@
-import { ConvictSchema } from '../../../src';
+import { ConvictSchema, AnyObject } from '../../../src';
 
 export default class Schema extends ConvictSchema<any, any> {
-    build() {
+    build(): AnyObject {
         return {
             example: {
                 default: 'examples are quick and easy',

--- a/packages/job-components/test/operations/shims/legacy-processor-spec.ts
+++ b/packages/job-components/test/operations/shims/legacy-processor-spec.ts
@@ -22,7 +22,7 @@ describe('Legacy Processor Shim', () => {
     }
 
     class ExampleBatchProcessor extends BatchProcessor<ExampleOpConfig> {
-        async onBatch(data: DataEntity[]) {
+        async onBatch(data: DataEntity[]): Promise<DataEntity[]> {
             return data.map((d) => {
                 d.name = 'hello';
                 return d;

--- a/packages/job-components/test/operations/shims/legacy-reader-spec.ts
+++ b/packages/job-components/test/operations/shims/legacy-reader-spec.ts
@@ -32,7 +32,7 @@ describe('Legacy Reader Shim', () => {
             };
         }
 
-        async shutdown() {
+        async shutdown(): Promise<void> {
             slicerShutdown();
         }
     }

--- a/packages/job-components/test/operations/shims/legacy-slice-events-spec.ts
+++ b/packages/job-components/test/operations/shims/legacy-slice-events-spec.ts
@@ -22,7 +22,7 @@ describe('Legacy Slice Events Shim', () => {
     class ExampleOp<T = Record<string, any>> extends EachProcessor<T> {
         forEach(_data: DataEntity) {}
 
-        async shutdown() {
+        async shutdown(): Promise<void> {
             workerShutdown();
         }
 

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.27.2",
+    "version": "0.27.3",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -49,7 +49,7 @@
         "node-yaml": "^4.0.0",
         "prompts": "^2.3.2",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.25.2",
+        "teraslice-client-js": "^0.25.3",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.3",
         "yargs": "^15.4.1",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.25.2",
+    "version": "0.25.3",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.37.0",
+        "@terascope/job-components": "^0.37.1",
         "auto-bind": "^4.0.0",
         "got": "^11.5.0"
     },

--- a/packages/teraslice-messaging/src/messenger/client.ts
+++ b/packages/teraslice-messaging/src/messenger/client.ts
@@ -289,7 +289,7 @@ export class Client extends Core {
         return !this.serverShutdown && this.ready;
     }
 
-    async shutdown() {
+    async shutdown(): Promise<void> {
         if (this.isClientReady()) {
             try {
                 await this.send(

--- a/packages/teraslice-messaging/src/messenger/server.ts
+++ b/packages/teraslice-messaging/src/messenger/server.ts
@@ -145,7 +145,7 @@ export class Server extends Core {
         );
     }
 
-    async shutdown() {
+    async shutdown(): Promise<void> {
         this.isShuttingDown = true;
 
         if (this._cleanupClients != null) {

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-op-test-harness",
     "displayName": "Teraslice Op Test Harness",
-    "version": "1.21.0",
+    "version": "1.21.1",
     "description": "A testing harness to simplify testing Teraslice processors and operations.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-op-test-harness#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.37.0",
+        "@terascope/job-components": "^0.37.1",
         "bluebird": "^3.7.2"
     },
     "devDependencies": {},

--- a/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
+++ b/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
@@ -34,9 +34,9 @@ export default class ESCachedStateStorage {
         this.es = esApi(client, logger);
     }
 
-    async initialize() {}
+    async initialize(): Promise<void> {}
 
-    async shutdown() {
+    async shutdown(): Promise<void> {
         this.cache.clear();
     }
 

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "0.23.1",
+    "version": "0.23.2",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -30,8 +30,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.37.0",
-        "@terascope/teraslice-op-test-harness": "^1.21.0"
+        "@terascope/job-components": "^0.37.1",
+        "@terascope/teraslice-op-test-harness": "^1.21.1"
     },
     "devDependencies": {},
     "engines": {

--- a/packages/teraslice-test-harness/src/base-test-harness.ts
+++ b/packages/teraslice-test-harness/src/base-test-harness.ts
@@ -21,9 +21,9 @@ import { resolveAssetDir } from './utils';
  * @todo Add support for validating the asset.json?
 */
 export default class BaseTestHarness<U extends ExecutionContext> {
-    events: EventEmitter;
-    protected executionContext: U;
-    protected context: TestContext;
+    readonly events: EventEmitter;
+    readonly executionContext: U;
+    readonly context: TestContext;
 
     constructor(job: JobConfig, options: JobHarnessOptions, assignment: Assignment) {
         const testName = [assignment, job.name].filter((s) => s).join(':');
@@ -41,17 +41,17 @@ export default class BaseTestHarness<U extends ExecutionContext> {
     /**
      * Initialize any test cod
     */
-    async initialize() {
+    async initialize(): Promise<void> {
     }
 
-    setClients(clients: TestClientConfig[]) {
+    setClients(clients: TestClientConfig[]): void {
         this.context.apis.setTestClients(clients);
     }
 
     /**
      * Cleanup test code
     */
-    async shutdown() {
+    async shutdown(): Promise<void> {
         this.events.removeAllListeners();
     }
 

--- a/packages/teraslice-test-harness/src/job-test-harness.ts
+++ b/packages/teraslice-test-harness/src/job-test-harness.ts
@@ -10,7 +10,6 @@ import {
     SlicerRecoveryData,
     pDelay,
     flatten,
-    APICore
 } from '@terascope/job-components';
 import SlicerTestHarness from './slicer-test-harness';
 import WorkerTestHarness from './worker-test-harness';
@@ -26,8 +25,8 @@ import { JobHarnessOptions, SliceResults } from './interfaces';
 */
 
 export default class JobTestHarness {
-    private workerHarness: WorkerTestHarness;
-    private slicerHarness: SlicerTestHarness;
+    readonly workerHarness: WorkerTestHarness;
+    readonly slicerHarness: SlicerTestHarness;
 
     constructor(job: JobConfig, options: JobHarnessOptions) {
         this.workerHarness = new WorkerTestHarness(job, options);
@@ -48,10 +47,6 @@ export default class JobTestHarness {
 
     get apis(): WorkerTestHarness['apis'] {
         return this.workerHarness.apis;
-    }
-
-    getOperationAPI<T extends APICore = APICore>(apiName: string): T {
-        return this.workerHarness.getOperationAPI<T>(apiName);
     }
 
     /**

--- a/packages/teraslice-test-harness/src/op-test-harness.ts
+++ b/packages/teraslice-test-harness/src/op-test-harness.ts
@@ -25,7 +25,7 @@ export default class OpTestHarness {
      * Set the Terafoundation Clients on both
      * the Slicer and Worker contexts
     */
-    setClients(clients: TestClientConfig[]) {
+    setClients(clients: TestClientConfig[]): void {
         this.harness.setClients(clients);
     }
 
@@ -40,7 +40,7 @@ export default class OpTestHarness {
     /**
      * Initialize the Operations on the ExecutionContext
     */
-    async initialize(options?: OpHarness.InitOptions) {
+    async initialize(options?: OpHarness.InitOptions): Promise<void> {
         const initOptions: OpHarness.InitOptions = options != null ? options : {
             opConfig: {
                 _op: 'test'
@@ -61,7 +61,7 @@ export default class OpTestHarness {
     /**
      * Shutdown the Operations on the ExecutionContext
     */
-    async shutdown() {
+    async shutdown(): Promise<void> {
         if (this.opTester != null) {
             await this.opTester.operation.shutdown();
         }

--- a/packages/teraslice-test-harness/src/slicer-test-harness.ts
+++ b/packages/teraslice-test-harness/src/slicer-test-harness.ts
@@ -178,8 +178,14 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
         return this.executionContext.apis;
     }
 
-    getOperationAPI<T extends APICore = APICore>(apiName: string): T {
-        return this.executionContext.api.getAPI<T>(apiName);
+    /**
+     * Get the Operation API Class Instance from the apis
+    */
+    getOperationAPI<T extends APICore = APICore>(name: string): T {
+        if (!this.apis[name]?.instance) {
+            throw new Error(`Operation API "${name}" not found`);
+        }
+        return this.apis[name].instance as T;
     }
 
     /**

--- a/packages/teraslice-test-harness/src/slicer-test-harness.ts
+++ b/packages/teraslice-test-harness/src/slicer-test-harness.ts
@@ -10,7 +10,8 @@ import {
     SlicerRecoveryData,
     times,
     isPlainObject,
-    APICore
+    APICore,
+    OpAPI
 } from '@terascope/job-components';
 import BaseTestHarness from './base-test-harness';
 import { JobHarnessOptions } from './interfaces';
@@ -179,7 +180,16 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
     }
 
     /**
-     * Get the Operation API Class Instance from the apis
+     * Get the reference to a created API that a operation will use.
+     * This is different than getOperationAPI which the OperationAPI class instance
+    */
+    getAPI<T extends OpAPI = any>(name: string): T {
+        return this.executionContext.api.getAPI<T>(name);
+    }
+
+    /**
+     * Get the instantiated OperationAPI class instance from the apis. If you are looking
+     * for the APIs that created during run time, use getAPI.
     */
     getOperationAPI<T extends APICore = APICore>(name: string): T {
         if (!this.apis[name]?.instance) {

--- a/packages/teraslice-test-harness/src/slicer-test-harness.ts
+++ b/packages/teraslice-test-harness/src/slicer-test-harness.ts
@@ -87,12 +87,6 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
     async createSlices(options: { fullResponse: false }): Promise<(SliceRequest|null)[]>;
     async createSlices(options: { fullResponse: true }): Promise<(Slice|null)[]>;
     async createSlices({ fullResponse = false } = {}): Promise<(SliceRequest|Slice|null)[]> {
-        if (this.executionContext.config.lifecycle === 'persistent') {
-            throw new Error(
-                'SlicerTestHarness->createSlices must be ran with once lifecycle'
-            );
-        }
-
         const slicers = this.slicer().slicers();
 
         await this.slicer().handle();
@@ -137,9 +131,10 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
     async getAllSlices(options: { fullResponse: false }): Promise<(Slice|null)[]>;
     async getAllSlices(options: { fullResponse: true }): Promise<(SliceRequest|null)[]>;
     async getAllSlices({ fullResponse = false } = {}): Promise<SliceResults> {
-        if (this.executionContext.config.lifecycle !== 'once') throw new Error('This method can only be used when lifecycle is set to "once"');
+        if (this.executionContext.config.lifecycle !== 'once') {
+            throw new Error('This method can only be used when lifecycle is set to "once"');
+        }
         const results: (SliceRequest|Slice|null)[] = [];
-        this.context.logger.info('before while');
 
         const run = async (): Promise<void> => {
             let sliceResults: SliceResults;

--- a/packages/teraslice-test-harness/src/worker-test-harness.ts
+++ b/packages/teraslice-test-harness/src/worker-test-harness.ts
@@ -71,8 +71,14 @@ export default class WorkerTestHarness extends BaseTestHarness<WorkerExecutionCo
         return this.executionContext.getOperation<T>(findBy);
     }
 
-    getOperationAPI<T extends APICore = APICore>(apiName: string): T {
-        return this.executionContext.api.getAPI<T>(apiName);
+    /**
+     * Get the Operation API Class Instance from the apis
+    */
+    getOperationAPI<T extends APICore = APICore>(name: string): T {
+        if (!this.apis[name]?.instance) {
+            throw new Error(`Operation API "${name}" not found`);
+        }
+        return this.apis[name].instance as T;
     }
 
     /**
@@ -143,13 +149,13 @@ export default class WorkerTestHarness extends BaseTestHarness<WorkerExecutionCo
     async flush(): Promise<DataEntity[] | undefined>;
     async flush(options: { fullResponse: false }): Promise<DataEntity[] | undefined>;
     async flush(options: { fullResponse: true }): Promise<RunSliceResult | undefined>;
-    async flush({ fullResponse = false } = {}) {
+    async flush({ fullResponse = false } = {}): Promise<DataEntity[] | RunSliceResult | undefined> {
         const response = await this.executionContext.flush();
         if (response != null) {
             if (fullResponse) return response;
             return response.results;
         }
-        // its undefined here
+        // its undefined or null here
         return response;
     }
 

--- a/packages/teraslice-test-harness/src/worker-test-harness.ts
+++ b/packages/teraslice-test-harness/src/worker-test-harness.ts
@@ -11,6 +11,7 @@ import {
     APICore,
     OpConfig,
     newTestJobConfig,
+    OpAPI,
 } from '@terascope/job-components';
 import BaseTestHarness from './base-test-harness';
 import { JobHarnessOptions } from './interfaces';
@@ -67,12 +68,24 @@ export default class WorkerTestHarness extends BaseTestHarness<WorkerExecutionCo
         return this.executionContext.apis;
     }
 
+    /**
+     * Get the reference to a created API that a operation will use.
+     * This is different than getOperationAPI which the OperationAPI class instance
+    */
+    getAPI<T extends OpAPI = any>(name: string): T {
+        return this.executionContext.api.getAPI<T>(name);
+    }
+
+    /**
+     * Get the instantiated Operation class instance from the operations list
+    */
     getOperation<T extends OperationCore = OperationCore>(findBy: string | number): T {
         return this.executionContext.getOperation<T>(findBy);
     }
 
     /**
-     * Get the Operation API Class Instance from the apis
+     * Get the instantiated OperationAPI class instance from the apis. If you are looking
+     * for the APIs that created during run time, use getAPI.
     */
     getOperationAPI<T extends APICore = APICore>(name: string): T {
         if (!this.apis[name]?.instance) {

--- a/packages/teraslice-test-harness/test/example-asset-spec.ts
+++ b/packages/teraslice-test-harness/test/example-asset-spec.ts
@@ -100,9 +100,19 @@ describe('Example Asset', () => {
         });
 
         it('can get apis using getOperationAPI', async () => {
-            const api = harness.getOperationAPI<SimpleAPI>(apiName);
+            const api = harness.getOperationAPI<SimpleAPIClass>(apiName);
 
             expect(api).toBeInstanceOf(SimpleAPIClass);
+        });
+
+        it('can get apis using getAPI', async () => {
+            const api = harness.getAPI<SimpleAPI>(apiName);
+
+            expect(api).toMatchObject({
+                count: expect.any(Number),
+                add: expect.any(Function),
+                sub: expect.any(Function),
+            });
         });
     });
 
@@ -236,12 +246,6 @@ describe('Example Asset', () => {
                     expect(result.scale).toBe(6);
                 }
             }
-        });
-
-        it('can get apis using getOperationAPI', async () => {
-            const api = harness.getOperationAPI<SimpleAPI>(apiName);
-
-            expect(api).toBeInstanceOf(SimpleAPIClass);
         });
     });
 });

--- a/packages/teraslice-test-harness/test/example-asset-spec.ts
+++ b/packages/teraslice-test-harness/test/example-asset-spec.ts
@@ -5,6 +5,7 @@ import SimpleClient from './fixtures/asset/simple-connector/client';
 import {
     JobTestHarness, newTestJobConfig, newTestSlice, SlicerTestHarness, WorkerTestHarness
 } from '../src';
+import SimpleAPIClass from './fixtures/asset/simple-api/api';
 import { SimpleAPI } from './fixtures/asset/simple-api/interfaces';
 
 jest.mock('./fixtures/asset/simple-connector/client');
@@ -101,10 +102,7 @@ describe('Example Asset', () => {
         it('can get apis using getOperationAPI', async () => {
             const api = harness.getOperationAPI<SimpleAPI>(apiName);
 
-            expect(api).toBeDefined();
-            expect(api.count).toBeNumber();
-            expect(api.add).toBeFunction();
-            expect(api.sub).toBeFunction();
+            expect(api).toBeInstanceOf(SimpleAPIClass);
         });
     });
 
@@ -243,10 +241,7 @@ describe('Example Asset', () => {
         it('can get apis using getOperationAPI', async () => {
             const api = harness.getOperationAPI<SimpleAPI>(apiName);
 
-            expect(api).toBeDefined();
-            expect(api.count).toBeNumber();
-            expect(api.add).toBeFunction();
-            expect(api.sub).toBeFunction();
+            expect(api).toBeInstanceOf(SimpleAPIClass);
         });
     });
 });

--- a/packages/teraslice-test-harness/test/fixtures/asset/parallel-reader/fetcher.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/parallel-reader/fetcher.ts
@@ -1,7 +1,9 @@
-import { Fetcher, SliceRequest, AnyObject } from '@terascope/job-components';
+import {
+    Fetcher, SliceRequest, AnyObject, DataEntity
+} from '@terascope/job-components';
 
 export default class TestFetcher extends Fetcher<AnyObject> {
-    async fetch(request: SliceRequest) {
-        return request;
+    async fetch(request: SliceRequest): Promise<DataEntity[]> {
+        return request as DataEntity[];
     }
 }

--- a/packages/teraslice-test-harness/test/fixtures/asset/parallel-reader/schema.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/parallel-reader/schema.ts
@@ -1,7 +1,7 @@
 import { ConvictSchema, AnyObject } from '@terascope/job-components';
 
 export default class Schema extends ConvictSchema<AnyObject> {
-    build() {
+    build(): AnyObject {
         return {};
     }
 }

--- a/packages/teraslice-test-harness/test/fixtures/asset/parallel-reader/slicer.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/parallel-reader/slicer.ts
@@ -1,10 +1,12 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { ParallelSlicer, AnyObject, pDelay } from '@terascope/job-components';
 
 export default class Counter extends ParallelSlicer<AnyObject> {
     count = 0;
 
-    async newSlicer(id: number) {
+    async newSlicer(id: number): Promise<() => Promise<({
+        count: number;
+        id: number;
+    }|null)>> {
         let count = 3;
         return async () => {
             const delay = Math.round(100 * Math.random());

--- a/packages/teraslice-test-harness/test/fixtures/asset/recoverable-reader.ts/fetcher.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/recoverable-reader.ts/fetcher.ts
@@ -1,7 +1,9 @@
-import { Fetcher, SliceRequest, AnyObject } from '@terascope/job-components';
+import {
+    Fetcher, SliceRequest, AnyObject, DataEntity
+} from '@terascope/job-components';
 
 export default class TestFetcher extends Fetcher<AnyObject> {
-    async fetch(request: SliceRequest) {
-        return request;
+    async fetch(request: SliceRequest): Promise<DataEntity[]> {
+        return request as DataEntity[];
     }
 }

--- a/packages/teraslice-test-harness/test/fixtures/asset/recoverable-reader.ts/schema.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/recoverable-reader.ts/schema.ts
@@ -1,7 +1,7 @@
 import { ConvictSchema, AnyObject } from '@terascope/job-components';
 
 export default class Schema extends ConvictSchema<AnyObject> {
-    build() {
+    build(): AnyObject {
         return {};
     }
 }

--- a/packages/teraslice-test-harness/test/fixtures/asset/recoverable-reader.ts/slicer.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/recoverable-reader.ts/slicer.ts
@@ -3,7 +3,7 @@ import { Slicer, AnyObject, SlicerRecoveryData } from '@terascope/job-components
 export default class Counter extends Slicer<AnyObject> {
     count = 0;
 
-    async initialize(recoveryData: SlicerRecoveryData[]) {
+    async initialize(recoveryData: SlicerRecoveryData[]): Promise<void> {
         super.initialize(recoveryData);
         if (this.recoveryData.length > 0) {
             const { lastSlice } = this.recoveryData[0];
@@ -13,11 +13,11 @@ export default class Counter extends Slicer<AnyObject> {
         }
     }
 
-    isRecoverable() {
+    isRecoverable(): boolean {
         return true;
     }
 
-    async slice() {
+    async slice(): Promise<{ count: number }> {
         this.count += 1;
         return { count: this.count };
     }

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-api/api.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-api/api.ts
@@ -2,13 +2,13 @@ import { OperationAPI } from '@terascope/job-components';
 import { SimpleAPIConfig, SimpleAPI } from './interfaces';
 
 export default class SimpleOperationAPI extends OperationAPI<SimpleAPIConfig> {
-    async createAPI() {
+    async createAPI(): Promise<SimpleAPI> {
         return {
             count: 0,
-            add(n = 1) {
+            add(n = 1): void {
                 this.count += n;
             },
-            sub(n = 1) {
+            sub(n = 1): void {
                 this.count += n;
             },
         } as SimpleAPI;

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-api/schema.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-api/schema.ts
@@ -1,8 +1,8 @@
-import { ConvictSchema } from '@terascope/job-components';
+import { ConvictSchema, AnyObject } from '@terascope/job-components';
 import { SimpleAPIConfig } from './interfaces';
 
 export default class Schema extends ConvictSchema<SimpleAPIConfig> {
-    build() {
+    build(): AnyObject {
         return {};
     }
 }

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-connector/client.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-connector/client.ts
@@ -1,5 +1,5 @@
 export = class SimpleClient {
-    fetchRecord(id: number) {
+    fetchRecord(id: number): { id: number, data: number[] } {
         return {
             id,
             data: [
@@ -10,13 +10,13 @@ export = class SimpleClient {
         };
     }
 
-    sliceRequest(count: number) {
+    sliceRequest(count: number): { count: number } {
         return {
             count
         };
     }
 
-    isFinished() {
+    isFinished(): boolean {
         return false;
     }
 };

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-flush/processor.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-flush/processor.ts
@@ -5,15 +5,15 @@ export default class Flusher extends BatchProcessor<FlusherConfig> {
     _flushing = false;
     _state: DataEntity[] = [];
 
-    onFlushStart() {
+    async onFlushStart(): Promise<void> {
         this._flushing = true;
     }
 
-    onFlushEnd() {
+    async onFlushEnd(): Promise<void> {
         this._flushing = false;
     }
 
-    async onBatch(data: DataEntity[]) {
+    async onBatch(data: DataEntity[]): Promise<DataEntity[]> {
         if (this._flushing) return this._state;
         this._state = data;
         return [];

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-flush/schema.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-flush/schema.ts
@@ -1,8 +1,8 @@
-import { ConvictSchema } from '@terascope/job-components';
+import { ConvictSchema, AnyObject } from '@terascope/job-components';
 import { FlusherConfig } from './interfaces';
 
 export default class Schema extends ConvictSchema<FlusherConfig> {
-    build() {
+    build(): AnyObject {
         return {
             someSetting: {
                 default: 'hello world'

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-reader/fetcher.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-reader/fetcher.ts
@@ -1,4 +1,6 @@
-import { Fetcher, SliceRequest, times } from '@terascope/job-components';
+import {
+    Fetcher, SliceRequest, times, WorkerContext, ExecutionConfig, DataEntity
+} from '@terascope/job-components';
 import { SimpleReaderConfig } from './interfaces';
 import SimpleClient from '../simple-connector/client';
 import { SimpleAPI } from '../simple-api/interfaces';
@@ -6,19 +8,21 @@ import { SimpleAPI } from '../simple-api/interfaces';
 export default class TestFetcher extends Fetcher<SimpleReaderConfig> {
     client: SimpleClient;
 
-    // @ts-expect-error
-    constructor(...args) {
-        // @ts-expect-error
-        super(...args);
+    constructor(
+        context: WorkerContext,
+        opConfig: SimpleReaderConfig,
+        executionConfig: ExecutionConfig
+    ) {
+        super(context, opConfig, executionConfig);
 
         this.client = this.context.apis.op_runner.getClient({}, 'simple-client');
     }
 
-    async fetch(request: SliceRequest) {
+    async fetch(request: SliceRequest): Promise<DataEntity[]> {
         const api = this.getAPI('simple-api') as SimpleAPI;
         return times(request.count, (id) => {
             api.add(2);
-            return this.client.fetchRecord(id);
+            return DataEntity.make(this.client.fetchRecord(id));
         });
     }
 }

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-reader/schema.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-reader/schema.ts
@@ -1,8 +1,8 @@
-import { ConvictSchema } from '@terascope/job-components';
+import { ConvictSchema, AnyObject } from '@terascope/job-components';
 import { SimpleReaderConfig } from './interfaces';
 
 export default class Schema extends ConvictSchema<SimpleReaderConfig> {
-    build() {
+    build(): AnyObject {
         return {
             slicesToCreate: {
                 default: 10,

--- a/packages/teraslice-test-harness/test/fixtures/asset/simple-reader/slicer.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/simple-reader/slicer.ts
@@ -1,19 +1,23 @@
-import { Slicer, times } from '@terascope/job-components';
+import {
+    Slicer, times, WorkerContext, ExecutionConfig
+} from '@terascope/job-components';
 import { SimpleReaderConfig } from './interfaces';
 import SimpleClient from '../simple-connector/client';
 
 export default class TestSlicer extends Slicer<SimpleReaderConfig> {
     client: SimpleClient;
 
-    // @ts-expect-error
-    constructor(...args) {
-        // @ts-expect-error
-        super(...args);
+    constructor(
+        context: WorkerContext,
+        opConfig: SimpleReaderConfig,
+        executionConfig: ExecutionConfig
+    ) {
+        super(context, opConfig, executionConfig);
 
         this.client = this.context.apis.op_runner.getClient({}, 'simple-client');
     }
 
-    async slice() {
+    async slice(): Promise<{ count: number }[]|null> {
         const { slicesToCreate, recordsToFetch } = this.opConfig;
 
         if (this.client.isFinished()) {

--- a/packages/teraslice-test-harness/test/fixtures/asset/transformer/processor.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/transformer/processor.ts
@@ -3,7 +3,7 @@ import { SimpleAPI } from '../simple-api/interfaces';
 import { TransformerConfig } from './interfaces';
 
 export default class Transformer extends MapProcessor<TransformerConfig> {
-    map(data: DataEntity) {
+    map(data: DataEntity): DataEntity {
         const api = this.simpleAPI();
         if (api != null) {
             api.sub();
@@ -25,7 +25,7 @@ export default class Transformer extends MapProcessor<TransformerConfig> {
         return data;
     }
 
-    simpleAPI() {
+    simpleAPI(): SimpleAPI|null {
         try {
             return this.getAPI('simple-api') as SimpleAPI;
         } catch (err) {

--- a/packages/teraslice-test-harness/test/fixtures/asset/transformer/schema.ts
+++ b/packages/teraslice-test-harness/test/fixtures/asset/transformer/schema.ts
@@ -1,8 +1,8 @@
-import { ConvictSchema } from '@terascope/job-components';
+import { ConvictSchema, AnyObject } from '@terascope/job-components';
 import { TransformerConfig, actions } from './interfaces';
 
 export default class Schema extends ConvictSchema<TransformerConfig> {
-    build() {
+    build(): AnyObject {
         return {
             action: {
                 default: null,

--- a/packages/teraslice-test-harness/test/slicer-test-harness-spec.ts
+++ b/packages/teraslice-test-harness/test/slicer-test-harness-spec.ts
@@ -219,7 +219,7 @@ describe('SlicerTestHarness', () => {
 
         it('getAllSlices will throw if not in once mode', async () => {
             await makeTest(2, 'persistent');
-            await expect(slicerHarness.createSlices()).toReject();
+            await expect(slicerHarness.getAllSlices()).toReject();
         });
     });
 });

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -38,7 +38,7 @@
     },
     "dependencies": {
         "@terascope/elasticsearch-api": "^2.10.1",
-        "@terascope/job-components": "^0.37.0",
+        "@terascope/job-components": "^0.37.1",
         "@terascope/teraslice-messaging": "^0.12.1",
         "@terascope/utils": "^0.28.1",
         "async-mutex": "^0.2.4",
@@ -66,7 +66,7 @@
         "uuid": "^8.2.0"
     },
     "devDependencies": {
-        "@terascope/teraslice-op-test-harness": "^1.21.0",
+        "@terascope/teraslice-op-test-harness": "^1.21.1",
         "archiver": "^4.0.2",
         "bufferstreams": "^3.0.0",
         "chance": "^1.1.6",


### PR DESCRIPTION
We added a `getOperationAPI` method to `teraslice-test-harness` but was return the created API instance which isn't ideal, there is already an API for that, so I changed to correctly return the API class instance.