### PR TITLE
Allow nil values in xLucene ORs and xpression improvements

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.19.5",
+    "version": "0.20.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -53,7 +53,7 @@
         "uuid": "^8.3.2",
         "valid-url": "^1.0.9",
         "validator": "^13.5.2",
-        "xlucene-parser": "^0.30.1"
+        "xlucene-parser": "^0.31.0"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.1",

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.40.5",
+    "version": "0.41.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,13 +24,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.19.5",
+        "@terascope/data-mate": "^0.20.0",
         "@terascope/data-types": "^0.25.1",
         "@terascope/types": "^0.7.0",
         "@terascope/utils": "^0.34.1",
         "ajv": "^6.12.6",
         "uuid": "^8.3.2",
-        "xlucene-translator": "^0.14.1"
+        "xlucene-translator": "^0.15.0"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.0",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.48.5",
+    "version": "0.49.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.19.5",
+        "@terascope/data-mate": "^0.20.0",
         "@terascope/types": "^0.7.0",
         "@terascope/utils": "^0.34.1",
         "awesome-phonenumber": "^2.43.0",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.30.1",
+    "version": "0.31.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-parser/src/parser.ts
+++ b/packages/xlucene-parser/src/parser.ts
@@ -215,7 +215,8 @@ export class Parser {
                 return coerceNodeValue(
                     node,
                     validatedVariables,
-                    parent?.type === i.ASTType.Function
+                    parent?.type === i.ASTType.Function,
+                    parent?.type === i.ASTType.Conjunction
                 );
             }
 
@@ -280,9 +281,12 @@ function coerceTermList(node: i.TermList, variables: xLuceneVariables) {
 function coerceNodeValue(
     node: i.Term|i.Regexp|i.Wildcard,
     variables: xLuceneVariables,
-    skipAutoFieldGroup?: boolean
+    skipAutoFieldGroup?: boolean,
+    allowNil?: boolean
 ): i.AnyAST {
-    const value = utils.getFieldValue<any>(node.value, variables);
+    const value = utils.getFieldValue<any>(
+        node.value, variables, allowNil
+    );
     const coerceFn = utils.makeCoerceFn(node.field_type);
 
     if (Array.isArray(value)) {

--- a/packages/xlucene-parser/src/parser.ts
+++ b/packages/xlucene-parser/src/parser.ts
@@ -287,7 +287,9 @@ function coerceNodeValue(
     const value = utils.getFieldValue<any>(
         node.value, variables, allowNil
     );
-    const coerceFn = utils.makeCoerceFn(node.field_type);
+    const coerceFn = allowNil && value == null
+        ? () => null
+        : utils.makeCoerceFn(node.field_type);
 
     if (Array.isArray(value)) {
         if (skipAutoFieldGroup) {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.14.1",
+    "version": "0.15.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -30,7 +30,7 @@
     "dependencies": {
         "@terascope/types": "^0.7.0",
         "@terascope/utils": "^0.34.1",
-        "xlucene-parser": "^0.30.1"
+        "xlucene-parser": "^0.31.0"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xlucene-translator/test/cases/translator/logical-group.ts
+++ b/packages/xlucene-translator/test/cases/translator/logical-group.ts
@@ -58,6 +58,32 @@ export default [
         ],
     ],
     [
+        'some:$some_null_value OR other:$thing',
+        'query.constant_score.filter.bool.should',
+        [
+            {
+                bool: {
+                    filter: [
+                        {
+                            match: {
+                                other: {
+                                    query: 'something',
+                                    operator: 'and',
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        ],
+        {
+            variables: {
+                some_null_value: null,
+                thing: 'something'
+            }
+        }
+    ],
+    [
         'NOT value:awesome AND other:thing',
         'query.constant_score.filter.bool.should[0].bool',
         {

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -22,7 +22,9 @@
         "test:debug": "ts-scripts test --debug . --",
         "test:watch": "ts-scripts test --watch . --"
     },
-    "dependencies": {},
+    "dependencies": {
+        "@terascope/utils": "^0.34.1"
+    },
     "devDependencies": {
         "@terascope/types": "^0.7.0"
     },

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {

--- a/packages/xpressions/src/interfaces.ts
+++ b/packages/xpressions/src/interfaces.ts
@@ -4,11 +4,12 @@ export interface Options {
     variables: xLuceneVariables
 }
 
-export type AST = readonly Node[];
+export type Nodes = readonly Node[];
 
 export enum NodeType {
     LITERAL = 'LITERAL',
     EXPRESSION = 'EXPRESSION',
+    VARIABLE = 'VARIABLE',
 }
 
 export interface Node {
@@ -27,14 +28,19 @@ export function isLiteralNode(node: Node): node is LiteralNode {
 export interface ExpressionNode extends Node {
     readonly type: NodeType.EXPRESSION;
     readonly value: string;
-    readonly variables: readonly Variable[];
-}
-
-export interface Variable {
-    scoped: boolean;
-    value: string;
+    readonly nodes: Nodes;
 }
 
 export function isExpressionNode(node: Node): node is ExpressionNode {
     return node.type === NodeType.EXPRESSION;
+}
+
+export interface VariableNode extends Node {
+    readonly type: NodeType.VARIABLE;
+    readonly scoped: boolean;
+    readonly value: string;
+}
+
+export function isVariableNode(node: Node): node is VariableNode {
+    return node.type === NodeType.VARIABLE;
 }

--- a/packages/xpressions/src/interfaces.ts
+++ b/packages/xpressions/src/interfaces.ts
@@ -14,6 +14,10 @@ export enum NodeType {
 
 export interface Node {
     readonly type: NodeType;
+    readonly loc: {
+        readonly start: number;
+        readonly end: number;
+    }
 }
 
 export interface LiteralNode extends Node {

--- a/packages/xpressions/src/parse.ts
+++ b/packages/xpressions/src/parse.ts
@@ -1,5 +1,5 @@
 import {
-    AST, ExpressionNode, LiteralNode, NodeType, Options
+    Nodes, ExpressionNode, LiteralNode, NodeType, VariableNode
 } from './interfaces';
 
 /**
@@ -7,9 +7,9 @@ import {
  *
  * @returns a list of errors
 */
-export function parse(input: string, _options: Options): AST {
+export function parse(input: string): Nodes {
     const len = input.length;
-    const ast: (LiteralNode|ExpressionNode)[] = [];
+    const ast: (LiteralNode|ExpressionNode|VariableNode)[] = [];
     let chunk = '';
     function finishChunk() {
         if (!chunk) return;
@@ -37,14 +37,11 @@ export function parse(input: string, _options: Options): AST {
                 }
             }
             if (terminated) {
-                const variable = expression.trim();
+                const variable = expression.trim().replace(/^\$/, '');
                 ast.push({
-                    type: NodeType.EXPRESSION,
-                    value: expression,
-                    variables: [{
-                        scoped: variable.startsWith('@'),
-                        value: variable
-                    }]
+                    type: NodeType.VARIABLE,
+                    scoped: variable.startsWith('@'),
+                    value: variable,
                 });
             } else {
                 ast.push({

--- a/packages/xpressions/src/parse.ts
+++ b/packages/xpressions/src/parse.ts
@@ -1,62 +1,93 @@
+import { TSError } from '@terascope/utils';
 import {
     Nodes, ExpressionNode, LiteralNode, NodeType, VariableNode
 } from './interfaces';
 
 /**
- * Parse and validate an expression string and return the parsed AST
+ * Parse and validate an templated expression string
  *
- * @returns a list of errors
+ * @returns the parsed ast
 */
 export function parse(input: string): Nodes {
     const len = input.length;
     const ast: (LiteralNode|ExpressionNode|VariableNode)[] = [];
+    let chunkStart = 0;
     let chunk = '';
-    function finishChunk() {
+    function finishChunk(chunkEnd: number) {
         if (!chunk) return;
         ast.push({
             type: NodeType.LITERAL,
             value: chunk,
-        });
+            loc: {
+                start: chunkStart,
+                end: chunkEnd
+            }
+        } as LiteralNode);
         chunk = '';
+        chunkStart = chunkEnd;
     }
 
     for (let i = 0; i < len; i++) {
         const char = input[i];
         const nextChar = input[i + 1];
         if (char === '$' && nextChar === '{' && !isEscaped(input, i)) {
-            finishChunk();
-            let expression = '';
-            let terminated = false;
-            for (let j = (i + 2); j < len; j++) {
-                if (input[j] === '}' && !isEscaped(input, j)) {
-                    i = j;
-                    terminated = true;
-                    break;
-                } else {
-                    expression += input[j];
-                }
-            }
-            if (terminated) {
-                const variable = expression.trim().replace(/^\$/, '');
-                ast.push({
-                    type: NodeType.VARIABLE,
-                    scoped: variable.startsWith('@'),
-                    value: variable,
-                });
-            } else {
-                ast.push({
-                    type: NodeType.LITERAL,
-                    value: `\${${expression}`,
-                });
-                break;
-            }
+            finishChunk(i);
+            const expr = parseExpression(input, i + 2, true);
+            ast.push(expr);
+            i = expr.loc.end;
+            chunkStart = i;
         } else {
             chunk += char;
         }
     }
-    finishChunk();
+    finishChunk(input.length);
 
     return ast.slice();
+}
+
+/**
+ * Parse and validate an expression
+ *
+ * @returns return the parsed expression
+*/
+export function parseExpression(
+    input: string, startPosition = 0, isInTemplate?: boolean
+): ExpressionNode {
+    let expression = '';
+    let terminated = false;
+    for (let j = startPosition; j < input.length; j++) {
+        if (input[j] === '}' && !isEscaped(input, j)) {
+            terminated = true;
+            break;
+        } else {
+            expression += input[j];
+        }
+    }
+    if (terminated || !isInTemplate) {
+        const variable = expression.trim();
+        const scoped = variable.startsWith('@');
+        return {
+            type: NodeType.EXPRESSION,
+            value: expression,
+            nodes: [{
+                type: NodeType.VARIABLE,
+                scoped,
+                value: scoped ? variable : variable.replace(/^\$/, ''),
+                loc: {
+                    start: startPosition + expression.indexOf(variable),
+                    end: startPosition + variable.length
+                }
+            } as VariableNode],
+            loc: {
+                start: startPosition,
+                end: startPosition + expression.length,
+            }
+        };
+    }
+    throw new TSError('Expected } for end of expression, found EOL', {
+        statusCode: 400,
+        context: { safe: true }
+    });
 }
 
 function isEscaped(input: string, pos: number): boolean {

--- a/packages/xpressions/src/transform.ts
+++ b/packages/xpressions/src/transform.ts
@@ -1,6 +1,6 @@
-import { evaluate } from './evaluate';
+import { evaluate, evaluateVariableNode } from './evaluate';
 import {
-    Nodes, isExpressionNode, isLiteralNode, Options
+    Nodes, isExpressionNode, isLiteralNode, Options, isVariableNode
 } from './interfaces';
 import { parse } from './parse';
 
@@ -13,8 +13,8 @@ export function transform(input: Nodes|string, options: Options): string {
     const ast = typeof input === 'string' ? parse(input) : input;
     return ast.map((node): string => {
         if (isLiteralNode(node)) return node.value;
-        if (isExpressionNode(node)) return evaluate(node.value, options);
-        if (isLiteralNode(node)) return evaluate(node.value, options);
+        if (isExpressionNode(node)) return evaluate(node, options);
+        if (isVariableNode(node)) return evaluateVariableNode(node, options);
         throw new Error(`Unexpected expression node type ${node.type}`);
     }).join('');
 }

--- a/packages/xpressions/src/transform.ts
+++ b/packages/xpressions/src/transform.ts
@@ -1,6 +1,6 @@
 import { evaluate } from './evaluate';
 import {
-    AST, isExpressionNode, isLiteralNode, Options
+    Nodes, isExpressionNode, isLiteralNode, Options
 } from './interfaces';
 import { parse } from './parse';
 
@@ -9,11 +9,12 @@ import { parse } from './parse';
  *
  * @returns the input with the translated values
 */
-export function transform(input: AST|string, options: Options): string {
-    const ast = typeof input === 'string' ? parse(input, options) : input;
+export function transform(input: Nodes|string, options: Options): string {
+    const ast = typeof input === 'string' ? parse(input) : input;
     return ast.map((node): string => {
         if (isLiteralNode(node)) return node.value;
         if (isExpressionNode(node)) return evaluate(node.value, options);
+        if (isLiteralNode(node)) return evaluate(node.value, options);
         throw new Error(`Unexpected expression node type ${node.type}`);
     }).join('');
 }

--- a/packages/xpressions/test/evaluate-spec.ts
+++ b/packages/xpressions/test/evaluate-spec.ts
@@ -33,7 +33,7 @@ describe('evaluate', () => {
                         bar_var: 'bar'
                     }
                 });
-            }).toThrow('Invalid expression "unknown" given');
+            }).toThrow('Missing variable "unknown" in expression');
         });
     });
 });

--- a/packages/xpressions/test/parse-spec.ts
+++ b/packages/xpressions/test/parse-spec.ts
@@ -5,7 +5,7 @@ import { NodeType, parse } from '../src';
 describe('parse', () => {
     describe('when given non-templated string', () => {
         it('should return the original string', () => {
-            expect(parse('foo:bar', { variables: { } })).toEqual([{
+            expect(parse('foo:bar')).toEqual([{
                 type: NodeType.LITERAL,
                 value: 'foo:bar'
             }]);
@@ -14,108 +14,81 @@ describe('parse', () => {
 
     describe('when given single expression string', () => {
         it('should return the valuated string', () => {
-            expect(parse('${foo_var}', {
-                variables: {
-                    foo_var: 'foo'
-                }
-            })).toEqual([{
-                type: NodeType.EXPRESSION,
+            expect(parse('${foo_var}')).toEqual([{
+                type: NodeType.VARIABLE,
                 value: 'foo_var',
-                variables: [{
-                    scoped: false,
-                    value: 'foo_var'
-                }]
+            }]);
+        });
+    });
+
+    describe('when given single expression string with a dollar sign', () => {
+        it('should return the valuated string', () => {
+            expect(parse('${$foo_var}')).toEqual([{
+                type: NodeType.VARIABLE,
+                value: 'foo_var',
+                scoped: false,
             }]);
         });
     });
 
     describe('when given scoped variable expression', () => {
         it('should return the valuated string', () => {
-            expect(parse('${@foo_var}', {
-                variables: {
-                    '@foo_var': 'foo'
-                }
-            })).toEqual([{
-                type: NodeType.EXPRESSION,
-                value: '@foo_var',
-                variables: [{
-                    scoped: true,
-                    value: '@foo_var'
-                }]
+            expect(parse('${@foo_var}')).toEqual([{
+                type: NodeType.VARIABLE,
+                scoped: true,
+                value: '@foo_var'
             }]);
         });
     });
 
     describe('when given multiple expression string', () => {
         it('should return the valuated string', () => {
-            expect(parse('${foo_var} OR ${bar_var} AND foo:${foo_var}', {
-                variables: {
-                    foo_var: 'foo',
-                    bar_var: 'bar',
-                }
-            })).toEqual([{
-                type: NodeType.EXPRESSION,
-                value: 'foo_var',
-                variables: [{
-                    scoped: false,
-                    value: 'foo_var'
-                }]
+            expect(parse('${foo_var} OR ${bar_var} AND foo:${foo_var}')).toEqual([{
+                type: NodeType.VARIABLE,
+                scoped: false,
+                value: 'foo_var'
             }, {
                 type: NodeType.LITERAL,
                 value: ' OR ',
             }, {
-                type: NodeType.EXPRESSION,
-                value: 'bar_var',
-                variables: [{
-                    scoped: false,
-                    value: 'bar_var'
-                }]
+                type: NodeType.VARIABLE,
+                scoped: false,
+                value: 'bar_var'
             }, {
                 type: NodeType.LITERAL,
                 value: ' AND foo:'
             }, {
-                type: NodeType.EXPRESSION,
-                value: 'foo_var',
-                variables: [{
-                    scoped: false,
-                    value: 'foo_var'
-                }]
+                type: NodeType.VARIABLE,
+                scoped: false,
+                value: 'foo_var'
             }]);
         });
     });
 
     describe('when given a simple escaped expression string', () => {
         it('should not evaluate the expression with \\$', () => {
-            expect(parse('\\${foo_var}', {
-                variables: {}
-            })).toEqual([{
+            expect(parse('\\${foo_var}')).toEqual([{
                 type: NodeType.LITERAL,
                 value: '\\${foo_var}'
             }]);
         });
 
         it('should not evaluate the expression with \\}', () => {
-            expect(parse('${foo_var\\}', {
-                variables: {}
-            })).toEqual([{
+            expect(parse('${foo_var\\}')).toEqual([{
                 type: NodeType.LITERAL,
                 value: '${foo_var\\}'
             }]);
         });
 
         it('should not evaluate the expression with \\{', () => {
-            expect(parse('$\\{foo_var}', {
-                variables: {}
-            })).toEqual([{
+            expect(parse('$\\{foo_var}')).toEqual([{
                 type: NodeType.LITERAL,
                 value: '$\\{foo_var}'
             }]);
         });
 
         it('should not evaluate the expression with escaped everywhere', () => {
-            expect(parse('\\$\\{foo_var\\}', {
-                variables: {}
-            })).toEqual([{
+            expect(parse('\\$\\{foo_var\\}')).toEqual([{
                 type: NodeType.LITERAL,
                 value: '\\$\\{foo_var\\}'
             }]);
@@ -124,18 +97,13 @@ describe('parse', () => {
 
     describe('when given a double escaped expression string', () => {
         it('should evaluate the expression and return the escape', () => {
-            expect(parse('\\\\${foo_var}', {
-                variables: { foo_var: 'foo' }
-            })).toEqual([{
+            expect(parse('\\\\${foo_var}')).toEqual([{
                 type: NodeType.LITERAL,
                 value: '\\\\'
             }, {
-                type: NodeType.EXPRESSION,
-                value: 'foo_var',
-                variables: [{
-                    scoped: false,
-                    value: 'foo_var'
-                }]
+                type: NodeType.VARIABLE,
+                scoped: false,
+                value: 'foo_var'
             }]);
         });
     });

--- a/packages/xpressions/test/transform-spec.ts
+++ b/packages/xpressions/test/transform-spec.ts
@@ -47,7 +47,7 @@ describe('transform', () => {
                         foo_var: 'foo'
                     }
                 });
-            }).toThrow('Invalid expression "foo_var2" given');
+            }).toThrow('Missing variable "foo_var2" in expression');
         });
     });
 
@@ -69,10 +69,12 @@ describe('transform', () => {
             })).toBe('\\${foo_var}');
         });
 
-        it('should not evaluate the expression with \\}', () => {
-            expect(transform('${foo_var\\}', {
-                variables: {}
-            })).toBe('${foo_var\\}');
+        it('should throw when evaluating the expression with \\}', () => {
+            expect(() => {
+                transform('${foo_var\\}', {
+                    variables: {}
+                });
+            }).toThrowError('Expected } for end of expression, found EOL');
         });
 
         it('should not evaluate the expression with \\{', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,9 +41,6 @@
             "path": "packages/utils"
         },
         {
-            "path": "packages/xpressions"
-        },
-        {
             "path": "packages/data-types"
         },
         {
@@ -60,6 +57,9 @@
         },
         {
             "path": "packages/xlucene-parser"
+        },
+        {
+            "path": "packages/xpressions"
         },
         {
             "path": "packages/data-mate"


### PR DESCRIPTION
- Allow nil values in xLucene variables when used in the context of an OR variable
- Change xpressions to support explicit variables using $
- Improve xpression API to be more composable