### PR TITLE
Fix time series index support in elasticsearch-store

### DIFF
--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.33.0",
+    "version": "0.34.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/elasticsearch-store/src/index-manager.ts
+++ b/packages/elasticsearch-store/src/index-manager.ts
@@ -32,6 +32,11 @@ export default class IndexManager {
         });
     }
 
+    /**
+     * Format the current index name.
+     *
+     * @param useWildcard if true a wildcard is added to the end of the end the index name
+    */
     formatIndexName<T = any>(config: IndexConfig<T>, useWildcard = true): string {
         utils.validateIndexConfig(config);
 
@@ -53,6 +58,10 @@ export default class IndexManager {
         return indexName;
     }
 
+    /**
+     * Format the template name, similar to formatIndexName except it excludes
+     * template wildcards and the time series parts of the index name.
+    */
     formatTemplateName<T = any>(config: IndexConfig<T>): string {
         utils.validateIndexConfig(config);
 

--- a/packages/elasticsearch-store/src/index-manager.ts
+++ b/packages/elasticsearch-store/src/index-manager.ts
@@ -62,9 +62,6 @@ export default class IndexManager {
             namespace, name, utils.getDataVersionStr(config)
         ]);
 
-        if (utils.isTemplatedIndex(config.index_schema)) {
-            return `${indexName}-*`;
-        }
         return indexName;
     }
 
@@ -106,6 +103,7 @@ export default class IndexManager {
             await this.upsertTemplate(
                 {
                     ...body,
+                    index_patterns: [this.formatIndexName(config, true)],
                     version: schemaVersion,
                 },
                 logger

--- a/packages/elasticsearch-store/src/index-manager.ts
+++ b/packages/elasticsearch-store/src/index-manager.ts
@@ -47,7 +47,7 @@ export default class IndexManager {
         }
 
         if (utils.isTemplatedIndex(config.index_schema) && useWildcard) {
-            return `${indexName}*`;
+            return `${indexName}-*`;
         }
 
         return indexName;
@@ -58,11 +58,18 @@ export default class IndexManager {
 
         const { name, namespace } = config;
 
-        return utils.formatIndexName([namespace, name, utils.getDataVersionStr(config)]);
+        const indexName = utils.formatIndexName([
+            namespace, name, utils.getDataVersionStr(config)
+        ]);
+
+        if (utils.isTemplatedIndex(config.index_schema)) {
+            return `${indexName}-*`;
+        }
+        return indexName;
     }
 
     /**
-     * Safely setup a versioned Index, its template and any other required resouces
+     * Safely setup a versioned Index, its template and any other required resources
      *
      * @todo this should handle better index change detection
      *
@@ -169,11 +176,11 @@ export default class IndexManager {
     /**
      * Perform an Index Migration
      *
-     * **IMPORTANT** This is a potentionally dangerous operation
+     * **IMPORTANT** This is a potentially dangerous operation
      * and should only when the cluster is properly shutdown.
      *
      * @todo add support for timeseries and templated indexes
-     * @todo add support for complicated reindexing behaviors
+     * @todo add support for complicated re-indexing behaviors
      */
     async migrateIndex<T>(options: MigrateIndexOptions<T>): Promise<any> {
         const {
@@ -309,7 +316,7 @@ export default class IndexManager {
 
         if (breakingChange) {
             // FIXME should we crash
-            logger.error(`Index ${index} (${type}) has breaking change in the index, evaulate the differences and migrate if needed`);
+            logger.error(`Index ${index} (${type}) has breaking change in the index, evaluate the differences and migrate if needed`);
             return;
         }
 
@@ -330,7 +337,9 @@ export default class IndexManager {
     /**
      * Safely create or update a template
      */
-    async upsertTemplate(template: Record<string, any>, logger?: ts.Logger): Promise<void> {
+    async upsertTemplate(
+        template: Record<string, any>, logger?: ts.Logger
+    ): Promise<void> {
         const { template: name, version } = template;
         try {
             const templates = await this.getTemplate(name, true);

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -26,7 +26,6 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
         const {
             timeseries,
             version,
-            rollover_frequency,
             schema,
             strict_mode,
             index_settings,
@@ -40,7 +39,7 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
                 version,
                 template: true,
                 timeseries: true,
-                rollover_frequency
+                rollover_frequency: options.rollover_frequency
             } : {
                 version,
             },

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -138,6 +138,24 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
     }
 
     /**
+     * Create a bulk record and put it into the bulk request queue
+     */
+    async createBulkRecord(record: i.CreateRecordInput<T>): Promise<void> {
+        const docInput = {
+            ...record,
+            _deleted: false,
+            _created: ts.makeISODate(),
+            _updated: ts.makeISODate(),
+        } as T;
+
+        const id = uuid();
+        docInput._key = id;
+
+        const doc = this._sanitizeRecord(docInput);
+        return this.bulk('index', doc, id);
+    }
+
+    /**
      * Soft deletes a record by ID
      */
     async deleteRecord(id: string, clientId?: number): Promise<boolean> {
@@ -180,24 +198,6 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
         } as AnyInput<T>, clientId);
 
         return count === ids.length;
-    }
-
-    /**
-     * Create a bulk record
-     */
-    async createBulkRecord(record: i.CreateRecordInput<T>): Promise<void> {
-        const docInput = {
-            ...record,
-            _deleted: false,
-            _created: ts.makeISODate(),
-            _updated: ts.makeISODate(),
-        } as T;
-
-        const id = uuid();
-        docInput._key = id;
-
-        const doc = this._sanitizeRecord(docInput);
-        return this.bulk('index', doc, id);
     }
 
     protected _sanitizeRecord(record: T): T {

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -138,21 +138,25 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
     }
 
     /**
-     * Create a bulk record and put it into the bulk request queue
+     * Create a bulk records and put it them into bulk request queue
      */
-    async createBulkRecord(record: i.CreateRecordInput<T>): Promise<void> {
-        const docInput = {
-            ...record,
-            _deleted: false,
-            _created: ts.makeISODate(),
-            _updated: ts.makeISODate(),
-        } as T;
+    async bulkCreateRecords(
+        records: i.CreateRecordInput<T>[]
+    ): Promise<void> {
+        for (const record of records) {
+            const docInput = {
+                ...record,
+                _deleted: false,
+                _created: ts.makeISODate(),
+                _updated: ts.makeISODate(),
+            } as T;
 
-        const id = uuid();
-        docInput._key = id;
+            const id = uuid();
+            docInput._key = id;
 
-        const doc = this._sanitizeRecord(docInput);
-        return this.bulk('index', doc, id);
+            const doc = this._sanitizeRecord(docInput);
+            await this.bulk('index', doc, id);
+        }
     }
 
     /**

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -8,7 +8,7 @@ import * as utils from './utils';
 import * as i from './interfaces';
 
 /**
- * An high-level, opionionated, abstract class
+ * An high-level, opinionated, abstract class
  * for an elasticsearch DataType, with a CRUD-like interface
  */
 export default abstract class IndexModel<T extends i.IndexModelRecord> extends IndexStore<T> {

--- a/packages/elasticsearch-store/src/index-store.ts
+++ b/packages/elasticsearch-store/src/index-store.ts
@@ -90,7 +90,7 @@ export default class IndexStore<T extends ts.AnyObject> {
     /**
      * The index typically used for searching across all of the open indices
     */
-    get searchQuery(): string {
+    get searchIndex(): string {
         return this.manager.formatIndexName(this.config);
     }
 
@@ -160,7 +160,7 @@ export default class IndexStore<T extends ts.AnyObject> {
     async countRequest(params: es.CountParams): Promise<number> {
         return ts.pRetry(async () => {
             const { count } = await this.client.count(this.getDefaultParams<es.CountParams>(
-                this.searchQuery,
+                this.searchIndex,
                 params
             ));
             return count;
@@ -638,7 +638,7 @@ export default class IndexStore<T extends ts.AnyObject> {
 
         const response = await ts.pRetry(async () => this.client.search<T>(
             this.getDefaultParams<es.SearchParams>(
-                this.searchQuery,
+                this.searchIndex,
                 params,
             )
         ), utils.getRetryConfig());

--- a/packages/elasticsearch-store/src/interfaces.ts
+++ b/packages/elasticsearch-store/src/interfaces.ts
@@ -249,14 +249,6 @@ IndexConfig<T>,
      * Use a Timeseries Index
      */
     timeseries?: boolean;
-
-    /**
-     * Rollover Frequency for the Timeseries Index.
-     * This is only valid if timeseries is set to true
-     *
-     * @default monthly
-     */
-    rollover_frequency?: TimeSeriesFormat;
 };
 
 export type SanitizeFields = {
@@ -281,6 +273,14 @@ export interface IndexModelOptions {
      * Enable index mutations so indexes will be auto created or updated
     */
     enable_index_mutations?: boolean;
+
+    /**
+     * Rollover Frequency for the Timeseries Index.
+     * This is only valid if timeseries is set to true
+     *
+     * @default monthly
+     */
+    rollover_frequency?: TimeSeriesFormat;
 }
 
 export type FindOptions<T> = {

--- a/packages/elasticsearch-store/src/interfaces.ts
+++ b/packages/elasticsearch-store/src/interfaces.ts
@@ -58,7 +58,7 @@ export interface IndexConfig<T extends AnyObject> {
     bulk_max_size?: number;
 
     /**
-     * Logger to use for debugging and certian internal errors
+     * Logger to use for debugging and certain internal errors
      *
      * @defaults to a debug logger
      */
@@ -150,7 +150,7 @@ export interface DataSchema {
 
     /**
      * If enabled this will allow the use of some of
-     * the slower but more correct JSON Schema's formatters:
+     * the slower but more correct JSON Schema formatters:
      *
      * - "date"
      * - "time"
@@ -196,7 +196,7 @@ export interface IndexModelRecord {
     _key: string;
 
     /**
-     * The mutli-tenant ID representing the client
+     * The multi-tenant ID representing the client
      */
     client_id: number;
 
@@ -226,20 +226,17 @@ export type UpdateRecordInput<T extends IndexModelRecord> =
         client_id?: number;
     };
 
-export interface IndexModelConfig<T extends IndexModelRecord> {
+export type IndexModelConfig<T extends IndexModelRecord> = Omit<
+IndexConfig<T>,
+'namespace'|'id_field'|'index_schema'|'data_schema'|'default_query_access'|'enable_index_mutations'
+> & {
     /** Schema Version */
     version: number;
-
-    /** Name of the Model/Data Type */
-    name: string;
-
-    /** The DataType of the model */
-    data_type: DataType;
 
     /** JSON Schema */
     schema: any;
 
-    /** Unqiue fields across on Index */
+    /** Unique fields across on Index */
     unique_fields?: (keyof T)[];
 
     /** Sanitize / cleanup fields mapping, like trim or trimAndToLower */
@@ -248,9 +245,19 @@ export interface IndexModelConfig<T extends IndexModelRecord> {
     /** Specify whether the data should be strictly validated, defaults to true */
     strict_mode?: boolean;
 
-    /** The default sort field and direction */
-    default_sort?: string;
-}
+    /**
+     * Use a Timeseries Index
+     */
+    timeseries?: boolean;
+
+    /**
+     * Rollover Frequency for the Timeseries Index.
+     * This is only valid if timeseries is set to true
+     *
+     * @default monthly
+     */
+    rollover_frequency?: TimeSeriesFormat;
+};
 
 export type SanitizeFields = {
     [field: string]: 'trimAndToLower' | 'trim' | 'toSafeString';

--- a/packages/elasticsearch-store/src/utils/elasticsearch.ts
+++ b/packages/elasticsearch-store/src/utils/elasticsearch.ts
@@ -20,7 +20,7 @@ export function verifyIndexShards(shards: i.Shard[]): boolean {
 
 export const __timeSeriesTest: { date?: Date } = {};
 
-const formatter = {
+const formatter: Record<i.TimeSeriesFormat, number> = {
     daily: 10,
     monthly: 7,
     yearly: 4,
@@ -28,6 +28,7 @@ const formatter = {
 export function timeSeriesIndex(index: string, timeSeriesFormat: i.TimeSeriesFormat = 'monthly'): string {
     const format = formatter[timeSeriesFormat];
     if (!format) throw new Error(`Unsupported format "${timeSeriesFormat}"`);
+
     let dateStr: string;
     if (isTest && __timeSeriesTest.date) {
         dateStr = __timeSeriesTest.date.toISOString();
@@ -128,6 +129,22 @@ export function fixMappingRequest(
     const defaultParams: any = {};
 
     const esVersion = getESVersion(client);
+
+    if (esVersion === 5) {
+        if (params.body.index_patterns) {
+            if (isTemplate) {
+                params.body.template = ts.getFirst(params.body.index_patterns);
+            }
+            delete params.body.index_patterns;
+        }
+
+        if (Array.isArray(params.body.template)) {
+            if (isTemplate) {
+                params.body.template = ts.getFirst(params.body.template);
+            }
+        }
+    }
+
     if (esVersion >= 6) {
         if (params.body.template) {
             if (isTemplate) {

--- a/packages/elasticsearch-store/src/utils/elasticsearch.ts
+++ b/packages/elasticsearch-store/src/utils/elasticsearch.ts
@@ -131,23 +131,17 @@ export function fixMappingRequest(
     const esVersion = getESVersion(client);
 
     if (esVersion === 5) {
-        if (params.body.index_patterns) {
-            if (isTemplate) {
+        if (params.body.index_patterns != null) {
+            if (isTemplate && params.body.template == null) {
                 params.body.template = ts.getFirst(params.body.index_patterns);
             }
             delete params.body.index_patterns;
         }
-
-        if (Array.isArray(params.body.template)) {
-            if (isTemplate) {
-                params.body.template = ts.getFirst(params.body.template);
-            }
-        }
     }
 
     if (esVersion >= 6) {
-        if (params.body.template) {
-            if (isTemplate) {
+        if (params.body.template != null) {
+            if (isTemplate && params.body.index_patterns == null) {
                 params.body.index_patterns = ts.castArray(params.body.template).slice();
             }
             delete params.body.template;

--- a/packages/elasticsearch-store/src/utils/validation.ts
+++ b/packages/elasticsearch-store/src/utils/validation.ts
@@ -9,7 +9,14 @@ export function isValidName(name: string): boolean {
 }
 
 export function validateId(id: unknown, action: string, throwError = true): id is string {
-    if (ts.isString(id) && id) return true;
+    if (!id) {
+        if (!throwError) return false;
+        throw new ts.TSError(`Missing required ID for ${action}`, {
+            statusCode: 400
+        });
+    }
+
+    if (ts.isString(id)) return true;
     if (!throwError) return false;
 
     throw new ts.TSError(`Invalid ID given to ${action}, expected string, got ${ts.getTypeOf(id)}`, {

--- a/packages/elasticsearch-store/test/helpers/elasticsearch.ts
+++ b/packages/elasticsearch-store/test/helpers/elasticsearch.ts
@@ -36,7 +36,7 @@ export async function cleanupIndex(
 export function cleanupIndexStore(
     store: IndexStore<any>
 ): Promise<void> {
-    const { client, indexQuery } = store;
+    const { client, searchQuery } = store;
 
-    return cleanupIndex(client, indexQuery);
+    return cleanupIndex(client, searchQuery);
 }

--- a/packages/elasticsearch-store/test/helpers/elasticsearch.ts
+++ b/packages/elasticsearch-store/test/helpers/elasticsearch.ts
@@ -36,7 +36,5 @@ export async function cleanupIndex(
 export function cleanupIndexStore(
     store: IndexStore<any>
 ): Promise<void> {
-    const { client, searchQuery } = store;
-
-    return cleanupIndex(client, searchQuery);
+    return cleanupIndex(store.client, store.searchIndex);
 }

--- a/packages/elasticsearch-store/test/index-manager-index-setup-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-index-setup-spec.ts
@@ -92,7 +92,7 @@ describe('IndexManager->indexSetup()', () => {
         };
 
         const index = `${config.name}-v1-s1`;
-        const templateName = `${config.name}-v1-*`;
+        const templateName = `${config.name}-v1`;
 
         const indexManager = new IndexManager(client);
         let result = false;
@@ -217,7 +217,7 @@ describe('IndexManager->indexSetup()', () => {
 
         const index = `${config.name}-v1-*`;
         const currentIndexName = timeSeriesIndex(`${config.name}-v1-s1`, 'daily');
-        const templateName = `${config.name}-v1-*`;
+        const templateName = `${config.name}-v1`;
 
         const indexManager = new IndexManager(client);
         let result = false;

--- a/packages/elasticsearch-store/test/index-manager-index-setup-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-index-setup-spec.ts
@@ -92,7 +92,7 @@ describe('IndexManager->indexSetup()', () => {
         };
 
         const index = `${config.name}-v1-s1`;
-        const templateName = `${config.name}-v1`;
+        const templateName = `${config.name}-v1-*`;
 
         const indexManager = new IndexManager(client);
         let result = false;
@@ -217,7 +217,7 @@ describe('IndexManager->indexSetup()', () => {
 
         const index = `${config.name}-v1-*`;
         const currentIndexName = timeSeriesIndex(`${config.name}-v1-s1`, 'daily');
-        const templateName = `${config.name}-v1`;
+        const templateName = `${config.name}-v1-*`;
 
         const indexManager = new IndexManager(client);
         let result = false;
@@ -270,14 +270,18 @@ describe('IndexManager->indexSetup()', () => {
             // disable index mutations
             const noIndexMutations = new IndexManager(client, false);
             const originalIndex = indexManager.formatIndexName(config, false);
+
             const ONE_HOUR = 60 * 60 * 1000;
             const ONE_DAY = 24 * ONE_HOUR;
+
             __timeSeriesTest.date = new Date(Date.now() + ONE_DAY + ONE_HOUR);
             const newIndex = noIndexMutations.formatIndexName(config, false);
+
             const created = await noIndexMutations.indexSetup({
                 ...config,
                 enable_index_mutations: false,
             });
+
             expect(created).toBeTrue();
             expect(await noIndexMutations.exists(newIndex)).toBeTrue();
             expect(newIndex).not.toBe(originalIndex);

--- a/packages/elasticsearch-store/test/index-manager-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-spec.ts
@@ -125,7 +125,7 @@ describe('IndexManager', () => {
                         },
                     });
 
-                    expect(indexName).toEqual('hello-v1-s1*');
+                    expect(indexName).toEqual('hello-v1-s1-*');
                 });
             });
 

--- a/packages/elasticsearch-store/test/index-store-timeseries-spec.ts
+++ b/packages/elasticsearch-store/test/index-store-timeseries-spec.ts
@@ -1,0 +1,590 @@
+import 'jest-extended';
+import {
+    times, pDelay, DataEntity, TSError, debugLogger
+} from '@terascope/utils';
+import { Translator } from 'xlucene-translator';
+import {
+    SimpleRecord, SimpleRecordInput, dataType
+} from './helpers/simple-index';
+import { makeClient, cleanupIndexStore } from './helpers/elasticsearch';
+import { TEST_INDEX_PREFIX } from './helpers/config';
+import { IndexStore, IndexConfig, __timeSeriesTest } from '../src';
+
+describe('IndexStore (timeseries)', () => {
+    const client = makeClient();
+    const logger = debugLogger(__filename);
+
+    describe.each([0, 1])('when %d days pass', (numDays) => {
+        const ONE_HOUR = 60 * 60 * 1000;
+        const ONE_DAY = 24 * ONE_HOUR;
+        __timeSeriesTest.date = new Date(
+            Date.now() + ((ONE_DAY + ONE_HOUR) * numDays)
+        );
+
+        const config: IndexConfig<SimpleRecord> = {
+            name: `${TEST_INDEX_PREFIX}timeseries`,
+            data_type: dataType,
+            index_schema: {
+                version: 1,
+                strict: true,
+                template: true,
+                timeseries: true,
+                rollover_frequency: 'daily',
+            },
+            version: 1,
+            index_settings: {
+                'index.number_of_shards': 1,
+                'index.number_of_replicas': 0,
+            },
+            logger,
+            bulk_max_size: 50,
+            bulk_max_wait: 300,
+            id_field: 'test_id',
+            ingest_time_field: '_created',
+            event_time_field: '_updated',
+            enable_index_mutations: false
+        };
+        const indexStore = new IndexStore<SimpleRecord>(client, config);
+
+        beforeAll(async () => {
+            await cleanupIndexStore(indexStore);
+
+            await indexStore.initialize();
+        });
+
+        afterAll(async () => {
+            await cleanupIndexStore(indexStore);
+
+            await indexStore.shutdown();
+        });
+
+        it('should create the versioned index', async () => {
+            expect(indexStore.indexQuery).not.toBe(indexStore.writeIndex);
+            const exists = await client.indices.exists({
+                index: indexStore.writeIndex
+            });
+
+            expect(exists).toBeTrue();
+        });
+
+        describe('when dealing with a record', () => {
+            const record: SimpleRecordInput = {
+                test_id: 'hello-1234',
+                test_keyword: 'hello',
+                test_object: {
+                    some_obj: true,
+                },
+                test_number: 1234,
+                test_boolean: false,
+                _created: new Date().toISOString(),
+                _updated: new Date().toISOString(),
+            };
+
+            beforeAll(() => indexStore.createById(record.test_id, record));
+
+            it('should not be able to create a record again', async () => {
+                expect.hasAssertions();
+
+                try {
+                    await indexStore.createById(record.test_id, record);
+                } catch (err) {
+                    expect(err).toBeInstanceOf(TSError);
+                    expect(err.message).toInclude('Document Already Exists');
+                    expect(err.statusCode).toEqual(409);
+                }
+            });
+
+            it('should be able to index the same record', () => indexStore.indexById(record.test_id, record));
+
+            it('should be able to index the record without an id', async () => {
+                const lonelyRecord: SimpleRecordInput = {
+                    test_id: 'lonely-1234',
+                    test_keyword: 'other',
+                    test_object: {},
+                    test_number: 1234,
+                    test_boolean: false,
+                };
+
+                await indexStore.index(lonelyRecord);
+
+                const count = await indexStore.count(`test_id: ${lonelyRecord.test_id}`);
+                expect(count).toBe(1);
+            });
+
+            it('should be able to index a different record with id', async () => {
+                const otherRecord: SimpleRecordInput = {
+                    test_id: 'other-1234',
+                    test_keyword: 'other',
+                    test_object: {},
+                    test_number: 1234,
+                    test_boolean: false,
+                };
+
+                await indexStore.indexById(otherRecord.test_id, otherRecord);
+
+                const count = await indexStore.count(`test_id: ${otherRecord.test_id}`);
+                expect(count).toBe(1);
+            });
+
+            it('can use count with variables', async () => {
+                const testRecord: SimpleRecordInput = {
+                    test_id: 'hello',
+                    test_keyword: 'world',
+                    test_object: {},
+                    test_number: 5678,
+                    test_boolean: true,
+                };
+
+                const variables = {
+                    id: 'hello'
+                };
+
+                await indexStore.indexById(testRecord.test_id, testRecord);
+
+                const count = await indexStore.count('test_id: $id', { variables });
+                expect(count).toBe(1);
+            });
+
+            it('can use countBy with variables', async () => {
+                const testRecord: SimpleRecordInput = {
+                    test_id: 'goodbye',
+                    test_keyword: 'jimmy',
+                    test_object: {},
+                    test_number: 1111,
+                    test_boolean: false,
+                };
+
+                const variables = {
+                    id: 'goodbye'
+                };
+
+                await indexStore.indexById(testRecord.test_id, testRecord);
+
+                const count = await indexStore.countBy({ test_id: '$id' }, 'OR', { variables });
+                expect(count).toBe(1);
+            });
+
+            it('can use search with variables', async () => {
+                const testRecord: SimpleRecordInput = {
+                    test_id: 'iamtest',
+                    test_keyword: 'aloha',
+                    test_object: {},
+                    test_number: 111111111,
+                    test_boolean: true,
+                };
+
+                const variables = {
+                    word: 'aloha'
+                };
+
+                await indexStore.indexById(testRecord.test_id, testRecord);
+
+                const { results } = await indexStore.search('test_keyword:$word', { variables });
+                expect(results).toEqual([testRecord]);
+            });
+
+            it('can use findBy with variables', async () => {
+                const testRecord: SimpleRecordInput = {
+                    test_id: 'iamfindby',
+                    test_keyword: 'iamfindby',
+                    test_object: {},
+                    test_number: 1,
+                    test_boolean: false,
+                };
+
+                const variables = {
+                    word: 'iamfindby'
+                };
+
+                await indexStore.indexById(testRecord.test_id, testRecord);
+
+                const results = await indexStore.findBy({ test_keyword: '$word' }, 'OR', { variables });
+                expect(results).toEqual(testRecord);
+            });
+
+            it('should be able to get the count', () => expect(indexStore.count(`test_id: ${record.test_id}`)).resolves.toBe(1));
+
+            it('should get zero when the using the wrong id', () => expect(indexStore.count('test_id: wrong-id')).resolves.toBe(0));
+
+            it('should be able to update the record', async () => {
+                await indexStore.update(
+                    record.test_id,
+                    {
+                        doc: {
+                            test_number: 4231,
+                        },
+                    },
+                );
+
+                const updated = await indexStore.get(record.test_id);
+                expect(updated).toHaveProperty('test_number', 4231);
+
+                await indexStore.update(record.test_id, { doc: record });
+            });
+
+            it('should throw when updating a record that does not exist', async () => {
+                expect.hasAssertions();
+
+                try {
+                    await indexStore.update(
+                        'wrong-id',
+                        {
+                            doc: {
+                                test_number: 1,
+                            },
+                        },
+                    );
+                } catch (err) {
+                    expect(err).toBeInstanceOf(TSError);
+                    expect(err.message).toInclude('Not Found');
+                    expect(err.statusCode).toEqual(404);
+                }
+            });
+
+            it('should be able to get the record by id', async () => {
+                const r: DataEntity<SimpleRecord> = (await indexStore.get(record.test_id)) as any;
+
+                expect(DataEntity.isDataEntity(r)).toBeTrue();
+                expect(r).toEqual(record);
+
+                const metadata = r.getMetadata();
+                expect(metadata).toMatchObject({
+                    _index: indexStore.writeIndex,
+                    _key: record.test_id,
+                    _type: indexStore.esVersion >= 7 ? '_doc' : indexStore.config.name,
+                });
+
+                expect(metadata._processTime).toBeNumber();
+
+                const ingestTime = record._created ? new Date(record._created).getTime() : null;
+                expect(metadata).toHaveProperty('_ingestTime', ingestTime);
+
+                const eventTime = record._updated ? new Date(record._updated).getTime() : null;
+                expect(metadata).toHaveProperty('_eventTime', eventTime);
+            });
+
+            it('should throw when getting a record that does not exist', async () => {
+                expect.hasAssertions();
+
+                try {
+                    await indexStore.get('wrong-id');
+                } catch (err) {
+                    expect(err).toBeInstanceOf(TSError);
+                    expect(err.message).toInclude('Not Found');
+                    expect(err.statusCode).toEqual(404);
+                }
+            });
+
+            it('should be able to remove the record', async () => {
+                await indexStore.deleteById(record.test_id);
+            });
+
+            it('should throw when trying to remove a record that does not exist', async () => {
+                expect.hasAssertions();
+
+                try {
+                    await indexStore.deleteById('wrong-id');
+                } catch (err) {
+                    expect(err).toBeInstanceOf(TSError);
+                    expect(err.message).toInclude('Not Found');
+                    expect(err.statusCode).toEqual(404);
+                }
+            });
+        });
+
+        describe('when dealing with multiple a records', () => {
+            const keyword = 'example-record';
+            const records: SimpleRecordInput[] = [
+                {
+                    test_id: 'example-1',
+                    test_keyword: keyword,
+                    test_object: {
+                        example: 'obj',
+                    },
+                    test_number: 5555,
+                    test_boolean: true,
+                    _created: new Date().toISOString(),
+                    _updated: new Date().toISOString(),
+                },
+                {
+                    test_id: 'example-2',
+                    test_keyword: keyword,
+                    test_object: {
+                        example: 'obj',
+                    },
+                    test_number: 3333,
+                    test_boolean: true,
+                    _created: new Date().toISOString(),
+                    _updated: new Date().toISOString(),
+                },
+                {
+                    test_id: 'example-3',
+                    test_keyword: keyword,
+                    test_object: {
+                        example: 'obj',
+                    },
+                    test_number: 999,
+                    test_boolean: true,
+                    _created: new Date().toISOString(),
+                    _updated: new Date().toISOString(),
+                },
+            ];
+
+            beforeAll(async () => {
+                await Promise.all(
+                    records.map((record) => indexStore.createById(record.test_id, record, {
+                        refresh: false,
+                    }))
+                );
+
+                await indexStore.refresh();
+            });
+
+            it('should be able to mget all of the records', async () => {
+                const docs = records.map((r) => ({
+                    _id: r.test_id,
+                }));
+
+                const result = await indexStore.mget({ docs });
+
+                expect(DataEntity.isDataEntityArray(result)).toBeTrue();
+                expect(result).toEqual(records);
+            });
+
+            it('should be able to search the records', async () => {
+                const {
+                    results,
+                } = await indexStore.search(`test_keyword: ${keyword}`, {
+                    sort: 'test_id',
+                });
+
+                expect(DataEntity.isDataEntityArray(results)).toBeTrue();
+                expect(results).toEqual(records);
+            });
+
+            it('should be able to search the records and get the total', async () => {
+                const {
+                    results
+                } = await indexStore.search(`test_keyword: ${keyword}`, {
+                    sort: 'test_id',
+                });
+
+                expect(results).toEqual(records);
+            });
+        });
+
+        describe('when bulk sending records', () => {
+            const keyword = 'bulk-record';
+
+            const records: SimpleRecordInput[] = times(100, (n) => ({
+                test_id: `bulk-${n + 1}`,
+                test_keyword: keyword,
+                test_object: { bulk: true },
+                test_number: (n + 10) * 2,
+                test_boolean: n % 2 === 0,
+                _updated: new Date().toISOString(),
+            }));
+
+            beforeAll(async () => {
+                let useIndex = false;
+                for (const record of records) {
+                    if (useIndex) {
+                        await indexStore.bulk('index', record, record.test_id);
+                    } else {
+                        await indexStore.bulk('create', record, record.test_id);
+                    }
+                    useIndex = !useIndex;
+                }
+
+                await pDelay(500);
+                await indexStore.refresh();
+            });
+
+            afterAll(async () => {
+                for (const record of records.slice(0, 10)) {
+                    await indexStore.bulk(
+                        'update',
+                        {
+                            test_object: {
+                                updateAfterShutdown: true,
+                            },
+                        },
+                        record.test_id
+                    );
+                }
+            });
+
+            // eslint-disable-next-line
+            xit('compare xlucene query', async () => {
+                const q = '_exists_:test_number OR test_number:<0 OR test_number:100000 NOT test_keyword:other-keyword';
+                const realResult = await indexStore.searchRequest({
+                    q,
+                    _sourceInclude: ['test_id', 'test_boolean'],
+                    sort: 'test_number:asc',
+                    size: 200,
+                });
+                const {
+                    results: xluceneResult
+                } = await indexStore.search(q, {
+                    size: 200,
+                    includes: ['test_id', 'test_boolean'],
+                    sort: 'test_number:asc',
+                });
+
+                await indexStore.searchRequest({
+                    body: {
+                        query: {
+                            constant_score: {
+                                filter: {
+                                    bool: {
+                                        filter: [
+                                            {
+                                                exists: {
+                                                    field: 'test_number',
+                                                },
+                                            },
+                                        ],
+                                        must_not: [
+                                            {
+                                                term: {
+                                                    test_keyword: 'other-keyword',
+                                                },
+                                            },
+                                        ],
+                                        should: [
+                                            {
+                                                range: {
+                                                    test_number: {
+                                                        gte: 10,
+                                                    },
+                                                },
+                                            },
+                                            {
+                                                term: {
+                                                    test_boolean: false,
+                                                },
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    _sourceInclude: ['test_id', 'test_boolean'],
+                    sort: 'test_number:asc',
+                    size: 200,
+                });
+
+                const translated = new Translator(q, {
+                    type_config: indexStore.xLuceneTypeConfig
+                }).toElasticsearchDSL();
+
+                // eslint-disable-next-line no-console
+                console.log(JSON.stringify({ q, translated }, null, 4));
+
+                // expect(realResult).toEqual(modifiedResult);
+                expect(xluceneResult).toEqual(realResult);
+
+                // eslint-disable-next-line no-console
+                console.dir(xluceneResult);
+            });
+
+            // eslint-disable-next-line
+            xit('test lucene query', async () => {
+                const result = await indexStore.searchRequest({
+                    q: '*rec?rd',
+                    size: 200,
+                    _sourceInclude: ['test_id', 'test_number'],
+                    sort: 'test_number:asc',
+                });
+                // expect(result).toBeArrayOfSize(0);
+
+                // eslint-disable-next-line no-console
+                console.dir(result);
+            });
+
+            it('should be able to search the records', async () => {
+                const {
+                    results
+                } = await indexStore.search(`test_keyword: ${keyword}`, {
+                    sort: 'test_number',
+                    size: records.length + 1,
+                });
+
+                expect(results).toBeArrayOfSize(records.length);
+                expect(DataEntity.isDataEntityArray(results)).toBeTrue();
+            });
+
+            it('should be able use exists and range xlucene syntax', async () => {
+                const {
+                    results
+                } = await indexStore.search('_exists_:test_number AND test_number: <100', {
+                    sort: 'test_number',
+                    size: 5,
+                });
+
+                expect(results).toBeArrayOfSize(5);
+                expect(DataEntity.isDataEntityArray(results)).toBeTrue();
+            });
+
+            it('should be able use multi-term xlucene syntax', async () => {
+                const query = 'test_id:/bulk-.*/ AND test_number:(20 OR 22 OR 26)';
+                const {
+                    results
+                } = await indexStore.search(query, {
+                    sort: 'test_number',
+                });
+
+                expect(results).toBeArrayOfSize(3);
+                expect(DataEntity.isDataEntityArray(results)).toBeTrue();
+            });
+
+            it('should be able to bulk update the records', async () => {
+                for (const record of records) {
+                    await indexStore.bulk(
+                        'index',
+                        Object.assign(record, {
+                            test_object: {
+                                updated: true,
+                            },
+                        }),
+                        record.test_id
+                    );
+                }
+
+                await indexStore.flush(true);
+                await indexStore.refresh();
+
+                const {
+                    results
+                } = await indexStore.search(`test_keyword: ${keyword}`, {
+                    sort: 'test_id',
+                    size: records.length + 1,
+                });
+
+                expect(results[0]).toHaveProperty('test_object', {
+                    updated: true,
+                });
+            });
+
+            it('should be able to bulk delete the records', async () => {
+                for (const record of records) {
+                    await indexStore.bulk('delete', record.test_id);
+                }
+
+                await indexStore.flush(true);
+
+                await indexStore.refresh();
+
+                const {
+                    results
+                } = await indexStore.search(`test_keyword: ${keyword}`, {
+                    sort: 'test_id',
+                    size: records.length + 1,
+                });
+
+                expect(results).toBeArrayOfSize(0);
+            });
+        });
+    });
+});

--- a/packages/elasticsearch-store/test/index-store-timeseries-spec.ts
+++ b/packages/elasticsearch-store/test/index-store-timeseries-spec.ts
@@ -22,7 +22,7 @@ describe('IndexStore (timeseries)', () => {
         );
 
         const config: IndexConfig<SimpleRecord> = {
-            name: `${TEST_INDEX_PREFIX}timeseries`,
+            name: `${TEST_INDEX_PREFIX}time_store`,
             data_type: dataType,
             index_schema: {
                 version: 1,
@@ -59,7 +59,7 @@ describe('IndexStore (timeseries)', () => {
         });
 
         it('should create the versioned index', async () => {
-            expect(indexStore.indexQuery).not.toBe(indexStore.writeIndex);
+            expect(indexStore.searchQuery).not.toBe(indexStore.writeIndex);
             const exists = await client.indices.exists({
                 index: indexStore.writeIndex
             });

--- a/packages/elasticsearch-store/test/index-store-timeseries-spec.ts
+++ b/packages/elasticsearch-store/test/index-store-timeseries-spec.ts
@@ -59,7 +59,7 @@ describe('IndexStore (timeseries)', () => {
         });
 
         it('should create the versioned index', async () => {
-            expect(indexStore.searchQuery).not.toBe(indexStore.writeIndex);
+            expect(indexStore.searchIndex).not.toBe(indexStore.writeIndex);
             const exists = await client.indices.exists({
                 index: indexStore.writeIndex
             });

--- a/packages/elasticsearch-store/test/utils-spec.ts
+++ b/packages/elasticsearch-store/test/utils-spec.ts
@@ -15,7 +15,7 @@ describe('Elasticsearch Store Utils', () => {
             ).toEqual('/fooBar0123/');
         });
 
-        it('should return . for each dashe', () => {
+        it('should return . for each dash', () => {
             expect(
                 uniqueFieldQuery('test-a-b-c')
             ).toEqual('/test.a.b.c/');


### PR DESCRIPTION
- Fix time series support in elasticsearch-store
- Add `writeIndex` to  `IndexStore`
- Add `aggregate` function to `IndexStore`
- Add the ability to pass in more configuration options from `IndexModelConfig`
- Add `createBulkRecord` to `IndexModel`
- BREAKING: `indexQuery` is now `searchIndex` to  `IndexStore`
- BREAKING: The first argument to `getDefaultParams` in `IndexStore` is now the index to use
- Fix spelling issues