### PR TITLE
Fix spelling and interfaces

### DIFF
--- a/packages/data-mate/src/adapters/argument-validator/index.ts
+++ b/packages/data-mate/src/adapters/argument-validator/index.ts
@@ -77,7 +77,9 @@ export function validateFunctionArgs(
     // check required fields
     if (fnDef?.required_arguments?.length) {
         if (isNil(args)) {
-            throw new Error(`No arguments were provided but ${fnDef.name} requires ${joinList(fnDef.required_arguments)} to be set`);
+            throw new Error(`No arguments were provided but ${fnDef.name} requires ${joinList(
+                fnDef.required_arguments as string[]
+            )} to be set`);
         }
 
         for (const field of fnDef.required_arguments) {

--- a/packages/data-mate/src/adapters/argument-validator/index.ts
+++ b/packages/data-mate/src/adapters/argument-validator/index.ts
@@ -13,7 +13,7 @@ import {
 } from '@terascope/utils';
 import { DataTypeFieldConfig, FieldType } from '@terascope/types';
 import {
-    FunctionDefinitions,
+    FunctionDefinitionConfig,
 } from '../../function-configs/interfaces';
 
 // TODO: migrate IPRange to IP?
@@ -70,7 +70,10 @@ function isEmptyLike(input: unknown): boolean {
     return isNil(input) || (!isBoolean(input) && !isNumber(input) && isEmpty(input));
 }
 
-export function validateFunctionArgs(fnDef: FunctionDefinitions, args?: Record<string, any>): void {
+export function validateFunctionArgs(
+    fnDef: FunctionDefinitionConfig<any>,
+    args?: Record<string, any>
+): void {
     // check required fields
     if (fnDef?.required_arguments?.length) {
         if (isNil(args)) {

--- a/packages/data-mate/src/adapters/data-frame-adapter/index.ts
+++ b/packages/data-mate/src/adapters/data-frame-adapter/index.ts
@@ -51,7 +51,7 @@ const FieldTypeToVectorDict: Record<FieldType, VectorType> = {
     [FieldType.Tuple]: VectorType.Any,
 };
 
-function getVectorType(input: FieldType[]): VectorType[] {
+function getVectorType(input: readonly FieldType[]): VectorType[] {
     return input.map((fType) => {
         const type = FieldTypeToVectorDict[fType];
         if (isNil(type)) {

--- a/packages/data-mate/src/adapters/data-frame-adapter/index.ts
+++ b/packages/data-mate/src/adapters/data-frame-adapter/index.ts
@@ -7,7 +7,8 @@ import {
 import { DataFrame } from '../../data-frame';
 import {
     FieldTransformConfig, isFieldTransform, isFieldValidation, ProcessMode,
-    FieldValidateConfig, FunctionDefinitions, isFieldOperation, DataTypeFieldAndChildren
+    FieldValidateConfig, isFieldOperation,
+    DataTypeFieldAndChildren, FunctionDefinitionConfig
 } from '../../function-configs/interfaces';
 
 import {
@@ -60,7 +61,7 @@ function getVectorType(input: FieldType[]): VectorType[] {
     });
 }
 
-export interface DateFrameAdapterOptions<T extends Record<string, any>> {
+export interface DataFrameAdapterOptions<T extends Record<string, any>> {
     args?: T,
     inputConfig?: DataTypeFieldConfig,
     field?: string;
@@ -76,7 +77,9 @@ export interface FrameAdapterFn extends ColumnAdapterFn {
     ): DataFrame<Record<string, unknown>>
 }
 
-function getMode(fnDef: FunctionDefinitions): TransformMode {
+function getMode<T extends Record<string, any>>(
+    fnDef: FunctionDefinitionConfig<T>
+): TransformMode {
     if (isFieldOperation(fnDef)) {
         const mode = fnDef.process_mode;
         if (mode === ProcessMode.INDIVIDUAL_VALUES) {
@@ -242,17 +245,9 @@ function transformFrame(
     };
 }
 
-export function dateFrameAdapter<T extends Record<string, any> = Record<string, unknown>>(
-    fnDef: FieldValidateConfig<T>,
-    options?: DateFrameAdapterOptions<T>
-): FrameAdapterFn
-export function dateFrameAdapter<T extends Record<string, any> = Record<string, unknown>>(
-    fnDef: FieldTransformConfig<T>,
-    options?: DateFrameAdapterOptions<T>
-): FrameAdapterFn
-export function dateFrameAdapter<T extends Record<string, any> = Record<string, unknown>>(
-    fnDef: FunctionDefinitions,
-    options: DateFrameAdapterOptions<T> = {}
+export function dataFrameAdapter<T extends Record<string, any> = Record<string, unknown>>(
+    fnDef: FunctionDefinitionConfig<T>,
+    options: DataFrameAdapterOptions<T> = {}
 ): FrameAdapterFn {
     const { field, args } = options;
 

--- a/packages/data-mate/src/adapters/function-adapter/index.ts
+++ b/packages/data-mate/src/adapters/function-adapter/index.ts
@@ -15,7 +15,6 @@ import {
     FunctionAdapterOptions, RecordFunctionAdapterOperation, FieldFunctionAdapterOperation
 } from './interfaces';
 import {
-    FunctionDefinitions,
     FieldValidateConfig,
     FieldTransformConfig,
     isFieldValidation,
@@ -23,32 +22,24 @@ import {
     RecordValidationConfig,
     RecordTransformConfig,
     isRecordValidation,
-    ProcessMode
+    ProcessMode,
+    FunctionDefinitionConfig
 } from '../../function-configs/interfaces';
 import { validateFunctionArgs } from '../argument-validator';
 
-// @TODO: fix any type
 export function functionAdapter<T extends Record<string, any> = Record<string, unknown>>(
-    fnDef: FieldValidateConfig<T>,
+    fnDef: FieldValidateConfig<T>|FieldTransformConfig<T>,
     options?: FunctionAdapterOptions<T>
 ): FieldFunctionAdapterOperation
 export function functionAdapter<T extends Record<string, any> = Record<string, unknown>>(
-    fnDef: FieldTransformConfig<T>,
-    options?: FunctionAdapterOptions<T>
-): FieldFunctionAdapterOperation
-export function functionAdapter<T extends Record<string, any> = Record<string, unknown>>(
-    fnDef: RecordValidationConfig<T>,
-    options?: FunctionAdapterOptions<T>
-): RecordFunctionAdapterOperation
-export function functionAdapter<T extends Record<string, any> = Record<string, unknown>>(
-    fnDef: RecordTransformConfig<T>,
+    fnDef: RecordValidationConfig<T>|RecordTransformConfig<T>|FunctionDefinitionConfig<T>,
     options?: FunctionAdapterOptions<T>
 ): RecordFunctionAdapterOperation
 export function functionAdapter<T extends Record<string, any> = Record<string, unknown>>(
     /** The field validation or transform function definition */
-    fnDef: FunctionDefinitions,
+    fnDef: FunctionDefinitionConfig<T>,
     options: FunctionAdapterOptions<T> = {}
-): any {
+): RecordFunctionAdapterOperation|FieldFunctionAdapterOperation {
     const {
         args,
         field,
@@ -76,7 +67,6 @@ export function functionAdapter<T extends Record<string, any> = Record<string, u
                 fn, preserveNulls, preserveEmptyObjects, field
             ),
             column: fieldValidationColumnExecution(fn, preserveNulls)
-
         };
     }
 
@@ -104,7 +94,7 @@ export function functionAdapter<T extends Record<string, any> = Record<string, u
     if (isRecordValidation(fnDef)) {
         const fn = fnDef.create(args ?? {});
         return {
-            rows: recordValidationExecution(fn, preserveNulls)
+            rows: recordValidationExecution(fn)
         };
     }
 

--- a/packages/data-mate/src/adapters/function-adapter/interfaces.ts
+++ b/packages/data-mate/src/adapters/function-adapter/interfaces.ts
@@ -9,7 +9,7 @@ export interface FunctionAdapterOptions<T extends Record<string, any>> {
 }
 
 export interface RecordFunctionAdapterOperation {
-    rows(records: Record<string, unknown>[]): Record<string, unknown>[];
+    rows<T extends Record<string, any>>(records: T[]): Record<string, unknown>[];
 }
 
 export interface FieldFunctionAdapterOperation extends RecordFunctionAdapterOperation {

--- a/packages/data-mate/src/adapters/function-adapter/transformers/field.ts
+++ b/packages/data-mate/src/adapters/function-adapter/transformers/field.ts
@@ -8,13 +8,13 @@ import {
     unset
 } from '@terascope/utils';
 
-export function fieldTransformRowExecution(
+export function fieldTransformRowExecution<T extends Record<string, any>>(
     fn: (input: unknown) => unknown,
     preserveNulls: boolean,
     preserveEmptyObjects: boolean,
-    field?: string
-): (input: unknown[]) => unknown[] {
-    return function _wholeFieldTransformRowExecution(input: unknown[]): unknown[] {
+    field?: keyof T
+): (input: T[]) => T[] {
+    return function _wholeFieldTransformRowExecution(input: T[]): T[] {
         if (isNil(field)) throw new Error('Must provide a field option when running a row');
         if (!Array.isArray(input)) {
             throw new Error('Invalid input, expected an array of objects');
@@ -29,7 +29,7 @@ export function fieldTransformRowExecution(
                 throw new Error(`Invalid record ${JSON.stringify(record)}, expected an array of simple objects or data-entities`);
             }
 
-            const value = get(clone, field);
+            const value: unknown = get(clone, field);
 
             try {
                 if (Array.isArray(value)) {
@@ -107,13 +107,13 @@ export function fieldTransformRowExecution(
     };
 }
 
-export function wholeFieldTransformRowExecution(
+export function wholeFieldTransformRowExecution<T extends Record<string, any>>(
     fn: (input: unknown) => unknown,
     preserveNulls: boolean,
     preserveEmptyObjects: boolean,
-    field?: string
-): (input: unknown[]) => unknown[] {
-    return function _wholeFieldTransformRowExecution(input: unknown[]): unknown[] {
+    field?: keyof T
+): (input: T[]) => T[] {
+    return function _wholeFieldTransformRowExecution(input: T[]): T[] {
         if (isNil(field)) throw new Error('Must provide a field option when running a row');
         if (!Array.isArray(input)) {
             throw new Error('Invalid input, expected an array of objects');
@@ -166,15 +166,16 @@ export function wholeFieldTransformRowExecution(
 }
 
 export function wholeFieldTransformColumnExecution(
-    fn: (input: unknown) => unknown, preserveNulls: boolean
+    fn: (input: unknown) => unknown,
+    preserveNulls: boolean
 ) {
     return function _wholeFieldTransformColumnExecution(
         input: unknown[]
-    ): (unknown|null)[] {
+    ): unknown[] {
         if (!Array.isArray(input)) {
             throw new Error('Invalid input, expected an array of values');
         }
-        const results = [];
+        const results: unknown[] = [];
 
         for (const value of input) {
             if (isNotNil(value)) {

--- a/packages/data-mate/src/adapters/function-adapter/validators/rows.ts
+++ b/packages/data-mate/src/adapters/function-adapter/validators/rows.ts
@@ -1,17 +1,16 @@
 import { isObjectEntity, cloneDeep } from '@terascope/utils';
 
-export function recordValidationExecution(
-    fn: (input: Record<string, unknown>) => boolean,
-    preserveNulls: boolean
+export function recordValidationExecution<T extends Record<string, any>>(
+    fn: (input: T) => boolean,
 ) {
     return function _row(
-        input: Record<string, unknown>[]
-    ): (Record<string, unknown> | null)[] {
+        input: T[]
+    ): Record<string, unknown>[] {
         if (!Array.isArray(input)) {
             throw new Error('Invalid input, expected an array of objects');
         }
 
-        const results: (Record<string, unknown>|null)[] = [];
+        const results: T[] = [];
 
         for (const record of input) {
             if (!isObjectEntity(record)) {
@@ -23,8 +22,6 @@ export function recordValidationExecution(
             // TODO: how much error handling should be here vs the function
             if (fn(clone)) {
                 results.push(clone);
-            } else if (preserveNulls) {
-                results.push(null);
             }
         }
 

--- a/packages/data-mate/src/adapters/index.ts
+++ b/packages/data-mate/src/adapters/index.ts
@@ -1,3 +1,3 @@
 export * from './function-adapter';
 export * from './argument-validator';
-export * from './date-frame-adapter';
+export * from './data-frame-adapter';

--- a/packages/data-mate/src/column/utils.ts
+++ b/packages/data-mate/src/column/utils.ts
@@ -121,6 +121,7 @@ export function validateFieldTransformType(
     accepts: VectorType[], vector: Vector<any>
 ): void {
     if (!accepts?.length) return;
+
     // if the type is a List, then we need to give the child type
     const type = vector.type === VectorType.List ? Vector.make([], {
         config: { ...vector.config, array: false }

--- a/packages/data-mate/src/function-configs/interfaces.ts
+++ b/packages/data-mate/src/function-configs/interfaces.ts
@@ -1,4 +1,6 @@
-import { DataTypeFieldConfig, FieldType, DataTypeFields } from '@terascope/types';
+import {
+    DataTypeFieldConfig, FieldType, DataTypeFields, ReadonlyDataTypeFields
+} from '@terascope/types';
 
 export enum FunctionDefinitionType {
     FIELD_TRANSFORM = 'FIELD_TRANSFORM',
@@ -15,62 +17,69 @@ export enum ProcessMode {
 }
 
 export interface FunctionDefinitionConfig<T extends Record<string, any>> {
-    name: string,
+    /**
+     * The name of the function
+    */
+    readonly name: string;
     /** Type of operation that will be preformed */
-    type: FunctionDefinitionType,
+    readonly type: FunctionDefinitionType;
     /** Used to generate documentation */
-    description: string,
-    /** Used for validating and defining the types of the input arguments,
-     * please include description field when creating the schema */
-    argument_schema?: DataTypeFields,
-    /** Used to determine what of the possible args are required, as DataType configs does not have
+    readonly description: string;
+    /**
+     * Used for validating and defining the types of the input arguments,
+     * please include description field when creating the schema
+     */
+    readonly argument_schema?: DataTypeFields;
+    /**
+     * Used to determine what of the possible args are required, as DataType configs does not have
      * a mechanism to specify what is required
      */
-    required_arguments?: string[]
-    /** Can be used in strongly typed contexts to throw early, some types
+    readonly required_arguments?: readonly string[];
+    /**
+     * Can be used in strongly typed contexts to throw early, some types
      * or only compatible with a given operation
      */
-    accepts: FieldType[],
+    readonly accepts: readonly FieldType[];
     /** Used for additional custom validation of args, called after generic arg validation */
-    validate_arguments?: (args: T) => void
+    readonly validate_arguments?: (args: T) => void;
 }
 
 export interface FieldValidateConfig<
     T extends Record<string, any> = Record<string, unknown>
 > extends FunctionDefinitionConfig<T> {
-    type: FunctionDefinitionType.FIELD_VALIDATION,
-    process_mode: ProcessMode,
-    create: (
+    readonly type: FunctionDefinitionType.FIELD_VALIDATION;
+    readonly process_mode: ProcessMode;
+    readonly create: (
         args: T,
         inputConfig?: DataTypeFieldAndChildren,
-    ) => (value: unknown) => boolean
+    ) => (value: unknown) => boolean;
 }
 
 export interface FieldTransformConfig<
     T extends Record<string, any> = Record<string, unknown>
 > extends FunctionDefinitionConfig<T> {
-    type: FunctionDefinitionType.FIELD_TRANSFORM,
-    process_mode: ProcessMode,
-    output_type?: (
+    readonly type: FunctionDefinitionType.FIELD_TRANSFORM,
+    readonly process_mode: ProcessMode,
+    readonly output_type?: (
         inputConfig: DataTypeFieldAndChildren,
         args?: T
-    ) => DataTypeFieldAndChildren,
-    create: (
+    ) => DataTypeFieldAndChildren;
+    readonly create: (
         args: T,
         inputConfig?: DataTypeFieldAndChildren,
         outputConfig?: DataTypeFieldAndChildren,
-    ) => (value: unknown) => unknown
+    ) => (value: unknown) => unknown;
 }
 
 export interface RecordTransformConfig<
     T extends Record<string, any> = Record<string, unknown>
 > extends FunctionDefinitionConfig<T> {
-    type: FunctionDefinitionType.RECORD_TRANSFORM,
-    output_type: (
+    readonly type: FunctionDefinitionType.RECORD_TRANSFORM,
+    readonly output_type: (
         inputConfig: DataTypeFieldAndChildren,
         args?: T
     ) => DataTypeFieldAndChildren,
-    create: (
+    readonly create: (
         args: T,
         inputConfig?: DataTypeFieldAndChildren,
         outputConfig?: DataTypeFieldAndChildren,
@@ -80,8 +89,8 @@ export interface RecordTransformConfig<
 export interface RecordValidationConfig<
     T extends Record<string, any> = Record<string, unknown>
 > extends FunctionDefinitionConfig<T> {
-    type: FunctionDefinitionType.RECORD_VALIDATION,
-    create: (
+    readonly type: FunctionDefinitionType.RECORD_VALIDATION,
+    readonly create: (
         args: T,
         inputConfig?: DataTypeFieldAndChildren,
         outputConfig?: DataTypeFieldAndChildren,
@@ -96,13 +105,13 @@ export interface OutputType<T> {
 }
 
 export interface DataTypeFieldAndChildren {
-    field_config: DataTypeFieldConfig,
-    child_config?: DataTypeFields
+    readonly field_config: Readonly<DataTypeFieldConfig>,
+    readonly child_config?: ReadonlyDataTypeFields
 }
 
 // TODO: verify this type
 export interface FunctionConfigRepository {
-    [key: string]: FunctionDefinitionConfig<Record<string, unknown>>;
+    readonly [key: string]: FunctionDefinitionConfig<Record<string, unknown>>;
 }
 
 export function isFieldValidation<T extends Record<string, any>>(

--- a/packages/data-mate/src/function-configs/interfaces.ts
+++ b/packages/data-mate/src/function-configs/interfaces.ts
@@ -99,49 +99,44 @@ export interface DataTypeFieldAndChildren {
     field_config: DataTypeFieldConfig,
     child_config?: DataTypeFields
 }
-// Make a separate one for record level adapters
-export type FunctionDefinitions = FieldValidateConfig<Record<string, unknown>>
-| FieldTransformConfig<Record<string, unknown>>
-| RecordValidationConfig<Record<string, unknown>>
-| RecordTransformConfig<Record<string, unknown>>
 
 // TODO: verify this type
 export interface FunctionConfigRepository {
-    [key: string]: FunctionDefinitions;
+    [key: string]: FunctionDefinitionConfig<Record<string, unknown>>;
 }
 
-export function isFieldValidation(
-    input: FunctionDefinitionConfig<Record<string, unknown>>
+export function isFieldValidation<T extends Record<string, any>>(
+    input: FunctionDefinitionConfig<T>
 ): input is FieldValidateConfig {
     return input && input.type === FunctionDefinitionType.FIELD_VALIDATION;
 }
 
-export function isFieldTransform(
-    input: FunctionDefinitionConfig<Record<string, unknown>>
+export function isFieldTransform<T extends Record<string, any>>(
+    input: FunctionDefinitionConfig<T>
 ): input is FieldTransformConfig {
     return input && input.type === FunctionDefinitionType.FIELD_TRANSFORM;
 }
 
-export function isFieldOperation(
-    input: FunctionDefinitionConfig<Record<string, unknown>>
+export function isFieldOperation<T extends Record<string, any>>(
+    input: FunctionDefinitionConfig<T>
 ): input is (FieldValidateConfig | FieldValidateConfig) {
     return isFieldValidation(input) || isFieldTransform(input);
 }
 
-export function isRecordTransform(
-    input: FunctionDefinitionConfig<Record<string, unknown>>
+export function isRecordTransform<T extends Record<string, any>>(
+    input: FunctionDefinitionConfig<T>
 ): input is RecordTransformConfig {
     return input && input.type === FunctionDefinitionType.RECORD_TRANSFORM;
 }
 
-export function isRecordValidation(
-    input: FunctionDefinitionConfig<Record<string, unknown>>
+export function isRecordValidation<T extends Record<string, any>>(
+    input: FunctionDefinitionConfig<T>
 ): input is RecordValidationConfig {
     return input && input.type === FunctionDefinitionType.RECORD_VALIDATION;
 }
 
-export function isTransformOperation(
-    input: FunctionDefinitionConfig<Record<string, unknown>>
+export function isTransformOperation<T extends Record<string, any>>(
+    input: FunctionDefinitionConfig<T>
 ): input is (RecordTransformConfig | FieldTransformConfig) {
     return isFieldTransform(input) || isRecordValidation(input);
 }

--- a/packages/data-mate/src/function-configs/interfaces.ts
+++ b/packages/data-mate/src/function-configs/interfaces.ts
@@ -16,6 +16,21 @@ export enum ProcessMode {
     FULL_VALUES = 'FULL_VALUES'
 }
 
+export interface FunctionDefinitionExample {
+    /**
+     * An example input value that will be pretty printed for documentation.
+    */
+    readonly input: unknown;
+    /**
+     * The outputted value that will be pretty printed for documentation
+    */
+    readonly output: unknown;
+    /**
+     * Optionally describe the behavior of this example
+    */
+    readonly description?: string;
+}
+
 export interface FunctionDefinitionConfig<T extends Record<string, any>> {
     /**
      * The name of the function
@@ -25,6 +40,11 @@ export interface FunctionDefinitionConfig<T extends Record<string, any>> {
     readonly type: FunctionDefinitionType;
     /** Used to generate documentation */
     readonly description: string;
+    /**
+     * Examples that will be used in the documentation and potentially
+     * in the automated tests
+    */
+    readonly examples?: readonly FunctionDefinitionExample[];
     /**
      * Used for validating and defining the types of the input arguments,
      * please include description field when creating the schema

--- a/packages/data-mate/test/function-configs/functionTestHarness.ts
+++ b/packages/data-mate/test/function-configs/functionTestHarness.ts
@@ -1,0 +1,37 @@
+import { DataTypeConfig } from '@terascope/types';
+import {
+    functionAdapter,
+    dataFrameAdapter,
+    FunctionDefinitionConfig,
+    DataFrame
+} from '../../src';
+
+export interface FunctionTestCaseConfig {
+    readonly config: DataTypeConfig;
+    readonly data: Record<string, unknown>[];
+}
+
+/**
+ * This tests a function config
+*/
+export function functionTestHarness(
+    fnDef: FunctionDefinitionConfig<Record<string, unknown>>,
+    cases: readonly [msg: string, config: FunctionTestCaseConfig][],
+): void {
+    describe(fnDef.name, () => {
+        describe.each(cases)('%s', (_msg, config) => {
+            describe('when using the function adapter', () => {
+                it('should return the correct data', () => {
+                    expect(functionAdapter(fnDef).rows(config.data)).toMatchSnapshot();
+                });
+            });
+
+            describe('when using the data frame adapter', () => {
+                it('should return the correct data', () => {
+                    const frame = DataFrame.fromJSON(config.config, config.data);
+                    expect(dataFrameAdapter(fnDef).frame(frame)).toMatchSnapshot();
+                });
+            });
+        });
+    });
+}

--- a/packages/data-mate/test/function-configs/geo/toGeoPoint-spec.ts
+++ b/packages/data-mate/test/function-configs/geo/toGeoPoint-spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@terascope/types';
 import {
     functionConfigRepository, functionAdapter, FunctionDefinitionType,
-    ProcessMode, Column, dateFrameAdapter
+    ProcessMode, Column, dataFrameAdapter
 } from '../../../src';
 import { ColumnTests, RowsTests } from '../interfaces';
 
@@ -186,7 +186,7 @@ describe('toGeoPointConfig', () => {
         });
     });
 
-    describe('when paired with dateFrameAdapter', () => {
+    describe('when paired with dataFrameAdapter', () => {
         let stringCol: Column<string>;
         let objCol: Column<GeoPointInput>;
         let tupleCol: Column<number[]>;
@@ -218,7 +218,7 @@ describe('toGeoPointConfig', () => {
         });
 
         it('should be able to transform using toGeoPoint', () => {
-            const api = dateFrameAdapter(toGeoPointConfig);
+            const api = dataFrameAdapter(toGeoPointConfig);
 
             const geoStringResults = api.column(stringCol);
 

--- a/packages/data-mate/test/function-configs/json/parseJSON-spec.ts
+++ b/packages/data-mate/test/function-configs/json/parseJSON-spec.ts
@@ -3,7 +3,7 @@ import {
     FieldType, Maybe, DataTypeFields
 } from '@terascope/types'; import {
     functionConfigRepository, FunctionDefinitionType, ProcessMode,
-    Column, dateFrameAdapter
+    Column, dataFrameAdapter
 } from '../../../src';
 
 const parseJSONConfig = functionConfigRepository.parseJSON;
@@ -43,7 +43,7 @@ describe('parseJSON', () => {
                 type: FieldType.String,
             }, values);
 
-            const api = dateFrameAdapter(parseJSONConfig);
+            const api = dataFrameAdapter(parseJSONConfig);
             const newCol = api.column(col);
 
             const { type } = newCol.config;
@@ -72,7 +72,7 @@ describe('parseJSON', () => {
                 type: FieldType.Integer,
                 array: true
             };
-            const api = dateFrameAdapter(parseJSONConfig, { args });
+            const api = dataFrameAdapter(parseJSONConfig, { args });
             const newCol = api.column(col);
 
             const { type, array } = newCol.config;
@@ -112,7 +112,7 @@ describe('parseJSON', () => {
                 type: FieldType.Object,
                 child_config: frameTestChildConfig
             };
-            const api = dateFrameAdapter(parseJSONConfig, { args });
+            const api = dataFrameAdapter(parseJSONConfig, { args });
             const newCol = api.column(col);
 
             const { config: { type }, vector: { childConfig } } = newCol;

--- a/packages/data-mate/test/function-configs/json/toJSON-spec.ts
+++ b/packages/data-mate/test/function-configs/json/toJSON-spec.ts
@@ -5,7 +5,7 @@ import {
 } from '@terascope/types';
 import {
     functionConfigRepository, FunctionDefinitionType,
-    ProcessMode, Column, dateFrameAdapter
+    ProcessMode, Column, dataFrameAdapter
 } from '../../../src';
 
 const toJSONConfig = functionConfigRepository.toJSON;
@@ -47,7 +47,7 @@ describe('toJSONConfig', () => {
             const col = Column.fromJSON<bigint>('score', {
                 type: FieldType.Long,
             }, values);
-            const api = dateFrameAdapter(toJSONConfig);
+            const api = dataFrameAdapter(toJSONConfig);
             const newCol = api.column(col);
 
             expect(newCol.toJSON()).toEqual([
@@ -71,7 +71,7 @@ describe('toJSONConfig', () => {
                 type: FieldType.Boolean,
                 array: true
             }, values);
-            const api = dateFrameAdapter(toJSONConfig);
+            const api = dataFrameAdapter(toJSONConfig);
             const newCol = api.column(col);
 
             const { type, array } = newCol.config;
@@ -111,7 +111,7 @@ describe('toJSONConfig', () => {
                 type: FieldType.Object,
             }, values, 1, frameTestChildConfig);
 
-            const api = dateFrameAdapter(toJSONConfig);
+            const api = dataFrameAdapter(toJSONConfig);
             const newCol = api.column(col);
 
             const { config: { type, array }, vector: { childConfig } } = newCol;

--- a/packages/data-mate/test/function-configs/number/add-spec.ts
+++ b/packages/data-mate/test/function-configs/number/add-spec.ts
@@ -3,7 +3,7 @@ import { FieldType, Maybe } from '@terascope/types';
 import { bigIntToJSON } from '@terascope/utils';
 import {
     functionConfigRepository, FunctionDefinitionType, ProcessMode,
-    dateFrameAdapter, Column
+    dataFrameAdapter, Column
 } from '../../../src';
 
 describe('add', () => {
@@ -46,7 +46,7 @@ describe('add', () => {
             });
 
             it('should be able to transform the column using add', () => {
-                const add = dateFrameAdapter(addConfigConfig).column;
+                const add = dataFrameAdapter(addConfigConfig).column;
                 const newCol = add(col);
 
                 expect(newCol.id).not.toBe(col.id);
@@ -60,7 +60,7 @@ describe('add', () => {
 
             it('should be able to transform the column using add(by: 1.5)', () => {
                 const args = { by: 1.5 };
-                const add = dateFrameAdapter(addConfigConfig, { args }).column;
+                const add = dataFrameAdapter(addConfigConfig, { args }).column;
 
                 const newCol = add(col);
 
@@ -92,7 +92,7 @@ describe('add', () => {
 
             it('should be able to transform the column using add(by: 1.5)', () => {
                 const args = { by: 1.5 };
-                const add = dateFrameAdapter(addConfigConfig, { args }).column;
+                const add = dataFrameAdapter(addConfigConfig, { args }).column;
 
                 const newCol = add(col);
 
@@ -124,7 +124,7 @@ describe('add', () => {
 
             it('should be able to transform the column using add(by: 100)', () => {
                 const args = { by: 100 };
-                const add = dateFrameAdapter(addConfigConfig, { args }).column;
+                const add = dataFrameAdapter(addConfigConfig, { args }).column;
 
                 const newCol = add(col);
                 expect(newCol.id).not.toBe(col.id);

--- a/packages/data-mate/test/function-configs/number/subtract-spec.ts
+++ b/packages/data-mate/test/function-configs/number/subtract-spec.ts
@@ -3,7 +3,7 @@ import { FieldType, Maybe } from '@terascope/types';
 import { bigIntToJSON } from '@terascope/utils';
 import {
     functionConfigRepository, FunctionDefinitionType, ProcessMode,
-    dateFrameAdapter, Column
+    dataFrameAdapter, Column
 } from '../../../src';
 
 describe('subtract', () => {
@@ -46,7 +46,7 @@ describe('subtract', () => {
             });
 
             it('should be able to transform the column using subtract', () => {
-                const subtract = dateFrameAdapter(subtractConfigConfig).column;
+                const subtract = dataFrameAdapter(subtractConfigConfig).column;
                 const newCol = subtract(col);
 
                 expect(newCol.id).not.toBe(col.id);
@@ -60,7 +60,7 @@ describe('subtract', () => {
 
             it('should be able to transform the column using subtract(by: 1.5)', () => {
                 const args = { by: 1.5 };
-                const subtract = dateFrameAdapter(subtractConfigConfig, { args }).column;
+                const subtract = dataFrameAdapter(subtractConfigConfig, { args }).column;
 
                 const newCol = subtract(col);
 
@@ -92,7 +92,7 @@ describe('subtract', () => {
 
             it('should be able to transform the column using subtract(by: 1.5)', () => {
                 const args = { by: 1.5 };
-                const subtract = dateFrameAdapter(subtractConfigConfig, { args }).column;
+                const subtract = dataFrameAdapter(subtractConfigConfig, { args }).column;
 
                 const newCol = subtract(col);
 
@@ -124,7 +124,7 @@ describe('subtract', () => {
 
             it('should be able to transform the column using subtract(by: 100)', () => {
                 const args = { by: 100 };
-                const subtract = dateFrameAdapter(subtractConfigConfig, { args }).column;
+                const subtract = dataFrameAdapter(subtractConfigConfig, { args }).column;
 
                 const newCol = subtract(col);
                 expect(newCol.id).not.toBe(col.id);

--- a/packages/data-mate/test/function-configs/object/isEmpty-spec.ts
+++ b/packages/data-mate/test/function-configs/object/isEmpty-spec.ts
@@ -6,7 +6,7 @@ import {
 
 const isEmptyConfig = functionConfigRepository.isEmpty;
 
-describe('isHashConfig', () => {
+describe('isEmpty', () => {
     it('has proper configuration', () => {
         expect(isEmptyConfig).toBeDefined();
         expect(isEmptyConfig).toHaveProperty('name', 'isEmpty');
@@ -61,7 +61,7 @@ describe('isHashConfig', () => {
             const results = api.column(fullColumnData);
             const results2 = api.column(emptyColumnData);
 
-            expect(results).toBeNull();
+            expect(results).toEqual([null, null]);
             expect(results2).toEqual(emptyColumnData);
         });
     });

--- a/packages/data-mate/test/function-configs/string/decodeHex-spec.ts
+++ b/packages/data-mate/test/function-configs/string/decodeHex-spec.ts
@@ -5,7 +5,7 @@ import {
 import { LATEST_VERSION } from '@terascope/data-types';
 import {
     functionConfigRepository, FunctionDefinitionType,
-    ProcessMode, Column, dateFrameAdapter, DataFrame, VectorType
+    ProcessMode, Column, dataFrameAdapter, DataFrame, VectorType
 } from '../../../src';
 
 const decodeHexConfig = functionConfigRepository.decodeHex;
@@ -58,7 +58,7 @@ describe('decodeHexConfig', () => {
             col = Column.fromJSON<string>(field, {
                 type: FieldType.String
             }, testValues);
-            const api = dateFrameAdapter(decodeHexConfig);
+            const api = dataFrameAdapter(decodeHexConfig);
             const newCol = api.column(col);
 
             expect(newCol.toJSON()).toEqual(originalValues);
@@ -67,7 +67,7 @@ describe('decodeHexConfig', () => {
         it('should be able to transform a dataFrame using decodeHex', () => {
             const frame = DataFrame.fromJSON(frameTestConfig, frameData);
 
-            const api = dateFrameAdapter(decodeHexConfig, { field });
+            const api = dataFrameAdapter(decodeHexConfig, { field });
             const newFrame = api.frame(frame);
 
             expect(newFrame.toJSON()).toEqual([

--- a/packages/data-mate/test/function-configs/string/encodeHex-spec.ts
+++ b/packages/data-mate/test/function-configs/string/encodeHex-spec.ts
@@ -6,7 +6,7 @@ import {
 import { LATEST_VERSION } from '@terascope/data-types';
 import {
     functionConfigRepository, FunctionDefinitionType,
-    ProcessMode, Column, dateFrameAdapter, DataFrame, VectorType
+    ProcessMode, Column, dataFrameAdapter, DataFrame, VectorType
 } from '../../../src';
 
 const encodeHexConfig = functionConfigRepository.encodeHex;
@@ -66,7 +66,7 @@ describe('encodeHexConfig', () => {
             col = Column.fromJSON<string>(field, {
                 type: FieldType.String
             }, originalValues.slice());
-            const api = dateFrameAdapter(encodeHexConfig);
+            const api = dataFrameAdapter(encodeHexConfig);
             const newCol = api.column(col);
 
             expect(newCol.toJSON()).toEqual(encodedValues);
@@ -74,7 +74,7 @@ describe('encodeHexConfig', () => {
 
         it('should be able to transform a dataFrame using encodeHex', () => {
             const frame = DataFrame.fromJSON(frameTestConfig, frameData);
-            const api = dateFrameAdapter(encodeHexConfig, { field });
+            const api = dataFrameAdapter(encodeHexConfig, { field });
             const newFrame = api.frame(frame);
 
             const results = newFrame.toJSON();

--- a/packages/data-mate/test/function-configs/string/encodeSHA-spec.ts
+++ b/packages/data-mate/test/function-configs/string/encodeSHA-spec.ts
@@ -6,7 +6,7 @@ import {
 import { LATEST_VERSION } from '@terascope/data-types';
 import {
     functionConfigRepository, FunctionDefinitionType,
-    ProcessMode, Column, dateFrameAdapter, DataFrame, VectorType
+    ProcessMode, Column, dataFrameAdapter, DataFrame, VectorType
 } from '../../../src';
 import { encodeSHA } from '../../../src/function-configs/string/encodeSHA';
 
@@ -63,7 +63,7 @@ describe('EncodeSHA1Config', () => {
             col = Column.fromJSON<string>(field, {
                 type: FieldType.String
             }, originalValues.slice());
-            const api = dateFrameAdapter(encodeSHAConfig);
+            const api = dataFrameAdapter(encodeSHAConfig);
             const newCol = api.column(col);
 
             expect(newCol.toJSON()).toEqual(encodedValues);
@@ -71,7 +71,7 @@ describe('EncodeSHA1Config', () => {
 
         it('should be able to transform a dataFrame using encodeSHA', () => {
             const frame = DataFrame.fromJSON(frameTestConfig, frameData);
-            const api = dateFrameAdapter(encodeSHAConfig, { field });
+            const api = dataFrameAdapter(encodeSHAConfig, { field });
             const newFrame = api.frame(frame);
 
             const results = newFrame.toJSON();

--- a/packages/data-mate/test/function-configs/string/encodeSHA1-spec.ts
+++ b/packages/data-mate/test/function-configs/string/encodeSHA1-spec.ts
@@ -6,7 +6,7 @@ import {
 import { LATEST_VERSION } from '@terascope/data-types';
 import {
     functionConfigRepository, FunctionDefinitionType,
-    ProcessMode, Column, dateFrameAdapter, DataFrame, VectorType
+    ProcessMode, Column, dataFrameAdapter, DataFrame, VectorType
 } from '../../../src';
 import { encodeSHA1 } from '../../../src/function-configs/string/encodeSHA1';
 
@@ -63,7 +63,7 @@ describe('EncodeSHA1Config', () => {
             col = Column.fromJSON<string>(field, {
                 type: FieldType.String
             }, originalValues.slice());
-            const api = dateFrameAdapter(encodeSHA1Config);
+            const api = dataFrameAdapter(encodeSHA1Config);
             const newCol = api.column(col);
 
             expect(newCol.toJSON()).toEqual(encodedValues);
@@ -71,7 +71,7 @@ describe('EncodeSHA1Config', () => {
 
         it('should be able to transform a dataFrame using encodeSHA1', () => {
             const frame = DataFrame.fromJSON(frameTestConfig, frameData);
-            const api = dateFrameAdapter(encodeSHA1Config, { field });
+            const api = dataFrameAdapter(encodeSHA1Config, { field });
             const newFrame = api.frame(frame);
 
             const results = newFrame.toJSON();

--- a/packages/data-mate/test/function-configs/string/encodeURL-spec.ts
+++ b/packages/data-mate/test/function-configs/string/encodeURL-spec.ts
@@ -6,7 +6,7 @@ import {
 import { LATEST_VERSION } from '@terascope/data-types';
 import {
     functionConfigRepository, FunctionDefinitionType,
-    ProcessMode, Column, dateFrameAdapter, DataFrame, VectorType
+    ProcessMode, Column, dataFrameAdapter, DataFrame, VectorType
 } from '../../../src';
 
 const encodeURLConfig = functionConfigRepository.encodeURL;
@@ -66,7 +66,7 @@ describe('encodeURLConfig', () => {
             col = Column.fromJSON<string>(field, {
                 type: FieldType.String
             }, originalValues.slice());
-            const api = dateFrameAdapter(encodeURLConfig);
+            const api = dataFrameAdapter(encodeURLConfig);
             const newCol = api.column(col);
 
             expect(newCol.toJSON()).toEqual(encodedValues);
@@ -74,7 +74,7 @@ describe('encodeURLConfig', () => {
 
         it('should be able to transform a dataFrame using encodeURL', () => {
             const frame = DataFrame.fromJSON(frameTestConfig, frameData);
-            const api = dateFrameAdapter(encodeURLConfig, { field });
+            const api = dataFrameAdapter(encodeURLConfig, { field });
             const newFrame = api.frame(frame);
 
             const results = newFrame.toJSON();

--- a/packages/data-mate/test/function-configs/string/isHash-spec.ts
+++ b/packages/data-mate/test/function-configs/string/isHash-spec.ts
@@ -3,7 +3,7 @@ import { FieldType, Maybe } from '@terascope/types';
 import {
     functionConfigRepository, functionAdapter,
     FunctionDefinitionType, ProcessMode,
-    dateFrameAdapter, Column
+    dataFrameAdapter, Column
 } from '../../../src';
 
 const isHashConfig = functionConfigRepository.isHash;
@@ -78,7 +78,7 @@ describe('isHashConfig', () => {
         });
     });
 
-    describe('when paired with dateFrameAdapter', () => {
+    describe('when paired with dataFrameAdapter', () => {
         let col: Column<string>;
         const values: Maybe<string>[] = [
             '85031b6f407e7f25cf826193338f7a4c2dc8c8b5130f5ca2c69a66d9f5107e33',
@@ -97,7 +97,7 @@ describe('isHashConfig', () => {
         });
 
         it('should be able to validate using isHash', () => {
-            const api = dateFrameAdapter(isHashConfig, { args: { algo } });
+            const api = dataFrameAdapter(isHashConfig, { args: { algo } });
             const newCol = api.column(col);
 
             expect(newCol.toJSON()).toEqual([

--- a/packages/data-mate/test/function-configs/string/reverse-spec.ts
+++ b/packages/data-mate/test/function-configs/string/reverse-spec.ts
@@ -2,7 +2,7 @@ import 'jest-extended';
 import { FieldType } from '@terascope/types';
 import {
     functionConfigRepository, FunctionDefinitionType, ProcessMode,
-    Column, dateFrameAdapter,
+    Column, dataFrameAdapter,
 } from '../../../src';
 
 const reverseConfig = functionConfigRepository.reverse;
@@ -44,7 +44,7 @@ describe('reverseConfig', () => {
                 type: FieldType.String
             }, values);
 
-            const api = dateFrameAdapter(reverseConfig);
+            const api = dataFrameAdapter(reverseConfig);
             const newCol = api.column(col);
 
             expect(newCol.toJSON()).toEqual([
@@ -61,7 +61,7 @@ describe('reverseConfig', () => {
                 type: FieldType.Number
             }, [12, 34234, undefined, 1324234234]);
 
-            const api = dateFrameAdapter(reverseConfig);
+            const api = dataFrameAdapter(reverseConfig);
             expect(() => api.column(col)).toThrowError('Incompatible with field type Float, must be String');
         });
     });

--- a/packages/data-mate/test/function-configs/string/toISDN-spec.ts
+++ b/packages/data-mate/test/function-configs/string/toISDN-spec.ts
@@ -3,7 +3,7 @@ import {
     FieldType, Maybe
 } from '@terascope/types'; import {
     functionConfigRepository, FunctionDefinitionType, ProcessMode,
-    Column, dateFrameAdapter
+    Column, dataFrameAdapter
 } from '../../../src';
 
 const toISDNConfig = functionConfigRepository.toISDN;
@@ -52,7 +52,7 @@ describe('toISDN', () => {
                 type: FieldType.Number,
             }, values);
 
-            const api = dateFrameAdapter(toISDNConfig);
+            const api = dataFrameAdapter(toISDNConfig);
             const newCol = api.column(col);
 
             const { type, array } = newCol.config;

--- a/packages/data-mate/test/function-configs/string/toString-spec.ts
+++ b/packages/data-mate/test/function-configs/string/toString-spec.ts
@@ -5,7 +5,7 @@ import {
 } from '@terascope/types';
 import {
     functionConfigRepository, FunctionDefinitionType,
-    ProcessMode, Column, dateFrameAdapter
+    ProcessMode, Column, dataFrameAdapter
 } from '../../../src';
 
 const toStringConfig = functionConfigRepository.toString;
@@ -47,7 +47,7 @@ describe('toStringConfig', () => {
             const col = Column.fromJSON<bigint>('score', {
                 type: FieldType.Long,
             }, values);
-            const api = dateFrameAdapter(toStringConfig);
+            const api = dataFrameAdapter(toStringConfig);
             const newCol = api.column(col);
 
             expect(newCol.toJSON()).toEqual([
@@ -71,7 +71,7 @@ describe('toStringConfig', () => {
                 type: FieldType.Boolean,
                 array: true
             }, values);
-            const api = dateFrameAdapter(toStringConfig);
+            const api = dataFrameAdapter(toStringConfig);
             const newCol = api.column(col);
 
             const { type, array } = newCol.config;
@@ -111,7 +111,7 @@ describe('toStringConfig', () => {
                 type: FieldType.Object,
             }, values, 1, frameTestChildConfig);
 
-            const api = dateFrameAdapter(toStringConfig);
+            const api = dataFrameAdapter(toStringConfig);
             const newCol = api.column(col);
 
             const { config: { type, array }, vector: { childConfig } } = newCol;

--- a/packages/data-mate/test/function-configs/string/toUpperCase-spec.ts
+++ b/packages/data-mate/test/function-configs/string/toUpperCase-spec.ts
@@ -7,7 +7,7 @@ import { LATEST_VERSION } from '@terascope/data-types';
 import { DataTypeConfig, FieldType, Maybe } from '@terascope/types';
 import {
     functionConfigRepository, functionAdapter, FunctionDefinitionType,
-    ProcessMode, Column, dateFrameAdapter, DataFrame, VectorType
+    ProcessMode, Column, dataFrameAdapter, DataFrame, VectorType
 } from '../../../src';
 import { ColumnTests, RowsTests } from '../interfaces';
 
@@ -209,7 +209,7 @@ describe('toUpperCaseConfig', () => {
         });
     });
 
-    describe('when paired with dateFrameAdapter', () => {
+    describe('when paired with dataFrameAdapter', () => {
         let col: Column<string>;
 
         const values: Maybe<string>[] = [
@@ -242,7 +242,7 @@ describe('toUpperCaseConfig', () => {
         });
 
         it('should be able to transform a column using toUpperCase', () => {
-            const api = dateFrameAdapter(toUpperCaseConfig);
+            const api = dataFrameAdapter(toUpperCaseConfig);
             const newCol = api.column(col);
 
             expect(newCol.toJSON()).toEqual([
@@ -257,7 +257,7 @@ describe('toUpperCaseConfig', () => {
         it('should be able to transform a dataFrame using toUpperCase', () => {
             const frame = DataFrame.fromJSON(frameTestConfig, frameData);
 
-            const api = dateFrameAdapter(toUpperCaseConfig, { field });
+            const api = dataFrameAdapter(toUpperCaseConfig, { field });
             const newFrame = api.frame(frame);
 
             expect(newFrame.toJSON()).toEqual([

--- a/packages/data-mate/test/function-configs/string/trim-spec.ts
+++ b/packages/data-mate/test/function-configs/string/trim-spec.ts
@@ -5,7 +5,7 @@ import {
 import { LATEST_VERSION } from '@terascope/data-types';
 import {
     functionConfigRepository, FunctionDefinitionType,
-    ProcessMode, Column, dateFrameAdapter, DataFrame, VectorType
+    ProcessMode, Column, dataFrameAdapter, DataFrame, VectorType
 } from '../../../src';
 
 const trimConfig = functionConfigRepository.trim;
@@ -70,7 +70,7 @@ describe('trimConfig', () => {
             col = Column.fromJSON<string>(field, {
                 type: FieldType.String
             }, values);
-            const api = dateFrameAdapter(trimConfig);
+            const api = dataFrameAdapter(trimConfig);
             const newCol = api.column(col);
 
             expect(newCol.toJSON()).toEqual([
@@ -85,7 +85,7 @@ describe('trimConfig', () => {
         it('should be able to transform a dataFrame using trim', () => {
             const frame = DataFrame.fromJSON(frameTestConfig, frameData);
 
-            const api = dateFrameAdapter(trimConfig, { field });
+            const api = dataFrameAdapter(trimConfig, { field });
             const newFrame = api.frame(frame);
 
             expect(newFrame.toJSON()).toEqual([

--- a/packages/data-mate/test/function-configs/string/trimEnd-spec.ts
+++ b/packages/data-mate/test/function-configs/string/trimEnd-spec.ts
@@ -6,7 +6,7 @@ import {
 import { LATEST_VERSION } from '@terascope/data-types';
 import {
     functionConfigRepository, FunctionDefinitionType,
-    ProcessMode, Column, dateFrameAdapter, DataFrame, VectorType
+    ProcessMode, Column, dataFrameAdapter, DataFrame, VectorType
 } from '../../../src';
 
 const trimEndConfig = functionConfigRepository.trimEnd;
@@ -71,7 +71,7 @@ describe('trimEndConfig', () => {
             col = Column.fromJSON<string>(field, {
                 type: FieldType.String
             }, values);
-            const api = dateFrameAdapter(trimEndConfig);
+            const api = dataFrameAdapter(trimEndConfig);
             const newCol = api.column(col);
 
             expect(newCol.toJSON()).toEqual([
@@ -86,7 +86,7 @@ describe('trimEndConfig', () => {
         it('should be able to transform a dataFrame using trim', () => {
             const frame = DataFrame.fromJSON(frameTestConfig, frameData);
 
-            const api = dateFrameAdapter(trimEndConfig, { field });
+            const api = dataFrameAdapter(trimEndConfig, { field });
             const newFrame = api.frame(frame);
 
             expect(newFrame.toJSON()).toEqual([

--- a/packages/data-mate/test/function-configs/string/trimStart-spec.ts
+++ b/packages/data-mate/test/function-configs/string/trimStart-spec.ts
@@ -5,7 +5,7 @@ import {
 import { LATEST_VERSION } from '@terascope/data-types';
 import {
     functionConfigRepository, FunctionDefinitionType,
-    ProcessMode, Column, dateFrameAdapter, DataFrame, VectorType
+    ProcessMode, Column, dataFrameAdapter, DataFrame, VectorType
 } from '../../../src';
 
 const trimStartConfig = functionConfigRepository.trimStart;
@@ -70,7 +70,7 @@ describe('trimStartConfig', () => {
             col = Column.fromJSON<string>(field, {
                 type: FieldType.String
             }, values);
-            const api = dateFrameAdapter(trimStartConfig);
+            const api = dataFrameAdapter(trimStartConfig);
             const newCol = api.column(col);
 
             expect(newCol.toJSON()).toEqual([
@@ -85,7 +85,7 @@ describe('trimStartConfig', () => {
         it('should be able to transform a dataFrame using trim', () => {
             const frame = DataFrame.fromJSON(frameTestConfig, frameData);
 
-            const api = dateFrameAdapter(trimStartConfig, { field });
+            const api = dataFrameAdapter(trimStartConfig, { field });
             const newFrame = api.frame(frame);
 
             expect(newFrame.toJSON()).toEqual([

--- a/packages/data-mate/test/function-configs/string/truncate-spec.ts
+++ b/packages/data-mate/test/function-configs/string/truncate-spec.ts
@@ -2,7 +2,7 @@ import 'jest-extended';
 import { FieldType } from '@terascope/types';
 import {
     functionConfigRepository, FunctionDefinitionType,
-    ProcessMode, Column, dateFrameAdapter
+    ProcessMode, Column, dataFrameAdapter
 } from '../../../src';
 
 const truncateConfig = functionConfigRepository.truncate;
@@ -44,7 +44,7 @@ describe('truncateConfig', () => {
 
         it('can shorten strings', () => {
             const args = { size: 3 };
-            const api = dateFrameAdapter(truncateConfig, { args });
+            const api = dataFrameAdapter(truncateConfig, { args });
             const newCol = api.column(col);
 
             expect(newCol.toJSON()).toEqual([
@@ -57,15 +57,15 @@ describe('truncateConfig', () => {
         });
 
         it('should throw if improper args are given', () => {
-            expect(() => dateFrameAdapter(truncateConfig, { })).toThrowError(
+            expect(() => dataFrameAdapter(truncateConfig, { })).toThrowError(
                 'No arguments were provided but truncate requires size to be set'
             );
 
-            expect(() => dateFrameAdapter(truncateConfig, { args: { size: 'ha' as unknown as number } })).toThrowError(
+            expect(() => dataFrameAdapter(truncateConfig, { args: { size: 'ha' as unknown as number } })).toThrowError(
                 'Invalid argument value set at key size, expected String to be compatible with type Number'
             );
 
-            expect(() => dateFrameAdapter(truncateConfig, { args: { size: -1231 } })).toThrowError(
+            expect(() => dataFrameAdapter(truncateConfig, { args: { size: -1231 } })).toThrowError(
                 'Invalid parameter size, expected a positive integer, got -1231'
             );
         });


### PR DESCRIPTION
- Fix the spelling of data frame adapter (it is not date adapter)
- Fix the interfaces to work a little better in typescript (make some properties readonly)
- Add a basic function test harness (not used yet)
- Update the function definition config to also include the examples (so we can add them while we develop)