### PR TITLE
DataFrame nested object improvements

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -29,9 +29,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.25.1",
+        "@terascope/data-types": "^0.26.0-rc.0",
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.34.1",
+        "@terascope/utils": "^0.35.0-rc.0",
         "@turf/bbox": "^6.2.0",
         "@turf/bbox-polygon": "^6.3.0",
         "@turf/boolean-point-in-polygon": "^6.2.0",
@@ -50,7 +50,7 @@
         "uuid": "^8.3.2",
         "valid-url": "^1.0.9",
         "validator": "^13.5.2",
-        "xlucene-parser": "^0.31.1"
+        "xlucene-parser": "^0.32.0-rc.0"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.1",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.20.2",
+    "version": "0.21.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -29,9 +29,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.26.0-rc.1",
+        "@terascope/data-types": "^0.26.0",
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.35.0-rc.1",
+        "@terascope/utils": "^0.35.0",
         "@turf/bbox": "^6.2.0",
         "@turf/bbox-polygon": "^6.3.0",
         "@turf/boolean-point-in-polygon": "^6.2.0",
@@ -50,7 +50,7 @@
         "uuid": "^8.3.2",
         "valid-url": "^1.0.9",
         "validator": "^13.5.2",
-        "xlucene-parser": "^0.32.0-rc.1"
+        "xlucene-parser": "^0.32.0"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.1",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -29,9 +29,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.26.0-rc.0",
+        "@terascope/data-types": "^0.26.0-rc.1",
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.35.0-rc.0",
+        "@terascope/utils": "^0.35.0-rc.1",
         "@turf/bbox": "^6.2.0",
         "@turf/bbox-polygon": "^6.3.0",
         "@turf/boolean-point-in-polygon": "^6.2.0",
@@ -50,7 +50,7 @@
         "uuid": "^8.3.2",
         "valid-url": "^1.0.9",
         "validator": "^13.5.2",
-        "xlucene-parser": "^0.32.0-rc.0"
+        "xlucene-parser": "^0.32.0-rc.1"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.1",

--- a/packages/data-mate/src/builder/types/GeoJSONBuilder.ts
+++ b/packages/data-mate/src/builder/types/GeoJSONBuilder.ts
@@ -24,6 +24,6 @@ export class GeoJSONBuilder extends BuilderWithCache<GeoShape> {
             throw new TypeError(`Expected ${toString(value)} (${getTypeOf(value)}) to be a valid GeoJSON shape`);
         }
         const type = esTypeMap[value.type] ? esTypeMap[value.type] : value.type;
-        return createObjectValue({ ...value, type });
+        return createObjectValue({ ...value, type }, false);
     }
 }

--- a/packages/data-mate/src/builder/types/GeoPointBuilder.ts
+++ b/packages/data-mate/src/builder/types/GeoPointBuilder.ts
@@ -16,6 +16,7 @@ export class GeoPointBuilder extends BuilderWithCache<GeoPoint> {
     _valueFrom(value: unknown): GeoPoint {
         return createObjectValue(
             parseGeoPoint(value as any, true),
+            false,
         );
     }
 }

--- a/packages/data-mate/src/builder/types/ObjectBuilder.ts
+++ b/packages/data-mate/src/builder/types/ObjectBuilder.ts
@@ -1,6 +1,6 @@
 import { FieldType } from '@terascope/types';
 import {
-    getTypeOf, isNotNil, isPlainObject, toString
+    getTypeOf, isNotNil, isPlainObject, sortBy, toString
 } from '@terascope/utils';
 import { createObjectValue, getObjectDataTypeConfig, WritableData } from '../../core';
 
@@ -50,7 +50,7 @@ export class ObjectBuilder<
             })
             .filter(isNotNil) as ChildFields<T>;
 
-        this.#childFields = childFields;
+        this.#childFields = sortBy(childFields as [string, Builder<any>][], '[0]');
         return childFields;
     }
 
@@ -64,13 +64,14 @@ export class ObjectBuilder<
         }
 
         const input = value as Readonly<Record<keyof T, unknown>>;
-        const result: Partial<T> = {};
+        const result: Partial<T> = Object.create(null);
 
         for (const [field, builder] of this.childFields) {
             if (input[field] != null) {
                 const fieldValue: any = builder.valueFrom(input[field]);
                 Object.defineProperty(result, field, {
                     value: fieldValue,
+                    enumerable: true,
                     writable: false
                 });
             }

--- a/packages/data-mate/src/builder/types/ObjectBuilder.ts
+++ b/packages/data-mate/src/builder/types/ObjectBuilder.ts
@@ -2,7 +2,7 @@ import { FieldType } from '@terascope/types';
 import {
     getTypeOf, isNotNil, isPlainObject, sortBy, toString
 } from '@terascope/utils';
-import { createObjectValue, getObjectDataTypeConfig, WritableData } from '../../core';
+import { createObjectValue, getChildDataTypeConfig, WritableData } from '../../core';
 
 import { VectorType } from '../../vector';
 import { Builder, BuilderOptions } from '../Builder';
@@ -37,12 +37,10 @@ export class ObjectBuilder<
                 const [base] = field.split('.');
                 if (base !== field && this.childConfig![base]) return;
 
-                const childConfig = (config.type === FieldType.Object
-                    ? getObjectDataTypeConfig(this.childConfig!, field)
-                    : undefined);
-
                 const builder = Builder.make<any>(WritableData.emptyData, {
-                    childConfig,
+                    childConfig: getChildDataTypeConfig(
+                        this.childConfig!, field, config.type as FieldType
+                    ),
                     config,
                     name: this._getChildName(field),
                 });

--- a/packages/data-mate/src/builder/types/ObjectBuilder.ts
+++ b/packages/data-mate/src/builder/types/ObjectBuilder.ts
@@ -61,8 +61,10 @@ export class ObjectBuilder<
         const result: Partial<T> = {};
 
         for (const [field, builder] of this.childFields) {
-            const fieldValue: any = input[field] != null ? builder.valueFrom(input[field]) : null;
-            Object.defineProperty(result, field, { value: fieldValue, writable: false });
+            if (input[field] != null) {
+                const fieldValue: any = builder.valueFrom(input[field]);
+                Object.defineProperty(result, field, { value: fieldValue, writable: false });
+            }
         }
 
         return createObjectValue(result as T, true);

--- a/packages/data-mate/src/builder/types/ObjectBuilder.ts
+++ b/packages/data-mate/src/builder/types/ObjectBuilder.ts
@@ -63,7 +63,10 @@ export class ObjectBuilder<
         for (const [field, builder] of this.childFields) {
             if (input[field] != null) {
                 const fieldValue: any = builder.valueFrom(input[field]);
-                Object.defineProperty(result, field, { value: fieldValue, writable: false });
+                Object.defineProperty(result, field, {
+                    value: fieldValue,
+                    writable: false
+                });
             }
         }
 

--- a/packages/data-mate/src/builder/types/ObjectBuilder.ts
+++ b/packages/data-mate/src/builder/types/ObjectBuilder.ts
@@ -54,7 +54,7 @@ export class ObjectBuilder<
         }
 
         if (!this.childFields.length) {
-            return createObjectValue({ ...value as T });
+            return createObjectValue({ ...value as T }, false);
         }
 
         const input = value as Readonly<Record<keyof T, unknown>>;

--- a/packages/data-mate/src/builder/types/ObjectBuilder.ts
+++ b/packages/data-mate/src/builder/types/ObjectBuilder.ts
@@ -1,5 +1,7 @@
 import { FieldType } from '@terascope/types';
-import { getTypeOf, isPlainObject, toString } from '@terascope/utils';
+import {
+    getTypeOf, isNotNil, isPlainObject, toString
+} from '@terascope/utils';
 import { createObjectValue, getObjectDataTypeConfig, WritableData } from '../../core';
 
 import { VectorType } from '../../vector';
@@ -31,7 +33,10 @@ export class ObjectBuilder<
         }
 
         const childFields: ChildFields<T> = Object.entries(this.childConfig)
-            .map(([field, config]) => {
+            .map(([field, config]): [string, Builder<any>]|undefined => {
+                const [base] = field.split('.');
+                if (base !== field && this.childConfig![base]) return;
+
                 const childConfig = (config.type === FieldType.Object
                     ? getObjectDataTypeConfig(this.childConfig!, field)
                     : undefined);
@@ -42,7 +47,8 @@ export class ObjectBuilder<
                     name: this._getChildName(field),
                 });
                 return [field, builder];
-            });
+            })
+            .filter(isNotNil) as ChildFields<T>;
 
         this.#childFields = childFields;
         return childFields;

--- a/packages/data-mate/src/builder/types/TupleBuilder.ts
+++ b/packages/data-mate/src/builder/types/TupleBuilder.ts
@@ -3,7 +3,7 @@ import {
     getTypeOf, isArrayLike, toString, TSError
 } from '@terascope/utils';
 import {
-    createArrayValue, getObjectDataTypeConfig, WritableData
+    createArrayValue, getChildDataTypeConfig, WritableData
 } from '../../core';
 import { VectorType } from '../../vector';
 import { Builder, BuilderOptions } from '../Builder';
@@ -36,17 +36,13 @@ export class TupleBuilder<T extends [...any] = [...any]> extends BuilderWithCach
         }
 
         const childFields: ChildFields = Object.entries(this.childConfig)
-            .map(([field, config], index) => {
-                const childConfig = (config.type === FieldType.Object
-                    ? getObjectDataTypeConfig(this.childConfig!, field)
-                    : undefined);
-
-                return Builder.make<any>(WritableData.emptyData, {
-                    childConfig,
-                    config,
-                    name: this._getChildName(index),
-                });
-            });
+            .map(([field, config], index) => Builder.make<any>(WritableData.emptyData, {
+                childConfig: getChildDataTypeConfig(
+                    this.childConfig!, field, config.type as FieldType
+                ),
+                config,
+                name: this._getChildName(index),
+            }));
 
         this.#childFields = childFields;
         return childFields;

--- a/packages/data-mate/src/column/Column.ts
+++ b/packages/data-mate/src/column/Column.ts
@@ -4,7 +4,7 @@ import {
 } from '@terascope/types';
 import { Builder } from '../builder';
 import {
-    JSONValue, Vector
+    JSONValue, ValueToJSONOptions, Vector
 } from '../vector';
 import {
     ColumnOptions, ColumnTransformConfig, ColumnValidateConfig, TransformMode
@@ -319,7 +319,7 @@ export class Column<T = unknown, N extends NameType = string> {
      *
      * @note probably only useful for debugging
     */
-    toJSON(skipNullFields?: boolean): Maybe<JSONValue<T>>[] {
-        return this.vector.toJSON(skipNullFields);
+    toJSON(options?: ValueToJSONOptions): Maybe<JSONValue<T>>[] {
+        return this.vector.toJSON(options);
     }
 }

--- a/packages/data-mate/src/column/Column.ts
+++ b/packages/data-mate/src/column/Column.ts
@@ -4,7 +4,7 @@ import {
 } from '@terascope/types';
 import { Builder } from '../builder';
 import {
-    JSONValue, ValueToJSONOptions, Vector
+    JSONValue, SerializeOptions, Vector
 } from '../vector';
 import {
     ColumnOptions, ColumnTransformConfig, ColumnValidateConfig, TransformMode
@@ -319,7 +319,7 @@ export class Column<T = unknown, N extends NameType = string> {
      *
      * @note probably only useful for debugging
     */
-    toJSON(options?: ValueToJSONOptions): Maybe<JSONValue<T>>[] {
+    toJSON(options?: SerializeOptions): Maybe<JSONValue<T>>[] {
         return this.vector.toJSON(options);
     }
 }

--- a/packages/data-mate/src/column/Column.ts
+++ b/packages/data-mate/src/column/Column.ts
@@ -267,7 +267,7 @@ export class Column<T = unknown, N extends NameType = string> {
      *
      * @note probably only useful for debugging
     */
-    toJSON(): Maybe<JSONValue<T>>[] {
-        return this.vector.toJSON();
+    toJSON(skipNullFields?: boolean): Maybe<JSONValue<T>>[] {
+        return this.vector.toJSON(skipNullFields);
     }
 }

--- a/packages/data-mate/src/column/Column.ts
+++ b/packages/data-mate/src/column/Column.ts
@@ -269,18 +269,9 @@ export class Column<T = unknown, N extends NameType = string> {
     */
     selectSubFields(fields: string[]): Column<T, N> {
         if (!this.vector.childConfig) return this;
-        const existingChildFields = Object.keys(this.vector.childConfig).sort();
-        const selectedChildFields = fields.sort();
-
-        if (selectedChildFields.join() === existingChildFields.join()) {
-            // all of the fields are selected so
-            // we don't have to recreate the whole
-            // column
-            return this;
-        }
 
         const childConfig: DataTypeFields = {};
-        for (const field of selectedChildFields) {
+        for (const field of fields) {
             if (this.vector.childConfig[field]) {
                 childConfig[field] = this.vector.childConfig[field];
             }
@@ -296,6 +287,16 @@ export class Column<T = unknown, N extends NameType = string> {
                     childConfig[parentField] = this.vector.childConfig[parentField];
                 }
             }
+        }
+
+        const existingChildFields = Object.keys(this.vector.childConfig).sort();
+        const selectedChildFields = Object.keys(childConfig).sort();
+
+        if (selectedChildFields.join() === existingChildFields.join()) {
+            // all of the fields are selected so
+            // we don't have to recreate the whole
+            // column
+            return this;
         }
 
         const builder = Builder.make<T>(

--- a/packages/data-mate/src/column/aggregations.ts
+++ b/packages/data-mate/src/column/aggregations.ts
@@ -3,7 +3,7 @@ import {
     isBigInt, toBigInt
 } from '@terascope/utils';
 import {
-    Vector, VectorType, getNumericValues
+    Vector, VectorType, getNumericValues, SerializeOptions
 } from '../vector';
 import { DateValue, getHashCodeFrom } from '../core';
 
@@ -192,7 +192,7 @@ function makeDateAgg(dateFormat: string): MakeKeyAggFn {
     };
 }
 
-export function makeUniqueKeyAgg(vector: Vector<any>): KeyAggFn {
+export function makeUniqueKeyAgg(vector: Vector<any>, options?: SerializeOptions): KeyAggFn {
     return (index) => {
         const value = vector.get(index, false);
         if (value == null) {
@@ -201,7 +201,9 @@ export function makeUniqueKeyAgg(vector: Vector<any>): KeyAggFn {
 
         return {
             key: getHashCodeFrom(value),
-            value
+            value: options && vector.valueToJSON
+                ? vector.valueToJSON(value, options)
+                : value
         };
     };
 }

--- a/packages/data-mate/src/core/IPValue.ts
+++ b/packages/data-mate/src/core/IPValue.ts
@@ -3,6 +3,7 @@ import { parse } from 'ip-bigint';
 import {
     getTypeOf,
     isString,
+    primitiveToString,
 } from '@terascope/utils';
 import { HASH_CODE_SYMBOL } from './interfaces';
 
@@ -23,10 +24,11 @@ export class IPValue {
     static fromValue(
         value: unknown,
     ): IPValue {
-        if (!isValidIP(value)) {
+        const ipValue = primitiveToString(value);
+        if (!isValidIP(ipValue)) {
             throw new TypeError(`Expected ${value} (${getTypeOf(value)}) to be a valid IP`);
         }
-        return new IPValue(value);
+        return new IPValue(ipValue);
     }
 
     /**

--- a/packages/data-mate/src/core/utils.ts
+++ b/packages/data-mate/src/core/utils.ts
@@ -5,7 +5,7 @@ import {
     isPrimitiveValue, TSError
 } from '@terascope/utils';
 import {
-    DataTypeFields, ReadonlyDataTypeFields,
+    DataTypeFields, FieldType, ReadonlyDataTypeFields,
     TypedArray, TypedArrayConstructor
 } from '@terascope/types';
 import {
@@ -175,9 +175,20 @@ export function freezeArray<T extends ArrLike>(
     return Object.freeze(input.slice()) as any;
 }
 
-export function getObjectDataTypeConfig(
-    config: DataTypeFields|ReadonlyDataTypeFields, baseField: string
-): DataTypeFields {
+/**
+ * This is used in the Vector and Builder classes
+ * to get the correctly scoped field configurations
+ * since we use dot notation for nested field configurations
+*/
+export function getChildDataTypeConfig(
+    config: DataTypeFields|ReadonlyDataTypeFields,
+    baseField: string,
+    fieldType: FieldType
+): DataTypeFields|undefined {
+    // Tuples are configured like objects except the nested field names
+    // are the positional indexes in the tuple
+    if (fieldType !== FieldType.Object && fieldType !== FieldType.Tuple) return;
+
     const childConfig: DataTypeFields = {};
     for (const [field, fieldConfig] of Object.entries(config)) {
         const withoutBase = field.replace(`${baseField}.`, '');

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -5,7 +5,7 @@ import {
 import {
     DataEntity, TSError,
     getTypeOf, isFunction,
-    isPlainObject, trimFP
+    isPlainObject, trimFP, matchWildcard
 } from '@terascope/utils';
 import { Column, KeyAggFn, makeUniqueKeyAgg } from '../column';
 import { AggregationFrame } from '../aggregation-frame';
@@ -182,6 +182,9 @@ export class DataFrame<
             return (selector: string): boolean => {
                 if (field === selector) return true;
                 if (field.startsWith(`${selector}.`)) return true;
+                if (selector.includes('*')) {
+                    return matchWildcard(selector, field);
+                }
                 return false;
             };
         }

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -425,15 +425,9 @@ export class DataFrame<
     /**
      * Reduce amount of noise in a DataFrame by
      * removing the amount of duplicates, including
-     * duplicate objects in lists
+     * duplicate objects in array values
     */
-    compact(options?: {
-        preserveDuplicates?: boolean;
-    }): DataFrame<T> {
-        if (options?.preserveDuplicates) {
-            return this;
-        }
-
+    compact(): DataFrame<T> {
         const serializeOptions: SerializeOptions = {
             skipDuplicateObjects: true,
             skipEmptyObjects: true,

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -5,7 +5,8 @@ import {
 import {
     DataEntity, TSError,
     getTypeOf, isFunction,
-    isPlainObject, trimFP, matchWildcard
+    isPlainObject, trimFP,
+    matchWildcard, isWildCardString
 } from '@terascope/utils';
 import { Column, KeyAggFn, makeUniqueKeyAgg } from '../column';
 import { AggregationFrame } from '../aggregation-frame';
@@ -184,7 +185,7 @@ export class DataFrame<
             return (selector: string): boolean => {
                 if (field === selector) return true;
                 if (field.startsWith(`${selector}.`)) return true;
-                if (selector.includes('*')) {
+                if (isWildCardString(selector)) {
                     return matchWildcard(selector, field);
                 }
                 return false;
@@ -539,6 +540,7 @@ export class DataFrame<
                 statusCode: 400
             });
         }
+
         const columns = fields.map((field) => this.getColumnOrThrow(field));
         const childConfig: DataTypeFields = {};
         columns.forEach((col, index) => {

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -586,6 +586,15 @@ export class DataFrame<
     }
 
     /**
+     * Reduce amount of noise in a DataFrame,
+     * by removing the amount of duplicates and
+     * dropping nil fields
+    */
+    compact(): DataFrame<T> {
+        return this;
+    }
+
+    /**
      * Returns a DataFrame with a limited number of rows
     */
     limit(num: number): DataFrame<T> {

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -374,6 +374,13 @@ export class DataFrame<
     }
 
     /**
+     * Alias for unique
+    */
+    distinct(...fieldArg: FieldArg<keyof T>[]): DataFrame<T> {
+        return this.unique(...fieldArg);
+    }
+
+    /**
      * Like unique but will allow passing serialization options
     */
     private _unique(
@@ -431,16 +438,11 @@ export class DataFrame<
         const serializeOptions: SerializeOptions = {
             skipDuplicateObjects: true,
             skipEmptyObjects: true,
+            skipNilValues: true,
+            skipNilObjectValues: true,
         };
 
         return this._unique(this.fields, serializeOptions);
-    }
-
-    /**
-     * Alias for unique
-    */
-    distinct(...fieldArg: FieldArg<keyof T>[]): DataFrame<T> {
-        return this.unique(...fieldArg);
     }
 
     /**

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -544,7 +544,7 @@ export class DataFrame<
         const columns = fields.map((field) => this.getColumnOrThrow(field));
         const childConfig: DataTypeFields = {};
         columns.forEach((col, index) => {
-            childConfig[`${as}.${index}`] = col.config;
+            childConfig[index] = col.config;
         });
 
         const config: DataTypeFieldConfig = Object.freeze({ type: FieldType.Tuple });

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -129,7 +129,7 @@ export class DataFrame<
             .sort()
             .join(':');
 
-        const id = createHashCode(long) as string;
+        const id = createHashCode(long);
         this.#id = id;
         return id;
     }
@@ -427,10 +427,14 @@ export class DataFrame<
      * removing the amount of duplicates, including
      * duplicate objects in lists
     */
-    compact(): DataFrame<T> {
+    compact(options?: {
+        preserveDuplicates?: boolean;
+    }): DataFrame<T> {
+        if (options?.preserveDuplicates) {
+            return this;
+        }
+
         const serializeOptions: SerializeOptions = {
-            useNullForUndefined: true,
-            skipNilValues: true,
             skipDuplicateObjects: true,
             skipEmptyObjects: true,
         };

--- a/packages/data-mate/src/data-frame/utils.ts
+++ b/packages/data-mate/src/data-frame/utils.ts
@@ -6,7 +6,6 @@ import {
 import { Builder, getBuildersForConfig } from '../builder';
 import { Column, KeyAggFn } from '../column';
 import { createHashCode } from '../core';
-import { ListVector, ObjectVector } from '../vector';
 
 export function buildRecords<T extends Record<string, any>>(
     builders: Map<keyof T, Builder<unknown>>,
@@ -69,11 +68,9 @@ export function columnsToDataTypeConfig<T extends Record<string, unknown>>(
         versions.add(col.version);
         fields[String(col.name)] = col.config;
         // make sure we populate the nested fields
-        if (col.vector instanceof ObjectVector || col.vector instanceof ListVector) {
-            if (col.vector.childConfig) {
-                for (const nestedField of Object.keys(col.vector.childConfig)) {
-                    fields[`${col.name}.${nestedField}`] = col.vector.childConfig[nestedField];
-                }
+        if (col.vector.childConfig) {
+            for (const nestedField of Object.keys(col.vector.childConfig)) {
+                fields[`${col.name}.${nestedField}`] = col.vector.childConfig[nestedField];
             }
         }
     }

--- a/packages/data-mate/src/vector/ListVector.ts
+++ b/packages/data-mate/src/vector/ListVector.ts
@@ -1,18 +1,19 @@
 import { Maybe } from '@terascope/types';
+import { isNotNil } from '@terascope/utils';
 import { Vector, VectorOptions } from './Vector';
 import { VectorType } from './interfaces';
 import { ReadableData } from '../core';
 
 export class ListVector<T = unknown> extends Vector<readonly Maybe<T>[]> {
-    readonly convertValueToJSON: (value: Maybe<T>) => any;
+    readonly convertValueToJSON: (skipNullFields?: boolean) => (value: Maybe<T>) => any;
     #_valueVector?: Vector<T>;
 
     constructor(data: ReadableData<readonly Maybe<T>[]>, options: VectorOptions) {
         super(VectorType.List, data, options);
         this.sortable = false;
-        this.convertValueToJSON = (value: Maybe<T>): any => {
+        this.convertValueToJSON = (skipNullFields?: boolean) => (value: Maybe<T>): any => {
             if (value == null || !this.valueVector.valueToJSON) return value;
-            return this.valueVector.valueToJSON(value);
+            return this.valueVector.valueToJSON(value, skipNullFields);
         };
     }
 
@@ -32,7 +33,9 @@ export class ListVector<T = unknown> extends Vector<readonly Maybe<T>[]> {
         return this.#_valueVector;
     }
 
-    valueToJSON(values: readonly Maybe<T>[]): any {
-        return values.map(this.convertValueToJSON);
+    valueToJSON(values: readonly Maybe<T>[], skipNullFields?: boolean): any {
+        const result = values.map(this.convertValueToJSON(skipNullFields));
+        if (!skipNullFields) return false;
+        return result.filter(isNotNil);
     }
 }

--- a/packages/data-mate/src/vector/ListVector.ts
+++ b/packages/data-mate/src/vector/ListVector.ts
@@ -35,7 +35,7 @@ export class ListVector<T = unknown> extends Vector<readonly Maybe<T>[]> {
 
     valueToJSON(values: readonly Maybe<T>[], skipNullFields?: boolean): any {
         const result = values.map(this.convertValueToJSON(skipNullFields));
-        if (!skipNullFields) return false;
+        if (!skipNullFields) return result;
         return result.filter(isNotNil);
     }
 }

--- a/packages/data-mate/src/vector/ListVector.ts
+++ b/packages/data-mate/src/vector/ListVector.ts
@@ -1,17 +1,17 @@
 import { Maybe } from '@terascope/types';
 import { isNotNil } from '@terascope/utils';
 import { Vector, VectorOptions } from './Vector';
-import { ValueToJSONOptions, VectorType } from './interfaces';
+import { SerializeOptions, VectorType } from './interfaces';
 import { ReadableData } from '../core';
 
 export class ListVector<T = unknown> extends Vector<readonly Maybe<T>[]> {
-    readonly convertValueToJSON: (options?: ValueToJSONOptions) => (value: Maybe<T>) => any;
+    readonly convertValueToJSON: (options?: SerializeOptions) => (value: Maybe<T>) => any;
     #_valueVector?: Vector<T>;
 
     constructor(data: ReadableData<readonly Maybe<T>[]>, options: VectorOptions) {
         super(VectorType.List, data, options);
         this.sortable = false;
-        this.convertValueToJSON = (opts?: ValueToJSONOptions) => {
+        this.convertValueToJSON = (opts?: SerializeOptions) => {
             const nilValue: any = opts?.useNullForUndefined ? null : undefined;
             return (value: Maybe<T>): any => {
                 if (value == null || !this.valueVector.valueToJSON) {
@@ -38,9 +38,9 @@ export class ListVector<T = unknown> extends Vector<readonly Maybe<T>[]> {
         return this.#_valueVector;
     }
 
-    valueToJSON(values: readonly Maybe<T>[], options?: ValueToJSONOptions): any {
+    valueToJSON(values: readonly Maybe<T>[], options?: SerializeOptions): any {
         const result = values.map(this.convertValueToJSON(options));
-        if (!options?.skipNullFields) return result;
+        if (!options?.skipNilValues) return result;
         return result.filter(isNotNil);
     }
 }

--- a/packages/data-mate/src/vector/Vector.ts
+++ b/packages/data-mate/src/vector/Vector.ts
@@ -114,7 +114,7 @@ export abstract class Vector<T = unknown> {
      * A function for converting an in-memory representation of
      * a value to an JSON spec compatible format.
     */
-    abstract valueToJSON?(value: T): any;
+    abstract valueToJSON?(value: T, skipNullFields?: boolean): any;
 
     * [Symbol.iterator](): IterableIterator<Maybe<T>> {
         yield* this.data;
@@ -169,7 +169,7 @@ export abstract class Vector<T = unknown> {
     /**
      * Get value by index
     */
-    get(index: number, json?: boolean): Maybe<T>|Maybe<JSONValue<T>> {
+    get(index: number, json?: boolean, skipNullFields?: boolean): Maybe<T>|Maybe<JSONValue<T>> {
         const val = this.data.get(index);
 
         if (!json || !this.valueToJSON) {
@@ -177,7 +177,7 @@ export abstract class Vector<T = unknown> {
         }
 
         if (val == null) return val;
-        return this.valueToJSON(val as T);
+        return this.valueToJSON(val as T, skipNullFields);
     }
 
     /**
@@ -216,10 +216,10 @@ export abstract class Vector<T = unknown> {
     /**
      * Convert the Vector an array of values (the output is JSON compatible)
     */
-    toJSON(): Maybe<JSONValue<T>>[] {
+    toJSON(skipNullFields?: boolean): Maybe<JSONValue<T>>[] {
         const res: Maybe<JSONValue<T>>[] = Array(this.size);
         for (let i = 0; i < this.size; i++) {
-            res[i] = this.get(i, true) as JSONValue<T>;
+            res[i] = this.get(i, true, skipNullFields) as JSONValue<T>;
         }
         return res;
     }

--- a/packages/data-mate/src/vector/Vector.ts
+++ b/packages/data-mate/src/vector/Vector.ts
@@ -6,7 +6,7 @@ import {
 import {
     ReadableData, createHashCode, HASH_CODE_SYMBOL, getHashCodeFrom
 } from '../core';
-import { ValueToJSONOptions, VectorType } from './interfaces';
+import { SerializeOptions, VectorType } from './interfaces';
 
 /**
  * An immutable typed Array class with a constrained API.
@@ -114,7 +114,7 @@ export abstract class Vector<T = unknown> {
      * A function for converting an in-memory representation of
      * a value to an JSON spec compatible format.
     */
-    abstract valueToJSON?(value: T, options?: ValueToJSONOptions): any;
+    abstract valueToJSON?(value: T, options?: SerializeOptions): any;
 
     * [Symbol.iterator](): IterableIterator<Maybe<T>> {
         yield* this.data;
@@ -169,7 +169,7 @@ export abstract class Vector<T = unknown> {
     /**
      * Get value by index
     */
-    get(index: number, json?: boolean, options?: ValueToJSONOptions): Maybe<T>|Maybe<JSONValue<T>> {
+    get(index: number, json?: boolean, options?: SerializeOptions): Maybe<T>|Maybe<JSONValue<T>> {
         const nilValue: any = options?.useNullForUndefined ? null : undefined;
 
         const val = this.data.get(index);
@@ -219,7 +219,7 @@ export abstract class Vector<T = unknown> {
     /**
      * Convert the Vector an array of values (the output is JSON compatible)
     */
-    toJSON(options?: ValueToJSONOptions): Maybe<JSONValue<T>>[] {
+    toJSON(options?: SerializeOptions): Maybe<JSONValue<T>>[] {
         const res: Maybe<JSONValue<T>>[] = Array(this.size);
         for (let i = 0; i < this.size; i++) {
             res[i] = this.get(i, true, options) as JSONValue<T>;

--- a/packages/data-mate/src/vector/Vector.ts
+++ b/packages/data-mate/src/vector/Vector.ts
@@ -150,10 +150,11 @@ export abstract class Vector<T = unknown> {
     }
 
     /**
-     * Get the unique values
+     * Get the unique values with the index in a tuple form.
+     * This is useful for reconstructing an Vector
+     * with only the unique values
     */
     * unique(): Iterable<[index: number, value: T]> {
-        const results: T[] = [];
         const hashes = new Set<any>();
         const getHash = this.data.isPrimitive ? (v: unknown) => v : getHashCodeFrom;
         for (const [index, value] of this.data.values) {
@@ -163,7 +164,22 @@ export abstract class Vector<T = unknown> {
                 yield [index, value];
             }
         }
-        return results;
+    }
+
+    /**
+    * Get the unique values, excluding nil values.
+    * Useful for getting a list of unique values.
+    */
+    * uniqueValues(): Iterable<T> {
+        const hashes = new Set<any>();
+        const getHash = this.data.isPrimitive ? (v: unknown) => v : getHashCodeFrom;
+        for (const value of this.data.values.values()) {
+            const hash = getHash(value);
+            if (!hashes.has(hash)) {
+                hashes.add(hash);
+                yield value;
+            }
+        }
     }
 
     /**

--- a/packages/data-mate/src/vector/interfaces.ts
+++ b/packages/data-mate/src/vector/interfaces.ts
@@ -60,8 +60,28 @@ export type DataValueTuple<T> = readonly [
     indices: readonly number[], value: T|null
 ];
 
-export interface ValueToJSONOptions {
-    skipNullFields?: boolean;
+/**
+ * Options used for JSON serialization
+*/
+export interface SerializeOptions {
+    /**
+     * Don't return any values that are null/undefined
+    */
+    skipNilValues?: boolean;
+
+    /**
+     * Use a null values in-place of undefined so
+     * it can preserved when calling JSON.stringify
+    */
     useNullForUndefined?: boolean;
+
+    /**
+     * Remove objects with properties
+    */
     skipEmptyObjects?: boolean;
+
+    /**
+     * Remove duplicate objects in a list vector
+    */
+    skipDuplicateObjects?: boolean;
 }

--- a/packages/data-mate/src/vector/interfaces.ts
+++ b/packages/data-mate/src/vector/interfaces.ts
@@ -59,3 +59,9 @@ export type OldData<T> = Readonly<{
 export type DataValueTuple<T> = readonly [
     indices: readonly number[], value: T|null
 ];
+
+export interface ValueToJSONOptions {
+    skipNullFields?: boolean;
+    useNullForUndefined?: boolean;
+    skipEmptyObjects?: boolean;
+}

--- a/packages/data-mate/src/vector/interfaces.ts
+++ b/packages/data-mate/src/vector/interfaces.ts
@@ -65,15 +65,28 @@ export type DataValueTuple<T> = readonly [
 */
 export interface SerializeOptions {
     /**
-     * Don't return any values that are null/undefined
-    */
-    skipNilValues?: boolean;
-
-    /**
      * Use a null values in-place of undefined so
      * it can preserved when calling JSON.stringify
     */
     useNullForUndefined?: boolean;
+
+    /**
+     * Don't return any values that are null/undefined.
+     * This does not apply to list or tuples, use skipNilListValues or skipNilObjectValues
+     * instead.
+    */
+    skipNilValues?: boolean;
+
+    /**
+     * Don't return any values that are null/undefined
+    */
+    skipNilListValues?: boolean;
+
+    /**
+     * Don't return any object values in list that are null/undefined.
+     * This will have no change in behavior if skipNilListValues is true
+    */
+    skipNilObjectValues?: boolean;
 
     /**
      * Remove objects with properties

--- a/packages/data-mate/src/vector/types/ObjectVector.ts
+++ b/packages/data-mate/src/vector/types/ObjectVector.ts
@@ -61,6 +61,7 @@ export class ObjectVector<
         const input = value as Readonly<Record<keyof T, unknown>>;
         const result: Partial<T> = {};
         let numKeys = 0;
+        const { skipNilValues, skipEmptyObjects } = options ?? {};
 
         for (const [field, vector] of this.childFields) {
             if (input[field] != null) {
@@ -69,24 +70,22 @@ export class ObjectVector<
                         input[field], options
                     ) : input[field]
                 );
-                if (options?.skipNilValues && fieldValue == null) {
-                    if (nilValue === null) result[field] = nilValue;
-                } else if (
-                    options?.skipEmptyObjects
-                    && vector.config.type === FieldType.Object
-                    && !Object.keys(fieldValue).length
-                ) {
-                    if (nilValue === null) result[field] = nilValue;
+                if (fieldValue == null) {
+                    if (!skipNilValues && nilValue === null) {
+                        result[field] = nilValue;
+                    }
                 } else {
                     numKeys++;
                     result[field] = fieldValue;
                 }
-            } else if (!options?.skipNilValues && nilValue === null) {
+            // set value to nilValue if it exists in the
+            // child config but not the input object
+            } else if (!skipNilValues && nilValue === null) {
                 result[field] = nilValue;
             }
         }
 
-        if (options?.skipEmptyObjects && !numKeys) return nilValue;
+        if (skipEmptyObjects && !numKeys) return nilValue;
         return result;
     }
 

--- a/packages/data-mate/src/vector/types/ObjectVector.ts
+++ b/packages/data-mate/src/vector/types/ObjectVector.ts
@@ -1,4 +1,5 @@
 import { FieldType } from '@terascope/types';
+import { isNotNil } from '@terascope/utils';
 import { Vector, VectorOptions } from '../Vector';
 import { VectorType } from '../interfaces';
 import { getObjectDataTypeConfig, ReadableData } from '../../core';
@@ -25,7 +26,10 @@ export class ObjectVector<
             return this.#childFields;
         }
         const childFields: ChildFields<T> = Object.entries(this.childConfig)
-            .map(([field, config]) => {
+            .map(([field, config]): [string, Vector<any>]|undefined => {
+                const [base] = field.split('.');
+                if (base !== field && this.childConfig![base]) return;
+
                 const childConfig = (config.type === FieldType.Object
                     ? getObjectDataTypeConfig(this.childConfig!, field)
                     : undefined);
@@ -36,7 +40,8 @@ export class ObjectVector<
                     name: this._getChildName(field)
                 });
                 return [field, vector];
-            });
+            })
+            .filter(isNotNil) as ChildFields<T>;
 
         this.#childFields = childFields;
         return childFields;

--- a/packages/data-mate/src/vector/types/ObjectVector.ts
+++ b/packages/data-mate/src/vector/types/ObjectVector.ts
@@ -2,7 +2,7 @@ import { FieldType } from '@terascope/types';
 import { isNotNil } from '@terascope/utils';
 import { Vector, VectorOptions } from '../Vector';
 import { SerializeOptions, VectorType } from '../interfaces';
-import { getObjectDataTypeConfig, ReadableData } from '../../core';
+import { getChildDataTypeConfig, ReadableData } from '../../core';
 
 type ChildFields<T extends Record<string, any>> = readonly (
     [field: (keyof T), vector: Vector<any>]
@@ -30,12 +30,10 @@ export class ObjectVector<
                 const [base] = field.split('.');
                 if (base !== field && this.childConfig![base]) return;
 
-                const childConfig = (config.type === FieldType.Object
-                    ? getObjectDataTypeConfig(this.childConfig!, field)
-                    : undefined);
-
                 const vector = Vector.make<any>(ReadableData.emptyData, {
-                    childConfig,
+                    childConfig: getChildDataTypeConfig(
+                        this.childConfig!, field, config.type as FieldType
+                    ),
                     config,
                     name: this._getChildName(field)
                 });

--- a/packages/data-mate/src/vector/types/ObjectVector.ts
+++ b/packages/data-mate/src/vector/types/ObjectVector.ts
@@ -56,8 +56,6 @@ export class ObjectVector<
                 result[field] = (
                     vector.valueToJSON ? vector.valueToJSON(input[field]) : input[field]
                 );
-            } else {
-                result[field] = undefined;
             }
         }
 

--- a/packages/data-mate/src/vector/types/ObjectVector.ts
+++ b/packages/data-mate/src/vector/types/ObjectVector.ts
@@ -1,7 +1,7 @@
 import { FieldType } from '@terascope/types';
 import { isNotNil } from '@terascope/utils';
 import { Vector, VectorOptions } from '../Vector';
-import { ValueToJSONOptions, VectorType } from '../interfaces';
+import { SerializeOptions, VectorType } from '../interfaces';
 import { getObjectDataTypeConfig, ReadableData } from '../../core';
 
 type ChildFields<T extends Record<string, any>> = readonly (
@@ -47,7 +47,7 @@ export class ObjectVector<
         return childFields;
     }
 
-    valueToJSON(value: T, options?: ValueToJSONOptions): any {
+    valueToJSON(value: T, options?: SerializeOptions): any {
         const val = value as Record<string, any>;
         const nilValue: any = options?.useNullForUndefined ? null : undefined;
 
@@ -69,7 +69,7 @@ export class ObjectVector<
                         input[field], options
                     ) : input[field]
                 );
-                if (options?.skipNullFields && fieldValue == null) {
+                if (options?.skipNilValues && fieldValue == null) {
                     if (nilValue === null) result[field] = nilValue;
                 } else if (
                     options?.skipEmptyObjects
@@ -81,7 +81,7 @@ export class ObjectVector<
                     numKeys++;
                     result[field] = fieldValue;
                 }
-            } else if (!options?.skipNullFields && nilValue === null) {
+            } else if (!options?.skipNilValues && nilValue === null) {
                 result[field] = nilValue;
             }
         }

--- a/packages/data-mate/src/vector/types/TupleVector.ts
+++ b/packages/data-mate/src/vector/types/TupleVector.ts
@@ -39,11 +39,11 @@ export class TupleVector<
         return childFields;
     }
 
-    valueToJSON(values: T): any {
+    valueToJSON(values: T, skipNullFields?: boolean): any {
         return this.childFields.map((vector, index) => {
             const value = values[index];
             if (value == null || !vector.valueToJSON) return value;
-            return vector.valueToJSON(value);
+            return vector.valueToJSON(value, skipNullFields);
         });
     }
 

--- a/packages/data-mate/src/vector/types/TupleVector.ts
+++ b/packages/data-mate/src/vector/types/TupleVector.ts
@@ -1,6 +1,6 @@
 import { FieldType } from '@terascope/types';
 import { Vector, VectorOptions } from '../Vector';
-import { VectorType } from '../interfaces';
+import { ValueToJSONOptions, VectorType } from '../interfaces';
 import { getObjectDataTypeConfig, ReadableData } from '../../core';
 
 type ChildFields = readonly Vector<any>[];
@@ -39,11 +39,12 @@ export class TupleVector<
         return childFields;
     }
 
-    valueToJSON(values: T, skipNullFields?: boolean): any {
+    valueToJSON(values: T, options?: ValueToJSONOptions): any {
+        const nilValue: any = options?.useNullForUndefined ? null : undefined;
         return this.childFields.map((vector, index) => {
             const value = values[index];
-            if (value == null || !vector.valueToJSON) return value;
-            return vector.valueToJSON(value, skipNullFields);
+            if (value == null || !vector.valueToJSON) return value ?? nilValue;
+            return vector.valueToJSON(value, options);
         });
     }
 

--- a/packages/data-mate/src/vector/types/TupleVector.ts
+++ b/packages/data-mate/src/vector/types/TupleVector.ts
@@ -1,7 +1,7 @@
 import { FieldType } from '@terascope/types';
 import { Vector, VectorOptions } from '../Vector';
 import { SerializeOptions, VectorType } from '../interfaces';
-import { getObjectDataTypeConfig, ReadableData } from '../../core';
+import { getChildDataTypeConfig, ReadableData } from '../../core';
 
 type ChildFields = readonly Vector<any>[];
 
@@ -23,17 +23,13 @@ export class TupleVector<
             return this.#childFields;
         }
         const childFields: ChildFields = Object.entries(this.childConfig)
-            .map(([field, config], index) => {
-                const childConfig = (config.type === FieldType.Object
-                    ? getObjectDataTypeConfig(this.childConfig!, field)
-                    : undefined);
-
-                return Vector.make<any>(ReadableData.emptyData, {
-                    childConfig,
-                    config,
-                    name: this._getChildName(index)
-                });
-            });
+            .map(([field, config], index) => Vector.make<any>(ReadableData.emptyData, {
+                childConfig: getChildDataTypeConfig(
+                    this.childConfig!, field, config.type as FieldType
+                ),
+                config,
+                name: this._getChildName(index)
+            }));
 
         this.#childFields = childFields;
         return childFields;

--- a/packages/data-mate/src/vector/types/TupleVector.ts
+++ b/packages/data-mate/src/vector/types/TupleVector.ts
@@ -41,6 +41,7 @@ export class TupleVector<
 
     valueToJSON(values: T, options?: SerializeOptions): any {
         const nilValue: any = options?.useNullForUndefined ? null : undefined;
+
         return this.childFields.map((vector, index) => {
             const value = values[index];
             if (value == null || !vector.valueToJSON) return value ?? nilValue;

--- a/packages/data-mate/src/vector/types/TupleVector.ts
+++ b/packages/data-mate/src/vector/types/TupleVector.ts
@@ -1,6 +1,6 @@
 import { FieldType } from '@terascope/types';
 import { Vector, VectorOptions } from '../Vector';
-import { ValueToJSONOptions, VectorType } from '../interfaces';
+import { SerializeOptions, VectorType } from '../interfaces';
 import { getObjectDataTypeConfig, ReadableData } from '../../core';
 
 type ChildFields = readonly Vector<any>[];
@@ -39,7 +39,7 @@ export class TupleVector<
         return childFields;
     }
 
-    valueToJSON(values: T, options?: ValueToJSONOptions): any {
+    valueToJSON(values: T, options?: SerializeOptions): any {
         const nilValue: any = options?.useNullForUndefined ? null : undefined;
         return this.childFields.map((vector, index) => {
             const value = values[index];

--- a/packages/data-mate/test/aggregation-frame-spec.ts
+++ b/packages/data-mate/test/aggregation-frame-spec.ts
@@ -444,7 +444,7 @@ describe('AggregationFrame', () => {
                 },
                 {
                     name: 'Nick',
-                    scores: [1, 1, 10, null],
+                    scores: [1, 1, 10, undefined],
                     date: '2018-01-15T10:39:11.195Z',
                 }
             ]);
@@ -499,7 +499,7 @@ describe('AggregationFrame', () => {
                 },
                 {
                     name: 'Nick',
-                    scores: [1, 1, 10, null],
+                    scores: [1, 1, 10, undefined],
                     date: '2018-01-15T10:39:11.195Z',
                 }
             ]);
@@ -555,7 +555,7 @@ describe('AggregationFrame', () => {
                 },
                 {
                     name: 1,
-                    scores: [1, 1, 10, null],
+                    scores: [1, 1, 10, undefined],
                     date: '2018-01-15T10:39:11.195Z',
                 }
             ]);
@@ -602,7 +602,7 @@ describe('AggregationFrame', () => {
                 {
                     name: 'Nick',
                     count: 1,
-                    scores: [1, 1, 10, null],
+                    scores: [1, 1, 10, undefined],
                     date: '2018-01-15T10:39:11.195Z',
                 }
             ]);
@@ -637,7 +637,7 @@ describe('AggregationFrame', () => {
                 },
                 {
                     name: 1,
-                    scores: [1, 1, 10, null],
+                    scores: [1, 1, 10, undefined],
                     date: '2018-01-15T10:39:11.195Z',
                 }
             ]);
@@ -668,7 +668,7 @@ describe('AggregationFrame', () => {
                 {
                     name: 'Nick',
                     count: 1,
-                    scores: [1, 1, 10, null],
+                    scores: [1, 1, 10, undefined],
                     date: '2018-01-15T10:39:11.195Z',
                 }
             ]);

--- a/packages/data-mate/test/column/column-boolean-spec.ts
+++ b/packages/data-mate/test/column/column-boolean-spec.ts
@@ -36,7 +36,13 @@ describe('Column (Boolean Types)', () => {
         });
 
         it('should be able to iterate over the values', () => {
-            expect(col.toJSON()).toEqual(values);
+            expect(col.toJSON()).toEqual([
+                true,
+                false,
+                true,
+                undefined,
+                false,
+            ]);
         });
 
         it('should be able to get the Vector', () => {
@@ -46,7 +52,13 @@ describe('Column (Boolean Types)', () => {
         it('should be able to validate the values', () => {
             const newCol = col.validate(ColumnValidator.isBoolean);
             expect(newCol.id).not.toBe(col.id);
-            expect(newCol.toJSON()).toEqual(values);
+            expect(newCol.toJSON()).toEqual([
+                true,
+                false,
+                true,
+                undefined,
+                false,
+            ]);
         });
 
         it('should be able to get unique with the same length', () => {
@@ -56,9 +68,9 @@ describe('Column (Boolean Types)', () => {
             expect(newCol.toJSON()).toEqual([
                 true,
                 false,
-                null,
-                null,
-                null,
+                undefined,
+                undefined,
+                undefined,
             ]);
         });
 
@@ -72,7 +84,7 @@ describe('Column (Boolean Types)', () => {
             });
 
             expect(newCol.toJSON()).toEqual(values.map((value) => {
-                if (value == null) return null;
+                if (value == null) return undefined;
                 return `${value}`;
             }));
         });
@@ -111,7 +123,16 @@ describe('Column (Boolean Types)', () => {
 
         it('should be able to iterate over the values', () => {
             expect([...col]).toEqual(values);
-            expect(col.toJSON()).toEqual(values);
+            expect(col.toJSON()).toEqual([
+                'True',
+                'yes',
+                'no',
+                undefined,
+                'NO',
+                'False',
+                'NOT_BOOLEAN',
+                'WHO'
+            ]);
         });
 
         it('should be able to get the Vector', () => {
@@ -122,7 +143,7 @@ describe('Column (Boolean Types)', () => {
             const newCol = col.validate(ColumnValidator.isBoolean);
             expect(newCol.id).not.toBe(col.id);
             expect(newCol.toJSON()).toEqual(
-                values.map(() => null)
+                values.map(() => undefined)
             );
         });
 
@@ -133,11 +154,11 @@ describe('Column (Boolean Types)', () => {
                 'True',
                 'yes',
                 'no',
-                null,
+                undefined,
                 'NO',
                 'False',
-                null,
-                null
+                undefined,
+                undefined
             ]);
         });
 
@@ -150,7 +171,7 @@ describe('Column (Boolean Types)', () => {
                 type: FieldType.Boolean
             });
             expect(newCol.toJSON()).toEqual(values.map((value) => {
-                if (value == null) return null;
+                if (value == null) return undefined;
                 return toBoolean(value);
             }));
         });
@@ -161,7 +182,7 @@ describe('Column (Boolean Types)', () => {
         const values: Maybe<string[]>[] = [
             ['True'],
             [],
-            null,
+            undefined,
             ['NO'],
             ['False'],
             ['NOT_BOOLEAN', 'True'],
@@ -199,13 +220,13 @@ describe('Column (Boolean Types)', () => {
             const newCol = col.validate(ColumnValidator.isBoolean);
             expect(newCol.id).not.toBe(col.id);
             expect(newCol.toJSON()).toEqual([
-                [null],
+                [undefined],
                 [],
-                null,
-                [null],
-                [null],
-                [null, null],
-                [null]
+                undefined,
+                [undefined],
+                [undefined],
+                [undefined, undefined],
+                [undefined]
             ]);
         });
 
@@ -215,11 +236,11 @@ describe('Column (Boolean Types)', () => {
             expect(newCol.toJSON()).toEqual([
                 ['True'],
                 [],
-                null,
+                undefined,
                 ['NO'],
                 ['False'],
-                [null, 'True'],
-                [null]
+                [undefined, 'True'],
+                [undefined]
             ]);
         });
 
@@ -235,7 +256,7 @@ describe('Column (Boolean Types)', () => {
             expect(newCol.toJSON()).toEqual([
                 [true],
                 [],
-                null,
+                undefined,
                 [false],
                 [false],
                 [true, true],

--- a/packages/data-mate/test/column/column-date-spec.ts
+++ b/packages/data-mate/test/column/column-date-spec.ts
@@ -41,7 +41,7 @@ describe('Column (Date Types)', () => {
                 '1941-08-20T07:00:00.000Z',
                 '2020-09-23T00:00:00.000Z',
                 1600875138416,
-                null,
+                undefined,
                 '2019-01-20T12:50:20.000Z'
             ]);
         });
@@ -63,7 +63,7 @@ describe('Column (Date Types)', () => {
                 '1941-08-20T07:00:00.000Z',
                 '2020-09-23T00:00:00.000Z',
                 '2020-09-23T15:32:18.416Z',
-                null,
+                undefined,
                 '2019-01-20T12:50:20.000Z'
             ]);
         });
@@ -84,7 +84,7 @@ describe('Column (Date Types)', () => {
                 '1941-08-20 07:00:00',
                 '2020-09-23 00:00:00',
                 '2020-09-23 15:32:18',
-                null,
+                undefined,
                 '2019-01-20 12:50:20',
             ]);
         });
@@ -96,7 +96,7 @@ describe('Column (Date Types)', () => {
         let col: Column<string>;
         const values: Maybe<string>[] = [
             '2020-09-23',
-            null,
+            undefined,
             '2020-01-20',
         ];
 
@@ -156,7 +156,7 @@ describe('Column (Date Types)', () => {
             });
             expect(newCol.toJSON()).toEqual([
                 '2018-02-02 00:23:01',
-                null,
+                undefined,
                 '2016-12-12 19:23:02',
             ]);
         });
@@ -174,7 +174,7 @@ describe('Column (Date Types)', () => {
         let col: Column<string>;
         const values: Maybe<string>[] = [
             '2018-02-02 00:23:0 -08:00',
-            null,
+            undefined,
             '2016-12-12 19:23:02 +02:00',
         ];
 
@@ -211,7 +211,7 @@ describe('Column (Date Types)', () => {
         let col: Column<number>;
         const values: Maybe<number>[] = [
             1600844405020,
-            null,
+            undefined,
             1579503620931,
         ];
 
@@ -262,7 +262,7 @@ describe('Column (Date Types)', () => {
 
             expect(newCol.toJSON()).toEqual([
                 1600844405020,
-                null,
+                undefined,
                 1579503620931,
             ]);
         });
@@ -301,7 +301,7 @@ describe('Column (Date Types)', () => {
         let col: Column<number>;
         const values: Maybe<number>[] = [
             1600844405,
-            null,
+            undefined,
             1579503621,
         ];
 
@@ -340,7 +340,7 @@ describe('Column (Date Types)', () => {
 
             expect(newCol.toJSON()).toEqual([
                 1600844405,
-                null,
+                undefined,
                 1579503621,
             ]);
         });

--- a/packages/data-mate/test/column/column-number-spec.ts
+++ b/packages/data-mate/test/column/column-number-spec.ts
@@ -39,8 +39,8 @@ describe('Column (Number Types)', () => {
         });
 
         it('should be able to sort the values in asc order', () => {
-            expect(col.sort().toJSON()).toEqual([
-                null,
+            expect(col.sort().toJSON()).toStrictEqual([
+                undefined,
                 2,
                 4,
                 6,
@@ -49,12 +49,12 @@ describe('Column (Number Types)', () => {
         });
 
         it('should be able to sort the values in desc order', () => {
-            expect(col.sort('desc').toJSON()).toEqual([
+            expect(col.sort('desc').toJSON()).toStrictEqual([
                 7,
                 6,
                 4,
                 2,
-                null,
+                undefined,
             ]);
         });
 
@@ -68,7 +68,7 @@ describe('Column (Number Types)', () => {
             });
 
             expect(newCol.toJSON()).toEqual(values.map((value) => {
-                if (value == null) return null;
+                if (value == null) return undefined;
                 return `${value}`;
             }));
         });
@@ -91,7 +91,7 @@ describe('Column (Number Types)', () => {
                 ['7'],
                 ['2'],
                 ['6'],
-                null,
+                undefined,
                 ['4'],
             ]);
         });
@@ -103,7 +103,7 @@ describe('Column (Number Types)', () => {
             expect(newCol.config).toEqual(col.config);
 
             expect(newCol.toJSON()).toEqual(values.map((value) => {
-                if (value == null) return null;
+                if (value == null) return undefined;
                 return value + 1;
             }));
         });
@@ -117,7 +117,7 @@ describe('Column (Number Types)', () => {
             expect(newCol.config).toEqual(col.config);
 
             expect(newCol.toJSON()).toEqual(values.map((value) => {
-                if (value == null) return null;
+                if (value == null) return undefined;
                 return parseInt(`${value + 1.5}`, 10);
             }));
         });
@@ -129,7 +129,7 @@ describe('Column (Number Types)', () => {
             expect(newCol.config).toEqual(col.config);
 
             expect(newCol.toJSON()).toEqual(values.map((value) => {
-                if (value == null) return null;
+                if (value == null) return undefined;
                 return value - 1;
             }));
         });
@@ -143,7 +143,7 @@ describe('Column (Number Types)', () => {
             expect(newCol.config).toEqual(col.config);
 
             expect(newCol.toJSON()).toEqual(values.map((value) => {
-                if (value == null) return null;
+                if (value == null) return undefined;
                 return parseInt(`${value - 1.5}`, 10);
             }));
         });
@@ -181,8 +181,8 @@ describe('Column (Number Types)', () => {
         });
 
         it('should be able to sort the values in asc order', () => {
-            expect(col.sort().toJSON()).toEqual([
-                null,
+            expect(col.sort().toJSON()).toStrictEqual([
+                undefined,
                 2.2444233334,
                 4.3333334,
                 6,
@@ -196,7 +196,7 @@ describe('Column (Number Types)', () => {
                 6,
                 4.3333334,
                 2.2444233334,
-                null,
+                undefined,
             ]);
         });
 
@@ -210,7 +210,7 @@ describe('Column (Number Types)', () => {
             });
 
             expect(newCol.toJSON()).toEqual(values.map((value) => {
-                if (value == null) return null;
+                if (value == null) return undefined;
                 return `${value}`;
             }));
         });
@@ -224,7 +224,7 @@ describe('Column (Number Types)', () => {
             expect(newCol.config).toEqual(col.config);
 
             expect(newCol.toJSON()).toEqual(values.map((value) => {
-                if (value == null) return null;
+                if (value == null) return undefined;
                 return value + 1.5;
             }));
         });
@@ -238,7 +238,7 @@ describe('Column (Number Types)', () => {
             expect(newCol.config).toEqual(col.config);
 
             expect(newCol.toJSON()).toEqual(values.map((value) => {
-                if (value == null) return null;
+                if (value == null) return undefined;
                 return value - 1.5;
             }));
         });
@@ -286,10 +286,10 @@ describe('Column (Number Types)', () => {
             });
 
             expect(newCol.toJSON()).toEqual(values.map((value) => {
-                if (value == null) return null;
+                if (value == null) return undefined;
 
                 return value.map((val) => (
-                    val != null ? `${val}` : null
+                    val != null ? `${val}` : undefined
                 ));
             }));
         });
@@ -321,7 +321,7 @@ describe('Column (Number Types)', () => {
 
             expect(newCol.toJSON()).toEqual([
                 [7, 3],
-                [2, null, 4],
+                [2, undefined, 4],
                 [6, 324, 5],
                 [-50],
                 [4, 2, 0],
@@ -376,8 +376,8 @@ describe('Column (Number Types)', () => {
         });
 
         it('should be able to sort the values in asc order', () => {
-            expect(col.sort().toJSON()).toEqual([
-                null,
+            expect(col.sort().toJSON()).toStrictEqual([
+                undefined,
                 bigIntToJSON(BigInt(12) ** multiplier),
                 bigIntToJSON(BigInt(16) ** multiplier),
                 bigIntToJSON(BigInt(19) ** multiplier),
@@ -386,12 +386,12 @@ describe('Column (Number Types)', () => {
         });
 
         it('should be able to sort the values in desc order', () => {
-            expect(col.sort('desc').toJSON()).toEqual([
+            expect(col.sort('desc').toJSON()).toStrictEqual([
                 bigIntToJSON(BigInt(21) ** multiplier),
                 bigIntToJSON(BigInt(19) ** multiplier),
                 bigIntToJSON(BigInt(16) ** multiplier),
                 bigIntToJSON(BigInt(12) ** multiplier),
-                null,
+                undefined,
             ]);
         });
 
@@ -405,7 +405,7 @@ describe('Column (Number Types)', () => {
             });
 
             expect(newCol.toJSON()).toEqual(values.map((value) => {
-                if (value == null) return null;
+                if (value == null) return undefined;
                 return `${value}`;
             }));
         });
@@ -419,7 +419,7 @@ describe('Column (Number Types)', () => {
             expect(newCol.config).toEqual(col.config);
 
             expect(newCol.toJSON()).toEqual(values.map((value) => {
-                if (value == null) return null;
+                if (value == null) return undefined;
                 return bigIntToJSON(value + BigInt(100));
             }));
         });
@@ -433,7 +433,7 @@ describe('Column (Number Types)', () => {
             expect(newCol.config).toEqual(col.config);
 
             expect(newCol.toJSON()).toEqual(values.map((value) => {
-                if (value == null) return null;
+                if (value == null) return undefined;
                 return bigIntToJSON(value - BigInt(100));
             }));
         });

--- a/packages/data-mate/test/column/column-string-spec.ts
+++ b/packages/data-mate/test/column/column-string-spec.ts
@@ -36,7 +36,13 @@ describe('Column (String Types)', () => {
 
         it('should be able to iterate over the values', () => {
             expect([...col]).toEqual(values);
-            expect(col.toJSON()).toEqual(values);
+            expect(col.toJSON()).toEqual([
+                'Batman',
+                'Robin',
+                'Superman',
+                undefined,
+                'SpiderMan',
+            ]);
         });
 
         it('should be able to get the Vector', () => {
@@ -51,7 +57,7 @@ describe('Column (String Types)', () => {
                 'Batman',
                 'Robin',
                 'Superman',
-                null,
+                undefined,
                 'SpiderMan',
             ]);
         });
@@ -63,7 +69,7 @@ describe('Column (String Types)', () => {
                 'http://xn--fsqu00a.xn--3lr804guic',
                 'http://example.com',
                 'BAD-URL',
-                null,
+                undefined,
             ]).validate(ColumnValidator.isURL);
 
             expect(newCol.toJSON()).toEqual([
@@ -71,8 +77,8 @@ describe('Column (String Types)', () => {
                 'ftp://someurl.bom:8080?some=bar&hi=bob',
                 'http://xn--fsqu00a.xn--3lr804guic',
                 'http://example.com',
-                null,
-                null,
+                undefined,
+                undefined,
             ]);
         });
 
@@ -81,14 +87,14 @@ describe('Column (String Types)', () => {
                 '0668CF8B-27F8-2F4D-4F2D-763AC7C8F68B',
                 'BAD-UUID',
                 '6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b',
-                null,
+                undefined,
             ]).validate(ColumnValidator.isUUID);
 
             expect(newCol.toJSON()).toEqual([
                 '0668CF8B-27F8-2F4D-4F2D-763AC7C8F68B',
-                null,
+                undefined,
                 '6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b',
-                null,
+                undefined,
             ]);
         });
 
@@ -106,9 +112,9 @@ describe('Column (String Types)', () => {
                 'ha3ke5@pawnage.com',
                 'user@blah.com/junk.junk?a=<tag value="junk"',
                 'email@example.com',
-                null,
-                null,
-                null,
+                undefined,
+                undefined,
+                undefined,
             ]);
         });
 
@@ -124,11 +130,11 @@ describe('Column (String Types)', () => {
 
             expect(newCol.toJSON()).toEqual([
                 'Example',
-                null,
-                null,
-                null,
-                null,
-                null,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
             ]);
         });
 
@@ -145,10 +151,10 @@ describe('Column (String Types)', () => {
             expect(newCol.toJSON()).toEqual([
                 'Example',
                 'example123',
-                null,
-                null,
-                null,
-                null,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
             ]);
         });
 
@@ -160,11 +166,11 @@ describe('Column (String Types)', () => {
             expect(newCol.id).not.toBe(col.id);
             expect(newCol.config).toEqual(col.config);
             expect(newCol.toJSON()).toEqual([
-                null,
-                null,
+                undefined,
+                undefined,
                 'Superman',
-                null,
-                null,
+                undefined,
+                undefined,
             ]);
         });
 
@@ -179,7 +185,7 @@ describe('Column (String Types)', () => {
                 ['Batman'],
                 ['Robin'],
                 ['Superman'],
-                null,
+                undefined,
                 ['SpiderMan'],
             ]);
         });
@@ -193,7 +199,7 @@ describe('Column (String Types)', () => {
                 'BATMAN',
                 'ROBIN',
                 'SUPERMAN',
-                null,
+                undefined,
                 'SPIDERMAN',
             ]);
         });
@@ -207,7 +213,7 @@ describe('Column (String Types)', () => {
                 'batman',
                 'robin',
                 'superman',
-                null,
+                undefined,
                 'spiderman',
             ]);
         });
@@ -223,7 +229,7 @@ describe('Column (String Types)', () => {
                 'Batma',
                 'Robin',
                 'Super',
-                null,
+                undefined,
                 'Spide',
             ]);
         });

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -543,76 +543,58 @@ describe('DataFrame', () => {
                     }]);
                 });
 
-                describe('when preserveDuplicates is false', () => {
-                    it('should compact the data from the people frame', () => {
-                        const resultFrame = dupePeopleFrame.compact();
-                        expect(resultFrame.toJSON()).toEqual([
-                            {
-                                name: 'Jill',
-                                age: 39,
-                            },
-                            {
-                                name: 'Billy',
-                                age: 47,
-                                friends: ['Jill']
-                            },
-                            {
-                                name: 'Jill',
-                                friends: ['Frank']
-                            }
-                        ]);
-                    });
-
-                    it('should compact the data from the deep obj frame', () => {
-                        const resultFrame = dupeDeepObjFrame.compact();
-
-                        expect(resultFrame.toJSON()).toEqual([{
-                            _key: 'id-1',
-                            config: {
-                                id: 'config-1',
-                                name: 'config-1',
-                                owner: {
-                                    id: 'config-owner-1',
-                                    name: 'config-owner-name-1'
-                                }
-                            },
-                            states: [{ id: 'state-1', name: 'state-1' }, { id: 'state-2', name: 'state-2' }]
-                        }, {
-                            _key: 'id-2',
-                            config: {
-                                id: 'config-2',
-                                name: 'config-2',
-                                owner: {
-                                    id: 'config-owner-2',
-                                    name: 'config-owner-name-2'
-                                }
-                            },
-                            states: [{ id: 'state-3', name: 'state-3' }]
-                        }, {
-                            _key: 'id-2',
-                            config: {
-                                id: 'config-2',
-                                name: 'config-2',
-                            },
-                            states: [{ name: 'state-3' }, { id: 'state-3' }]
-                        }]);
-                    });
+                it('should compact the data from the people frame', () => {
+                    const resultFrame = dupePeopleFrame.compact();
+                    expect(resultFrame.toJSON()).toEqual([
+                        {
+                            name: 'Jill',
+                            age: 39,
+                        },
+                        {
+                            name: 'Billy',
+                            age: 47,
+                            friends: ['Jill']
+                        },
+                        {
+                            name: 'Jill',
+                            friends: ['Frank']
+                        }
+                    ]);
                 });
 
-                describe('when preserveDuplicates is true', () => {
-                    it('should not compact the data from the people frame', () => {
-                        const resultFrame = dupePeopleFrame.compact({
-                            preserveDuplicates: true
-                        });
-                        expect(resultFrame.toJSON()).toEqual(dupePeopleFrame.toJSON());
-                    });
+                it('should compact the data from the deep obj frame', () => {
+                    const resultFrame = dupeDeepObjFrame.compact();
 
-                    it('should not compact the data from the deep obj frame', () => {
-                        const resultFrame = dupeDeepObjFrame.compact({
-                            preserveDuplicates: true
-                        });
-                        expect(resultFrame.toJSON()).toEqual(dupeDeepObjFrame.toJSON());
-                    });
+                    expect(resultFrame.toJSON()).toEqual([{
+                        _key: 'id-1',
+                        config: {
+                            id: 'config-1',
+                            name: 'config-1',
+                            owner: {
+                                id: 'config-owner-1',
+                                name: 'config-owner-name-1'
+                            }
+                        },
+                        states: [{ id: 'state-1', name: 'state-1' }, { id: 'state-2', name: 'state-2' }]
+                    }, {
+                        _key: 'id-2',
+                        config: {
+                            id: 'config-2',
+                            name: 'config-2',
+                            owner: {
+                                id: 'config-owner-2',
+                                name: 'config-owner-name-2'
+                            }
+                        },
+                        states: [{ id: 'state-3', name: 'state-3' }]
+                    }, {
+                        _key: 'id-2',
+                        config: {
+                            id: 'config-2',
+                            name: 'config-2',
+                        },
+                        states: [{ name: 'state-3' }, { id: 'state-3' }]
+                    }]);
                 });
             });
         });

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -473,6 +473,104 @@ describe('DataFrame', () => {
                     expect(resultFrame.toJSON()).toEqual(deepObjDataFrame.toJSON());
                 });
             });
+
+            describe('when no options are given and there are duplicate rows to compact', () => {
+                it('should preserve the data from the people frame', () => {
+                    const frame = createPeopleDataFrame([
+                        {
+                            name: 'Jill',
+                            age: 39,
+                            friends: ['Frank']
+                        },
+                        {
+                            name: 'Billy',
+                            age: 47,
+                            friends: ['Jill']
+                        },
+                        {
+                            name: 'Jill',
+                            age: 39,
+                            friends: ['Frank']
+                        },
+                    ]);
+
+                    const resultFrame = frame.compact();
+                    expect(resultFrame.toJSON()).toEqual([
+                        {
+                            name: 'Jill',
+                            age: 39,
+                            friends: ['Frank']
+                        },
+                        {
+                            name: 'Billy',
+                            age: 47,
+                            friends: ['Jill']
+                        },
+                    ]);
+                });
+
+                it('should preserve the data from the deep obj frame', () => {
+                    const frame = createDeepObjectDataFrame([{
+                        _key: 'id-1',
+                        config: {
+                            id: 'config-1',
+                            name: 'config-1',
+                            owner: {
+                                id: 'config-owner-1',
+                                name: 'config-owner-name-1'
+                            }
+                        },
+                        states: [{ id: 'state-1', name: 'state-1' }, { id: 'state-2', name: 'state-2' }]
+                    }, {
+                        _key: 'id-1',
+                        config: {
+                            id: 'config-1',
+                            name: 'config-1',
+                            owner: {
+                                id: 'config-owner-1',
+                                name: 'config-owner-name-1'
+                            }
+                        },
+                        states: [{ id: 'state-1', name: 'state-1' }, { id: 'state-2', name: 'state-2' }]
+                    }, {
+                        _key: 'id-2',
+                        config: {
+                            id: 'config-2',
+                            name: 'config-2',
+                            owner: {
+                                id: 'config-owner-2',
+                                name: 'config-owner-name-2'
+                            }
+                        },
+                        states: [{ id: 'state-3', name: 'state-3' }, { id: 'state-3', name: 'state-3' }]
+                    }]);
+
+                    const resultFrame = frame.compact();
+                    expect(resultFrame.toJSON()).toEqual([{
+                        _key: 'id-1',
+                        config: {
+                            id: 'config-1',
+                            name: 'config-1',
+                            owner: {
+                                id: 'config-owner-1',
+                                name: 'config-owner-name-1'
+                            }
+                        },
+                        states: [{ id: 'state-1', name: 'state-1' }, { id: 'state-2', name: 'state-2' }]
+                    }, {
+                        _key: 'id-2',
+                        config: {
+                            id: 'config-2',
+                            name: 'config-2',
+                            owner: {
+                                id: 'config-owner-2',
+                                name: 'config-owner-name-2'
+                            }
+                        },
+                        states: [{ id: 'state-3', name: 'state-3' }]
+                    }]);
+                });
+            });
         });
 
         describe('->assign', () => {

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -1090,6 +1090,17 @@ describe('DataFrame', () => {
             it('should be able to to merge all of the columns', () => {
                 const resultFrame = peopleDataFrame.createTupleFrom(peopleDataFrame.fields, 'merged');
 
+                expect(resultFrame.config).toEqual({
+                    version: peopleDTConfig.version,
+                    fields: {
+                        ...peopleDTConfig.fields,
+                        merged: { type: FieldType.Tuple },
+                        'merged.0': peopleDTConfig.fields.name,
+                        'merged.1': peopleDTConfig.fields.age,
+                        'merged.2': peopleDTConfig.fields.friends,
+                    }
+                });
+
                 expect(resultFrame.toJSON()).toEqual([
                     {
                         name: 'Jill',

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -475,7 +475,7 @@ describe('DataFrame', () => {
             });
 
             describe('when no options are given and there are duplicate rows to compact', () => {
-                it('should preserve the data from the people frame', () => {
+                it('should compact the data from the people frame', () => {
                     const frame = createPeopleDataFrame([
                         {
                             name: 'Jill',
@@ -509,7 +509,7 @@ describe('DataFrame', () => {
                     ]);
                 });
 
-                it('should preserve the data from the deep obj frame', () => {
+                it('should compact the data from the deep obj frame', () => {
                     const frame = createDeepObjectDataFrame([{
                         _key: 'id-1',
                         config: {

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -973,12 +973,12 @@ describe('DataFrame', () => {
                     {
                         name: 'Jane',
                         friends: ['Jill'],
-                        merged: ['Jane', null, ['Jill']]
+                        merged: ['Jane', undefined, ['Jill']]
                     },
                     {
                         name: 'Nancy',
                         age: 10,
-                        merged: ['Nancy', 10, null]
+                        merged: ['Nancy', 10, undefined]
                     },
                 ]);
                 expect(resultFrame.id).not.toEqual(dataFrame.id);

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -226,16 +226,16 @@ describe('DataFrame', () => {
         let peopleDataFrame: DataFrame<Person>;
 
         type DeepObj = {
-            _key: string;
-            config: {
-                id: string;
-                name: string;
-                owner: {
-                    id: string;
-                    name: string;
+            _key?: string;
+            config?: {
+                id?: string;
+                name?: string;
+                owner?: {
+                    id?: string;
+                    name?: string;
                 }
             };
-            states: { id: string; name: string }[];
+            states?: { id?: string; name?: string }[];
         }
 
         const deepObjectDTConfig: DataTypeConfig = {
@@ -294,6 +294,10 @@ describe('DataFrame', () => {
             return DataFrame.fromJSON<Person>(peopleDTConfig, data);
         }
 
+        function createDeepObjectDataFrame(data: DeepObj[]) {
+            return DataFrame.fromJSON<DeepObj>(deepObjectDTConfig, data);
+        }
+
         beforeAll(() => {
             peopleDataFrame = createPeopleDataFrame([
                 {
@@ -322,31 +326,29 @@ describe('DataFrame', () => {
                     friends: null as any
                 },
             ]);
-            deepObjDataFrame = DataFrame.fromJSON<DeepObj>(
-                deepObjectDTConfig, [{
-                    _key: 'id-1',
-                    config: {
-                        id: 'config-1',
-                        name: 'config-1',
-                        owner: {
-                            id: 'config-owner-1',
-                            name: 'config-owner-name-1'
-                        }
-                    },
-                    states: [{ id: 'state-1', name: 'state-1' }, { id: 'state-2', name: 'state-2' }]
-                }, {
-                    _key: 'id-2',
-                    config: {
-                        id: 'config-2',
-                        name: 'config-2',
-                        owner: {
-                            id: 'config-owner-2',
-                            name: 'config-owner-name-2'
-                        }
-                    },
-                    states: [{ id: 'state-3', name: 'state-3' }, { id: 'state-4', name: 'state-4' }]
-                }]
-            );
+            deepObjDataFrame = createDeepObjectDataFrame([{
+                _key: 'id-1',
+                config: {
+                    id: 'config-1',
+                    name: 'config-1',
+                    owner: {
+                        id: 'config-owner-1',
+                        name: 'config-owner-name-1'
+                    }
+                },
+                states: [{ id: 'state-1', name: 'state-1' }, { id: 'state-2', name: 'state-2' }]
+            }, {
+                _key: 'id-2',
+                config: {
+                    id: 'config-2',
+                    name: 'config-2',
+                    owner: {
+                        id: 'config-owner-2',
+                        name: 'config-owner-name-2'
+                    }
+                },
+                states: [{ id: 'state-3', name: 'state-3' }, { id: 'state-4', name: 'state-4' }]
+            }]);
         });
 
         describe('->select', () => {
@@ -456,6 +458,20 @@ describe('DataFrame', () => {
                 expect(names).toEqual(['age', 'friends']);
                 expect(resultFrame.size).toEqual(peopleDataFrame.size);
                 expect(resultFrame.id).not.toEqual(peopleDataFrame.id);
+            });
+        });
+
+        describe('->compact', () => {
+            describe('when no options are given and there is nothing to compact', () => {
+                it('should preserve the data from the people frame', () => {
+                    const resultFrame = peopleDataFrame.compact();
+                    expect(resultFrame.toJSON()).toEqual(peopleDataFrame.toJSON());
+                });
+
+                it('should preserve the data from the deep obj frame', () => {
+                    const resultFrame = deepObjDataFrame.compact();
+                    expect(resultFrame.toJSON()).toEqual(deepObjDataFrame.toJSON());
+                });
             });
         });
 

--- a/packages/data-mate/test/vector/list-vector-spec.ts
+++ b/packages/data-mate/test/vector/list-vector-spec.ts
@@ -12,7 +12,7 @@ describe('ListVector', () => {
         [
             FieldType.Any,
             [['foo'], 'bar', [undefined], 2, [null, {}], null, undefined],
-            [['foo'], ['bar'], [null], [2], [null, {}], null, undefined]
+            [['foo'], ['bar'], [undefined], [2], [undefined, {}], undefined, undefined]
         ],
     ];
 
@@ -30,7 +30,7 @@ describe('ListVector', () => {
                 if (typeof val === 'bigint') {
                     return bigIntToJSON(val);
                 }
-                if (val === undefined) return null;
+                if (val == null) return undefined;
                 return val;
             });
         });

--- a/packages/data-mate/test/vector/vector-spec.ts
+++ b/packages/data-mate/test/vector/vector-spec.ts
@@ -279,11 +279,11 @@ describe('Vector', () => {
             [
                 [true, 'hi', 3],
                 [false, '2', 1],
-                [null, null, null],
-                [null, 'hello', null],
-                [null, null, null],
-                null,
-                null
+                [undefined, undefined, undefined],
+                [undefined, 'hello', undefined],
+                [undefined, undefined, undefined],
+                undefined,
+                undefined
             ],
             [
                 [true, 'hi', 'hello', 'extra-arg'],
@@ -309,7 +309,7 @@ describe('Vector', () => {
                 if (typeof val === 'bigint') {
                     return bigIntToJSON(val);
                 }
-                if (val === undefined && !output) return null;
+                if (val == null) return undefined;
                 return val;
             });
         });

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.25.1",
+    "version": "0.26.0-rc.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.34.1",
+        "@terascope/utils": "^0.35.0-rc.0",
         "graphql": "^15.4.0",
         "lodash.defaultsdeep": "^4.6.1",
         "yargs": "^16.2.0"

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.26.0-rc.1",
+    "version": "0.26.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.35.0-rc.1",
+        "@terascope/utils": "^0.35.0",
         "graphql": "^15.4.0",
         "lodash.defaultsdeep": "^4.6.1",
         "yargs": "^16.2.0"

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.26.0-rc.0",
+    "version": "0.26.0-rc.1",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.35.0-rc.0",
+        "@terascope/utils": "^0.35.0-rc.1",
         "graphql": "^15.4.0",
         "lodash.defaultsdeep": "^4.6.1",
         "yargs": "^16.2.0"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.16.1",
+    "version": "2.17.0-rc.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.34.1",
+        "@terascope/utils": "^0.35.0-rc.0",
         "bluebird": "^3.7.2",
         "lodash.isequal": "^4.5.0"
     },

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.17.0-rc.1",
+    "version": "2.17.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.0-rc.1",
+        "@terascope/utils": "^0.35.0",
         "bluebird": "^3.7.2",
         "lodash.isequal": "^4.5.0"
     },

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.17.0-rc.0",
+    "version": "2.17.0-rc.1",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.0-rc.0",
+        "@terascope/utils": "^0.35.0-rc.1",
         "bluebird": "^3.7.2",
         "lodash.isequal": "^4.5.0"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -25,12 +25,12 @@
     },
     "dependencies": {
         "@terascope/data-mate": "^0.20.2",
-        "@terascope/data-types": "^0.25.1",
+        "@terascope/data-types": "^0.26.0-rc.0",
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.34.1",
+        "@terascope/utils": "^0.35.0-rc.0",
         "ajv": "^6.12.6",
         "uuid": "^8.3.2",
-        "xlucene-translator": "^0.15.1"
+        "xlucene-translator": "^0.16.0-rc.0"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.0",

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -27,10 +27,10 @@
         "@terascope/data-mate": "^0.20.2",
         "@terascope/data-types": "^0.26.0-rc.0",
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.35.0-rc.0",
+        "@terascope/utils": "^0.35.0-rc.1",
         "ajv": "^6.12.6",
         "uuid": "^8.3.2",
-        "xlucene-translator": "^0.16.0-rc.0"
+        "xlucene-translator": "^0.16.0-rc.1"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.0",

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.41.2",
+    "version": "0.42.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,13 +24,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.20.2",
-        "@terascope/data-types": "^0.26.0-rc.0",
+        "@terascope/data-mate": "^0.21.0",
+        "@terascope/data-types": "^0.26.0",
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.35.0-rc.1",
+        "@terascope/utils": "^0.35.0",
         "ajv": "^6.12.6",
         "uuid": "^8.3.2",
-        "xlucene-translator": "^0.16.0-rc.1"
+        "xlucene-translator": "^0.16.0"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.0",

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.15.0-rc.0",
+    "version": "0.15.0-rc.1",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.0-rc.0",
+        "@terascope/utils": "^0.35.0-rc.1",
         "chalk": "^4.1.0",
         "lodash.defaultsdeep": "^4.6.1",
         "yeoman-generator": "^4.12.0",

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.14.1",
+    "version": "0.15.0-rc.0",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.34.1",
+        "@terascope/utils": "^0.35.0-rc.0",
         "chalk": "^4.1.0",
         "lodash.defaultsdeep": "^4.6.1",
         "yeoman-generator": "^4.12.0",

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.15.0-rc.1",
+    "version": "0.15.0",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.0-rc.1",
+        "@terascope/utils": "^0.35.0",
         "chalk": "^4.1.0",
         "lodash.defaultsdeep": "^4.6.1",
         "yeoman-generator": "^4.12.0",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.45.0-rc.1",
+    "version": "0.45.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.0-rc.1",
+        "@terascope/utils": "^0.35.0",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^8.3.2"

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.45.0-rc.0",
+    "version": "0.45.0-rc.1",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.0-rc.0",
+        "@terascope/utils": "^0.35.0-rc.1",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^8.3.2"

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.44.1",
+    "version": "0.45.0-rc.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.34.1",
+        "@terascope/utils": "^0.35.0-rc.0",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^8.3.2"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.30.0-rc.1",
+    "version": "0.30.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.18.5",
-        "@terascope/utils": "^0.35.0-rc.1",
+        "@terascope/utils": "^0.35.0",
         "codecov": "^3.8.1",
         "execa": "^5.0.0",
         "fs-extra": "^9.1.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.29.5",
+    "version": "0.30.0-rc.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.18.5",
-        "@terascope/utils": "^0.34.1",
+        "@terascope/utils": "^0.35.0-rc.0",
         "codecov": "^3.8.1",
         "execa": "^5.0.0",
         "fs-extra": "^9.1.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.30.0-rc.0",
+    "version": "0.30.0-rc.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.18.5",
-        "@terascope/utils": "^0.35.0-rc.0",
+        "@terascope/utils": "^0.35.0-rc.1",
         "codecov": "^3.8.1",
         "execa": "^5.0.0",
         "fs-extra": "^9.1.0",

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -9,7 +9,7 @@ export const FORCE_COLOR = toBoolean(forceColor)
 export const HOST_IP = process.env.HOST_IP || address();
 export const USE_EXISTING_SERVICES = toBoolean(process.env.USE_EXISTING_SERVICES);
 export const SERVICES_USE_TMPFS = toBoolean(process.env.SERVICES_USE_TMPFS || 'true');
-export const SERVICE_HEAP_OPTS = process.env.SERVICE_HEAP_OPTS || '-Xms256m -Xmx256m';
+export const SERVICE_HEAP_OPTS = process.env.SERVICE_HEAP_OPTS || '-Xms512m -Xms512m';
 export const DOCKER_NETWORK_NAME = process.env.DOCKER_NETWORK_NAME || undefined;
 export const TEST_NAMESPACE = process.env.TEST_NAMESPACE || 'ts_test';
 

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.28.2",
+    "version": "0.29.0-rc.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.34.1",
+        "@terascope/utils": "^0.35.0-rc.0",
         "aws-sdk": "^2.804.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.15",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.29.0-rc.0",
+    "version": "0.29.0-rc.1",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.0-rc.0",
+        "@terascope/utils": "^0.35.0-rc.1",
         "aws-sdk": "^2.804.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.15",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.29.0-rc.1",
+    "version": "0.29.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.0-rc.1",
+        "@terascope/utils": "^0.35.0",
         "aws-sdk": "^2.804.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.15",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.36.0-rc.0",
+    "version": "0.36.0-rc.1",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.7.3",
-        "@terascope/utils": "^0.35.0-rc.0",
+        "@terascope/utils": "^0.35.0-rc.1",
         "chalk": "^4.1.0",
         "cli-table3": "^0.6.0",
         "easy-table": "^1.1.1",
@@ -48,7 +48,7 @@
         "pretty-bytes": "^5.5.0",
         "prompts": "^2.4.0",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.33.0-rc.0",
+        "teraslice-client-js": "^0.33.0-rc.1",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.3",
         "yargs": "^16.2.0",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.35.1",
+    "version": "0.36.0-rc.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.7.3",
-        "@terascope/utils": "^0.34.1",
+        "@terascope/utils": "^0.35.0-rc.0",
         "chalk": "^4.1.0",
         "cli-table3": "^0.6.0",
         "easy-table": "^1.1.1",
@@ -48,7 +48,7 @@
         "pretty-bytes": "^5.5.0",
         "prompts": "^2.4.0",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.32.1",
+        "teraslice-client-js": "^0.33.0-rc.0",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.3",
         "yargs": "^16.2.0",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.36.0-rc.1",
+    "version": "0.36.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.7.3",
-        "@terascope/utils": "^0.35.0-rc.1",
+        "@terascope/utils": "^0.35.0",
         "chalk": "^4.1.0",
         "cli-table3": "^0.6.0",
         "easy-table": "^1.1.1",
@@ -48,7 +48,7 @@
         "pretty-bytes": "^5.5.0",
         "prompts": "^2.4.0",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.33.0-rc.1",
+        "teraslice-client-js": "^0.33.0",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.3",
         "yargs": "^16.2.0",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.32.1",
+    "version": "0.33.0-rc.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.44.1",
+        "@terascope/job-components": "^0.45.0-rc.0",
         "auto-bind": "^4.0.0",
         "got": "^11.8.1"
     },

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.33.0-rc.1",
+    "version": "0.33.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.45.0-rc.1",
+        "@terascope/job-components": "^0.45.0",
         "auto-bind": "^4.0.0",
         "got": "^11.8.1"
     },

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.33.0-rc.0",
+    "version": "0.33.0-rc.1",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.45.0-rc.0",
+        "@terascope/job-components": "^0.45.0-rc.1",
         "auto-bind": "^4.0.0",
         "got": "^11.8.1"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.19.0-rc.0",
+    "version": "0.19.0-rc.1",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.0-rc.0",
+        "@terascope/utils": "^0.35.0-rc.1",
         "ms": "^2.1.2",
         "nanoid": "^3.1.20",
         "p-event": "^4.2.0",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.19.0-rc.1",
+    "version": "0.19.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.0-rc.1",
+        "@terascope/utils": "^0.35.0",
         "ms": "^2.1.2",
         "nanoid": "^3.1.20",
         "p-event": "^4.2.0",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.18.1",
+    "version": "0.19.0-rc.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/utils": "^0.34.1",
+        "@terascope/utils": "^0.35.0-rc.0",
         "ms": "^2.1.2",
         "nanoid": "^3.1.20",
         "p-event": "^4.2.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.45.0-rc.1"
+        "@terascope/job-components": "^0.45.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.45.0-rc.1"
+        "@terascope/job-components": "^0.45.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.45.0-rc.0"
+        "@terascope/job-components": "^0.45.0-rc.1"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.45.0-rc.0"
+        "@terascope/job-components": "^0.45.0-rc.1"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.44.1"
+        "@terascope/job-components": "^0.45.0-rc.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.44.1"
+        "@terascope/job-components": "^0.45.0-rc.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.23.1",
+    "version": "0.24.0-rc.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.16.1",
-        "@terascope/utils": "^0.34.1",
+        "@terascope/elasticsearch-api": "^2.17.0-rc.0",
+        "@terascope/utils": "^0.35.0-rc.0",
         "mnemonist": "^0.38.1"
     },
     "publishConfig": {

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.24.0-rc.1",
+    "version": "0.24.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.17.0-rc.1",
-        "@terascope/utils": "^0.35.0-rc.1",
+        "@terascope/elasticsearch-api": "^2.17.0",
+        "@terascope/utils": "^0.35.0",
         "mnemonist": "^0.38.1"
     },
     "publishConfig": {

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.24.0-rc.0",
+    "version": "0.24.0-rc.1",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.17.0-rc.0",
-        "@terascope/utils": "^0.35.0-rc.0",
+        "@terascope/elasticsearch-api": "^2.17.0-rc.1",
+        "@terascope/utils": "^0.35.0-rc.1",
         "mnemonist": "^0.38.1"
     },
     "publishConfig": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^9.1.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.45.0-rc.0"
+        "@terascope/job-components": "^0.45.0-rc.1"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.45.0-rc.0"
+        "@terascope/job-components": "^0.45.0-rc.1"
     },
     "engines": {
         "node": ">=10.16.0"

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^9.1.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.45.0-rc.1"
+        "@terascope/job-components": "^0.45.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.45.0-rc.1"
+        "@terascope/job-components": "^0.45.0"
     },
     "engines": {
         "node": ">=10.16.0"

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^9.1.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.44.1"
+        "@terascope/job-components": "^0.45.0-rc.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.44.1"
+        "@terascope/job-components": "^0.45.0-rc.0"
     },
     "engines": {
         "node": ">=10.16.0"

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.17.0-rc.0",
-        "@terascope/job-components": "^0.45.0-rc.0",
-        "@terascope/teraslice-messaging": "^0.19.0-rc.0",
-        "@terascope/utils": "^0.35.0-rc.0",
+        "@terascope/elasticsearch-api": "^2.17.0-rc.1",
+        "@terascope/job-components": "^0.45.0-rc.1",
+        "@terascope/teraslice-messaging": "^0.19.0-rc.1",
+        "@terascope/utils": "^0.35.0-rc.1",
         "async-mutex": "^0.2.6",
         "barbe": "^3.0.16",
         "body-parser": "^1.19.0",
@@ -61,7 +61,7 @@
         "semver": "^7.3.4",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.29.0-rc.0",
+        "terafoundation": "^0.29.0-rc.1",
         "uuid": "^8.3.2"
     },
     "devDependencies": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.16.1",
-        "@terascope/job-components": "^0.44.1",
-        "@terascope/teraslice-messaging": "^0.18.1",
-        "@terascope/utils": "^0.34.1",
+        "@terascope/elasticsearch-api": "^2.17.0-rc.0",
+        "@terascope/job-components": "^0.45.0-rc.0",
+        "@terascope/teraslice-messaging": "^0.19.0-rc.0",
+        "@terascope/utils": "^0.35.0-rc.0",
         "async-mutex": "^0.2.6",
         "barbe": "^3.0.16",
         "body-parser": "^1.19.0",
@@ -61,7 +61,7 @@
         "semver": "^7.3.4",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.28.2",
+        "terafoundation": "^0.29.0-rc.0",
         "uuid": "^8.3.2"
     },
     "devDependencies": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.17.0-rc.1",
-        "@terascope/job-components": "^0.45.0-rc.1",
-        "@terascope/teraslice-messaging": "^0.19.0-rc.1",
-        "@terascope/utils": "^0.35.0-rc.1",
+        "@terascope/elasticsearch-api": "^2.17.0",
+        "@terascope/job-components": "^0.45.0",
+        "@terascope/teraslice-messaging": "^0.19.0",
+        "@terascope/utils": "^0.35.0",
         "async-mutex": "^0.2.6",
         "barbe": "^3.0.16",
         "body-parser": "^1.19.0",
@@ -61,7 +61,7 @@
         "semver": "^7.3.4",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.29.0-rc.1",
+        "terafoundation": "^0.29.0",
         "uuid": "^8.3.2"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "@terascope/data-mate": "^0.20.2",
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.34.1",
+        "@terascope/utils": "^0.35.0-rc.0",
         "awesome-phonenumber": "^2.43.0",
         "graphlib": "^2.1.8",
         "is-ip": "^3.1.0",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.49.2",
+    "version": "0.50.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.20.2",
+        "@terascope/data-mate": "^0.21.0",
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.35.0-rc.1",
+        "@terascope/utils": "^0.35.0",
         "awesome-phonenumber": "^2.43.0",
         "graphlib": "^2.1.8",
         "is-ip": "^3.1.0",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "@terascope/data-mate": "^0.20.2",
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.35.0-rc.0",
+        "@terascope/utils": "^0.35.0-rc.1",
         "awesome-phonenumber": "^2.43.0",
         "graphlib": "^2.1.8",
         "is-ip": "^3.1.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.34.1",
+    "version": "0.35.0-rc.0",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.35.0-rc.1",
+    "version": "0.35.0",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.35.0-rc.0",
+    "version": "0.35.0-rc.1",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/regex.ts
+++ b/packages/utils/src/regex.ts
@@ -93,9 +93,8 @@ export function matchAllFP(regexp: string|RegExp): (value: string) => string[]|n
 }
 
 export function isWildCardString(term: string): boolean {
-    if (typeof term === 'string') {
-        if (term.match('[?+*+]')) return true;
-    }
+    if (typeof term !== 'string') return false;
+    if (term.includes('*') || term.includes('?')) return true;
     return false;
 }
 
@@ -109,8 +108,6 @@ export function wildCardToRegex(term: string): RegExp {
             baseRegex += '.*';
         } else if (char === '?') {
             baseRegex += '[^\\n\\r\\s]';
-        } else if (char === '.') {
-            baseRegex += '\\.{0,1}';
         } else if (char === ' ') {
             baseRegex += '\\s';
         } else if (WORD_CHARS[char] || char === '\\') {

--- a/packages/utils/src/strings.ts
+++ b/packages/utils/src/strings.ts
@@ -252,7 +252,7 @@ export function truncateFP(len: number, ellipsis = true) {
     };
 }
 
-const lowerChars = {
+export const LOWER_CASE_CHARS = {
     a: true,
     b: true,
     c: true,
@@ -281,7 +281,7 @@ const lowerChars = {
     z: true,
 } as const;
 
-const upperChars = {
+export const UPPER_CASE_CHARS = {
     A: true,
     B: true,
     C: true,
@@ -310,7 +310,7 @@ const upperChars = {
     Z: true,
 } as const;
 
-const numChars = {
+export const NUM_CHARS = {
     0: true,
     1: true,
     2: true,
@@ -323,16 +323,16 @@ const numChars = {
     9: true,
 } as const;
 
-const sepChars = {
+export const WORD_SEPARATOR_CHARS = {
     ' ': true,
     _: true,
     '-': true,
 } as const;
 
-const wordChars = {
-    ...lowerChars,
-    ...upperChars,
-    ...numChars,
+export const WORD_CHARS = {
+    ...LOWER_CASE_CHARS,
+    ...UPPER_CASE_CHARS,
+    ...NUM_CHARS,
 } as const;
 
 /**
@@ -353,7 +353,7 @@ export function getWordParts(input: string): string[] {
         const nextChar = input.charAt(i + 1);
 
         if (!started && char === '_') {
-            if (nextChar === '_' || wordChars[nextChar]) {
+            if (nextChar === '_' || WORD_CHARS[nextChar]) {
                 word += char;
                 continue;
             }
@@ -361,18 +361,18 @@ export function getWordParts(input: string): string[] {
 
         started = true;
 
-        if (char && wordChars[char]) {
+        if (char && WORD_CHARS[char]) {
             word += char;
         }
 
-        if (sepChars[nextChar]) {
+        if (WORD_SEPARATOR_CHARS[nextChar]) {
             parts.push(word);
             word = '';
         }
 
-        if (upperChars[nextChar]) {
+        if (UPPER_CASE_CHARS[nextChar]) {
             const nextNextChar = input.charAt(i + 2);
-            if (lowerChars[nextNextChar]) {
+            if (LOWER_CASE_CHARS[nextNextChar]) {
                 parts.push(word);
                 word = '';
             }
@@ -432,7 +432,7 @@ export function toSafeString(input: string): string {
 function _replaceFirstWordChar(str: string, fn: (char: string) => string): string {
     let found = false;
     return str.split('').map((s) => {
-        if (!found && wordChars[s]) {
+        if (!found && WORD_CHARS[s]) {
             found = true;
             return fn(s);
         }

--- a/packages/utils/test/regex-spec.ts
+++ b/packages/utils/test/regex-spec.ts
@@ -3,6 +3,7 @@ import {
     matchAll,
     match,
     formatRegex,
+    matchWildcard,
 } from '../src/regex';
 
 describe('Regex Utils', () => {
@@ -40,6 +41,23 @@ describe('Regex Utils', () => {
             ['<(\\w+)>.*<(\\d+)>', '<tag1> hello <1234>', ['tag1', '1234']]
         ])('should match all %p to %s', (input: RegExp|string, value: string, expected: any) => {
             expect(matchAll(input, value)).toEqual(expected);
+        });
+    });
+
+    describe('matchWildcard', () => {
+        test.each([
+            ['fo?', 'foo', true],
+            ['fo?', 'food', false],
+            ['fo?', 'fob', true],
+            ['fo*', 'foo', true],
+            ['fo*', 'food', true],
+            ['*\\.__*_value', 'nested.__foo_value', true],
+            ['*\\.__*_value', 'nested.__foo_bar', false],
+            ['*\\.__*_value', 'nested._foo_value', false],
+            ['__*_value', '__foo_bar', false],
+            ['__*_value', '___bar', false],
+        ])('should handle %p to %s', (input: string, value: string, expected: any) => {
+            expect(matchWildcard(input, value)).toEqual(expected);
         });
     });
 });

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.32.0-rc.1",
+    "version": "0.32.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.35.0-rc.1",
+        "@terascope/utils": "^0.35.0",
         "@turf/bbox": "^6.2.0",
         "@turf/bbox-polygon": "^6.3.0",
         "@turf/boolean-contains": "^6.3.0",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.31.1",
+    "version": "0.32.0-rc.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.34.1",
+        "@terascope/utils": "^0.35.0-rc.0",
         "@turf/bbox": "^6.2.0",
         "@turf/bbox-polygon": "^6.3.0",
         "@turf/boolean-contains": "^6.3.0",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.32.0-rc.0",
+    "version": "0.32.0-rc.1",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.35.0-rc.0",
+        "@terascope/utils": "^0.35.0-rc.1",
         "@turf/bbox": "^6.2.0",
         "@turf/bbox-polygon": "^6.3.0",
         "@turf/boolean-contains": "^6.3.0",

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.16.0-rc.0",
+    "version": "0.16.0-rc.1",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,8 +29,8 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.35.0-rc.0",
-        "xlucene-parser": "^0.32.0-rc.0"
+        "@terascope/utils": "^0.35.0-rc.1",
+        "xlucene-parser": "^0.32.0-rc.1"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.15.1",
+    "version": "0.16.0-rc.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,8 +29,8 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.34.1",
-        "xlucene-parser": "^0.31.1"
+        "@terascope/utils": "^0.35.0-rc.0",
+        "xlucene-parser": "^0.32.0-rc.0"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.16.0-rc.1",
+    "version": "0.16.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,8 +29,8 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.0",
-        "@terascope/utils": "^0.35.0-rc.1",
-        "xlucene-parser": "^0.32.0-rc.1"
+        "@terascope/utils": "^0.35.0",
+        "xlucene-parser": "^0.32.0"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "0.3.0-rc.1",
+    "version": "0.3.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.0-rc.1"
+        "@terascope/utils": "^0.35.0"
     },
     "devDependencies": {
         "@terascope/types": "^0.7.0"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "0.3.0-rc.0",
+    "version": "0.3.0-rc.1",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.0-rc.0"
+        "@terascope/utils": "^0.35.0-rc.1"
     },
     "devDependencies": {
         "@terascope/types": "^0.7.0"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "0.2.0",
+    "version": "0.3.0-rc.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.34.1"
+        "@terascope/utils": "^0.35.0-rc.0"
     },
     "devDependencies": {
         "@terascope/types": "^0.7.0"


### PR DESCRIPTION
- Fix `IPValue`s to gracefully handle multiple version of the data-mate
- Add support for `skipNullFields` when calling `toJSON` to cleanup nil values
- Adds `DataFrame.deepSelect` for selecting nested properties or fields matching a wildcard
- Fixes an issue with `wildCardToRegex` query
- Fixes object deduplication in data frames
- Better serialization options