### PR TITLE
Ip routable fix

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.20.1",
+    "version": "0.20.2",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-mate/src/validations/field-validator.ts
+++ b/packages/data-mate/src/validations/field-validator.ts
@@ -479,8 +479,7 @@ export function isRoutableIP(input: unknown, _parentContext?: unknown): boolean 
 function _isRoutableIP(input: unknown, _parentContext?: unknown): boolean {
     if (!isIP(input)) return false;
 
-    const range = ipaddr.parse(input as any).range();
-    return range !== 'private' && range !== 'uniqueLocal';
+    return _publicIp(input);
 }
 
 /**
@@ -509,8 +508,12 @@ export function isNonRoutableIP(input: unknown, _parentContext?: unknown): boole
 function _isNonRoutableIP(input: unknown, _parentContext?: unknown): boolean {
     if (!isIP(input)) return false;
 
+    return !_publicIp(input);
+}
+
+function _publicIp(input: unknown): boolean {
     const range = ipaddr.parse(input as any).range();
-    return range === 'private' || range === 'uniqueLocal';
+    return range !== 'private' && range !== 'uniqueLocal' && range !== 'loopback';
 }
 
 /**

--- a/packages/data-mate/test/field_validator-spec.ts
+++ b/packages/data-mate/test/field_validator-spec.ts
@@ -257,6 +257,9 @@ describe('field validators', () => {
             expect(FieldValidator.isRoutableIP('192.168.0.1')).toBe(false);
             expect(FieldValidator.isRoutableIP('fc00:db8::1')).toBe(false);
             expect(FieldValidator.isRoutableIP('badIpaddress')).toBe(false);
+            expect(FieldValidator.isRoutableIP('10.1.3.4')).toBe(false);
+            expect(FieldValidator.isRoutableIP('172.28.4.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('127.0.1.2')).toBe(false);
         });
 
         it('validates an array of values, ignores undefined/null', () => {
@@ -270,6 +273,9 @@ describe('field validators', () => {
             expect(FieldValidator.isNonRoutableIP('10.16.32.210')).toBe(true);
             expect(FieldValidator.isNonRoutableIP('172.18.12.74')).toBe(true);
             expect(FieldValidator.isNonRoutableIP('fc00:db8::1')).toBe(true);
+            expect(FieldValidator.isNonRoutableIP('10.1.3.4')).toBe(true);
+            expect(FieldValidator.isNonRoutableIP('172.28.4.1')).toBe(true);
+            expect(FieldValidator.isNonRoutableIP('127.0.1.2')).toBe(true);
         });
 
         it('should return false for a routable ip address or invalid ip address', () => {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.41.1",
+    "version": "0.41.2",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.20.1",
+        "@terascope/data-mate": "^0.20.2",
         "@terascope/data-types": "^0.25.1",
         "@terascope/types": "^0.7.0",
         "@terascope/utils": "^0.34.1",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.49.1",
+    "version": "0.49.2",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.20.1",
+        "@terascope/data-mate": "^0.20.2",
         "@terascope/types": "^0.7.0",
         "@terascope/utils": "^0.34.1",
         "awesome-phonenumber": "^2.43.0",


### PR DESCRIPTION
date-mate field validator was not checking ips in the loopback range

since both isRoutableIp and IsNonRoutableIP shared basically the same logic I extracted the publicIP check to it's own function.  Not sure if that is the best place for it.  I checked in @terascope/utils but didn't see an obvious place there.

If it should go somewhere else let me know

Added tests to include all the private ip ranges and loopback range

bumped data-mate to 0.20.2