### PR TITLE
v0.69.2 - update base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM terascope/node-base:12.18.1-1
+FROM terascope/node-base:12.18.3
 
 ENV NODE_ENV production
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "0.69.1",
+    "version": "0.69.2",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "0.69.1",
+    "version": "0.69.2",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
- updates `terafoundation_kafka_connector` to include `librdkafka@1.4.2` (from `1.2.2`) which includes a fix for [disconnects while rebalancing](https://github.com/edenhill/librdkafka/releases/tag/v1.4.0)
- updates `node` to `12.18.3` (from `12.18.1`) for a potential [memory leak fix](https://github.com/nodejs/node/issues/33266)