### PR TITLE
Add limit to DataFrame.appendAll

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.24.0",
+    "version": "0.25.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-mate/src/aggregation-frame/AggregationFrame.ts
+++ b/packages/data-mate/src/aggregation-frame/AggregationFrame.ts
@@ -360,7 +360,7 @@ export class AggregationFrame<
     getColumnOrThrow<P extends keyof T>(field: P): Column<T[P], P> {
         const column = this.getColumn(field);
         if (!column) {
-            throw new Error(`Unknown column ${field} in ${
+            throw new Error(`Unknown column ${field} in${
                 this.name ? ` ${this.name}` : ''
             } ${this.constructor.name}`);
         }

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -566,11 +566,19 @@ export class DataFrame<
      * all of the config matches in the Data Frame. If you're not
      * absolutely sure, use DataFrame->concat
     */
-    appendAll(frames: Iterable<DataFrame<T>>): DataFrame<T> {
+    appendAll(frames: Iterable<DataFrame<T>>, limit?: number): DataFrame<T> {
         let { size } = this;
         for (const frame of frames) {
+            if (limit != null && size >= limit) {
+                break;
+            }
             size += frame.size;
         }
+
+        if (limit != null && size > limit) {
+            size = limit;
+        }
+
         // nothing changed
         if (size === this.size) return this;
 
@@ -580,18 +588,26 @@ export class DataFrame<
 
         let currIndex = this.size;
         for (const frame of frames) {
+            // no need to process more frames
+            if (currIndex > size) break;
+
             for (const column of frame.columns) {
                 const builder = builders.get(column.name);
                 if (builder) {
                     for (let i = 0; i < frame.size; i++) {
                         // this just copies the underlying data
                         const value = column.vector.data.values.get(i);
+                        const valueIndex = currIndex + i;
+                        // don't exceed the limit size
+                        if ((valueIndex + 1) > size) break;
+
                         if (value != null) {
-                            builder.data.set(currIndex + i, value);
+                            builder.data.set(valueIndex, value);
                         }
                     }
                 }
             }
+
             currIndex += frame.size;
         }
 

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -668,7 +668,7 @@ export class DataFrame<
     getColumnOrThrow<P extends keyof T>(field: P): Column<T[P], P> {
         const column = this.getColumn(field);
         if (!column) {
-            throw new Error(`Unknown column ${field} in ${
+            throw new Error(`Unknown column ${field} in${
                 this.name ? ` ${this.name}` : ''
             } ${this.constructor.name}`);
         }

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -1086,6 +1086,72 @@ describe('DataFrame', () => {
                 expect(resultFrame.size).toEqual(peopleDataFrame.size * 4);
                 expect(resultFrame.id).not.toEqual(peopleDataFrame.id);
             });
+
+            it('should be able to append itself four times but limit itself', () => {
+                const limitSize = Math.round(peopleDataFrame.size * 3.5);
+
+                const resultFrame = peopleDataFrame.appendAll([
+                    peopleDataFrame, peopleDataFrame, peopleDataFrame, peopleDataFrame
+                ], limitSize);
+
+                const data = peopleDataFrame.toJSON();
+                expect(resultFrame.toJSON()).toEqual(
+                    data.concat(data, data, data).slice(0, limitSize)
+                );
+                expect(resultFrame.size).toEqual(limitSize);
+                expect(resultFrame.id).not.toEqual(peopleDataFrame.id);
+            });
+
+            it('should be able to append itself two times and ignore a limit greater than provided size', () => {
+                const limitSize = peopleDataFrame.size * 4;
+
+                const resultFrame = peopleDataFrame.appendAll([
+                    peopleDataFrame, peopleDataFrame
+                ], limitSize);
+
+                expect(resultFrame.size).toEqual(peopleDataFrame.size * 3);
+
+                const data = peopleDataFrame.toJSON();
+                expect(resultFrame.toJSON()).toEqual(
+                    data.concat(data, data)
+                );
+
+                expect(resultFrame.id).not.toEqual(peopleDataFrame.id);
+            });
+
+            it('should be able to append itself and limit itself to the original size', () => {
+                const limitSize = peopleDataFrame.size;
+
+                const resultFrame = peopleDataFrame.appendAll([
+                    peopleDataFrame
+                ], limitSize);
+
+                expect(resultFrame.id).toEqual(peopleDataFrame.id);
+            });
+
+            it('should be able to append itself but limit itself to 0', () => {
+                const limitSize = 0;
+
+                const resultFrame = peopleDataFrame.appendAll([
+                    peopleDataFrame
+                ], limitSize);
+
+                expect(resultFrame.toJSON()).toEqual([]);
+                expect(resultFrame.size).toEqual(limitSize);
+                expect(resultFrame.id).not.toEqual(peopleDataFrame.id);
+            });
+
+            it('should be able to append itself but limit itself to 1', () => {
+                const limitSize = 1;
+
+                const resultFrame = peopleDataFrame.appendAll([
+                    peopleDataFrame
+                ], limitSize);
+
+                expect(resultFrame.toJSON()).toEqual(peopleDataFrame.limit(1).toJSON());
+                expect(resultFrame.size).toEqual(limitSize);
+                expect(resultFrame.id).not.toEqual(peopleDataFrame.id);
+            });
         });
 
         describe('->filterBy', () => {

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -55,6 +55,44 @@ describe('DataFrame', () => {
         expect(resultFrame.id).toEqual(dataFrame.id);
     });
 
+    it('should throw a readable error when calling getColumnOrThrow', () => {
+        const dataFrame = DataFrame.fromJSON({
+            version: LATEST_VERSION,
+            fields: {
+                name: {
+                    type: FieldType.Keyword,
+                }
+            }
+        }, [
+            {
+                name: 'Billy'
+            }
+        ]);
+        expect(() => {
+            dataFrame.getColumnOrThrow('unknown' as any);
+        }).toThrowError('Unknown column unknown in DataFrame');
+    });
+
+    it('should throw a readable error when calling getColumnOrThrow and the data frame is named', () => {
+        const dataFrame = DataFrame.fromJSON({
+            version: LATEST_VERSION,
+            fields: {
+                name: {
+                    type: FieldType.Keyword,
+                }
+            }
+        }, [
+            {
+                name: 'Billy'
+            }
+        ], {
+            name: 'example'
+        });
+        expect(() => {
+            dataFrame.getColumnOrThrow('unknown' as any);
+        }).toThrowError('Unknown column unknown in example DataFrame');
+    });
+
     it('should handle a single column with null/undefined values', () => {
         const dataFrame = DataFrame.fromJSON({
             version: LATEST_VERSION,

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.46.0",
+    "version": "0.47.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.24.0",
+        "@terascope/data-mate": "^0.25.0",
         "@terascope/data-types": "^0.27.2",
         "@terascope/types": "^0.7.1",
         "@terascope/utils": "^0.36.2",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.53.0",
+    "version": "0.54.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.24.0",
+        "@terascope/data-mate": "^0.25.0",
         "@terascope/types": "^0.7.1",
         "@terascope/utils": "^0.36.2",
         "awesome-phonenumber": "^2.46.0",


### PR DESCRIPTION
- Add support to limit in appendAll so we can avoid extra overhead
- Fix getColumnOrThrow error message
