### PR TITLE
switch to the old deleteExecution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "0.69.3",
+    "version": "0.69.4",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "0.69.3",
+    "version": "0.69.4",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
This PR reverts Teraslice execution stopping (in k8s) back to the original `deleteExecution` implementation.  The newer implementation, still present as `deleteExecutionControlled` takes longer to shutdown, and with a five minute node shutdown timeout, will take MORE than five minutes to shut down in cases with a stuck worker.

Also, we encountered this error:

```
[2020-08-12T22:41:22.156Z] ERROR: teraslice/19 on teraslice-cluster1-master-82828282: Error encountered deleting pod deployment, continuing execution controller shutdown: Error: Timeout Waiting: pods matching app.kubernetes.io/component=worker,teraslice.terascope.io/exId=257246 is 1/0 (assignment=cluster_master, module=kubernetes_cluster_service, worker_id=qpKc8-kF)
    Error: Error encountered deleting pod deployment, continuing execution controller shutdown: Error: Timeout Waiting: pods matching app.kubernetes.io/component=worker,teraslice.terascope.io/exId=257246 is 1/0
        at K8s.deleteExecution (/app/source/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/k8s.js:344:25)
        at runMicrotasks (<anonymous>)
        at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

I did not expect to encounter this error since I was trying to make the `waitForNumPods` timeout big enough to ensure all worker pods would time out.  This doesn't matter if we accept this PR.