### PR TITLE
Add skipEmptyArrays to DataFrame serialize options

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.23.3",
+    "version": "0.24.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-mate/src/vector/ListVector.ts
+++ b/packages/data-mate/src/vector/ListVector.ts
@@ -54,6 +54,9 @@ export class ListVector<T = unknown> extends Vector<readonly Maybe<T>[]> {
         if (options?.skipDuplicateObjects && isObjectType) {
             result = dedupeValues(result);
         }
+        if (options?.skipEmptyArrays && !result.length) {
+            return options?.useNullForUndefined ? null : undefined;
+        }
         return result;
     }
 }

--- a/packages/data-mate/src/vector/interfaces.ts
+++ b/packages/data-mate/src/vector/interfaces.ts
@@ -78,6 +78,11 @@ export interface SerializeOptions {
     skipNilValues?: boolean;
 
     /**
+     * Don't return any empty List or Tuple values
+    */
+    skipEmptyArrays?: boolean;
+
+    /**
      * Don't return any values that are null/undefined
     */
     skipNilListValues?: boolean;

--- a/packages/data-mate/src/vector/types/TupleVector.ts
+++ b/packages/data-mate/src/vector/types/TupleVector.ts
@@ -38,11 +38,18 @@ export class TupleVector<
     valueToJSON(values: T, options?: SerializeOptions): any {
         const nilValue: any = options?.useNullForUndefined ? null : undefined;
 
-        return this.childFields.map((vector, index) => {
+        let nonNilValues = 0;
+        const result = this.childFields.map((vector, index) => {
             const value = values[index];
             if (value == null || !vector.valueToJSON) return value ?? nilValue;
+            nonNilValues++;
             return vector.valueToJSON(value, options);
         });
+
+        if (options?.skipEmptyArrays && !nonNilValues) {
+            return nilValue;
+        }
+        return result;
     }
 
     private _getChildName(index: number) {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.45.3",
+    "version": "0.46.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.23.3",
+        "@terascope/data-mate": "^0.24.0",
         "@terascope/data-types": "^0.27.2",
         "@terascope/types": "^0.7.1",
         "@terascope/utils": "^0.36.2",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.52.3",
+    "version": "0.53.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.23.3",
+        "@terascope/data-mate": "^0.24.0",
         "@terascope/types": "^0.7.1",
         "@terascope/utils": "^0.36.2",
         "awesome-phonenumber": "^2.46.0",


### PR DESCRIPTION
Adds a `skipEmptyArrays` option to DataFrame serialize options which will allow removing empty arrays