### PR TITLE
v0.69.3 - Reverts version of librdafka due to regression in stuck workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM terascope/node-base:12.18.3
+FROM terascope/node-base:12.18.3-1
 
 ENV NODE_ENV production
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "0.69.2",
+    "version": "0.69.3",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "0.69.2",
+    "version": "0.69.3",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
Fixes a regression in stuck workers we found in the latest version of node-rdkafka/librdkafka