### PR TITLE
Data frame multi field order by

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-mate/src/aggregation-frame/AggregationFrame.ts
+++ b/packages/data-mate/src/aggregation-frame/AggregationFrame.ts
@@ -361,6 +361,19 @@ export class AggregationFrame<
     }
 
     /**
+     * Get a column by name or throw if not found
+    */
+    getColumnOrThrow<P extends keyof T>(field: P): Column<T[P], P> {
+        const column = this.getColumn(field);
+        if (!column) {
+            throw new Error(`Unknown column ${field} in ${
+                this.name ? ` ${this.name}` : ''
+            } ${this.constructor.name}`);
+        }
+        return column;
+    }
+
+    /**
      * Get a column by index
     */
     getColumnAt<P extends keyof T>(index: number): Column<T[P], P>|undefined {
@@ -497,7 +510,7 @@ export class AggregationFrame<
         await pImmediate();
 
         this.columns = Object.freeze([...builders].map(([name, builder]) => {
-            const column = this.getColumn(name)!;
+            const column = this.getColumnOrThrow(name);
             return column.fork(builder.toVector());
         }));
         return this;

--- a/packages/data-mate/src/column/Column.ts
+++ b/packages/data-mate/src/column/Column.ts
@@ -201,7 +201,11 @@ export class Column<T = unknown, N extends NameType = string> {
      * Sort the column
     */
     sort(direction?: SortOrder): Column<T, N> {
-        const sortedIndices = this.vector.getSortedIndices(direction);
+        const sortedIndices = Vector.getSortedIndices([{
+            vector: this.vector,
+            direction: direction || 'asc'
+        }]);
+
         const len = sortedIndices.length;
         const builder = Builder.make<T>(new WritableData(len), {
             childConfig: this.vector.childConfig,

--- a/packages/data-mate/src/core/utils.ts
+++ b/packages/data-mate/src/core/utils.ts
@@ -19,14 +19,33 @@ export function getFieldsFromArg<
         throw new Error(`Expected field arg to an array, got ${arg} (${getTypeOf(arg)})`);
     }
 
+    const result = flattenStringArg(arg);
+
+    for (const field of result) {
+        if (!fields.includes(field)) {
+            throw new TSError(`Unknown field ${field}`, {
+                statusCode: 400
+            });
+        }
+    }
+
+    return result;
+}
+
+export function flattenStringArg<
+    K extends(number|string|symbol)
+>(arg: FieldArg<K>[]): ReadonlySet<K> {
+    if (!Array.isArray(arg)) {
+        throw new Error(`Expected field arg to an array, got ${arg} (${getTypeOf(arg)})`);
+    }
+
     const result = new Set<K>();
-    const addFieldArg = _makeAddFieldsArg(fields, result);
 
     for (const fieldArg of arg) {
         if (Array.isArray(fieldArg)) {
-            fieldArg.forEach(addFieldArg);
+            fieldArg.forEach((field) => result.add(field));
         } else {
-            addFieldArg(fieldArg as K);
+            result.add(fieldArg as K);
         }
     }
 
@@ -37,19 +56,6 @@ export function getFieldsFromArg<
     }
 
     return result;
-}
-
-function _makeAddFieldsArg<K extends(number|string|symbol)>(
-    fields: readonly K[],
-    result: Set<K>,) {
-    return function addFieldArg(field: K): void {
-        if (!fields.includes(field)) {
-            throw new TSError(`Unknown field ${field}`, {
-                statusCode: 400
-            });
-        }
-        result.add(field);
-    };
 }
 
 /**

--- a/packages/data-mate/src/index.ts
+++ b/packages/data-mate/src/index.ts
@@ -33,7 +33,6 @@ AggregationFrame.prototype.run = async function run() {
     if (aggFrame._sortFields?.length) {
         dataFrame = dataFrame.orderBy(
             aggFrame._sortFields,
-            aggFrame._sortDirection
         );
         if (aggFrame._limit != null) {
             dataFrame = dataFrame.limit(aggFrame._limit);

--- a/packages/data-mate/test/aggregation-frame-spec.ts
+++ b/packages/data-mate/test/aggregation-frame-spec.ts
@@ -677,7 +677,7 @@ describe('AggregationFrame', () => {
                 .count('name', 'count')
                 .select('name', 'count')
                 .rename('name', 'person')
-                .sort('count', 'asc')
+                .sort('count:asc')
                 .limit(3)
                 .run();
 

--- a/packages/data-mate/test/aggregation-frame-spec.ts
+++ b/packages/data-mate/test/aggregation-frame-spec.ts
@@ -350,7 +350,7 @@ describe('AggregationFrame', () => {
     describe('->col(gender)->unique()->count(gender)', () => {
         it('should get the right result when using aggregate()', async () => {
             const uniqFrame = dataFrame.assign([
-                dataFrame.getColumn('gender')!.unique()
+                dataFrame.getColumnOrThrow('gender').unique()
             ]);
             const resultFrame = await uniqFrame.aggregate().count('gender').run();
             expect(resultFrame.toJSON()).toEqual([

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -292,7 +292,7 @@ describe('DataFrame', () => {
         describe('->assign', () => {
             it('should be able to a new frame with the new column', () => {
                 const newCol = dataFrame
-                    .getColumn('name')!
+                    .getColumnOrThrow('name')
                     .transform(ColumnTransform.toUpperCase)
                     .rename('upper_name');
 
@@ -306,13 +306,13 @@ describe('DataFrame', () => {
             });
 
             it('should be able to a new frame with replaced columns', () => {
-                const newCol = dataFrame.getColumn('name')!.transform(ColumnTransform.toUpperCase);
+                const newCol = dataFrame.getColumnOrThrow('name').transform(ColumnTransform.toUpperCase);
                 const resultFrame = dataFrame.assign([newCol]);
 
                 const names = resultFrame.columns.map(({ name }) => name);
                 expect(names).toEqual(['name', 'age', 'friends']);
 
-                expect(resultFrame.getColumn('name')!.toJSON()).toEqual([
+                expect(resultFrame.getColumnOrThrow('name').toJSON()).toEqual([
                     'JILL',
                     'BILLY',
                     'FRANK',

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -487,7 +487,7 @@ describe('DataFrame', () => {
             });
 
             it('should be able to sort name by desc order', () => {
-                const resultFrame = dataFrame.orderBy('name', 'desc');
+                const resultFrame = dataFrame.orderBy('name:desc');
 
                 expect(resultFrame.toJSON()).toEqual([
                     {
@@ -549,7 +549,7 @@ describe('DataFrame', () => {
             });
 
             it('should be able to sort age by desc order', () => {
-                const resultFrame = dataFrame.orderBy('age', 'desc');
+                const resultFrame = dataFrame.orderBy('age:desc');
 
                 expect(resultFrame.toJSON()).toEqual([
                     {
@@ -561,6 +561,37 @@ describe('DataFrame', () => {
                         name: 'Jill',
                         age: 39,
                         friends: ['Frank']
+                    },
+                    {
+                        name: 'Frank',
+                        age: 20,
+                        friends: ['Jill']
+                    },
+                    {
+                        name: 'Nancy',
+                        age: 10
+                    },
+                    {
+                        name: 'Jane',
+                        friends: ['Jill']
+                    },
+                ]);
+                expect(resultFrame.id).not.toEqual(dataFrame.id);
+            });
+
+            it('should be able to sort name:desc and age:desc', () => {
+                const resultFrame = dataFrame.orderBy(['name:desc', 'age:desc']);
+
+                expect(resultFrame.toJSON()).toEqual([
+                    {
+                        name: 'Jill',
+                        age: 39,
+                        friends: ['Frank']
+                    },
+                    {
+                        name: 'Billy',
+                        age: 47,
+                        friends: ['Jill']
                     },
                     {
                         name: 'Frank',

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.40.2",
+    "version": "0.40.3",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.19.2",
+        "@terascope/data-mate": "^0.19.3",
         "@terascope/data-types": "^0.25.1",
         "@terascope/types": "^0.7.0",
         "@terascope/utils": "^0.34.1",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.48.2",
+    "version": "0.48.3",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.19.2",
+        "@terascope/data-mate": "^0.19.3",
         "@terascope/types": "^0.7.0",
         "@terascope/utils": "^0.34.1",
         "awesome-phonenumber": "^2.41.0",


### PR DESCRIPTION
- Adds multiple field orderBy support. **BREAKING** The interface changed from `orderBy(field(s), direction)` to `orderBy("${field}:${direction}")`
- Adds `getColumnOrThrow` to `DataFrame` for better errors