### PR TITLE
Add special flags to ts-scripts bump and publish

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.31.5",
+    "version": "0.32.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/cmds/bump.ts
+++ b/packages/scripts/src/cmds/bump.ts
@@ -25,6 +25,11 @@ const cmd: CommandModule = {
                 default: 'rc',
                 description: 'Specify the prerelease identifier, defaults to RC',
             })
+            .option('skip-reset', {
+                description: 'Skip resetting the packages to latest from NPM',
+                type: 'boolean',
+                default: false,
+            })
             .option('deps', {
                 alias: 'd',
                 description: "Bump the child dependencies recursively, (ignores the monorepo's main package)",
@@ -73,6 +78,7 @@ const cmd: CommandModule = {
             preId: argv['prerelease-id'] as string | undefined,
             release,
             deps: Boolean(argv.deps),
+            skipReset: Boolean(argv['skip-reset']),
         });
     },
 };

--- a/packages/scripts/src/cmds/publish.ts
+++ b/packages/scripts/src/cmds/publish.ts
@@ -9,6 +9,7 @@ interface Options {
     type: PublishType;
     action?: PublishAction;
     'dry-run': boolean;
+    'publish-outdated-packages': boolean;
 }
 
 const cmd: CommandModule<GlobalCMDOptions, Options> = {
@@ -28,6 +29,11 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
                 description: "For testing purposes, don't pushing or publishing",
                 type: 'boolean',
                 default: !isCI,
+            })
+            .option('publish-outdated-packages', {
+                description: 'Publish packages that may have newer versions',
+                type: 'boolean',
+                default: false,
             })
             .option('type', {
                 alias: 't',
@@ -50,6 +56,7 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
         return publish(argv.action!, {
             type: argv.type,
             dryRun: argv['dry-run'],
+            publishOutdatedPackages: argv['publish-outdated-packages'],
         });
     },
 };

--- a/packages/scripts/src/cmds/publish.ts
+++ b/packages/scripts/src/cmds/publish.ts
@@ -5,11 +5,11 @@ import { PublishAction, PublishType } from '../helpers/publish/interfaces';
 import { publish } from '../helpers/publish';
 import { syncAll } from '../helpers/sync';
 
-type Options = {
+interface Options {
     type: PublishType;
     action?: PublishAction;
     'dry-run': boolean;
-};
+}
 
 const cmd: CommandModule<GlobalCMDOptions, Options> = {
     command: 'publish <action>',
@@ -23,6 +23,7 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
             .example('$0 publish', '-t tag npm')
             .example('$0 publish', '-t latest npm')
             .example('$0 publish', '--dry-run npm')
+            .example('$0 publish', '--skip-reset npm')
             .option('dry-run', {
                 description: "For testing purposes, don't pushing or publishing",
                 type: 'boolean',

--- a/packages/scripts/src/helpers/bump/interfaces.ts
+++ b/packages/scripts/src/helpers/bump/interfaces.ts
@@ -1,15 +1,15 @@
 import { ReleaseType } from 'semver';
 import { PackageInfo } from '../interfaces';
 
-export type BumpPackageOptions = {
+export interface BumpPackageOptions {
     release: ReleaseType;
     packages: PackageInfo[];
     deps: boolean;
     preId?: string;
-    noReset?: boolean;
-};
+    skipReset?: boolean;
+}
 
-export type BumpPkgInfo = {
+export interface BumpPkgInfo {
     from: string;
     to: string;
     main: boolean;

--- a/packages/scripts/src/helpers/bump/utils.ts
+++ b/packages/scripts/src/helpers/bump/utils.ts
@@ -81,7 +81,7 @@ export async function getPackagesToBump(
     }
 
     async function _resetVersion(pkgInfo: PackageInfo) {
-        if (options.noReset) return;
+        if (options.skipReset) return;
         if (get(pkgInfo, 'terascope.root', false)) return;
         if (
             pkgInfo.private

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -145,9 +145,12 @@ async function publishToDocker(options: PublishOptions) {
         signale.info(`[DRY RUN] - skipping publish of docker images ${imagesToPush.join(', ')}`);
     } else {
         signale.info(`publishing docker images ${imagesToPush.join(', ')}`);
-        await Promise.all(concat(
+        await pMap(concat(
             imagesToPush,
             devImage,
-        ).map(dockerPush));
+        ), dockerPush, {
+            concurrency: 1,
+            stopOnError: false,
+        });
     }
 }

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -37,6 +37,7 @@ async function publishToNPM(options: PublishOptions) {
     }
     const result = await pMap(listPackages(), (pkgInfo) => npmPublish(pkgInfo, options), {
         concurrency: 3,
+        stopOnError: false,
     });
 
     const bumped = result.filter(isString);

--- a/packages/scripts/src/helpers/publish/interfaces.ts
+++ b/packages/scripts/src/helpers/publish/interfaces.ts
@@ -14,4 +14,8 @@ export enum PublishAction {
 export interface PublishOptions {
     type: PublishType;
     dryRun: boolean;
+    /**
+     * Publish packages that may have newer versions
+    */
+    publishOutdatedPackages?: boolean;
 }

--- a/packages/scripts/src/helpers/publish/interfaces.ts
+++ b/packages/scripts/src/helpers/publish/interfaces.ts
@@ -11,7 +11,7 @@ export enum PublishAction {
     NPM = 'npm',
 }
 
-export type PublishOptions = {
+export interface PublishOptions {
     type: PublishType;
     dryRun: boolean;
-};
+}

--- a/packages/scripts/test/bump-spec.ts
+++ b/packages/scripts/test/bump-spec.ts
@@ -68,7 +68,7 @@ describe('Bump Utils', () => {
             const options: BumpPackageOptions = {
                 release: 'minor',
                 deps: true,
-                noReset: true,
+                skipReset: true,
                 packages: [cloneDeep(pkgUtil1!)]
             };
             let result: Record<string, BumpPkgInfo>;
@@ -175,7 +175,7 @@ describe('Bump Utils', () => {
             const options: BumpPackageOptions = {
                 release: 'patch',
                 deps: false,
-                noReset: true,
+                skipReset: true,
                 packages: [cloneDeep(pkgUtil1!)]
             };
             let result: Record<string, BumpPkgInfo>;
@@ -276,7 +276,7 @@ describe('Bump Utils', () => {
             release: 'preminor',
             preId: 'rc',
             deps: true,
-            noReset: true,
+            skipReset: true,
             packages: [cloneDeep(pkgMain!), cloneDeep(pkgDep2!)]
         };
         let result: Record<string, BumpPkgInfo>;


### PR DESCRIPTION
- Add `--skip-reset` to bump script
- Add `--publish-outdated-packages` to publish
- Improvements to npm publish and docker push when there are unexpected errors

These flags are added to deal some edge cases particularly around bumping hot fix branches