### PR TITLE
Ip validation upgrade

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.25.3",
+    "version": "0.25.4",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-mate/src/core/IPValue.ts
+++ b/packages/data-mate/src/core/IPValue.ts
@@ -9,12 +9,7 @@ import { HASH_CODE_SYMBOL } from './interfaces';
 
 function isValidIP(input: unknown): input is string {
     if (!isString(input)) return false;
-    if (!isIP(input)) return false;
-
-    // needed to check for inputs like - '::192.168.1.18'
-    if (input.includes(':') && input.includes('.')) return false;
-
-    return true;
+    return isIP(input);
 }
 
 /**

--- a/packages/data-mate/src/validations/field-validator.ts
+++ b/packages/data-mate/src/validations/field-validator.ts
@@ -465,7 +465,7 @@ function isValidIP(input: unknown, _parentContext?: unknown) {
  *
  * @param {*} input
  * @returns {boolean} boolean
- * 
+ *
  * see:
  *  https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
  *  https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
@@ -496,10 +496,10 @@ function _isRoutableIP(input: unknown, _parentContext?: unknown): boolean {
  * FieldValidator.isNonRoutableIP('8.8.8.8'); // false
  * FieldValidator.isNonRoutableIP('2001:db8::1'); // false
  * FieldValidator.isNonRoutableIP(['10.16.32.210', '192.168.0.1']); // true
- * 
+ *
  * @param {*} input
  * @returns { boolean } boolean
- * 
+ *
  * see:
  *  https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
  *  https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
@@ -524,7 +524,7 @@ function _privateIP(input: string): boolean {
 
     const ipRangeName = parsedIp.range();
 
-    return _inPrivateIPRange(ipRangeName) || _inRestrictedIPRange(parsedIp)
+    return _inPrivateIPRange(ipRangeName) || _inRestrictedIPRange(parsedIp);
 }
 
 function _parseIpAddress(input: string) {

--- a/packages/data-mate/src/validations/field-validator.ts
+++ b/packages/data-mate/src/validations/field-validator.ts
@@ -459,11 +459,17 @@ function isValidIP(input: unknown, _parentContext?: unknown) {
  * FieldValidator.isRoutableIP('8.8.8.8'); // true
  * FieldValidator.isRoutableIP('2001:db8::1'); // true
  * FieldValidator.isRoutableIP('172.194.0.1'); // true
+ * FieldValidator.isRoutableIP('100.127.255.250'); // false
  * FieldValidator.isRoutableIP('192.168.0.1'); // false
  * FieldValidator.isRoutableIP(['172.194.0.1', '8.8.8.8']); // true
  *
  * @param {*} input
  * @returns {boolean} boolean
+ * 
+ * see:
+ *  https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+ *  https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
+ *  for ip range details
  */
 
 export function isRoutableIP(input: unknown, _parentContext?: unknown): boolean {
@@ -476,7 +482,7 @@ export function isRoutableIP(input: unknown, _parentContext?: unknown): boolean 
 function _isRoutableIP(input: unknown, _parentContext?: unknown): boolean {
     if (!isIP(input)) return false;
 
-    return _publicIp(input);
+    return !_privateIP(input);
 }
 
 /**
@@ -490,9 +496,14 @@ function _isRoutableIP(input: unknown, _parentContext?: unknown): boolean {
  * FieldValidator.isNonRoutableIP('8.8.8.8'); // false
  * FieldValidator.isNonRoutableIP('2001:db8::1'); // false
  * FieldValidator.isNonRoutableIP(['10.16.32.210', '192.168.0.1']); // true
- *
+ * 
  * @param {*} input
  * @returns { boolean } boolean
+ * 
+ * see:
+ *  https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+ *  https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
+ *  for ip range details
  */
 
 export function isNonRoutableIP(input: unknown, _parentContext?: unknown): boolean {
@@ -505,17 +516,15 @@ export function isNonRoutableIP(input: unknown, _parentContext?: unknown): boole
 function _isNonRoutableIP(input: unknown, _parentContext?: unknown): boolean {
     if (!isIP(input)) return false;
 
-    return !_publicIp(input);
+    return _privateIP(input);
 }
 
-function _publicIp(input: string): boolean {
+function _privateIP(input: string): boolean {
     const parsedIp = _parseIpAddress(input);
 
     const ipRangeName = parsedIp.range();
 
-    if (_inPrivateIPRange(ipRangeName) || _inRestrictedIPRange(parsedIp)) return false;
-
-    return true;
+    return _inPrivateIPRange(ipRangeName) || _inRestrictedIPRange(parsedIp)
 }
 
 function _parseIpAddress(input: string) {

--- a/packages/data-mate/test/field_validator-spec.ts
+++ b/packages/data-mate/test/field_validator-spec.ts
@@ -244,7 +244,7 @@ describe('field validators', () => {
         });
     });
 
-    fdescribe('isRoutableIP', () => {
+    describe('isRoutableIP', () => {
         it('should return true for a routable ip address', () => {
             // public ips
             expect(FieldValidator.isRoutableIP('8.8.8.8')).toBe(true);
@@ -361,13 +361,18 @@ describe('field validators', () => {
             expect(FieldValidator.isNonRoutableIP('10.1.3.4')).toBe(true);
             expect(FieldValidator.isNonRoutableIP('172.28.4.1')).toBe(true);
             expect(FieldValidator.isNonRoutableIP('127.0.1.2')).toBe(true);
+            expect(FieldValidator.isNonRoutableIP('2001:db8::1')).toBe(true);
+            expect(FieldValidator.isNonRoutableIP('2001:3:ffff:ffff:ffff:ffff:ffff:ffff')).toBe(true);
+            expect(FieldValidator.isNonRoutableIP('192.88.99.1')).toBe(true);
+            expect(FieldValidator.isNonRoutableIP('2001:2::')).toBe(true);
+
         });
 
         it('should return false for a routable ip address or invalid ip address', () => {
             expect(FieldValidator.isNonRoutableIP('8.8.8.8')).toBe(false);
-            expect(FieldValidator.isNonRoutableIP('2001:db8::1')).toBe(false);
             expect(FieldValidator.isNonRoutableIP('172.194.0.1')).toBe(false);
             expect(FieldValidator.isNonRoutableIP('badIpaddress')).toBe(false);
+            expect(FieldValidator.isNonRoutableIP('2001:2ff::ffff')).toBe(false);
         });
 
         it('validates an array of values, ignores undefined/null', () => {

--- a/packages/data-mate/test/field_validator-spec.ts
+++ b/packages/data-mate/test/field_validator-spec.ts
@@ -365,7 +365,6 @@ describe('field validators', () => {
             expect(FieldValidator.isNonRoutableIP('2001:3:ffff:ffff:ffff:ffff:ffff:ffff')).toBe(true);
             expect(FieldValidator.isNonRoutableIP('192.88.99.1')).toBe(true);
             expect(FieldValidator.isNonRoutableIP('2001:2::')).toBe(true);
-
         });
 
         it('should return false for a routable ip address or invalid ip address', () => {

--- a/packages/data-mate/test/field_validator-spec.ts
+++ b/packages/data-mate/test/field_validator-spec.ts
@@ -220,6 +220,7 @@ describe('field validators', () => {
             expect(FieldValidator.isIP('172.16.0.1')).toBe(true);
             expect(FieldValidator.isIP('10.168.0.1')).toBe(true);
             expect(FieldValidator.isIP('fc00:db8:85a3:8d3:1319:8a2e:370:7348')).toBe(true);
+            expect(FieldValidator.isIP('::192.168.1.18')).toBe(true);
         });
 
         it('return false for invalid ip addresses', () => {
@@ -228,7 +229,6 @@ describe('field validators', () => {
             expect(FieldValidator.isIP('172.394.0.1')).toBe(false);
             expect(FieldValidator.isIP(undefined)).toBe(false);
             expect(FieldValidator.isIP('ZXXY:db8:85a3:8d3:1319:8a2e:370:7348')).toBe(false);
-            expect(FieldValidator.isIP('::192.168.1.18')).toBe(false);
             expect(FieldValidator.isIP('11.222.33.001')).toBe(false);
             expect(FieldValidator.isIP('87')).toBe(false);
             expect(FieldValidator.isIP('02751178')).toBe(false);
@@ -244,21 +244,107 @@ describe('field validators', () => {
         });
     });
 
-    describe('isRoutableIP', () => {
+    fdescribe('isRoutableIP', () => {
         it('should return true for a routable ip address', () => {
             // public ips
             expect(FieldValidator.isRoutableIP('8.8.8.8')).toBe(true);
-            expect(FieldValidator.isRoutableIP('2001:db8::1')).toBe(true);
-            expect(FieldValidator.isRoutableIP('172.194.0.1')).toBe(true);
+            expect(FieldValidator.isRoutableIP('172.35.12.18')).toBe(true);
+            expect(FieldValidator.isRoutableIP('192.172.1.18')).toBe(true);
+            expect(FieldValidator.isRoutableIP('11.0.1.18')).toBe(true);
+            expect(FieldValidator.isRoutableIP('::2')).toBe(true);
+            expect(FieldValidator.isRoutableIP('::abcd')).toBe(true);
+            expect(FieldValidator.isRoutableIP('65:ff9b::ffff:ffff')).toBe(true);
+            expect(FieldValidator.isRoutableIP('99::')).toBe(true);
+            expect(FieldValidator.isRoutableIP('faff::12bc')).toBe(true);
+            expect(FieldValidator.isRoutableIP('2620:4f:123::')).toBe(true);
+            expect(FieldValidator.isRoutableIP('2003::')).toBe(true);
+            expect(FieldValidator.isRoutableIP('fe79::ffff')).toBe(true);
+            expect(FieldValidator.isRoutableIP('2001:2ff::ffff')).toBe(true);
         });
 
         it('should return false for a non-routable ip address or invalid ip address', () => {
+            expect(FieldValidator.isRoutableIP('0.0.0.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('0.220.5.132')).toBe(false);
+            expect(FieldValidator.isRoutableIP('0.0.0.0')).toBe(false);
+            expect(FieldValidator.isRoutableIP('10.0.0.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('10.22.23.123')).toBe(false);
+            expect(FieldValidator.isRoutableIP('100.64.123.123')).toBe(false);
+            expect(FieldValidator.isRoutableIP('100.127.255.250')).toBe(false);
+            expect(FieldValidator.isRoutableIP('127.0.0.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('127.230.10.19')).toBe(false);
+            expect(FieldValidator.isRoutableIP('169.254.0.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('169.254.250.127')).toBe(false);
+            expect(FieldValidator.isRoutableIP('172.16.0.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('172.31.250.192')).toBe(false);
+            expect(FieldValidator.isRoutableIP('192.0.0.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('192.0.0.254')).toBe(false);
+            expect(FieldValidator.isRoutableIP('192.0.2.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('192.0.2.182')).toBe(false);
+            expect(FieldValidator.isRoutableIP('192.31.196.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('192.31.196.254')).toBe(false);
+            expect(FieldValidator.isRoutableIP('192.52.193.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('192.52.193.254')).toBe(false);
+            expect(FieldValidator.isRoutableIP('192.88.99.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('192.88.99.254')).toBe(false);
             expect(FieldValidator.isRoutableIP('192.168.0.1')).toBe(false);
-            expect(FieldValidator.isRoutableIP('fc00:db8::1')).toBe(false);
-            expect(FieldValidator.isRoutableIP('badIpaddress')).toBe(false);
-            expect(FieldValidator.isRoutableIP('10.1.3.4')).toBe(false);
-            expect(FieldValidator.isRoutableIP('172.28.4.1')).toBe(false);
-            expect(FieldValidator.isRoutableIP('127.0.1.2')).toBe(false);
+            expect(FieldValidator.isRoutableIP('192.168.255.254')).toBe(false);
+            expect(FieldValidator.isRoutableIP('192.175.48.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('192.175.48.254')).toBe(false);
+            expect(FieldValidator.isRoutableIP('198.18.0.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('198.19.255.254')).toBe(false);
+            expect(FieldValidator.isRoutableIP('198.51.100.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('198.51.100.254')).toBe(false);
+            expect(FieldValidator.isRoutableIP('203.0.113.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('203.0.113.254')).toBe(false);
+            expect(FieldValidator.isRoutableIP('240.0.0.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('255.255.255.254')).toBe(false);
+            expect(FieldValidator.isRoutableIP('255.255.255.255')).toBe(false);
+            expect(FieldValidator.isRoutableIP('224.0.0.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('224.255.255.254')).toBe(false);
+            expect(FieldValidator.isRoutableIP('::1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('64:ff9b::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('64:ff9b::ffff:ffff')).toBe(false);
+            expect(FieldValidator.isRoutableIP('64:ff9b:1::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('64:ff9b:1:ffff:ffff:ffff:ffff:ffff')).toBe(false);
+            expect(FieldValidator.isRoutableIP('100::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('100::ffff:ffff:ffff:ffff')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:0:ffff:ffff:ffff:ffff:ffff:ffff')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:1::1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:1::2')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:2::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:2:0:ffff:ffff:ffff:ffff:ffff')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:3::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:3:ffff:ffff:ffff:ffff:ffff:ffff')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:4:112::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:4:112:ffff:ffff:ffff:ffff:ffff')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:10::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:1f:ffff:ffff:ffff:ffff:ffff:ffff')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:20::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:2f:ffff:ffff:ffff:ffff:ffff:ffff')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:db8::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2001:db8:ffff:ffff:ffff:ffff:ffff:ffff')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2002::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2620:4f:8000::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('2620:4f:8000:ffff:ffff:ffff:ffff:ffff')).toBe(false);
+            expect(FieldValidator.isRoutableIP('fc00::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff')).toBe(false);
+            expect(FieldValidator.isRoutableIP('fe80::')).toBe(false);
+            expect(FieldValidator.isRoutableIP('febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff')).toBe(false);
+        });
+
+        it('should return true for routable ipv4 mapped ipv6 addresses', () => {
+            expect(FieldValidator.isRoutableIP('::FFFF:12.155.166.101')).toBe(true);
+            expect(FieldValidator.isRoutableIP('::ffff:4.108.10.2')).toBe(true);
+        });
+
+        it('should return false for non-routable ipv4 mapped ipv6 addresses', () => {
+            expect(FieldValidator.isRoutableIP('::FFFF:192.52.193.1')).toBe(false);
+            expect(FieldValidator.isRoutableIP('::192.168.1.18')).toBe(false);
+            expect(FieldValidator.isRoutableIP('::ffff:0.0.0.0')).toBe(false);
         });
 
         it('validates an array of values, ignores undefined/null', () => {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.47.3",
+    "version": "0.47.4",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.25.3",
+        "@terascope/data-mate": "^0.25.4",
         "@terascope/data-types": "^0.27.5",
         "@terascope/types": "^0.7.1",
         "@terascope/utils": "^0.36.5",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.54.3",
+    "version": "0.54.4",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.25.3",
+        "@terascope/data-mate": "^0.25.4",
         "@terascope/types": "^0.7.1",
         "@terascope/utils": "^0.36.5",
         "awesome-phonenumber": "^2.48.0",


### PR DESCRIPTION
* changes to validation ip to allow for ipv4 mapped ipv6 addresses
* more thorough routable ip logic based on:
 * https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
 *  https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
* added comprehensive routable ip tests
* bumped version with bump script
