### PR TITLE
v0.73.1 - Make sure stopping jobs get set to stopped

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "0.73.0",
+    "version": "0.73.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.30.2",
+    "version": "0.30.3",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/terafoundation/src/connectors/s3.ts
+++ b/packages/terafoundation/src/connectors/s3.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import https from 'https';
 import { Logger } from '@terascope/utils';
-import { defer, promisifyAll } from 'bluebird';
+import { promisifyAll } from 'bluebird';
 
 function create(customConfig: Record<string, any>, logger: Logger): {
     client: any;
@@ -10,17 +10,12 @@ function create(customConfig: Record<string, any>, logger: Logger): {
 
     logger.info(`Using S3 endpoint: ${customConfig.endpoint}`);
 
-    customConfig.defer = function _defer() {
-        return defer();
-    };
-
     // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-registering-certs.html
     // Instead of updating the client, we can just update the config before creating the client
     if (customConfig.sslEnabled) {
         if (customConfig.certLocation.length === 0) {
             throw new Error(
-                `Must provide a certificate for S3 endpoint ${customConfig.endpoint} since SSL is`
-                + 'enabled!'
+                `Must provide a certificate for S3 endpoint ${customConfig.endpoint} since SSL is enabled`
             );
         }
         // Assumes all certs needed are in a single bundle

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.38.0",
+    "version": "0.38.1",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"

--- a/packages/teraslice-cli/src/helpers/tjm-util.ts
+++ b/packages/teraslice-cli/src/helpers/tjm-util.ts
@@ -59,6 +59,10 @@ export default class TjmUtil {
 
         try {
             const status = await this.client.jobs.wrap(this.job.id).status();
+            if (status === 'stopped') {
+                reply.info(`> job: ${this.job.name}, job id: ${this.job.id}, is already stopped running on cluster: ${this.job.clusterUrl}`);
+                return;
+            }
 
             if (terminalStatuses.includes(status)) {
                 reply.info(`> job: ${this.job.name}, job id: ${this.job.id}, is not running. Current status is ${status} on cluster: ${this.job.clusterUrl}`);

--- a/packages/teraslice-cli/src/helpers/tjm-util.ts
+++ b/packages/teraslice-cli/src/helpers/tjm-util.ts
@@ -1,9 +1,9 @@
-import { TerasliceClient, ExecutionStatus } from 'teraslice-client-js';
+import { TerasliceClient } from 'teraslice-client-js';
 import reply from '../helpers/reply';
 
 export default class TjmUtil {
     client: TerasliceClient;
-    job: any;
+    job: Record<string, any>;
 
     constructor(client: TerasliceClient, job: Record<string, any>) {
         this.client = client;
@@ -60,25 +60,19 @@ export default class TjmUtil {
         try {
             const status = await this.client.jobs.wrap(this.job.id).status();
 
-            if (status === 'stopping') {
-                reply.green(`job: ${this.job.name} is stopping, wait for job to stop`);
-                await this.client.jobs.wrap(this.job.id).waitForStatus(ExecutionStatus.stopped);
-                reply.green(`Stopped job ${this.job.name} on ${this.job.clusterUrl}`);
+            if (terminalStatuses.includes(status)) {
+                reply.info(`> job: ${this.job.name}, job id: ${this.job.id}, is not running. Current status is ${status} on cluster: ${this.job.clusterUrl}`);
                 return;
             }
 
-            if (terminalStatuses.includes(status)) {
-                reply.green(`job: ${this.job.name}, job id: ${this.job.id}, is not running.  Current status is ${status} on cluster: ${this.job.clusterUrl}`);
-            } else {
-                reply.green(`attempting to stop job: ${this.job.name}, job id: ${this.job.id}, on cluster ${this.job.clusterUrl}`);
-                const response = await this.client.jobs.wrap(this.job.id).stop();
-                const jobStatus = response.status;
+            reply.green(`attempting to stop job: ${this.job.name}, job id: ${this.job.id}, on cluster ${this.job.clusterUrl}`);
+            const response = await this.client.jobs.wrap(this.job.id).stop();
+            const jobStatus = response.status;
 
-                if (jobStatus !== 'stopped') {
-                    reply.fatal(`Could not stop ${this.job.name} on ${this.job.clusterUrl}`);
-                }
-
+            if (jobStatus === 'stopped') {
                 reply.green(`Stopped job ${this.job.name} on ${this.job.clusterUrl}`);
+            } else {
+                reply.fatal(`Could not stop job ${this.job.name} on ${this.job.clusterUrl}, current job status is ${jobStatus}`);
             }
         } catch (e) {
             reply.fatal(e);

--- a/packages/teraslice-cli/test/lib/config-spec.ts
+++ b/packages/teraslice-cli/test/lib/config-spec.ts
@@ -1,3 +1,4 @@
+import 'jest-extended';
 import path from 'path';
 import fs from 'fs';
 import { createTempDirSync } from 'jest-fixtures';

--- a/packages/teraslice-cli/test/lib/tjm-util-spec.ts
+++ b/packages/teraslice-cli/test/lib/tjm-util-spec.ts
@@ -105,6 +105,8 @@ describe('tjm-util stop function', () => {
     });
 
     it('should throw an error if the status is not stopped', async () => {
+        expect.hasAssertions();
+
         job.id = 'testJobId';
         job.name = 'testJobName';
         job.clusterUrl = 'testCluster';
@@ -115,16 +117,16 @@ describe('tjm-util stop function', () => {
         try {
             await tjmUtil.stop();
         } catch (e) {
-            expect(e.message).toBe('Could not stop testJobName on testCluster');
+            expect(e.message).toBe('Could not stop job testJobName on testCluster, current job status is running');
         }
     });
 
-    it('should wait for job to stop if status is stopping', async () => {
+    it('should stop the job again if status is stopping', async () => {
         job.id = 'testJobId';
         job.name = 'testJobName';
         job.clusterUrl = 'testCluster';
         statusResponse = 'stopping';
-        waitStatus = 'stopped';
+        stopResponse = { status: 'stopped' };
 
         const tjmUtil = new TjmUtil(client, job);
         const response = await tjmUtil.stop();

--- a/packages/teraslice/lib/cluster/services/execution.js
+++ b/packages/teraslice/lib/cluster/services/execution.js
@@ -14,6 +14,7 @@ const {
     includes,
     cloneDeep,
 } = require('@terascope/utils');
+const { setInterval } = require('timers');
 const { makeLogger } = require('../../workers/helpers/terafoundation');
 
 /**
@@ -41,6 +42,7 @@ module.exports = function executionService(context, { clusterMasterServer }) {
     let stateStore;
     let clusterService;
     let allocateInterval;
+    let reapInterval;
 
     function enqueue(ex) {
         const size = pendingExecutionQueue.size();
@@ -87,7 +89,9 @@ module.exports = function executionService(context, { clusterMasterServer }) {
         logger.info('shutting down');
 
         clearInterval(allocateInterval);
+        clearInterval(reapInterval);
         allocateInterval = null;
+        reapInterval = null;
 
         const query = exStore.getLivingStatuses().map((str) => `_status:${str}`).join(' OR ');
         const executions = await exStore.search(query);
@@ -369,6 +373,29 @@ module.exports = function executionService(context, { clusterMasterServer }) {
         };
     }
 
+    async function reapExecutions() {
+        // make sure to capture the error avoid throwing an
+        // unhandled rejection
+        try {
+            // sometimes in development an execution gets stuck in stopping
+            // status since the process gets force killed in before it
+            // can be updated to stopped.
+            const stopping = await exStore.search('_status:stopping');
+            for (const execution of stopping) {
+                const updatedAt = new Date(execution._updated).getTime();
+                const updatedWithTimeout = updatedAt + context.sysconfig.teraslice.shutdown_timeout;
+                // Since we don't want to break executions that actually are "stopping"
+                // we need to verify that the job has exceeded the shutdown timeout
+                if (Date.now() > updatedWithTimeout) {
+                    logger.info(`stopping stuck executing ${execution._status} execution: ${execution.ex_id}`);
+                    await exStore.setStatus(execution.ex_id, 'stopped');
+                }
+            }
+        } catch (err) {
+            logger.error(err, 'failure reaping executions');
+        }
+    }
+
     async function initialize() {
         exStore = context.stores.execution;
         stateStore = context.stores.state;
@@ -386,20 +413,9 @@ module.exports = function executionService(context, { clusterMasterServer }) {
         // listen for an execution finished events
         clusterMasterServer.onExecutionFinished(finishExecution);
 
-        // sometimes in development an execution gets stuck in stopping
-        // status since the process gets force killed in before it
-        // can be updated to stopped.
-        const stopping = await exStore.search('_status:stopping');
-        for (const execution of stopping) {
-            const updatedAt = new Date(execution._updated).getTime();
-            const updatedWithTimeout = updatedAt + context.sysconfig.teraslice.shutdown_timeout;
-            // Since we don't want to break executions that actually are "stopping"
-            // we need to verify that the job has exceeded the shutdown timeout
-            if (Date.now() > updatedWithTimeout) {
-                logger.info(`stopping stuck executing ${execution._status} execution: ${execution.ex_id}`);
-                await exStore.setStatus(execution.ex_id, 'stopped');
-            }
-        }
+        // lets call this before calling it
+        // in the background
+        await reapExecutions();
 
         const pending = await exStore.search('_status:pending', null, 10000, '_created:asc');
         for (const execution of pending) {
@@ -416,6 +432,10 @@ module.exports = function executionService(context, { clusterMasterServer }) {
         }
 
         allocateInterval = setInterval(_executionAllocator(), 1000);
+        reapInterval = setInterval(
+            reapExecutions,
+            context.sysconfig.teraslice.shutdown_timeout || 30000
+        );
     }
 
     return {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "0.73.0",
+    "version": "0.73.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -61,7 +61,7 @@
         "semver": "^7.3.4",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.30.2",
+        "terafoundation": "^0.30.3",
         "uuid": "^8.3.2"
     },
     "devDependencies": {


### PR DESCRIPTION
Sometimes in development an execution gets stuck in stopping status since the process gets force killed in before it can be updated to stopped. Now the execution will be marked as stopped when starting up the execution service. I didn't add tests because it is not really testable. 

I also fixed an error message in the s3 connector