### PR TITLE
Fix groupBy key generation

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.27.1",
+    "version": "0.27.2",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-mate/src/data-frame/utils.ts
+++ b/packages/data-mate/src/data-frame/utils.ts
@@ -168,17 +168,27 @@ export function makeKeyForRow<T extends Record<string, any>>(
     keyAggs: Map<keyof T, KeyAggFn>,
     index: number
 ): { row: Partial<T>; key: string }|undefined {
-    const row: Partial<T> = {};
+    const row: Partial<T> = Object.create(null);
+
     let valueKey = '';
+    let keyIndex = 0;
+    let hasValues = false;
+
     for (const [field, getKey] of keyAggs) {
         const res = getKey(index);
-        if (res.key) valueKey += res.key;
+        valueKey += keyIndex;
+        if (res.key) {
+            hasValues = true;
+            valueKey += res.key;
+        }
+
         row[field] = res.value as any;
+        keyIndex++;
     }
 
     // this ensures that without a key aggregation
     // we create a global bucket
-    if (!valueKey && keyAggs.size) return;
+    if (!hasValues && keyAggs.size) return;
 
     const groupKey = createHashCode(valueKey);
     return {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.49.1",
+    "version": "0.49.2",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.27.1",
+        "@terascope/data-mate": "^0.27.2",
         "@terascope/data-types": "^0.28.0",
         "@terascope/types": "^0.8.0",
         "@terascope/utils": "^0.37.0",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.56.1",
+    "version": "0.56.2",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.27.1",
+        "@terascope/data-mate": "^0.27.2",
         "@terascope/types": "^0.8.0",
         "@terascope/utils": "^0.37.0",
         "awesome-phonenumber": "^2.49.0",


### PR DESCRIPTION
- Fix groupBy key generation when different fields have the same value


Previously, this would have generated the same group by key for both records since 
the field name or position was not taken into account. This is incorrect, it should have generated two 
different buckets.


```js
[{
  "field1": "hello",
  "field2": null
}, {
  "field1": null,
  "field2": "hello"
}]
```


