### PR TITLE
Fix compatibility of setImmediate

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.26.0",
+    "version": "0.26.1",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -29,9 +29,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.27.6",
+        "@terascope/data-types": "^0.27.7",
         "@terascope/types": "^0.7.2",
-        "@terascope/utils": "^0.36.6",
+        "@terascope/utils": "^0.36.7",
         "@turf/bbox": "^6.2.0",
         "@turf/bbox-polygon": "^6.3.0",
         "@turf/boolean-point-in-polygon": "^6.2.0",
@@ -50,7 +50,7 @@
         "uuid": "^8.3.2",
         "valid-url": "^1.0.9",
         "validator": "^13.5.2",
-        "xlucene-parser": "^0.34.5"
+        "xlucene-parser": "^0.34.6"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.2",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.27.6",
+    "version": "0.27.7",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.2",
-        "@terascope/utils": "^0.36.6",
+        "@terascope/utils": "^0.36.7",
         "graphql": "^15.5.0",
         "lodash": "^4.17.21",
         "yargs": "^16.2.0"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.18.6",
+    "version": "2.18.7",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.36.6",
+        "@terascope/utils": "^0.36.7",
         "bluebird": "^3.7.2",
         "lodash": "^4.17.21"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.48.0",
+    "version": "0.48.1",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,13 +24,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.26.0",
-        "@terascope/data-types": "^0.27.6",
+        "@terascope/data-mate": "^0.26.1",
+        "@terascope/data-types": "^0.27.7",
         "@terascope/types": "^0.7.2",
-        "@terascope/utils": "^0.36.6",
+        "@terascope/utils": "^0.36.7",
         "ajv": "^6.12.6",
         "uuid": "^8.3.2",
-        "xlucene-translator": "^0.18.5"
+        "xlucene-translator": "^0.18.6"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.0",

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.16.6",
+    "version": "0.16.7",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.36.6",
+        "@terascope/utils": "^0.36.7",
         "chalk": "^4.1.0",
         "lodash": "^4.17.21",
         "yeoman-generator": "^4.13.0",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.48.3",
+    "version": "0.48.4",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.36.6",
+        "@terascope/utils": "^0.36.7",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^8.3.2"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.32.4",
+    "version": "0.32.5",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^4.0.0",
-        "@terascope/utils": "^0.36.6",
+        "@terascope/utils": "^0.36.7",
         "codecov": "^3.8.1",
         "execa": "^5.0.0",
         "fs-extra": "^9.1.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.30.7",
+    "version": "0.30.8",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.36.6",
+        "@terascope/utils": "^0.36.7",
         "aws-sdk": "^2.874.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.15",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.39.3",
+    "version": "0.39.4",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.7.6",
-        "@terascope/utils": "^0.36.6",
+        "@terascope/utils": "^0.36.7",
         "chalk": "^4.1.0",
         "cli-table3": "^0.6.0",
         "easy-table": "^1.1.1",
@@ -48,7 +48,7 @@
         "pretty-bytes": "^5.6.0",
         "prompts": "^2.4.0",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.36.3",
+        "teraslice-client-js": "^0.36.4",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.3",
         "yargs": "^16.2.0",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.36.3",
+    "version": "0.36.4",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.48.3",
+        "@terascope/job-components": "^0.48.4",
         "auto-bind": "^4.0.0",
         "got": "^11.8.2"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.20.6",
+    "version": "0.20.7",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/utils": "^0.36.6",
+        "@terascope/utils": "^0.36.7",
         "ms": "^2.1.3",
         "nanoid": "^3.1.21",
         "p-event": "^4.2.0",

--- a/packages/teraslice-messaging/src/messenger/client.ts
+++ b/packages/teraslice-messaging/src/messenger/client.ts
@@ -102,7 +102,7 @@ export class Client extends Core {
             } catch (err) {
                 this.logger.error(err);
             }
-            setTimeout(() => {
+            process.nextTick(() => {
                 this.socket.close();
             });
         });

--- a/packages/teraslice-messaging/src/messenger/client.ts
+++ b/packages/teraslice-messaging/src/messenger/client.ts
@@ -102,7 +102,7 @@ export class Client extends Core {
             } catch (err) {
                 this.logger.error(err);
             }
-            setImmediate(() => {
+            setTimeout(() => {
                 this.socket.close();
             });
         });

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.48.3"
+        "@terascope/job-components": "^0.48.4"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.48.3"
+        "@terascope/job-components": "^0.48.4"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.25.6",
+    "version": "0.25.7",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.18.6",
-        "@terascope/utils": "^0.36.6",
+        "@terascope/elasticsearch-api": "^2.18.7",
+        "@terascope/utils": "^0.36.7",
         "mnemonist": "^0.38.3"
     },
     "publishConfig": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^9.1.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.48.3"
+        "@terascope/job-components": "^0.48.4"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.48.3"
+        "@terascope/job-components": "^0.48.4"
     },
     "engines": {
         "node": ">=10.16.0"

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.18.6",
-        "@terascope/job-components": "^0.48.3",
-        "@terascope/teraslice-messaging": "^0.20.6",
-        "@terascope/utils": "^0.36.6",
+        "@terascope/elasticsearch-api": "^2.18.7",
+        "@terascope/job-components": "^0.48.4",
+        "@terascope/teraslice-messaging": "^0.20.7",
+        "@terascope/utils": "^0.36.7",
         "async-mutex": "^0.3.1",
         "barbe": "^3.0.16",
         "body-parser": "^1.19.0",
@@ -61,7 +61,7 @@
         "semver": "^7.3.5",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.30.7",
+        "terafoundation": "^0.30.8",
         "uuid": "^8.3.2"
     },
     "devDependencies": {

--- a/packages/teraslice/test/workers/execution-controller/execution-controller-spec.js
+++ b/packages/teraslice/test/workers/execution-controller/execution-controller-spec.js
@@ -316,14 +316,14 @@ describe('ExecutionController', () => {
                 });
 
                 it('should resolve when shutdown passes', async () => {
-                    setImmediate(() => {
+                    setTimeout(() => {
                         exController.events.emit('worker:shutdown:complete');
                     });
                     await expect(exController.shutdown()).resolves.toBeNil();
                 });
 
                 it('should reject when shutdown fails', async () => {
-                    setImmediate(() => {
+                    setTimeout(() => {
                         exController.events.emit('worker:shutdown:complete', new Error('Uh oh'));
                     });
                     await expect(exController.shutdown()).rejects.toThrowError('Uh oh');

--- a/packages/teraslice/test/workers/worker/worker-spec.js
+++ b/packages/teraslice/test/workers/worker/worker-spec.js
@@ -105,14 +105,14 @@ describe('Worker', () => {
 
             server.onSliceSuccess((workerId, _msg) => {
                 sliceSuccess = _msg;
-                setImmediate(() => {
+                setTimeout(() => {
                     shutdownPromise = server.shutdown();
                 });
             });
 
             server.onSliceFailure((workerId, _msg) => {
                 sliceFailure = _msg;
-                setImmediate(() => {
+                setTimeout(() => {
                     shutdownPromise = server.shutdown();
                 });
             });
@@ -399,14 +399,14 @@ describe('Worker', () => {
                 });
 
                 it('should resolve when shutdown passes', async () => {
-                    setImmediate(() => {
+                    setTimeout(() => {
                         worker.events.emit('worker:shutdown:complete');
                     });
                     await expect(worker.shutdown()).resolves.toBeNil();
                 });
 
                 it('should reject when shutdown fails', async () => {
-                    setImmediate(() => {
+                    setTimeout(() => {
                         worker.events.emit('worker:shutdown:complete', new Error('Uh oh'));
                     });
                     await expect(worker.shutdown()).rejects.toThrowError('Uh oh');

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.55.0",
+    "version": "0.55.1",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.26.0",
+        "@terascope/data-mate": "^0.26.1",
         "@terascope/types": "^0.7.2",
-        "@terascope/utils": "^0.36.6",
+        "@terascope/utils": "^0.36.7",
         "awesome-phonenumber": "^2.48.0",
         "graphlib": "^2.1.8",
         "is-ip": "^3.1.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.36.6",
+    "version": "0.36.7",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/numbers.ts
+++ b/packages/utils/src/numbers.ts
@@ -4,11 +4,9 @@ import { getTypeOf } from './deps';
 let supportsBigInt = true;
 try {
     if (typeof globalThis.BigInt === 'undefined') {
-        console.warn('BigInt isn\'t supported in this environment');
         supportsBigInt = false;
     }
 } catch (err) {
-    console.warn('BigInt isn\'t supported in this environment');
     supportsBigInt = false;
 }
 

--- a/packages/utils/src/promises.ts
+++ b/packages/utils/src/promises.ts
@@ -10,7 +10,7 @@ import {
 const logger = debugLogger('utils:promises');
 
 /** promisified setTimeout */
-export function pDelay<T = undefined>(delay = 1, arg?: T): Promise<T> {
+export function pDelay<T = undefined>(delay = 0, arg?: T): Promise<T> {
     return new Promise<T>((resolve) => {
         setTimeout(resolve, delay, arg);
     });
@@ -19,7 +19,13 @@ export function pDelay<T = undefined>(delay = 1, arg?: T): Promise<T> {
 /** promisified setImmediate */
 export function pImmediate<T = undefined>(arg?: T): Promise<T> {
     return new Promise<T>((resolve) => {
-        setImmediate(resolve, arg);
+        if (typeof process?.nextTick === 'function') {
+            process.nextTick(resolve, arg);
+        } else if (typeof setImmediate === 'function') {
+            setImmediate(resolve, arg);
+        } else {
+            setTimeout(resolve, 0, arg);
+        }
     });
 }
 

--- a/packages/utils/src/promises.ts
+++ b/packages/utils/src/promises.ts
@@ -16,12 +16,30 @@ export function pDelay<T = undefined>(delay = 0, arg?: T): Promise<T> {
     });
 }
 
-/** promisified setImmediate */
+let supportsSetImmediate = false;
+try {
+    if (typeof globalThis.setImmediate === 'function') {
+        supportsSetImmediate = true;
+    }
+} catch (err) {
+    supportsSetImmediate = false;
+}
+
+let supportsNextTick = false;
+try {
+    if (typeof globalThis.process.nextTick === 'function') {
+        supportsNextTick = true;
+    }
+} catch (err) {
+    supportsNextTick = false;
+}
+
+/** promisified process.nextTick,setImmediate or setTimeout depending on your environment */
 export function pImmediate<T = undefined>(arg?: T): Promise<T> {
     return new Promise<T>((resolve) => {
-        if (typeof process?.nextTick === 'function') {
+        if (supportsNextTick) {
             process.nextTick(resolve, arg);
-        } else if (typeof setImmediate === 'function') {
+        } else if (supportsSetImmediate) {
             setImmediate(resolve, arg);
         } else {
             setTimeout(resolve, 0, arg);

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.34.5",
+    "version": "0.34.6",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.2",
-        "@terascope/utils": "^0.36.6",
+        "@terascope/utils": "^0.36.7",
         "@turf/bbox": "^6.2.0",
         "@turf/bbox-polygon": "^6.3.0",
         "@turf/boolean-contains": "^6.3.0",

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.18.5",
+    "version": "0.18.6",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,8 +29,8 @@
     },
     "dependencies": {
         "@terascope/types": "^0.7.2",
-        "@terascope/utils": "^0.36.6",
-        "xlucene-parser": "^0.34.5"
+        "@terascope/utils": "^0.36.7",
+        "xlucene-parser": "^0.34.6"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "0.4.6",
+    "version": "0.4.7",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.36.6"
+        "@terascope/utils": "^0.36.7"
     },
     "devDependencies": {
         "@terascope/types": "^0.7.2"


### PR DESCRIPTION
`setImmediate` is no longer recommend for use, this fixes a couple cases where we use it. I also removed the `BigInt` warning since it was more annoying than helpful. I figured it would easier to tell it fail when using a `BigInt` instead of prematurally warning about it.