### PR TITLE
Add support for DataFrame->search(query)

### DIFF
--- a/packages/data-mate/bench/data-frame-search-suite.js
+++ b/packages/data-mate/bench/data-frame-search-suite.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { Suite } = require('./helpers');
+const { config, data } = require('./fixtures/data.json');
+const { DataFrame } = require('./src');
+
+const run = async () => {
+    const suite = Suite('Search');
+
+    const dataFrame = DataFrame.fromJSON(config, data);
+    suite.add('using query: "age:<20"', {
+        fn() {
+            dataFrame.search('age:<20');
+        }
+    });
+
+    suite.add('using query: "age:>80 AND alive:false"', {
+        fn() {
+            dataFrame.search('age:>80 AND alive:false');
+        }
+    });
+
+    return suite.run({
+        async: true,
+        initCount: 2,
+        minSamples: 2,
+        maxTime: 20,
+    });
+};
+if (require.main === module) {
+    run().then((suite) => {
+        suite.on('complete', () => {});
+    });
+} else {
+    module.exports = run;
+}

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.22.2",
+    "version": "0.23.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -50,7 +50,7 @@
         "uuid": "^8.3.2",
         "valid-url": "^1.0.9",
         "validator": "^13.5.2",
-        "xlucene-parser": "^0.33.2"
+        "xlucene-parser": "^0.34.0"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.1",

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -1,6 +1,8 @@
 import {
     DataTypeConfig, ReadonlyDataTypeConfig,
-    Maybe, SortOrder, FieldType, DataTypeFields, DataTypeFieldConfig
+    Maybe, SortOrder, FieldType,
+    DataTypeFields, DataTypeFieldConfig,
+    xLuceneVariables
 } from '@terascope/types';
 import {
     DataEntity, TSError,
@@ -322,6 +324,13 @@ export class DataFrame<
     sort(...fieldArgs: FieldArg<keyof T>[]): DataFrame<T>;
     sort(...fieldArgs: (FieldArg<keyof T>[]|FieldArg<string>[])): DataFrame<T> {
         return this.orderBy(...fieldArgs);
+    }
+
+    /**
+     * Search the DataFrame using an xLucene query
+    */
+    search(_query: string, _variables?: xLuceneVariables): DataFrame<T> {
+        return this;
     }
 
     /**

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -26,6 +26,7 @@ import {
 } from '../core';
 import { getMaxColumnSize } from '../aggregation-frame/utils';
 import { SerializeOptions, Vector } from '../vector';
+import { buildSearchMatcherForQuery } from './search-utils';
 
 /**
  * An immutable columnar table with APIs for data pipelines.
@@ -329,8 +330,9 @@ export class DataFrame<
     /**
      * Search the DataFrame using an xLucene query
     */
-    search(_query: string, _variables?: xLuceneVariables): DataFrame<T> {
-        return this;
+    search(query: string, variables?: xLuceneVariables): DataFrame<T> {
+        const matcher = buildSearchMatcherForQuery(this, query, variables);
+        return this.filterBy(matcher);
     }
 
     /**

--- a/packages/data-mate/src/data-frame/search-utils.ts
+++ b/packages/data-mate/src/data-frame/search-utils.ts
@@ -1,10 +1,26 @@
+import { DataType } from '@terascope/data-types';
+import { xLuceneTypeConfig, xLuceneVariables } from '@terascope/types';
 import * as p from 'xlucene-parser';
+import type { BooleanCB } from '../document-matcher/interfaces';
+import buildLogicFn from '../document-matcher/logic-builder';
+import type { DataFrame } from './DataFrame';
 
-export function makeNodeWalker() {
-    return function astWalker(node: p.Node): boolean {
-        if (p.isTermType(node)) {
-            return true;
-        }
-        return false;
-    };
+export function buildSearchMatcherForQuery(
+    frame: DataFrame<any>,
+    query: string,
+    variables?: xLuceneVariables
+): BooleanCB {
+    const parser = new p.Parser(query, { type_config: frameToXluceneConfig(frame) });
+    if (variables) {
+        return buildLogicFn(
+            parser.resolveVariables(variables),
+            variables
+        );
+    }
+    return buildLogicFn(parser);
+}
+
+function frameToXluceneConfig(frame: DataFrame<any>): xLuceneTypeConfig {
+    const dataType = new DataType(frame.config);
+    return dataType.toXlucene();
 }

--- a/packages/data-mate/src/data-frame/search-utils.ts
+++ b/packages/data-mate/src/data-frame/search-utils.ts
@@ -1,0 +1,10 @@
+import * as p from 'xlucene-parser';
+
+export function makeNodeWalker() {
+    return function astWalker(node: p.Node): boolean {
+        if (p.isTermType(node)) {
+            return true;
+        }
+        return false;
+    };
+}

--- a/packages/data-mate/src/document-matcher/logic-builder/dates.ts
+++ b/packages/data-mate/src/document-matcher/logic-builder/dates.ts
@@ -7,6 +7,7 @@ import {
     isInfiniteMax, isInfiniteMin, ParsedRange
 } from 'xlucene-parser';
 import { BooleanCB } from '../interfaces';
+import { DateValue } from '../../core';
 
 // TODO: handle datemath
 
@@ -54,7 +55,7 @@ export function dateRange(
     // verify it won't fail
     isWithinInterval(new Date(), interval);
 
-    return function dateRangeTerm(date: string): boolean {
+    return function dateRangeTerm(date: DateValue|string): boolean {
         const result = convertDate(date, 0, false);
         if (!result) return false;
 
@@ -66,10 +67,12 @@ export function dateRange(
     };
 }
 
-function convertDate(val: any, inclusive: number, throwErr: false): Date|undefined;
-function convertDate(val: any, inclusive: number, throwErr: true): Date;
-function convertDate(val: any, inclusive: number, throwErr: boolean): Date|undefined {
-    const result = getValidDate(val);
+function convertDate(val: unknown, inclusive: number, throwErr: false): Date|undefined;
+function convertDate(val: unknown, inclusive: number, throwErr: true): Date;
+function convertDate(val: unknown, inclusive: number, throwErr: boolean): Date|undefined {
+    if (val instanceof DateValue) return new Date(val.value);
+
+    const result = getValidDate(val as any);
     if (result) return handleInclusive(result, inclusive);
 
     if (throwErr) throw new Error(`Invalid date format ${val}`);

--- a/packages/data-mate/src/document-matcher/logic-builder/index.ts
+++ b/packages/data-mate/src/document-matcher/logic-builder/index.ts
@@ -96,11 +96,11 @@ function isFalse() {
 }
 
 function walkAst(
-    node: p.AnyAST,
+    node: p.Node,
     typeConfig: xLuceneTypeConfig,
     variables: xLuceneVariables,
 ): BooleanCB {
-    if (p.isEmptyAST(node)) {
+    if (p.isEmptyNode(node)) {
         return isFalse;
     }
 
@@ -206,7 +206,7 @@ function makeConjunctionFn(
 }
 
 function makeGroupFn(
-    node: p.GroupLikeAST,
+    node: p.GroupLikeNode,
     typeConfig: xLuceneTypeConfig,
     variables: xLuceneVariables,
 ) {

--- a/packages/data-mate/src/document-matcher/logic-builder/index.ts
+++ b/packages/data-mate/src/document-matcher/logic-builder/index.ts
@@ -10,10 +10,9 @@ import { ipTerm, ipRange } from './ip';
 
 export default function buildLogicFn(
     parser: p.Parser,
-    typeConfig: xLuceneTypeConfig = {},
     variables: xLuceneVariables = {}
 ): BooleanCB {
-    return walkAst(parser.ast, typeConfig, variables);
+    return walkAst(parser.ast, parser.typeConfig, variables);
 }
 
 function makeGetFn(field?: string) {

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -1233,10 +1233,50 @@ describe('DataFrame', () => {
                         name: 'Jill',
                         age: 39,
                         friends: ['Frank'],
-                        merged: ['Jill', 39, ['Frank']]
                     }
                 ]);
                 expect(resultFrame.id).not.toEqual(peopleDataFrame.id);
+            });
+
+            it('should find a value in the friends list', () => {
+                const resultFrame = peopleDataFrame.search('friends:Frank');
+
+                expect(resultFrame.toJSON()).toEqual([
+                    {
+                        name: 'Jill',
+                        age: 39,
+                        friends: ['Frank'],
+                    }
+                ]);
+            });
+
+            it('should return nothing if the value cannot be found', () => {
+                const resultFrame = peopleDataFrame.search('friends:Missing');
+
+                expect(resultFrame.size).toBe(0);
+            });
+
+            it('should be able to match the age using a range', () => {
+                const resultFrame = peopleDataFrame
+                    .search('age:>30')
+                    .select('name', 'age');
+
+                expect(resultFrame.toJSON()).toEqual([
+                    { name: 'Jill', age: 39 },
+                    { name: 'Billy', age: 47 },
+                ]);
+            });
+
+            it('should be able to match using a complicated conjunction', () => {
+                const resultFrame = peopleDataFrame
+                    .search('age:>30 OR (name:Nancy AND age:<30)')
+                    .select('name', 'age');
+
+                expect(resultFrame.toJSON()).toEqual([
+                    { name: 'Jill', age: 39 },
+                    { name: 'Billy', age: 47 },
+                    { name: 'Nancy', age: 10 }
+                ]);
             });
         });
     });

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -1223,5 +1223,21 @@ describe('DataFrame', () => {
                 expect(resultFrame.id).toEqual(peopleDataFrame.id);
             });
         });
+
+        describe('->search', () => {
+            it('should be able find all the people by name', () => {
+                const resultFrame = peopleDataFrame.search('name:Jill');
+
+                expect(resultFrame.toJSON()).toEqual([
+                    {
+                        name: 'Jill',
+                        age: 39,
+                        friends: ['Frank'],
+                        merged: ['Jill', 39, ['Frank']]
+                    }
+                ]);
+                expect(resultFrame.id).not.toEqual(peopleDataFrame.id);
+            });
+        });
     });
 });

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -1267,6 +1267,16 @@ describe('DataFrame', () => {
                 ]);
             });
 
+            it('should be able to match the age using variables', () => {
+                const resultFrame = peopleDataFrame
+                    .search('age:$age', { age: 47 })
+                    .select('name', 'age');
+
+                expect(resultFrame.toJSON()).toEqual([
+                    { name: 'Billy', age: 47 },
+                ]);
+            });
+
             it('should be able to match using a complicated conjunction', () => {
                 const resultFrame = peopleDataFrame
                     .search('age:>30 OR (name:Nancy AND age:<30)')
@@ -1277,6 +1287,70 @@ describe('DataFrame', () => {
                     { name: 'Billy', age: 47 },
                     { name: 'Nancy', age: 10 }
                 ]);
+            });
+
+            describe('when matching special data types', () => {
+                type Special = {
+                    ip?: string;
+                    date?: string;
+                };
+
+                const specialDTConfig: DataTypeConfig = {
+                    version: LATEST_VERSION,
+                    fields: {
+                        ip: { type: FieldType.IP },
+                        date: { type: FieldType.Date },
+                    }
+                };
+                let specialDataFrame: DataFrame<Special>;
+
+                beforeAll(() => {
+                    specialDataFrame = DataFrame.fromJSON<Special>(specialDTConfig, [
+                        { ip: '127.0.0.1', date: '2000-01-04T00:00:00.000Z' },
+                        { ip: '10.0.0.2', date: '2002-01-02T00:00:00.000Z' },
+                        { ip: '192.198.0.1', date: '1999-12-01T00:00:00.000Z' },
+                    ]);
+                });
+
+                it('should be able to match using a IP values', () => {
+                    const resultFrame = specialDataFrame
+                        .search('ip:127.0.0.1')
+                        .select('ip');
+
+                    expect(resultFrame.toJSON()).toEqual([
+                        { ip: '127.0.0.1' },
+                    ]);
+                });
+
+                it('should be able to match using a IP range', () => {
+                    const resultFrame = specialDataFrame
+                        .search('ip:"192.198.0.0/24"')
+                        .select('ip');
+
+                    expect(resultFrame.toJSON()).toEqual([
+                        { ip: '192.198.0.1' },
+                    ]);
+                });
+
+                it('should be able to match using a date values', () => {
+                    const resultFrame = specialDataFrame
+                        .search('date:"2000-01-04T00:00:00.000Z"')
+                        .select('date');
+
+                    expect(resultFrame.toJSON()).toEqual([
+                        { date: '2000-01-04T00:00:00.000Z' },
+                    ]);
+                });
+
+                it('should be able to match using a date range', () => {
+                    const resultFrame = specialDataFrame
+                        .search('date:[2001-01-01T00:00:00.000Z TO 2005-01-01T00:00:00.000Z]')
+                        .select('date');
+
+                    expect(resultFrame.toJSON()).toEqual([
+                        { date: '2002-01-02T00:00:00.000Z' },
+                    ]);
+                });
             });
         });
     });

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -1291,6 +1291,16 @@ describe('DataFrame', () => {
                 ]);
             });
 
+            it('should work with nested objects', () => {
+                const resultFrame = deepObjDataFrame
+                    .search('config.owner.id:config-owner-1')
+                    .select('_key');
+
+                expect(resultFrame.toJSON()).toEqual([
+                    { _key: 'id-1' }
+                ]);
+            });
+
             describe('when matching special data types', () => {
                 type Special = {
                     ip?: string;

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.43.2",
+    "version": "0.44.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,13 +24,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.22.2",
+        "@terascope/data-mate": "^0.23.0",
         "@terascope/data-types": "^0.27.2",
         "@terascope/types": "^0.7.1",
         "@terascope/utils": "^0.36.2",
         "ajv": "^6.12.6",
         "uuid": "^8.3.2",
-        "xlucene-translator": "^0.17.2"
+        "xlucene-translator": "^0.18.0"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.0",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.51.3",
+    "version": "0.52.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.22.2",
+        "@terascope/data-mate": "^0.23.0",
         "@terascope/types": "^0.7.1",
         "@terascope/utils": "^0.36.2",
         "awesome-phonenumber": "^2.43.0",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.33.2",
+    "version": "0.34.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-parser/src/context.ts
+++ b/packages/xlucene-parser/src/context.ts
@@ -34,7 +34,7 @@ export function makeContext(arg: i.ContextArg) {
     /**
     * Propagate the default field on a field group expression
     */
-    function propagateDefaultField(node: i.AnyAST, field: string): void {
+    function propagateDefaultField(node: i.Node, field: string): void {
         if (!node) return;
 
         if (utils.isRange(node)) {
@@ -88,10 +88,10 @@ export function makeContext(arg: i.ContextArg) {
     }
 
     // parse an inferred field type
-    function parseInferredTermType(field: string, value: any): i.TermLikeAST {
+    function parseInferredTermType(field: string, value: any): i.TermLikeNode {
         const fieldType = getFieldType(field);
         const term: any = {
-            type: i.ASTType.Term,
+            type: i.NodeType.Term,
             field_type: fieldType,
         };
 
@@ -151,7 +151,7 @@ export function makeContext(arg: i.ContextArg) {
             `coercing field "${field}":${value} type of ${node.field_type} to ${fieldType}`
         );
 
-        if (node.type === i.ASTType.Term && fieldType === xLuceneFieldType.IPRange) {
+        if (node.type === i.NodeType.Term && fieldType === xLuceneFieldType.IPRange) {
             Object.assign(node, utils.createIPRangeFromTerm(node, value));
             return;
         }

--- a/packages/xlucene-parser/src/interfaces.ts
+++ b/packages/xlucene-parser/src/interfaces.ts
@@ -10,37 +10,33 @@ export interface ContextArg {
     variables?: t.xLuceneVariables;
 }
 
-export type AST = EmptyAST | LogicalGroup | Term
-| Conjunction | Negation | FieldGroup
-| Exists | Range | Regexp | Wildcard
-| FunctionNode | TermList;
-
-export type AnyAST = AST;
-
 export type GroupLike = FieldGroup|LogicalGroup;
-export type GroupLikeType = ASTType.LogicalGroup|ASTType.FieldGroup;
+export type GroupLikeType = NodeType.LogicalGroup|NodeType.FieldGroup;
 
-export interface GroupLikeAST {
+export interface Node {
+    type: NodeType;
+}
+
+export interface GroupLikeNode extends Node {
     type: GroupLikeType;
     flow: Conjunction[];
 }
 
-export type TermLike = Term|Regexp|Range|Wildcard|FunctionNode|TermList;
 export type TermLikeType =
-    ASTType.Term|
-    ASTType.Regexp|
-    ASTType.Range|
-    ASTType.Wildcard|
-    ASTType.Function|
-    ASTType.TermList;
+    NodeType.Term|
+    NodeType.Regexp|
+    NodeType.Range|
+    NodeType.Wildcard|
+    NodeType.Function|
+    NodeType.TermList;
 
-export interface TermLikeAST {
+export interface TermLikeNode extends Node {
     type: TermLikeType;
     field: Field;
     analyzed?: boolean;
 }
 
-export enum ASTType {
+export enum NodeType {
     LogicalGroup = 'logical-group',
     FieldGroup = 'field-group',
     Conjunction = 'conjunction',
@@ -55,11 +51,8 @@ export enum ASTType {
     TermList = 'term-list',
 }
 
-export interface EmptyAST {
-    type: ASTType.Empty;
-    // we need this type for typescript to
-    // detect the union correctly
-    __empty?: boolean;
+export interface EmptyNode extends Node {
+    type: NodeType.Empty;
 }
 
 export type Field = string|null;
@@ -73,8 +66,8 @@ export type FieldValue<T> = {
     value: string;
 };
 
-export interface TermList extends TermLikeAST {
-    type: ASTType.TermList;
+export interface TermList extends TermLikeNode {
+    type: NodeType.TermList;
     value: FieldValue<any>[];
 }
 
@@ -104,49 +97,34 @@ export interface BooleanDataType {
     value: FieldValue<boolean>;
 }
 
-export interface LogicalGroup extends GroupLikeAST {
-    type: ASTType.LogicalGroup;
-    // we need this type for typescript to
-    // detect the union correctly
-    __logical_group?: boolean;
+export interface LogicalGroup extends GroupLikeNode {
+    type: NodeType.LogicalGroup;
 }
 
-export interface Conjunction {
-    type: ASTType.Conjunction;
-    nodes: AST[];
-    // we need this type for typescript to
-    // detect the union correctly
-    __conjunction?: boolean;
+export interface Conjunction extends Node {
+    type: NodeType.Conjunction;
+    nodes: Node[];
 }
 
-export interface Negation {
-    type: ASTType.Negation;
-    node: AST;
-    // we need this type for typescript to
-    // detect the union correctly
-    __negation?: boolean;
+export interface Negation extends Node {
+    type: NodeType.Negation;
+    node: Node;
 }
 
-export interface FieldGroup extends GroupLikeAST {
-    type: ASTType.FieldGroup;
+export interface FieldGroup extends GroupLikeNode {
+    type: NodeType.FieldGroup;
     field_type: t.xLuceneFieldType;
     field: string;
-    // we need this type for typescript to
-    // detect the union correctly
-    __field_group?: boolean;
 }
 
-export interface Exists {
-    type: ASTType.Exists;
+export interface Exists extends Node {
+    type: NodeType.Exists;
     field: string;
-    // we need this type for typescript to
-    // detect the union correctly
-    __exists?: boolean;
 }
 
 export type RangeOperator = 'gte'|'gt'|'lt'|'lte';
-export interface Range extends TermLikeAST {
-    type: ASTType.Range;
+export interface Range extends TermLikeNode {
+    type: NodeType.Range;
     field_type: t.xLuceneFieldType;
     left: RangeNode;
     right?: RangeNode;
@@ -166,38 +144,26 @@ export interface RangeNode {
     value: FieldValue<number|string>;
 }
 
-export interface FunctionNode extends TermLikeAST {
-    type: ASTType.Function;
+export interface FunctionNode extends TermLikeNode {
+    type: NodeType.Function;
     /**
      * The name of the function
     */
     name: string;
     description?: string;
     params: (Term|TermList)[];
-    // we need this type for typescript to
-    // detect the union correctly
-    __function?: boolean;
 }
 
-export interface Regexp extends StringDataType, TermLikeAST {
-    type: ASTType.Regexp;
-    // we need this type for typescript to
-    // detect the union correctly
-    __regexp?: boolean;
+export interface Regexp extends StringDataType, TermLikeNode {
+    type: NodeType.Regexp;
 }
 
-export interface Wildcard extends StringDataType, TermLikeAST {
-    type: ASTType.Wildcard;
-    // we need this type for typescript to
-    // detect the union correctly
-    __wildcard?: boolean;
+export interface Wildcard extends StringDataType, TermLikeNode {
+    type: NodeType.Wildcard;
 }
 
-export interface Term extends AnyDataType, TermLikeAST {
-    type: ASTType.Term;
-    // we need this type for typescript to
-    // detect the union correctly
-    __term?: boolean;
+export interface Term extends AnyDataType, TermLikeNode {
+    type: NodeType.Term;
 }
 
 export interface FunctionConfig {

--- a/packages/xlucene-parser/src/utils.ts
+++ b/packages/xlucene-parser/src/utils.ts
@@ -24,45 +24,45 @@ import * as i from './interfaces';
 
 export const logger = debugLogger('xlucene-parser');
 
-function _getType(node: unknown): i.ASTType|undefined {
+function _getType(node: unknown): i.NodeType|undefined {
     if (!node || typeof node !== 'object') return;
     return (node as any).type || undefined;
 }
 
 export function isLogicalGroup(node: unknown): node is i.LogicalGroup {
-    return _getType(node) === i.ASTType.LogicalGroup;
+    return _getType(node) === i.NodeType.LogicalGroup;
 }
 
 export function isConjunction(node: unknown): node is i.Conjunction {
-    return _getType(node) === i.ASTType.Conjunction;
+    return _getType(node) === i.NodeType.Conjunction;
 }
 
 export function isNegation(node: unknown): node is i.Negation {
-    return _getType(node) === i.ASTType.Negation;
+    return _getType(node) === i.NodeType.Negation;
 }
 
 export function isFieldGroup(node: unknown): node is i.FieldGroup {
-    return _getType(node) === i.ASTType.FieldGroup;
+    return _getType(node) === i.NodeType.FieldGroup;
 }
 
 export function isExists(node: unknown): node is i.Exists {
-    return _getType(node) === i.ASTType.Exists;
+    return _getType(node) === i.NodeType.Exists;
 }
 
 export function isRange(node: unknown): node is i.Range {
-    return _getType(node) === i.ASTType.Range;
+    return _getType(node) === i.NodeType.Range;
 }
 
 export function isFunctionNode(node: unknown): node is i.FunctionNode {
-    return _getType(node) === i.ASTType.Function;
+    return _getType(node) === i.NodeType.Function;
 }
 
 export function isRegexp(node: unknown): node is i.Regexp {
-    return _getType(node) === i.ASTType.Regexp;
+    return _getType(node) === i.NodeType.Regexp;
 }
 
 export function isWildcard(node: unknown): node is i.Wildcard {
-    return _getType(node) === i.ASTType.Wildcard;
+    return _getType(node) === i.NodeType.Wildcard;
 }
 
 export function isWildcardField(node: unknown): boolean {
@@ -70,11 +70,15 @@ export function isWildcardField(node: unknown): boolean {
 }
 
 export function isTerm(node: unknown): node is i.Term {
-    return _getType(node) === i.ASTType.Term;
+    return _getType(node) === i.NodeType.Term;
 }
 
-export function isEmptyAST(node: unknown): node is i.EmptyAST {
-    return isEmpty(node) || (_getType(node) === i.ASTType.Empty);
+export function isTermList(node: unknown): node is i.TermList {
+    return _getType(node) === i.NodeType.TermList;
+}
+
+export function isEmptyNode(node: unknown): node is i.EmptyNode {
+    return isEmpty(node) || (_getType(node) === i.NodeType.Empty);
 }
 
 export function isStringDataType(node: unknown): node is i.StringDataType {
@@ -100,23 +104,23 @@ export function getField(node: unknown): string|undefined {
 }
 
 /** term level queries with field (string|null)  */
-export const termTypes: readonly i.ASTType[] = [
-    i.ASTType.Term,
-    i.ASTType.Regexp,
-    i.ASTType.Range,
-    i.ASTType.Wildcard,
-    i.ASTType.Function,
-    i.ASTType.TermList,
+export const termTypes: readonly i.NodeType[] = [
+    i.NodeType.Term,
+    i.NodeType.Regexp,
+    i.NodeType.Range,
+    i.NodeType.Wildcard,
+    i.NodeType.Function,
+    i.NodeType.TermList,
 ];
 
-export function isTermType(node: unknown): node is i.TermLike {
+export function isTermType(node: unknown): node is i.TermLikeNode {
     return !!(node && termTypes.includes((node as any).type));
 }
 
 /** logical group or field group with flow */
-export const groupTypes: i.ASTType[] = [i.ASTType.LogicalGroup, i.ASTType.FieldGroup];
+export const groupTypes: i.NodeType[] = [i.NodeType.LogicalGroup, i.NodeType.FieldGroup];
 
-export function isGroupLike(node: unknown): node is i.GroupLikeAST {
+export function isGroupLike(node: unknown): node is i.GroupLikeNode {
     return !!(node && groupTypes.includes((node as any).type));
 }
 
@@ -266,7 +270,7 @@ export function createIPRangeFromTerm(node: i.Term, value: string): i.Range {
     const { start, end } = parseIPRange(value);
 
     return {
-        type: i.ASTType.Range,
+        type: i.NodeType.Range,
         field: node.field,
         field_type: node.field_type,
         left: {

--- a/packages/xlucene-parser/test/cases/empty.ts
+++ b/packages/xlucene-parser/test/cases/empty.ts
@@ -1,8 +1,8 @@
-import { ASTType } from '../../src';
+import { NodeType } from '../../src';
 import { TestCase } from './interfaces';
 
 export default [
     ['', 'an empty query', {
-        type: ASTType.Empty,
+        type: NodeType.Empty,
     }],
 ] as TestCase[];

--- a/packages/xlucene-parser/test/cases/exists.ts
+++ b/packages/xlucene-parser/test/cases/exists.ts
@@ -1,9 +1,9 @@
-import { ASTType } from '../../src';
+import { Exists, NodeType } from '../../src';
 import { TestCase } from './interfaces';
 
 export default [
     ['_exists_:hello', '_exists_ with a value', {
-        type: ASTType.Exists,
+        type: NodeType.Exists,
         field: 'hello',
-    }],
+    } as Exists],
 ] as TestCase[];

--- a/packages/xlucene-parser/test/cases/field-group.ts
+++ b/packages/xlucene-parser/test/cases/field-group.ts
@@ -1,17 +1,17 @@
 import { xLuceneFieldType } from '@terascope/types';
-import { ASTType } from '../../src';
+import { FieldGroup, NodeType, Term } from '../../src';
 import { TestCase } from './interfaces';
 
 export default [
     ['count:(>=10 AND <=20 AND >=100)', 'a field group expression with ranges', {
-        type: ASTType.FieldGroup,
+        type: NodeType.FieldGroup,
         field: 'count',
         flow: [
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Range,
+                        type: NodeType.Range,
                         field: 'count',
                         left: {
                             operator: 'gte',
@@ -20,7 +20,7 @@ export default [
                         }
                     },
                     {
-                        type: ASTType.Range,
+                        type: NodeType.Range,
                         field: 'count',
                         left: {
                             operator: 'lte',
@@ -29,7 +29,7 @@ export default [
                         }
                     },
                     {
-                        type: ASTType.Range,
+                        type: NodeType.Range,
                         field: 'count',
                         left: {
                             operator: 'gte',
@@ -42,14 +42,14 @@ export default [
         ]
     }],
     ['count:(>=$foo AND <=$bar AND >=$baz)', 'a field group expression with ranges with variables', {
-        type: ASTType.FieldGroup,
+        type: NodeType.FieldGroup,
         field: 'count',
         flow: [
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Range,
+                        type: NodeType.Range,
                         field: 'count',
                         left: {
                             operator: 'gte',
@@ -58,7 +58,7 @@ export default [
                         }
                     },
                     {
-                        type: ASTType.Range,
+                        type: NodeType.Range,
                         field: 'count',
                         left: {
                             operator: 'lte',
@@ -67,7 +67,7 @@ export default [
                         }
                     },
                     {
-                        type: ASTType.Range,
+                        type: NodeType.Range,
                         field: 'count',
                         left: {
                             operator: 'gte',
@@ -80,14 +80,14 @@ export default [
         ]
     }, { count: xLuceneFieldType.Integer }],
     ['count:(>=10 OR <=20 OR >=100)', 'a chained OR field group expression with ranges', {
-        type: ASTType.FieldGroup,
+        type: NodeType.FieldGroup,
         field: 'count',
         flow: [
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Range,
+                        type: NodeType.Range,
                         field: 'count',
                         left: {
                             operator: 'gte',
@@ -98,10 +98,10 @@ export default [
                 ]
             },
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Range,
+                        type: NodeType.Range,
                         field: 'count',
                         left: {
                             operator: 'lte',
@@ -112,10 +112,10 @@ export default [
                 ]
             },
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Range,
+                        type: NodeType.Range,
                         field: 'count',
                         left: {
                             operator: 'gte',
@@ -128,34 +128,34 @@ export default [
         ]
     }],
     ['id: (AqMvPMCS76u0 OR 497qIZuha9_u OR Oc2DG0O2gbcY)', 'chained ORs with restricted strings', {
-        type: ASTType.FieldGroup,
+        type: NodeType.FieldGroup,
         field: 'id',
         flow: [
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field_type: xLuceneFieldType.String,
                         value: { type: 'value', value: 'AqMvPMCS76u0', },
                     }
                 ]
             },
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field_type: xLuceneFieldType.String,
                         value: { type: 'value', value: '497qIZuha9_u', },
                     }
                 ]
             },
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field_type: xLuceneFieldType.String,
                         value: { type: 'value', value: 'Oc2DG0O2gbcY', },
                     }
@@ -164,23 +164,23 @@ export default [
         ]
     }],
     ['name:(Bob* OR Joe*)', 'chained ORs with wildcards', {
-        type: ASTType.FieldGroup,
+        type: NodeType.FieldGroup,
         field: 'name',
         flow: [
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Wildcard,
+                        type: NodeType.Wildcard,
                         value: { type: 'value', value: 'Bob*', },
                     }
                 ]
             },
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Wildcard,
+                        type: NodeType.Wildcard,
                         value: { type: 'value', value: 'Joe*', },
                     }
                 ]
@@ -188,14 +188,14 @@ export default [
         ]
     }],
     ['count:(155 "223")', 'implicit OR grouping', {
-        type: ASTType.FieldGroup,
+        type: NodeType.FieldGroup,
         field: 'count',
         flow: [
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field: 'count',
                         field_type: xLuceneFieldType.Integer,
                         value: { type: 'value', value: 155 },
@@ -203,10 +203,10 @@ export default [
                 ]
             },
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field: 'count',
                         field_type: xLuceneFieldType.String,
                         quoted: true,
@@ -217,14 +217,14 @@ export default [
         ]
     }],
     ['count:($foo $bar)', 'implicit OR grouping with variables', {
-        type: ASTType.FieldGroup,
+        type: NodeType.FieldGroup,
         field: 'count',
         flow: [
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field: 'count',
                         field_type: xLuceneFieldType.Integer,
                         value: { type: 'variable', value: 'foo' },
@@ -232,10 +232,10 @@ export default [
                 ]
             },
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field: 'count',
                         field_type: xLuceneFieldType.Integer,
                         value: { type: 'variable', value: 'bar' },
@@ -248,14 +248,14 @@ export default [
         'count:(155 OR "223")',
         'OR grouping with quoted and unquoted integers',
         {
-            type: ASTType.FieldGroup,
+            type: NodeType.FieldGroup,
             field: 'count',
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'count',
                             field_type: xLuceneFieldType.Integer,
                             value: { type: 'value', value: 155 },
@@ -263,10 +263,10 @@ export default [
                     ]
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'count',
                             field_type: xLuceneFieldType.Integer,
                             value: { type: 'value', value: 223 },
@@ -283,14 +283,14 @@ export default [
         'count:($foo OR $bar)',
         'OR grouping with quoted and unquoted integers with variables',
         {
-            type: ASTType.FieldGroup,
+            type: NodeType.FieldGroup,
             field: 'count',
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'count',
                             field_type: xLuceneFieldType.Integer,
                             value: { type: 'variable', value: 'foo' },
@@ -298,10 +298,10 @@ export default [
                     ]
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'count',
                             field_type: xLuceneFieldType.Integer,
                             value: { type: 'variable', value: 'bar' },
@@ -318,14 +318,14 @@ export default [
         'bool:(true OR "false")',
         'OR grouping with quoted and unquoted booleans',
         {
-            type: ASTType.FieldGroup,
+            type: NodeType.FieldGroup,
             field: 'bool',
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'bool',
                             field_type: xLuceneFieldType.Boolean,
                             value: { type: 'value', value: true },
@@ -333,10 +333,10 @@ export default [
                     ]
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'bool',
                             field_type: xLuceneFieldType.Boolean,
                             value: { type: 'value', value: false },
@@ -350,26 +350,26 @@ export default [
         }
     ],
     ['example:("foo" AND ("bar" OR "baz"))', 'implicit or grouping', {
-        type: ASTType.FieldGroup,
+        type: NodeType.FieldGroup,
         field: 'example',
         flow: [
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field: 'example',
                         field_type: xLuceneFieldType.String,
                         value: { type: 'value', value: 'foo' },
                     },
                     {
-                        type: ASTType.LogicalGroup,
+                        type: NodeType.LogicalGroup,
                         flow: [
                             {
-                                type: ASTType.Conjunction,
+                                type: NodeType.Conjunction,
                                 nodes: [
                                     {
-                                        type: ASTType.Term,
+                                        type: NodeType.Term,
                                         field: 'example',
                                         field_type: xLuceneFieldType.String,
                                         value: { type: 'value', value: 'bar' },
@@ -377,10 +377,10 @@ export default [
                                 ]
                             },
                             {
-                                type: ASTType.Conjunction,
+                                type: NodeType.Conjunction,
                                 nodes: [
                                     {
-                                        type: ASTType.Term,
+                                        type: NodeType.Term,
                                         field: 'example',
                                         field_type: xLuceneFieldType.String,
                                         value: { type: 'value', value: 'baz' },
@@ -394,20 +394,20 @@ export default [
         ]
     }],
     ['example:("foo" AND other:"bar")', 'implicit or grouping', {
-        type: ASTType.FieldGroup,
+        type: NodeType.FieldGroup,
         field: 'example',
         flow: [
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field_type: xLuceneFieldType.String,
                         field: 'example',
                         value: { type: 'value', value: 'foo' },
                     },
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field: 'other',
                         field_type: xLuceneFieldType.String,
                         value: { type: 'value', value: 'bar' },
@@ -417,23 +417,23 @@ export default [
         ]
     }],
     ['val:(NOT 1 AND 2)', 'negated field group', {
-        type: ASTType.FieldGroup,
+        type: NodeType.FieldGroup,
         field: 'val',
         flow: [
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Negation,
+                        type: NodeType.Negation,
                         node: {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'val',
                             field_type: xLuceneFieldType.Integer,
                             value: { type: 'value', value: 1, },
                         }
                     },
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field: 'val',
                         field_type: xLuceneFieldType.Integer,
                         value: { type: 'value', value: 2 },
@@ -443,23 +443,23 @@ export default [
         ]
     }],
     ['val:(NOT $foo AND $bar)', 'negated field group with variables', {
-        type: ASTType.FieldGroup,
+        type: NodeType.FieldGroup,
         field: 'val',
         flow: [
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Negation,
+                        type: NodeType.Negation,
                         node: {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'val',
                             field_type: xLuceneFieldType.Integer,
                             value: { type: 'variable', value: 'foo', },
                         }
                     },
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field: 'val',
                         field_type: xLuceneFieldType.Integer,
                         value: { type: 'variable', value: 'bar' },
@@ -469,28 +469,28 @@ export default [
         ]
     }, { val: xLuceneFieldType.Integer }],
     ['some_ref:("A")', 'single value field group', {
-        type: ASTType.Term,
+        type: NodeType.Term,
         field_type: xLuceneFieldType.String,
         field: 'some_ref',
         quoted: true,
         value: { type: 'value', value: 'A', },
     }],
     ["some_ref:('A')", 'single value field group', {
-        type: ASTType.Term,
+        type: NodeType.Term,
         field_type: xLuceneFieldType.String,
         field: 'some_ref',
         quoted: true,
         value: { type: 'value', value: 'A', },
     }],
     ['foo:(bar baz)', 'multi-value field group with no quotes', {
-        type: ASTType.FieldGroup,
+        type: NodeType.FieldGroup,
         field: 'foo',
         flow: [
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field: 'foo',
                         field_type: xLuceneFieldType.String,
                         value: { type: 'value', value: 'bar', },
@@ -498,10 +498,10 @@ export default [
                 ],
             },
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field: 'foo',
                         field_type: xLuceneFieldType.String,
                         value: { type: 'value', value: 'baz' },
@@ -511,47 +511,47 @@ export default [
         ]
     }],
     ['foo:(@bar OR @baz)', 'multi-value field group with no quotes and @', {
-        type: ASTType.FieldGroup,
+        type: NodeType.FieldGroup,
         field: 'foo',
         flow: [
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field: 'foo',
                         field_type: xLuceneFieldType.String,
                         value: { type: 'variable', scoped: true, value: '@bar', },
-                    },
+                    } as Term,
                 ],
             },
             {
-                type: ASTType.Conjunction,
+                type: NodeType.Conjunction,
                 nodes: [
                     {
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field: 'foo',
                         field_type: xLuceneFieldType.String,
                         value: { type: 'variable', scoped: true, value: '@baz' },
-                    }
+                    } as Term
                 ]
             }
         ]
-    }, {
+    } as Partial<FieldGroup>, {
         foo: xLuceneFieldType.String,
     }],
     [
         'val:(155 223)',
         'a field with parens unquoted integers',
         {
-            type: ASTType.FieldGroup,
+            type: NodeType.FieldGroup,
             field: 'val',
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'val',
                             field_type: xLuceneFieldType.Integer,
                             value: { type: 'value', value: 155, },
@@ -559,10 +559,10 @@ export default [
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'val',
                             field_type: xLuceneFieldType.Integer,
                             value: { type: 'value', value: 223 },

--- a/packages/xlucene-parser/test/cases/geo.ts
+++ b/packages/xlucene-parser/test/cases/geo.ts
@@ -1,4 +1,4 @@
-import { ASTType } from '../../src';
+import { FunctionNode, NodeType } from '../../src';
 import { TestCase } from './interfaces';
 
 export default [
@@ -6,7 +6,7 @@ export default [
         'location:geoDistance(point:"33.435518,-111.873616", distance:"5000m", third: "data")',
         'a geo distance query with point double quoted',
         {
-            type: ASTType.Function,
+            type: NodeType.Function,
             field: 'location',
             name: 'geoDistance'
         },
@@ -15,7 +15,7 @@ export default [
         'location:geoBox(bottom_right:"32.813646,-111.058902" top_left:"33.906320,-112.758421")',
         'a geo point query bottom right and top left',
         {
-            type: ASTType.Function,
+            type: NodeType.Function,
             field: 'location',
             name: 'geoBox'
         },
@@ -24,7 +24,7 @@ export default [
         'location:geoPolygon(points:["60.43,111.43", "70.3,123.4", "65.23,118.34"])',
         'a geo polygon query',
         {
-            type: ASTType.Function,
+            type: NodeType.Function,
             field: 'location',
             name: 'geoPolygon'
         },
@@ -33,7 +33,7 @@ export default [
         'location:geoPolygon(points:$points)',
         'a geo polygon query with a variable',
         {
-            type: ASTType.Function,
+            type: NodeType.Function,
             field: 'location',
             name: 'geoPolygon'
         },
@@ -44,10 +44,10 @@ export default [
         'location:geoPolygon(points:$points, relation: $relation)',
         'a geo polygon query with variables and commas',
         {
-            type: ASTType.Function,
+            type: NodeType.Function,
             field: 'location',
             name: 'geoPolygon'
-        },
+        } as FunctionNode,
         {},
         { points: ['60.43,111.43', '70.3,123.4', '65.23,118.34'], relation: 'within' }
     ]

--- a/packages/xlucene-parser/test/cases/interfaces.ts
+++ b/packages/xlucene-parser/test/cases/interfaces.ts
@@ -1,6 +1,6 @@
 import { xLuceneVariables, xLuceneTypeConfig } from '@terascope/types';
 
-import { AST } from '../../src';
+import { Node } from '../../src';
 
 export type TestCase = [
     // when give query %s
@@ -8,7 +8,7 @@ export type TestCase = [
     // it should be able to parse %s
     string,
     // toMatchObject(%j)
-    AST,
+    Partial<Node>,
     // Type config to pass in
     xLuceneTypeConfig?,
     xLuceneVariables?

--- a/packages/xlucene-parser/test/cases/logical-group.ts
+++ b/packages/xlucene-parser/test/cases/logical-group.ts
@@ -1,5 +1,5 @@
 import { xLuceneFieldType } from '@terascope/types';
-import { ASTType } from '../../src';
+import { FunctionNode, LogicalGroup, NodeType } from '../../src';
 import { TestCase } from './interfaces';
 
 export default [
@@ -7,18 +7,18 @@ export default [
         'a:1 AND b:1',
         'a simple AND conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'a',
                             value: { type: 'value', value: 1, },
                         },
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'b',
                             value: { type: 'value', value: 1, },
                         },
@@ -31,18 +31,18 @@ export default [
         'a:$foo AND b:$bar',
         'a simple AND conjunction with variables',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'a',
                             value: { type: 'variable', value: 'foo', },
                         },
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'b',
                             value: { type: 'variable', value: 'bar', },
                         },
@@ -56,18 +56,18 @@ export default [
         '(a:1 AND b:1)',
         'a simple AND conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'a',
                             value: { type: 'value', value: 1, },
                         },
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'b',
                             value: { type: 'value', value: 1, },
                         },
@@ -80,18 +80,18 @@ export default [
         'a:1 && b:1',
         'a simple && conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'a',
                             value: { type: 'value', value: 1, },
                         },
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'b',
                             value: { type: 'value', value: 1, },
                         },
@@ -104,23 +104,23 @@ export default [
         'a:1 OR b:1',
         'a simple OR conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'a',
                             value: { type: 'value', value: 1, },
                         },
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'b',
                             value: { type: 'value', value: 1, },
                         },
@@ -133,7 +133,7 @@ export default [
         'foo:$bar',
         'variable array substitution',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field: 'foo',
             value: { type: 'variable', value: 'bar', },
         },
@@ -145,35 +145,35 @@ export default [
         'foo:$bar',
         'variable array substitution',
         {
-            type: ASTType.FieldGroup,
+            type: NodeType.FieldGroup,
             field: 'foo',
             field_type: xLuceneFieldType.Integer,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.Integer,
                             value: { type: 'value', value: 1 },
                         }
                     ]
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.Integer,
                             value: { type: 'value', value: 2 },
                         }
                     ]
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.Integer,
                             value: { type: 'value', value: 3 },
                         }
@@ -192,23 +192,23 @@ export default [
         '(a:1 OR b:1)',
         'a simple OR conjunction with top-level parens',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'a',
                             value: { type: 'value', value: 1, },
                         },
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'b',
                             value: { type: 'value', value: 1, },
                         },
@@ -221,23 +221,23 @@ export default [
         'foo:"bar" fo?',
         'a implicit OR with wildcard',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'foo',
                             value: { type: 'value', value: 'bar', },
                         },
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Wildcard,
+                            type: NodeType.Wildcard,
                             field: null,
                             value: { type: 'value', value: 'fo?', },
                         },
@@ -250,23 +250,23 @@ export default [
         'a:1 || b:1',
         'a simple || conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'a',
                             value: { type: 'value', value: 1, },
                         },
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'b',
                             value: { type: 'value', value: 1, },
                         },
@@ -279,33 +279,33 @@ export default [
         'a:1 OR b:1 OR c:1',
         'a chained OR conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'a',
                             value: { type: 'value', value: 1, },
                         },
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'b',
                             value: { type: 'value', value: 1, },
                         },
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'c',
                             value: { type: 'value', value: 1, },
                         },
@@ -318,23 +318,23 @@ export default [
         'a:1 AND b:1 AND c:1',
         'a double chained AND conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'a',
                             value: { type: 'value', value: 1, },
                         },
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'b',
                             value: { type: 'value', value: 1, },
                         },
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'c',
                             value: { type: 'value', value: 1, },
                         },
@@ -350,20 +350,20 @@ export default [
             type: 'logical-group',
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.String,
                             value: { type: 'value', value: 'AqMvPMCS76u0', },
                         },
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.String,
                             value: { type: 'value', value: 'foo', },
                         },
@@ -376,43 +376,43 @@ export default [
         'a:1 OR b:1 OR c:1 AND d:1 AND e:1',
         'a chained AND/OR conjunctions',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'a',
                             value: { type: 'value', value: 1, },
                         },
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'b',
                             value: { type: 'value', value: 1, },
                         },
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'c',
                             value: { type: 'value', value: 1, },
                         },
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'd',
                             value: { type: 'value', value: 1, },
                         },
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'e',
                             value: { type: 'value', value: 1, },
                         },
@@ -425,13 +425,13 @@ export default [
         'foo "bar"',
         'implicit OR conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.String,
                             restricted: true,
                             field: null,
@@ -440,10 +440,10 @@ export default [
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.String,
                             field: null,
                             quoted: true,
@@ -458,13 +458,13 @@ export default [
         '"foo" bar:baz',
         'implicit OR conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.String,
                             field: null,
                             quoted: true,
@@ -473,10 +473,10 @@ export default [
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.String,
                             field: 'bar',
                             value: { type: 'value', value: 'baz', },
@@ -490,13 +490,13 @@ export default [
         'hi:"foo" hello:"bar"',
         'implicit OR conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.String,
                             field: 'hi',
                             quoted: true,
@@ -505,10 +505,10 @@ export default [
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.String,
                             field: 'hello',
                             quoted: true,
@@ -523,13 +523,13 @@ export default [
         ' foo:   bar baz',
         'field and space between multiple values into a conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.String,
                             field: 'foo',
                             quoted: false,
@@ -538,10 +538,10 @@ export default [
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.String,
                             field: null,
                             quoted: false,
@@ -556,34 +556,34 @@ export default [
         'a:1 AND (b:1 OR c:1) AND d:1',
         'AND/OR conjunction with parens',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'a',
                             value: { type: 'value', value: 1, },
                         },
                         {
-                            type: ASTType.LogicalGroup,
+                            type: NodeType.LogicalGroup,
                             flow: [
                                 {
-                                    type: ASTType.Conjunction,
+                                    type: NodeType.Conjunction,
                                     nodes: [
                                         {
-                                            type: ASTType.Term,
+                                            type: NodeType.Term,
                                             field: 'b',
                                             value: { type: 'value', value: 1, },
                                         },
                                     ],
                                 },
                                 {
-                                    type: ASTType.Conjunction,
+                                    type: NodeType.Conjunction,
                                     nodes: [
                                         {
-                                            type: ASTType.Term,
+                                            type: NodeType.Term,
                                             field: 'c',
                                             value: { type: 'value', value: 1, },
                                         },
@@ -592,7 +592,7 @@ export default [
                             ],
                         },
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'd',
                             value: { type: 'value', value: 1, },
                         },
@@ -605,16 +605,16 @@ export default [
         '(a:1 OR b:1) AND (c:1 OR d:1)',
         'AND/OR conjunction with two parens',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.LogicalGroup,
+                            type: NodeType.LogicalGroup,
                             flow: [
                                 {
-                                    type: ASTType.Conjunction,
+                                    type: NodeType.Conjunction,
                                     nodes: [
                                         {
                                             field_type: xLuceneFieldType.Integer,
@@ -624,7 +624,7 @@ export default [
                                     ],
                                 },
                                 {
-                                    type: ASTType.Conjunction,
+                                    type: NodeType.Conjunction,
                                     nodes: [
                                         {
                                             field_type: xLuceneFieldType.Integer,
@@ -636,10 +636,10 @@ export default [
                             ],
                         },
                         {
-                            type: ASTType.LogicalGroup,
+                            type: NodeType.LogicalGroup,
                             flow: [
                                 {
-                                    type: ASTType.Conjunction,
+                                    type: NodeType.Conjunction,
                                     nodes: [
                                         {
                                             field_type: xLuceneFieldType.Integer,
@@ -649,7 +649,7 @@ export default [
                                     ],
                                 },
                                 {
-                                    type: ASTType.Conjunction,
+                                    type: NodeType.Conjunction,
                                     nodes: [
                                         {
                                             field_type: xLuceneFieldType.Integer,
@@ -669,18 +669,18 @@ export default [
         '(a:1) AND (b:1)',
         'a simple AND with parens conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'a',
                             value: { type: 'value', value: 1, },
                         },
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'b',
                             value: { type: 'value', value: 1, },
                         },
@@ -693,13 +693,13 @@ export default [
         '((field: value OR field2:value))',
         'double parens expression',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.String,
                             restricted: true,
                             quoted: false,
@@ -709,10 +709,10 @@ export default [
                     ]
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field_type: xLuceneFieldType.String,
                             restricted: true,
                             quoted: false,
@@ -728,18 +728,18 @@ export default [
         '((a:1) AND (b:1))',
         'double parens AND with parens conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'a',
                             value: { type: 'value', value: 1, },
                         },
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'b',
                             value: { type: 'value', value: 1, },
                         },
@@ -752,25 +752,26 @@ export default [
         'a:1 AND location:geoDistance(point:"33.435518,-111.873616" distance:5000m)',
         'a simple AND with geoDistance function',
         {
-            type: 'logical-group',
+
+            type: NodeType.LogicalGroup,
             flow: [
                 {
                     type: 'conjunction',
                     nodes: [
                         {
-                            type: 'term',
+                            type: NodeType.Term,
                             field_type: 'integer',
                             value: { type: 'value', value: 1, },
                             field: 'a'
                         },
                         {
-                            type: 'function',
+                            type: NodeType.Function,
                             field: 'location',
                             name: 'geoDistance'
-                        }
+                        } as FunctionNode
                     ]
                 }
             ]
-        },
+        } as LogicalGroup,
     ],
 ] as TestCase[];

--- a/packages/xlucene-parser/test/cases/negation.ts
+++ b/packages/xlucene-parser/test/cases/negation.ts
@@ -1,5 +1,7 @@
 import { xLuceneFieldType } from '@terascope/types';
-import { ASTType } from '../../src';
+import {
+    LogicalGroup, Negation, NodeType, Term
+} from '../../src';
 import { TestCase } from './interfaces';
 
 export default [
@@ -7,9 +9,9 @@ export default [
         'NOT name:Madman',
         'negate a single field/value',
         {
-            type: ASTType.Negation,
+            type: NodeType.Negation,
             node: {
-                type: ASTType.Term,
+                type: NodeType.Term,
                 field_type: xLuceneFieldType.String,
                 field: 'name',
                 value: { type: 'value', value: 'Madman', },
@@ -20,9 +22,9 @@ export default [
         '(NOT name:Madman)',
         'negate with parens and a single field/value',
         {
-            type: ASTType.Negation,
+            type: NodeType.Negation,
             node: {
-                type: ASTType.Term,
+                type: NodeType.Term,
                 field_type: xLuceneFieldType.String,
                 field: 'name',
                 value: { type: 'value', value: 'Madman', },
@@ -33,9 +35,9 @@ export default [
         '!name:Madman',
         'negate a single field/value',
         {
-            type: ASTType.Negation,
+            type: NodeType.Negation,
             node: {
-                type: ASTType.Term,
+                type: NodeType.Term,
                 field_type: xLuceneFieldType.String,
                 field: 'name',
                 value: { type: 'value', value: 'Madman', },
@@ -46,9 +48,9 @@ export default [
         'NOT name:$foo',
         'negate a single field/value with variables',
         {
-            type: ASTType.Negation,
+            type: NodeType.Negation,
             node: {
-                type: ASTType.Term,
+                type: NodeType.Term,
                 field_type: xLuceneFieldType.String,
                 field: 'name',
                 value: { type: 'variable', value: 'foo', },
@@ -60,9 +62,9 @@ export default [
         '(NOT name:$foo)',
         'negate with parens and a single field/value with variables',
         {
-            type: ASTType.Negation,
+            type: NodeType.Negation,
             node: {
-                type: ASTType.Term,
+                type: NodeType.Term,
                 field_type: xLuceneFieldType.String,
                 field: 'name',
                 value: { type: 'variable', value: 'foo', },
@@ -74,9 +76,9 @@ export default [
         '!name:$foo',
         'negate a single field/value with variables',
         {
-            type: ASTType.Negation,
+            type: NodeType.Negation,
             node: {
-                type: ASTType.Term,
+                type: NodeType.Term,
                 field_type: xLuceneFieldType.String,
                 field: 'name',
                 value: { type: 'variable', value: 'foo', },
@@ -88,9 +90,9 @@ export default [
         '!(name:$foo)',
         'parens negate a single field/value with variables',
         {
-            type: ASTType.Negation,
+            type: NodeType.Negation,
             node: {
-                type: ASTType.Term,
+                type: NodeType.Term,
                 field_type: xLuceneFieldType.String,
                 field: 'name',
                 value: { type: 'variable', value: 'foo', },
@@ -102,20 +104,20 @@ export default [
         'foo:bar NOT name:Madman',
         'simple NOT conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'foo',
                             value: { type: 'value', value: 'bar', },
                         },
                         {
-                            type: ASTType.Negation,
+                            type: NodeType.Negation,
                             node: {
-                                type: ASTType.Term,
+                                type: NodeType.Term,
                                 field_type: xLuceneFieldType.String,
                                 field: 'name',
                                 value: { type: 'value', value: 'Madman', },
@@ -130,25 +132,25 @@ export default [
         'foo:bar ! name:Madman',
         'an implicit OR with ! negation',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'foo',
                             value: { type: 'value', value: 'bar', },
                         },
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Negation,
+                            type: NodeType.Negation,
                             node: {
-                                type: ASTType.Term,
+                                type: NodeType.Term,
                                 field_type: xLuceneFieldType.String,
                                 field: 'name',
                                 value: { type: 'value', value: 'Madman', },
@@ -163,20 +165,20 @@ export default [
         'foo:bar AND NOT name:Madman',
         'simple AND NOT conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'foo',
                             value: { type: 'value', value: 'bar', },
                         },
                         {
-                            type: ASTType.Negation,
+                            type: NodeType.Negation,
                             node: {
-                                type: ASTType.Term,
+                                type: NodeType.Term,
                                 field_type: xLuceneFieldType.String,
                                 field: 'name',
                                 value: { type: 'value', value: 'Madman', },
@@ -191,25 +193,25 @@ export default [
         'foo:bar OR NOT name:Madman',
         'simple OR NOT conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'foo',
                             value: { type: 'value', value: 'bar', },
                         },
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Negation,
+                            type: NodeType.Negation,
                             node: {
-                                type: ASTType.Term,
+                                type: NodeType.Term,
                                 field_type: xLuceneFieldType.String,
                                 field: 'name',
                                 value: { type: 'value', value: 'Madman', },
@@ -224,25 +226,25 @@ export default [
         'foo:bar OR !name:Madman',
         'simple OR ! conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'foo',
                             value: { type: 'value', value: 'bar', },
                         },
                     ],
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Negation,
+                            type: NodeType.Negation,
                             node: {
-                                type: ASTType.Term,
+                                type: NodeType.Term,
                                 field_type: xLuceneFieldType.String,
                                 field: 'name',
                                 value: { type: 'value', value: 'Madman', },
@@ -257,47 +259,47 @@ export default [
         'a:1 AND !(b:1 OR c:1)',
         'a parens negation conjunction',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [
                         {
-                            type: ASTType.Term,
+                            type: NodeType.Term,
                             field: 'a',
                             value: { type: 'value', value: 1, },
                         },
                         {
-                            type: ASTType.Negation,
+                            type: NodeType.Negation,
                             node: {
-                                type: ASTType.LogicalGroup,
+                                type: NodeType.LogicalGroup,
                                 flow: [
                                     {
-                                        type: ASTType.Conjunction,
+                                        type: NodeType.Conjunction,
                                         nodes: [
                                             {
-                                                type: ASTType.Term,
+                                                type: NodeType.Term,
                                                 field: 'b',
                                                 value: { type: 'value', value: 1, },
-                                            },
+                                            } as Term,
                                         ],
                                     },
                                     {
-                                        type: ASTType.Conjunction,
+                                        type: NodeType.Conjunction,
                                         nodes: [
                                             {
-                                                type: ASTType.Term,
+                                                type: NodeType.Term,
                                                 field: 'c',
                                                 value: { type: 'value', value: 1, },
-                                            },
+                                            } as Term,
                                         ],
                                     },
                                 ],
-                            },
-                        },
+                            } as LogicalGroup,
+                        } as Negation,
                     ],
                 },
             ],
-        },
+        } as LogicalGroup,
     ],
 ] as TestCase[];

--- a/packages/xlucene-parser/test/cases/range.ts
+++ b/packages/xlucene-parser/test/cases/range.ts
@@ -1,10 +1,10 @@
 import { xLuceneFieldType } from '@terascope/types';
-import { ASTType } from '../../src';
+import { NodeType, Range } from '../../src';
 import { TestCase } from './interfaces';
 
 export default [
     ['count: >=10', 'gte ranges', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'count',
         left: {
             operator: 'gte',
@@ -16,7 +16,7 @@ export default [
         }
     }],
     ['count: >=$foo', 'gte ranges with variables', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'count',
         left: {
             operator: 'gte',
@@ -25,7 +25,7 @@ export default [
         }
     }, { count: xLuceneFieldType.Integer }, { foo: 10 }],
     ['count:>10', 'gt ranges', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'count',
         left: {
             operator: 'gt',
@@ -34,7 +34,7 @@ export default [
         }
     }],
     ['count:<=20.10', 'lte ranges', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'count',
         left: {
             operator: 'lte',
@@ -43,7 +43,7 @@ export default [
         }
     }],
     ['count:<20', 'lt ranges', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'count',
         left: {
             operator: 'lt',
@@ -52,7 +52,7 @@ export default [
         }
     }],
     ['count:[1 TO 5]', 'inclusive ranges with integers', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'count',
         left: {
             operator: 'gte',
@@ -66,7 +66,7 @@ export default [
         }
     }],
     ['count:[$foo TO $bar]', 'inclusive ranges with integers with variables', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'count',
         left: {
             operator: 'gte',
@@ -80,7 +80,7 @@ export default [
         }
     }, { count: xLuceneFieldType.Integer }, { foo: 1, bar: 5 }],
     ['count:[1.5 TO 5.3]', 'inclusive ranges with floats', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'count',
         left: {
             operator: 'gte',
@@ -97,7 +97,7 @@ export default [
         'count:[1.5 TO 5.3]',
         'inclusive ranges with floats but with a type of integer',
         {
-            type: ASTType.Range,
+            type: NodeType.Range,
             field: 'count',
             left: {
                 operator: 'gte',
@@ -118,7 +118,7 @@ export default [
         'count:[1.5 TO 5.3]',
         'inclusive ranges with floats but with a type of string',
         {
-            type: ASTType.Range,
+            type: NodeType.Range,
             field: 'count',
             left: {
                 operator: 'gte',
@@ -136,7 +136,7 @@ export default [
         }
     ],
     ['count:{2 TO 6]', 'exclusive and inclusive ranges with integers', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'count',
         left: {
             operator: 'gt',
@@ -150,7 +150,7 @@ export default [
         }
     }],
     ['count:{1.5 TO 5.3}', 'exclusive ranges with floats', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'count',
         left: {
             operator: 'gt',
@@ -164,7 +164,7 @@ export default [
         }
     }],
     ['val:[alpha TO omega]', 'inclusive range of strings', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'val',
         left: {
             operator: 'gte',
@@ -180,7 +180,7 @@ export default [
         }
     }],
     ['val:{"alpha" TO "omega"}', 'exclusive range of quoted', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'val',
         left: {
             operator: 'gt',
@@ -196,7 +196,7 @@ export default [
         }
     }],
     ['val:[2012-01-01 TO 2012-12-31]', 'inclusive date range', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'val',
         left: {
             operator: 'gte',
@@ -212,7 +212,7 @@ export default [
         }
     }],
     ['val:[2012-01-01 TO *]', 'right unbounded date range', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'val',
         left: {
             operator: 'gte',
@@ -227,7 +227,7 @@ export default [
         }
     }],
     ['val:[* TO 10}', 'left unbounded range', {
-        type: ASTType.Range,
+        type: NodeType.Range,
         field: 'val',
         left: {
             operator: 'gte',
@@ -243,7 +243,7 @@ export default [
     [
         'date:[2020-02-10T10:06:06.0 TO 2020-02-10T10:06:07.199999999999999]',
         'left unbounded range', {
-            type: ASTType.Range,
+            type: NodeType.Range,
             field: 'date',
             left: {
                 field_type: xLuceneFieldType.Date,
@@ -261,7 +261,7 @@ export default [
     [
         'ip_range:"1.2.3.0/24"',
         'ip range', {
-            type: ASTType.Range,
+            type: NodeType.Range,
             field: 'ip_range',
             left: {
                 field_type: xLuceneFieldType.IP,
@@ -273,7 +273,7 @@ export default [
                 field_type: xLuceneFieldType.IP,
                 value: { type: 'value', value: '1.2.3.255' }
             }
-        },
+        } as Range,
         { ip_range: xLuceneFieldType.IPRange },
     ],
 ] as TestCase[];

--- a/packages/xlucene-parser/test/cases/regexp.ts
+++ b/packages/xlucene-parser/test/cases/regexp.ts
@@ -1,30 +1,30 @@
 import { xLuceneFieldType } from '@terascope/types';
-import { ASTType } from '../../src';
+import { NodeType, Regexp } from '../../src';
 import { TestCase } from './interfaces';
 
 export default [
     ['example:/[a-z]+/', 'a basic regexp', {
-        type: ASTType.Regexp,
+        type: NodeType.Regexp,
         field_type: xLuceneFieldType.String,
         field: 'example',
         value: { type: 'value', value: '[a-z]+' },
     }],
     ['example: $foo', 'a basic regexp with variables', {
-        type: ASTType.Regexp,
+        type: NodeType.Regexp,
         field_type: xLuceneFieldType.String,
         field: 'example',
         value: { type: 'value', value: '[a-z]+' },
-    }, { example: xLuceneFieldType.String }, { foo: /[a-z]+/ }],
+    } as Regexp, { example: xLuceneFieldType.String }, { foo: /[a-z]+/ }],
     ['example:/foo:bar/', 'a regexp with a colon', {
-        type: ASTType.Regexp,
+        type: NodeType.Regexp,
         field_type: xLuceneFieldType.String,
         field: 'example',
         value: { type: 'value', value: 'foo:bar' },
-    }],
+    } as Regexp],
     ['example:/0-9+\\//', 'regex with an escaped forward slash', {
-        type: ASTType.Regexp,
+        type: NodeType.Regexp,
         field_type: xLuceneFieldType.String,
         field: 'example',
         value: { type: 'value', value: '0-9+\\/' },
-    }],
+    } as Regexp],
 ] as TestCase[];

--- a/packages/xlucene-parser/test/cases/term.ts
+++ b/packages/xlucene-parser/test/cases/term.ts
@@ -1,7 +1,7 @@
 /* eslint-disable quotes */
 import { xLuceneFieldType } from '@terascope/types';
 import { escapeString } from '@terascope/utils';
-import { ASTType } from '../../src';
+import { NodeType, Term } from '../../src';
 import { TestCase } from './interfaces';
 
 export default [
@@ -9,23 +9,23 @@ export default [
         'bar',
         'an unquoted string',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: false,
             field: null,
             value: { type: 'value', value: 'bar', },
-        },
+        } as Term,
     ],
     [
         'foo bar',
         'an unquoted/un-grouped string',
         {
-            type: ASTType.LogicalGroup,
+            type: NodeType.LogicalGroup,
             flow: [
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [{
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field_type: xLuceneFieldType.String,
                         quoted: false,
                         field: null,
@@ -33,9 +33,9 @@ export default [
                     }]
                 },
                 {
-                    type: ASTType.Conjunction,
+                    type: NodeType.Conjunction,
                     nodes: [{
-                        type: ASTType.Term,
+                        type: NodeType.Term,
                         field_type: xLuceneFieldType.String,
                         quoted: false,
                         field: null,
@@ -49,7 +49,7 @@ export default [
         '"foo"',
         'a quoted string',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: null,
             quoted: true,
@@ -60,7 +60,7 @@ export default [
         "'foo'",
         'a quoted string',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: null,
             quoted: true,
@@ -71,7 +71,7 @@ export default [
         '\\"foo\\"',
         'an escaped quoted string',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: null,
             quoted: false,
@@ -82,7 +82,7 @@ export default [
         'foo:\\"bar\\"',
         'field with escaped quoted string',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'foo',
             quoted: false,
@@ -93,7 +93,7 @@ export default [
         'foo:\\"bar',
         'field with one escaped quoted string',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'foo',
             quoted: false,
@@ -107,7 +107,7 @@ export default [
         'foo:"\\""',
         'field with using a quoted escaped quote',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'foo',
             quoted: true,
@@ -121,7 +121,7 @@ export default [
         'foo:bar',
         'field with string value',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'foo',
             quoted: false,
@@ -135,7 +135,7 @@ export default [
         'phone.tokens:3848',
         'an analyzed field',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'phone.tokens',
             quoted: false,
@@ -150,7 +150,7 @@ export default [
         'foo:   bar',
         'field with space between string value',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'foo',
             quoted: false,
@@ -161,7 +161,7 @@ export default [
         'foo:"bar"',
         'field with quoted string value',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'foo',
             quoted: true,
@@ -175,7 +175,7 @@ export default [
         "foo:'bar'",
         'field with single quoted string value',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'foo',
             quoted: true,
@@ -189,7 +189,7 @@ export default [
         'count:123',
         'field with no type and unquoted integer value',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.Integer,
             field: 'count',
             value: { type: 'value', value: 123, },
@@ -199,7 +199,7 @@ export default [
         'count:"123"',
         'field with no type and quoted integer value',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'count',
             quoted: true,
@@ -210,7 +210,7 @@ export default [
         'count:"123"',
         'field with integer type and quoted integer value',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.Integer,
             field: 'count',
             value: { type: 'value', value: 123, },
@@ -223,7 +223,7 @@ export default [
         'count:"22.5"',
         'field with integer type and quoted float value',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.Integer,
             field: 'count',
             value: { type: 'value', value: 22, },
@@ -236,7 +236,7 @@ export default [
         'count:22.5',
         'field with integer type and unquoted float value',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.Integer,
             field: 'count',
             value: { type: 'value', value: 22, },
@@ -249,7 +249,7 @@ export default [
         'count_str:123',
         'field with unquoted string type that is numeric',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'count_str',
             quoted: false,
@@ -263,7 +263,7 @@ export default [
         'large_numeric_str:4555029426647693529',
         'field with unquoted string type that is large numeric value',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'large_numeric_str',
             quoted: false,
@@ -277,7 +277,7 @@ export default [
         'cash:50.50',
         'field with float value',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.Float,
             field: 'cash',
             value: { type: 'value', value: 50.5, },
@@ -290,7 +290,7 @@ export default [
         'cash:"50.50"',
         'field no type and quoted float value',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'cash',
             quoted: true,
@@ -301,7 +301,7 @@ export default [
         'cash:"50.50"',
         'field with float type and quoted float value',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.Float,
             field: 'cash',
             value: { type: 'value', value: 50.50, },
@@ -314,7 +314,7 @@ export default [
         'bool:false',
         'field with bool false',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.Boolean,
             field: 'bool',
             value: { type: 'value', value: false, },
@@ -324,7 +324,7 @@ export default [
         'bool:true',
         'field type of string with bool',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'bool',
             value: { type: 'value', value: 'true', },
@@ -337,7 +337,7 @@ export default [
         'bool:"false"',
         'field type of boolean with string "false"',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.Boolean,
             field: 'bool',
             value: { type: 'value', value: false, },
@@ -350,7 +350,7 @@ export default [
         'bool:"true"',
         'field with no type with a quoted boolean',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'bool',
             value: { type: 'value', value: 'true', },
@@ -360,7 +360,7 @@ export default [
         'fo?:bar',
         'field name with wildcard',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'fo?',
             value: { type: 'value', value: 'bar', },
@@ -370,7 +370,7 @@ export default [
         'foo:"ba?"',
         'field with q quoted wildcard',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'foo',
             quoted: true,
@@ -382,7 +382,7 @@ export default [
         '(155 223)',
         'a parens unquoted string',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: null,
             quoted: false,
@@ -393,7 +393,7 @@ export default [
         '(foo:bar)',
         'a field value with parens',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'foo',
             quoted: false,
@@ -404,7 +404,7 @@ export default [
         'id:some"thing"else',
         'an inner double quoted string string',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: false,
             field: 'id',
@@ -415,7 +415,7 @@ export default [
         'field:"valueSomething(abcd70576983)"',
         'a double quoted value with unescaped parens',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: true,
             field: 'field',
@@ -426,7 +426,7 @@ export default [
         '"hi(hello)howdy"',
         'a field-less double quoted value with unescaped parens',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: true,
             field: null,
@@ -437,7 +437,7 @@ export default [
         "field:' hello(123) there'",
         'a single quoted value with unescaped parens',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: true,
             field: 'field',
@@ -448,7 +448,7 @@ export default [
         "' :(hello)'",
         'a field-less single quoted value with unescaped parens',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: true,
             field: null,
@@ -459,7 +459,7 @@ export default [
         "example: '+ -  ( ) { } [ ] ^ \\' \" ? & | / ~ * OR NOT'",
         'a single quoted value with all of the reserved characters',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: true,
             field: 'example',
@@ -470,7 +470,7 @@ export default [
         'example: "+ -  ( ) { } [ ] ^ \' \\" ? & | / ~ * OR NOT" ',
         'a double quoted value with all of the reserved characters',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: true,
             field: 'example',
@@ -481,7 +481,7 @@ export default [
         "id:some'other'thing",
         'an inner single quoted string string',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: false,
             field: 'id',
@@ -492,7 +492,7 @@ export default [
         `id:${escapeString('some\\"thing\\"else')}`,
         'an unquoted string with qoutes inside',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: false,
             field: 'id',
@@ -503,7 +503,7 @@ export default [
         'id:"some thing else"',
         'a quoted multiword string with spaces',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: true,
             field: 'id',
@@ -514,7 +514,7 @@ export default [
         `id:"${escapeString('some \\"thing\\" else')}"`,
         'a double quoted value with escaped double qoutes',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: true,
             field: 'id',
@@ -525,7 +525,7 @@ export default [
         `id:'${escapeString('some\\ \\"thing\\" else')}'`,
         'a single quoted value with escaped double qoutes and spaces',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: true,
             field: 'id',
@@ -536,7 +536,7 @@ export default [
         "foo:'\"bar\"'",
         'double quoted escaped value at start and end',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: true,
             field: 'foo',
@@ -547,7 +547,7 @@ export default [
         `foo:'${escapeString(`"ba\\'r"`)}'`,
         'value with single quotes at the start, middle and end',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: true,
             field: 'foo',
@@ -558,7 +558,7 @@ export default [
         'foo:"\\"bar\\""',
         'double quoted escaped value at start and end',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: true,
             field: 'foo',
@@ -569,7 +569,7 @@ export default [
         `field:'${escapeString('/value\\\\')}'`,
         'single quoted value with ending double escape',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: true,
             field: 'field',
@@ -580,7 +580,7 @@ export default [
         `field:"${escapeString('/value\\\\')}"`,
         'double quoted value with ending double escape',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: true,
             field: 'field',
@@ -593,7 +593,7 @@ export default [
         {
             value: { type: 'variable', value: 'bar_val', },
             field: 'field',
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
         },
         {
@@ -606,7 +606,7 @@ export default [
         {
             value: { type: 'value', value: false, },
             field: 'field',
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.Boolean,
         },
         {
@@ -622,7 +622,7 @@ export default [
         {
             value: { type: 'variable', value: 'bar2', },
             field: 'field',
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.Integer,
         },
         {
@@ -635,7 +635,7 @@ export default [
         {
             value: { type: 'variable', value: '@bar2', scoped: true },
             field: 'field',
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.Integer,
         },
         {
@@ -648,7 +648,7 @@ export default [
         {
             value: { type: 'variable', value: '@example.foo', scoped: true },
             field: 'field',
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
         },
         {
@@ -661,7 +661,7 @@ export default [
         {
             value: { type: 'value', value: 'EXAMPLE' },
             field: 'field',
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
         },
         {
@@ -677,7 +677,7 @@ export default [
         {
             value: { type: 'value', value: '@example.foo' },
             field: 'field',
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
         },
         {
@@ -690,7 +690,7 @@ export default [
         {
             value: { type: 'value', value: '\\@example.foo' },
             field: 'field',
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
         },
         {
@@ -701,7 +701,7 @@ export default [
         'field:something.com',
         'can parse string values with dots',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: false,
             restricted: true,
@@ -713,7 +713,7 @@ export default [
         'field:foo@something.com',
         'can parse an email',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: false,
             restricted: true,
@@ -725,7 +725,7 @@ export default [
         'field:false.com',
         'can parse string values that have true/false in them',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: false,
             field: 'field',
@@ -736,7 +736,7 @@ export default [
         'field.right:false.com',
         'can parse string values that have true/false in them with fields that have dots',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: false,
             field: 'field.right',
@@ -747,7 +747,7 @@ export default [
         'field.right:3.com',
         'can parse string values that have integers in them',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: false,
             field: 'field.right',
@@ -758,7 +758,7 @@ export default [
         'field.right:3.3.com',
         'can parse string values that have floats in them',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             quoted: false,
             field: 'field.right',

--- a/packages/xlucene-parser/test/cases/wildcard.ts
+++ b/packages/xlucene-parser/test/cases/wildcard.ts
@@ -1,5 +1,5 @@
 import { xLuceneFieldType } from '@terascope/types';
-import { ASTType } from '../../src';
+import { NodeType, Wildcard } from '../../src';
 import { TestCase } from './interfaces';
 
 export default [
@@ -7,7 +7,7 @@ export default [
         'hi:the?e',
         'value with ? wildcard',
         {
-            type: ASTType.Wildcard,
+            type: NodeType.Wildcard,
             field_type: xLuceneFieldType.String,
             field: 'hi',
             value: { type: 'value', value: 'the?e', },
@@ -17,7 +17,7 @@ export default [
         'foo: $foo',
         'variable with * wildcard',
         {
-            type: ASTType.Term,
+            type: NodeType.Term,
             field_type: xLuceneFieldType.String,
             field: 'foo',
             value: { type: 'value', value: 'ba*' },
@@ -33,7 +33,7 @@ export default [
         'hi:?here',
         'value with a prefix wildcard',
         {
-            type: ASTType.Wildcard,
+            type: NodeType.Wildcard,
             field_type: xLuceneFieldType.String,
             field: 'hi',
             value: { type: 'value', value: '?here', },
@@ -46,7 +46,7 @@ export default [
         'hi:ther*',
         'value with a * wildcard',
         {
-            type: ASTType.Wildcard,
+            type: NodeType.Wildcard,
             field_type: xLuceneFieldType.String,
             field: 'hi',
             value: { type: 'value', value: 'ther*', },
@@ -59,7 +59,7 @@ export default [
         'hi:the?*',
         'value with a * and ? wildcard',
         {
-            type: ASTType.Wildcard,
+            type: NodeType.Wildcard,
             field_type: xLuceneFieldType.String,
             field: 'hi',
             value: { type: 'value', value: 'the?*', },
@@ -72,7 +72,7 @@ export default [
         'hi:th?r*',
         'value with a * and ? wildcard',
         {
-            type: ASTType.Wildcard,
+            type: NodeType.Wildcard,
             field_type: xLuceneFieldType.String,
             field: 'hi',
             value: { type: 'value', value: 'th?r*', },
@@ -85,16 +85,16 @@ export default [
         '*',
         'a field-less * query',
         {
-            type: ASTType.Wildcard,
+            type: NodeType.Wildcard,
             field: null,
             value: { type: 'value', value: '*', },
-        },
+        } as Wildcard,
     ],
     [
         '(*)',
         'a parens field-less * query',
         {
-            type: ASTType.Wildcard,
+            type: NodeType.Wildcard,
             field: null,
             value: { type: 'value', value: '*', },
         },
@@ -103,7 +103,7 @@ export default [
         '?',
         'a field-less ? query',
         {
-            type: ASTType.Wildcard,
+            type: NodeType.Wildcard,
             field: null,
             value: { type: 'value', value: '?', },
         },

--- a/packages/xlucene-parser/test/parser-spec.ts
+++ b/packages/xlucene-parser/test/parser-spec.ts
@@ -3,7 +3,7 @@ import { TSError, times, toString } from '@terascope/utils';
 import { xLuceneFieldType } from '@terascope/types';
 import allTestCases from './cases';
 import {
-    Parser, ASTType, FieldValue, TermLike
+    Parser, NodeType, FieldValue, TermLikeNode
 } from '../src';
 
 describe('Parser', () => {
@@ -38,7 +38,7 @@ describe('Parser', () => {
                 const partThree = times(500, (n) => `c:${n}`).join(') OR (');
                 const parser = new Parser(`(${partOne}) AND ${partTwo} OR (${partThree})`);
                 expect(parser.ast).toMatchObject({
-                    type: ASTType.LogicalGroup,
+                    type: NodeType.LogicalGroup,
                 });
             });
         });
@@ -109,7 +109,7 @@ describe('Parser', () => {
             },
         });
 
-        const nodes: [FieldValue<any>, TermLike][] = [];
+        const nodes: [FieldValue<any>, TermLikeNode][] = [];
         parser.forEachFieldValue((value, node) => nodes.push([value, node]));
         expect(nodes).toMatchSnapshot();
     });

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.17.2",
+    "version": "0.18.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -30,7 +30,7 @@
     "dependencies": {
         "@terascope/types": "^0.7.1",
         "@terascope/utils": "^0.36.2",
-        "xlucene-parser": "^0.33.2"
+        "xlucene-parser": "^0.34.0"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xlucene-translator/src/query-access/query-access.ts
+++ b/packages/xlucene-translator/src/query-access/query-access.ts
@@ -94,7 +94,7 @@ export class QueryAccess<T extends ts.AnyObject = ts.AnyObject> {
             });
         }
 
-        if (p.isEmptyAST(parser.ast)) {
+        if (p.isEmptyNode(parser.ast)) {
             if (!this.allowEmpty) {
                 throw new ts.TSError('Empty queries are restricted', {
                     statusCode: 403,
@@ -107,7 +107,7 @@ export class QueryAccess<T extends ts.AnyObject = ts.AnyObject> {
             return this._addConstraints(parser, parserOptions);
         }
 
-        parser.forTermTypes((node: p.TermLikeAST) => {
+        parser.forTermTypes((node: p.TermLikeNode) => {
             // restrict when a term is specified without a field
             if (!node.field) {
                 if (this.allowImplicitQueries) return;

--- a/packages/xlucene-translator/src/translator/utils.ts
+++ b/packages/xlucene-translator/src/translator/utils.ts
@@ -31,7 +31,7 @@ export function translateQuery(
     const { logger, type_config: typeConfig, variables } = options;
     let sort: i.AnyQuerySort|i.AnyQuerySort[]|undefined;
 
-    function buildAnyQuery(node: p.AST): i.AnyQuery | undefined {
+    function buildAnyQuery(node: p.Node): i.AnyQuery | undefined {
         // if no field and is wildcard
         if (
             p.isWildcard(node)
@@ -72,7 +72,7 @@ export function translateQuery(
         logger.error(error);
     }
 
-    function buildTermLevelQuery(node: p.TermLikeAST): i.AnyQuery | i.BoolQuery | undefined {
+    function buildTermLevelQuery(node: p.TermLikeNode): i.AnyQuery | i.BoolQuery | undefined {
         if (p.isWildcardField(node)) {
             if (isEmpty(typeConfig)) {
                 throw new Error(
@@ -128,7 +128,7 @@ export function translateQuery(
         }
     }
 
-    function buildMultiMatchQuery(node: p.TermLikeAST, query: string): i.MultiMatchQuery {
+    function buildMultiMatchQuery(node: p.TermLikeNode, query: string): i.MultiMatchQuery {
         const multiMatchQuery: i.MultiMatchQuery = {
             multi_match: {
                 query,
@@ -271,7 +271,7 @@ export function translateQuery(
         return existsQuery;
     }
 
-    function buildBoolQuery(node: p.GroupLikeAST): i.BoolQuery|undefined {
+    function buildBoolQuery(node: p.GroupLikeNode): i.BoolQuery|undefined {
         const should: i.AnyQuery[] = [];
 
         for (const conj of node.flow) {
@@ -319,7 +319,7 @@ export function translateQuery(
     }
 
     let topLevelQuery: i.MatchAllQuery|i.ConstantScoreQuery;
-    if (p.isEmptyAST(parser.ast)) {
+    if (p.isEmptyNode(parser.ast)) {
         topLevelQuery = {
             match_all: {},
         };
@@ -350,11 +350,11 @@ export function translateQuery(
     };
 }
 
-export function isMultiMatch(node: p.TermLikeAST): boolean {
+export function isMultiMatch(node: p.TermLikeNode): boolean {
     return !node.field || node.field === '*';
 }
 
-export function getTermField(node: p.TermLikeAST): string {
+export function getTermField(node: p.TermLikeNode): string {
     return node.field!;
 }
 


### PR DESCRIPTION
- [x] Refactor the xLucene types to not due unions which are better for typescript
- [x] Add support for `DataSearch->search(query)` that supports xLucene queries 
- [x] Verify that search function works with IP, Date, and object values.