### PR TITLE
Eslint improvements

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -5,7 +5,7 @@ const { rules, overrides } = require('./lib');
 module.exports = {
     extends: ['airbnb-base'],
     parserOptions: {
-        ecmaVersion: 8,
+        ecmaVersion: 9,
         sourceType: 'script',
     },
     env: {

--- a/packages/eslint-config/lib/overrides.js
+++ b/packages/eslint-config/lib/overrides.js
@@ -17,7 +17,7 @@ if (hasTypescript) {
             files: ['*.mjs'],
             extends: ['airbnb-base'],
             parserOptions: {
-                ecmaVersion: 8,
+                ecmaVersion: 9,
                 sourceType: 'module',
                 ecmaFeatures: {
                     modules: true,
@@ -43,7 +43,7 @@ if (hasTypescript) {
                 browser: true,
             },
             parserOptions: {
-                ecmaVersion: 8,
+                ecmaVersion: 9,
                 sourceType: 'module',
                 ecmaFeatures: {
                     modules: true,
@@ -60,7 +60,7 @@ if (hasTypescript) {
             plugins: ['@typescript-eslint'],
             parser: '@typescript-eslint/parser',
             parserOptions: {
-                ecmaVersion: 8,
+                ecmaVersion: 9,
                 sourceType: 'module',
                 ecmaFeatures: {
                     modules: true,

--- a/packages/eslint-config/lib/rules/javascript.js
+++ b/packages/eslint-config/lib/rules/javascript.js
@@ -18,6 +18,8 @@ module.exports = {
     'no-param-reassign': ['error', { props: false }],
     'no-use-before-define': ['error', { functions: false }],
     'import/no-dynamic-require': 'off',
+    // this is just annoying and doesn't help much
+    'no-useless-return': 'off',
     'global-require': 'off',
     strict: ['error', 'global'],
     'prefer-promise-reject-errors': 'warn',

--- a/packages/eslint-config/lib/rules/typescript.js
+++ b/packages/eslint-config/lib/rules/typescript.js
@@ -7,17 +7,13 @@ module.exports = Object.assign({}, jsRules, {
     // typescript preferences
     '@typescript-eslint/no-object-literal-type-assertion': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
-    // we should enable this in the future
-    '@typescript-eslint/explicit-function-return-type': ['warn', {
-        allowExpressions: true,
-        allowHigherOrderFunctions: true,
-        allowTypedFunctionExpressions: true,
-        allowConciseArrowFunctionExpressionsStartingWithVoid: true,
-    }],
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/no-empty-function': 'off',
+    // this is often better turned off, even though types are good
+    // it is a little more strict than it should be
+    '@typescript-eslint/explicit-function-return-type': 'off',
 
     // we SHOULD really make this an error but we've become dependent on it
     '@typescript-eslint/ban-ts-comment': ['warn', {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/eslint-config",
     "displayName": "Terascope ESLint Config",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "description": "A shared eslint config based on eslint-config-airbnb",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/eslint-config#readme",
     "bugs": {


### PR DESCRIPTION
- Adds support for ecmascript v9 (some features we use that are supported in node 10 weren't parsable by eslint)
- Remove the eslint rule that was recently re-enabled that required more types defined for private functions (that should be up to the developer but recommended).
- Disable `no-useless-return` since that would autofix functions while developing and require adding the returns back in