### PR TITLE
AggregationFrame/DataFrame performance improvements

### DIFF
--- a/packages/data-mate/bench/agg-perf-test.js
+++ b/packages/data-mate/bench/agg-perf-test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const { pDelay } = require('@terascope/utils');
+const fs = require('fs');
+const path = require('path');
+const { DataFrame } = require('./src');
+
+async function readData() {
+    console.time('readData');
+    try {
+        return await new Promise((resolve, reject) => {
+            fs.readFile(path.join(__dirname, 'fixtures/data.json'), (err, buf) => {
+                if (err) reject(err);
+                else resolve(JSON.parse(buf));
+            });
+        });
+    } finally {
+        console.timeEnd('readData');
+    }
+}
+
+async function setup({ config, data }) {
+    console.time('setup');
+    try {
+        const frame = DataFrame
+            .fromJSON(config, data)
+            .select('_key', 'birthday', 'age', 'ip');
+
+        await pDelay(0);
+        return frame;
+    } finally {
+        console.timeEnd('setup');
+    }
+}
+
+async function aggregate(dataFrame) {
+    console.time('aggregate');
+    try {
+        return await dataFrame
+            .aggregate()
+            .avg('age')
+            .yearly('birthday')
+            .run();
+    } finally {
+        console.timeEnd('aggregate');
+    }
+}
+
+Promise.resolve()
+    .then(readData)
+    .then(setup)
+    .then(aggregate)
+    .then(async (dataFrame) => {
+        // eslint-disable-next-line no-console
+        console.log(dataFrame.toJSON());
+        await pDelay(5000);
+        process.exit(0);
+    }, (err) => {
+        console.error(err);
+        process.exit(1);
+    });

--- a/packages/data-mate/bench/aggregrate-suite.js
+++ b/packages/data-mate/bench/aggregrate-suite.js
@@ -1,8 +1,11 @@
 'use strict';
 
+const { FieldType } = require('@terascope/types');
 const { Suite } = require('./helpers');
 const { config, data } = require('./fixtures/data.json');
-const { DataFrame, isNumberLike, ValueAggregation } = require('./src');
+const {
+    DataFrame, isNumberLike, ValueAggregation, KeyAggregation
+} = require('./src');
 
 const run = async () => {
     const suite = Suite('Aggregate');
@@ -12,6 +15,19 @@ const run = async () => {
         const fieldInfo = `${column.name} (${column.config.type}${column.config.array ? '[]' : ''})`;
         if (isNumberLike(column.config.type)) {
             for (const agg of Object.values(ValueAggregation)) {
+                const aggregateFrame = dataFrame.select(column.name).aggregate();
+
+                suite.add(`${agg} ${fieldInfo}`, {
+                    defer: true,
+                    fn(deferred) {
+                        aggregateFrame[agg](column.name)
+                            .run()
+                            .then(() => deferred.resolve(), deferred.reject);
+                    }
+                });
+            }
+        } else if (column.config.type === FieldType.Date) {
+            for (const agg of Object.values(KeyAggregation)) {
                 const aggregateFrame = dataFrame.select(column.name).aggregate();
 
                 suite.add(`${agg} ${fieldInfo}`, {

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.21.1",
+    "version": "0.22.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -29,9 +29,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.26.1",
+        "@terascope/data-types": "^0.27.0",
         "@terascope/types": "^0.7.1",
-        "@terascope/utils": "^0.35.1",
+        "@terascope/utils": "^0.36.0",
         "@turf/bbox": "^6.2.0",
         "@turf/bbox-polygon": "^6.3.0",
         "@turf/boolean-point-in-polygon": "^6.2.0",
@@ -50,7 +50,7 @@
         "uuid": "^8.3.2",
         "valid-url": "^1.0.9",
         "validator": "^13.5.2",
-        "xlucene-parser": "^0.32.1"
+        "xlucene-parser": "^0.33.0"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.1",

--- a/packages/data-mate/src/aggregation-frame/AggregationFrame.ts
+++ b/packages/data-mate/src/aggregation-frame/AggregationFrame.ts
@@ -1,5 +1,5 @@
 import { DataTypeConfig, FieldType } from '@terascope/types';
-import { pImmediate } from '@terascope/utils';
+import { EventLoop } from '@terascope/utils';
 import {
     Column,
     KeyAggregation, ValueAggregation, valueAggMap,
@@ -515,8 +515,8 @@ export class AggregationFrame<
 
         for (const bucket of buckets.values()) {
             await this._runBucket(builders, fieldAggs, bucket);
+            await EventLoop.wait();
         }
-        await pImmediate();
 
         this.columns = Object.freeze([...builders].map(([name, builder]) => {
             const column = this.getColumnOrThrow(name);
@@ -563,7 +563,7 @@ export class AggregationFrame<
             buckets.set(res.key, bucket);
         }
 
-        await pImmediate();
+        await EventLoop.wait();
         return buckets;
     }
 

--- a/packages/data-mate/src/aggregation-frame/AggregationFrame.ts
+++ b/packages/data-mate/src/aggregation-frame/AggregationFrame.ts
@@ -9,7 +9,7 @@ import { getCommonTupleType, isNumberLike } from '../vector';
 import { Builder } from '../builder';
 import { getBuilderForField, getMaxColumnSize } from './utils';
 import {
-    createHashCode, FieldArg, flattenStringArg, freezeArray, getFieldsFromArg
+    FieldArg, flattenStringArg, freezeArray, getFieldsFromArg
 } from '../core';
 import { columnsToDataTypeConfig, makeKeyForRow } from '../data-frame/utils';
 
@@ -558,11 +558,11 @@ export class AggregationFrame<
                 res.row[field] = col.vector.get(i);
             }
 
-            const groupKey = createHashCode(res.key) as string;
-            const bucket = buckets.get(groupKey) || [];
+            const bucket = buckets.get(res.key) || [];
             bucket.push(res.row);
-            buckets.set(groupKey, bucket);
+            buckets.set(res.key, bucket);
         }
+
         await pImmediate();
         return buckets;
     }
@@ -570,11 +570,11 @@ export class AggregationFrame<
     private _generateBuilders(buckets: Map<string, any[]>): Map<keyof T, Builder<any>> {
         const builders = new Map<keyof T, Builder<any>>();
         for (const col of this.columns) {
-            const agg = this._aggregations.get(col.name);
-            const builder = getBuilderForField(
-                col, buckets.size, agg?.key, agg?.value
-            );
             if (!this._selectFields?.length || this._selectFields.includes(col.name)) {
+                const agg = this._aggregations.get(col.name);
+                const builder = getBuilderForField(
+                    col, buckets.size, agg?.key, agg?.value
+                );
                 builders.set(col.name, builder);
             }
         }

--- a/packages/data-mate/src/column/aggregations.ts
+++ b/packages/data-mate/src/column/aggregations.ts
@@ -181,19 +181,21 @@ export const keyAggMap: Record<KeyAggregation, MakeKeyAggFn> = {
 };
 
 function makeDateAgg(dateFormat: string): MakeKeyAggFn {
-    return (vector) => (index) => {
-        const value = vector.get(index) as DateValue;
-        if (value == null) return { key: undefined, value };
+    return function _makeDateAgg(vector) {
+        return function dateAgg(index) {
+            const value = vector.get(index) as DateValue;
+            if (value == null) return { key: undefined, value };
 
-        return {
-            key: formatDate(value.value, dateFormat),
-            value,
+            return {
+                key: formatDate(value.value, dateFormat),
+                value,
+            };
         };
     };
 }
 
 export function makeUniqueKeyAgg(vector: Vector<any>, options?: SerializeOptions): KeyAggFn {
-    return (index) => {
+    return function uniqueKeyAgg(index) {
         const value = vector.get(index, false);
         if (value == null) {
             return { key: undefined, value: null };

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -1017,6 +1017,37 @@ describe('DataFrame', () => {
             });
         });
 
+        describe('->appendAll', () => {
+            it('should throw if given an empty array', () => {
+                const resultFrame = peopleDataFrame.appendAll([]);
+
+                expect(resultFrame.id).toEqual(peopleDataFrame.id);
+                expect(resultFrame.size).toEqual(peopleDataFrame.size);
+            });
+
+            it('should be able to append itself once', () => {
+                const resultFrame = peopleDataFrame.appendAll([peopleDataFrame]);
+                const data = peopleDataFrame.toJSON();
+                expect(resultFrame.toJSON()).toEqual(
+                    data.concat(data)
+                );
+                expect(resultFrame.size).toEqual(peopleDataFrame.size * 2);
+                expect(resultFrame.id).not.toEqual(peopleDataFrame.id);
+            });
+
+            it('should be able to append itself three times', () => {
+                const resultFrame = peopleDataFrame.appendAll([
+                    peopleDataFrame, peopleDataFrame, peopleDataFrame
+                ]);
+                const data = peopleDataFrame.toJSON();
+                expect(resultFrame.toJSON()).toEqual(
+                    data.concat(data, data, data)
+                );
+                expect(resultFrame.size).toEqual(peopleDataFrame.size * 4);
+                expect(resultFrame.id).not.toEqual(peopleDataFrame.id);
+            });
+        });
+
         describe('->filterBy', () => {
             it('should be able to filter by a single column', () => {
                 const resultFrame = peopleDataFrame.filterBy({

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.26.1",
+    "version": "0.27.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.1",
-        "@terascope/utils": "^0.35.1",
+        "@terascope/utils": "^0.36.0",
         "graphql": "^15.4.0",
         "lodash": "^4.17.20",
         "yargs": "^16.2.0"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.17.1",
+    "version": "2.18.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.1",
+        "@terascope/utils": "^0.36.0",
         "bluebird": "^3.7.2",
         "lodash": "^4.17.20"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.42.1",
+    "version": "0.43.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,13 +24,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.21.1",
-        "@terascope/data-types": "^0.26.1",
+        "@terascope/data-mate": "^0.22.0",
+        "@terascope/data-types": "^0.27.0",
         "@terascope/types": "^0.7.1",
-        "@terascope/utils": "^0.35.1",
+        "@terascope/utils": "^0.36.0",
         "ajv": "^6.12.6",
         "uuid": "^8.3.2",
-        "xlucene-translator": "^0.16.1"
+        "xlucene-translator": "^0.17.0"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.0",

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.15.1",
+    "version": "0.16.0",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.1",
+        "@terascope/utils": "^0.36.0",
         "chalk": "^4.1.0",
         "lodash": "^4.17.20",
         "yeoman-generator": "^4.12.0",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.45.1",
+    "version": "0.46.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.1",
+        "@terascope/utils": "^0.36.0",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^8.3.2"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.30.1",
+    "version": "0.31.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^3.18.5",
-        "@terascope/utils": "^0.35.1",
+        "@terascope/utils": "^0.36.0",
         "codecov": "^3.8.1",
         "execa": "^5.0.0",
         "fs-extra": "^9.1.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.29.1",
+    "version": "0.30.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.1",
+        "@terascope/utils": "^0.36.0",
         "aws-sdk": "^2.804.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.15",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.36.1",
+    "version": "0.37.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.7.3",
-        "@terascope/utils": "^0.35.1",
+        "@terascope/utils": "^0.36.0",
         "chalk": "^4.1.0",
         "cli-table3": "^0.6.0",
         "easy-table": "^1.1.1",
@@ -48,7 +48,7 @@
         "pretty-bytes": "^5.5.0",
         "prompts": "^2.4.0",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.33.1",
+        "teraslice-client-js": "^0.34.0",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.3",
         "yargs": "^16.2.0",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.33.1",
+    "version": "0.34.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.45.1",
+        "@terascope/job-components": "^0.46.0",
         "auto-bind": "^4.0.0",
         "got": "^11.8.1"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.19.1",
+    "version": "0.20.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.1",
+        "@terascope/utils": "^0.36.0",
         "ms": "^2.1.2",
         "nanoid": "^3.1.20",
         "p-event": "^4.2.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.45.1"
+        "@terascope/job-components": "^0.46.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.45.1"
+        "@terascope/job-components": "^0.46.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.24.1",
+    "version": "0.25.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.17.1",
-        "@terascope/utils": "^0.35.1",
+        "@terascope/elasticsearch-api": "^2.18.0",
+        "@terascope/utils": "^0.36.0",
         "mnemonist": "^0.38.1"
     },
     "publishConfig": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^9.1.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.45.1"
+        "@terascope/job-components": "^0.46.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.45.1"
+        "@terascope/job-components": "^0.46.0"
     },
     "engines": {
         "node": ">=10.16.0"

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.2"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.17.1",
-        "@terascope/job-components": "^0.45.1",
-        "@terascope/teraslice-messaging": "^0.19.1",
-        "@terascope/utils": "^0.35.1",
+        "@terascope/elasticsearch-api": "^2.18.0",
+        "@terascope/job-components": "^0.46.0",
+        "@terascope/teraslice-messaging": "^0.20.0",
+        "@terascope/utils": "^0.36.0",
         "async-mutex": "^0.2.6",
         "barbe": "^3.0.16",
         "body-parser": "^1.19.0",
@@ -61,7 +61,7 @@
         "semver": "^7.3.4",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.29.1",
+        "terafoundation": "^0.30.0",
         "uuid": "^8.3.2"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.50.1",
+    "version": "0.51.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.21.1",
+        "@terascope/data-mate": "^0.22.0",
         "@terascope/types": "^0.7.1",
-        "@terascope/utils": "^0.35.1",
+        "@terascope/utils": "^0.36.0",
         "awesome-phonenumber": "^2.43.0",
         "graphlib": "^2.1.8",
         "is-ip": "^3.1.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.35.1",
+    "version": "0.36.0",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/big-set.ts
+++ b/packages/utils/src/big-set.ts
@@ -1,0 +1,131 @@
+const defaultMaxSize = 2 ** 24;
+
+/**
+ * Avoid v8 maximum size for Set by spreading the cache across multiple Sets.
+ * This class has the same API as Set but minus more differences in ->add and ->forEach
+ */
+export class BigSet<V> {
+    readonly maxMapSize: number;
+    private _sets: Set<V>[];
+    private _current: Set<V>;
+    private _simpleMode: boolean;
+
+    constructor(maxMapSize = defaultMaxSize) {
+        this.maxMapSize = maxMapSize;
+        this._current = new Set();
+        this._simpleMode = true;
+        this._sets = [this._current];
+    }
+
+    add(value: V): Set<V> {
+        if (this._current.size >= this.maxMapSize) {
+            this._current = new Set();
+            this._sets.push(this._current);
+            this._simpleMode = false;
+        }
+
+        return this._current.add(value);
+    }
+
+    has(value: V): boolean {
+        if (this._simpleMode) {
+            return this._current.has(value);
+        }
+        return _getSetWithValue(this._sets, value) !== undefined;
+    }
+
+    delete(value: V): boolean {
+        if (this._simpleMode) {
+            return this._current.delete(value);
+        }
+
+        const set = _getSetWithValue(this._sets, value);
+
+        if (set !== undefined) {
+            return set.delete(value);
+        }
+
+        return false;
+    }
+
+    clear(): void {
+        if (this._simpleMode) {
+            return this._current.clear();
+        }
+
+        for (const set of this._sets) {
+            set.clear();
+        }
+
+        this._sets = [this._current];
+        this._simpleMode = true;
+    }
+
+    get size(): number {
+        if (this._simpleMode) {
+            return this._current.size;
+        }
+
+        let size = 0;
+
+        for (const map of this._sets) {
+            size += map.size;
+        }
+
+        return size;
+    }
+
+    forEach(callbackFn: (value: V, value2: V, map: BigSet<V>) => void, thisArg?: unknown): void {
+        if (thisArg) {
+            for (const value of this) {
+                callbackFn.call(thisArg, value, value, this);
+            }
+        } else {
+            for (const value of this) {
+                callbackFn(value, value, this);
+            }
+        }
+    }
+
+    [Symbol.iterator](): IterableIterator<V> {
+        if (this._simpleMode) {
+            return this._current[Symbol.iterator]();
+        }
+        return _iterator<V>(this._sets, Symbol.iterator);
+    }
+}
+
+function _getSetWithValue<V, M extends Set<V>>(sets: M[], value: V): M | undefined {
+    const start = sets.length - 1;
+    for (let index = start; index >= 0; index--) {
+        const set = sets[index];
+
+        if (set.has(value)) {
+            return set;
+        }
+    }
+    return undefined;
+}
+
+function _iterator<R>(items: Set<any>[], name: any): IterableIterator<R> {
+    let index = 0;
+
+    let iterator = items[index][name]();
+
+    return {
+        next: () => {
+            let result = iterator.next();
+
+            if (result.done && index < items.length - 1) {
+                index++;
+                iterator = items[index][name]();
+                result = iterator.next();
+            }
+
+            return result;
+        },
+        [Symbol.iterator]() {
+            return this;
+        },
+    } as IterableIterator<R>;
+}

--- a/packages/utils/src/event-loop.ts
+++ b/packages/utils/src/event-loop.ts
@@ -1,0 +1,76 @@
+import { debugLogger } from './logger';
+import { Logger } from './logger-interface';
+import { pDelay } from './promises';
+
+let _eventLoop: EventLoop|undefined;
+
+export class EventLoop {
+    /**
+     * Adds a setTimeout if the event loop is blocked
+    */
+    static wait(): Promise<void>|void {
+        if (!_eventLoop) {
+            EventLoop.init(debugLogger('event-loop'));
+        }
+        if (!_eventLoop?.blocked) return;
+
+        const delay = Math.max(_eventLoop.checkedInDiff - _eventLoop.heartbeat, 500);
+        if (delay <= 0) {
+            if (typeof process?.nextTick === 'function') {
+                return new Promise((resolve) => {
+                    process.nextTick(resolve);
+                });
+            }
+
+            return pDelay();
+        }
+
+        return pDelay(delay);
+    }
+
+    static init(logger: Logger): EventLoop {
+        if (_eventLoop) {
+            // there is no need to create multiple
+            // instances if the logger doesn't change
+            if (_eventLoop.logger === logger) return _eventLoop;
+            _eventLoop.cancel();
+        }
+        _eventLoop = new EventLoop(logger);
+        return _eventLoop;
+    }
+
+    checkedInDiff: number;
+
+    private readonly heartbeat = 500;
+
+    private checkedIn: number;
+    private interval: NodeJS.Timeout;
+
+    constructor(readonly logger: Logger) {
+        this.checkedIn = Date.now();
+        this.checkedInDiff = 0;
+
+        this.interval = setInterval(() => {
+            const now = Date.now();
+            this.checkedInDiff = now - this.checkedIn;
+            this.checkedIn = now;
+            if (this.blocked) {
+                logger.debug(`* EVENT LOOP IS PROBABLY BLOCKED (${this.checkedInDiff}ms diff) *`);
+            }
+        }, this.heartbeat);
+
+        // don't keep the process open
+        this.interval.unref();
+    }
+
+    get blocked(): boolean {
+        return this.checkedInDiff > (this.heartbeat * 2);
+    }
+
+    /**
+     * Cancel the event loop checker
+    */
+    cancel(): void {
+        clearInterval(this.interval);
+    }
+}

--- a/packages/utils/src/event-loop.ts
+++ b/packages/utils/src/event-loop.ts
@@ -4,9 +4,17 @@ import { pDelay } from './promises';
 
 let _eventLoop: EventLoop|undefined;
 
+/**
+ * A simple class for detecting when the event loop is blocked.
+ * The recommend use is to call `EventLoop.init(logger)` and then
+ * `await EventLoop.wait()` where you want to slow down potentially
+ * long running synchronous code
+*/
 export class EventLoop {
     /**
      * Adds a setTimeout if the event loop is blocked
+     * and will the delay will get slower the longer the event loop
+     * is block (with an upper limit)
     */
     static wait(): Promise<void>|void {
         if (!_eventLoop) {
@@ -28,6 +36,10 @@ export class EventLoop {
         return pDelay(delay);
     }
 
+    /**
+     * Creates or replaces an instead of a global
+     * EvenLoop
+    */
     static init(logger: Logger): EventLoop {
         if (_eventLoop) {
             // there is no need to create multiple
@@ -55,7 +67,7 @@ export class EventLoop {
             this.checkedInDiff = now - this.checkedIn;
             this.checkedIn = now;
             if (this.blocked) {
-                logger.debug(`* EVENT LOOP IS PROBABLY BLOCKED (${this.checkedInDiff}ms diff) *`);
+                this.logger.debug(`* EVENT LOOP IS PROBABLY BLOCKED (${this.checkedInDiff}ms diff) *`);
             }
         }, this.heartbeat);
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,6 +2,7 @@ import STATUS_CODES from './status-codes';
 
 export * from './arrays';
 export * from './big-map';
+export * from './big-set';
 export * from './booleans';
 export * from './buffers';
 export * from './collector';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -14,6 +14,7 @@ export * from './empty';
 export * from './env';
 export * from './equality';
 export * from './errors';
+export * from './event-loop';
 export * from './fp';
 export * from './functions';
 export * from './geo';

--- a/packages/utils/test/big-set-spec.ts
+++ b/packages/utils/test/big-set-spec.ts
@@ -1,0 +1,111 @@
+import 'jest-extended';
+import { BigSet } from '../src/big-set';
+
+describe('BigSet', () => {
+    let bigSet: BigSet<string>;
+    let set: Set<string>;
+
+    beforeEach(() => {
+        bigSet = new BigSet(1);
+        set = new Set();
+    });
+
+    afterEach(() => {
+        if (bigSet) bigSet.clear();
+        if (set) set.clear();
+    });
+
+    describe('when comparing against a regular Set', () => {
+        describe('->add', () => {
+            it('should return should not return the same thing all of the time', () => {
+                expect(bigSet.add('hello-0')).toEqual(set.add('hello-0'));
+                expect(bigSet.add('hello-1')).not.toEqual(set.add('hello-1'));
+            });
+        });
+
+        describe('->has', () => {
+            beforeEach(() => {
+                bigSet.add('hi-0');
+                set.add('hi-0');
+                bigSet.add('hi-1');
+                set.add('hi-1');
+            });
+
+            describe('when the key exists', () => {
+                it('should return the same thing', () => {
+                    expect(bigSet.has('hi-0')).toStrictEqual(set.has('hi-0'));
+                    expect(bigSet.has('hi-1')).toStrictEqual(set.has('hi-1'));
+                });
+            });
+
+            describe('when the key does NOT exists', () => {
+                it('should return the same thing', () => {
+                    expect(bigSet.has('wrong')).toStrictEqual(set.has('wrong'));
+                });
+            });
+        });
+
+        describe('->delete', () => {
+            beforeEach(() => {
+                bigSet.add('aloha-0');
+                set.add('aloha-0');
+                bigSet.add('aloha-1');
+                set.add('aloha-1');
+            });
+
+            it('should return the same thing', () => {
+                expect(bigSet.delete('aloha-0')).toEqual(set.delete('aloha-0'));
+                expect(bigSet.delete('aloha-1')).toEqual(set.delete('aloha-1'));
+            });
+        });
+
+        describe('->clear', () => {
+            beforeEach(() => {
+                bigSet.add('abc-0');
+                set.add('abc-0');
+                bigSet.add('abc-1');
+                set.add('abc-1');
+            });
+
+            it('should return the same thing', () => {
+                expect(bigSet.clear()).toEqual(set.clear());
+            });
+        });
+
+        describe('->size', () => {
+            beforeEach(() => {
+                bigSet.add('foo-0');
+                set.add('foo-0');
+                bigSet.add('foo-1');
+                set.add('foo-1');
+            });
+
+            it('should return the same thing', () => {
+                expect(bigSet.size).toEqual(set.size);
+            });
+        });
+
+        describe('->forEach', () => {
+            beforeEach(() => {
+                bigSet.add('bar-0');
+                set.add('bar-0');
+                bigSet.add('bar-1');
+                set.add('bar-1');
+            });
+
+            it('should be a called with similar arguments', () => {
+                const setFn = jest.fn();
+                set.forEach(setFn);
+
+                expect(setFn).toHaveBeenNthCalledWith(1, 'bar-0', 'bar-0', set);
+                expect(setFn).toHaveBeenNthCalledWith(2, 'bar-1', 'bar-1', set);
+
+                const bigSetFn = jest.fn();
+                bigSet.forEach(bigSetFn);
+
+                expect(bigSetFn).toHaveBeenNthCalledWith(1, 'bar-0', 'bar-0', bigSet);
+                expect(bigSetFn).toHaveBeenNthCalledWith(2, 'bar-1', 'bar-1', bigSet);
+            });
+        });
+    });
+});

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.32.1",
+    "version": "0.33.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.1",
-        "@terascope/utils": "^0.35.1",
+        "@terascope/utils": "^0.36.0",
         "@turf/bbox": "^6.2.0",
         "@turf/bbox-polygon": "^6.3.0",
         "@turf/boolean-contains": "^6.3.0",

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.16.1",
+    "version": "0.17.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,8 +29,8 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.1",
-        "@terascope/utils": "^0.35.1",
-        "xlucene-parser": "^0.32.1"
+        "@terascope/utils": "^0.36.0",
+        "xlucene-parser": "^0.33.0"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.35.1"
+        "@terascope/utils": "^0.36.0"
     },
     "devDependencies": {
         "@terascope/types": "^0.7.1"


### PR DESCRIPTION
- [x] Improves `date` aggregation performance by avoiding call to date-fns format
- [x] Removes unnecessary calls during aggregation
- [x] Adds `EventLoop` to `utils` to make easier to avoid blocking the event loop with long running synchronous tasks.
- [x] Adds `BigSet` to `utils` to allow creating sets with more than 16 millions keys.
- [x] Add `DataFrame->appendAll` method for creating a single data frame from many