### PR TITLE
Add more Data Mate math functions

### DIFF
--- a/docs/packages/data-mate/functions.md
+++ b/docs/packages/data-mate/functions.md
@@ -110,7 +110,7 @@ Must be represented in a Language Tags (BCP 47)
 
 **Type:** `FIELD_TRANSFORM`
 
-> Returns the hyperbolic arc-cosine of a given number. If given a number less than 1, it will throw.
+> Returns the hyperbolic arc-cosine of a given number. If given a number less than 1, null will be returned
 
 #### Accepts
 
@@ -122,8 +122,9 @@ Must be represented in a Language Tags (BCP 47)
 1 => acosh() // outputs 0
 ```
 
+Since this function doesn't work with numbers <=0, null will be returned
 ```ts
-0 => acosh() // throws Expected value greater than or equal to 0, got 0
+0 => acosh() // outputs null
 ```
 
 ### `add`
@@ -238,6 +239,163 @@ Must be represented in a Language Tags (BCP 47)
 1 => atan() // outputs 0.7853981633974483
 ```
 
+### `atan2`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the angle in the plane (in radians) between the positive x-axis and the ray from (0,0) to the point (x,y), for atan2(y,x)
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+[15, 90] => atan2() // outputs 1.4056476493802699
+```
+
+```ts
+[90, 15] => atan2() // outputs 0.16514867741462683
+```
+
+```ts
+[-90, null] => atan2() // throws Expected (x, y) coordinates, got [-90,null] (Array)
+```
+
+### `atanh`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the arctangent (in radians) of the given number
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+0.5 => atanh() // outputs 0.5493061443340548
+```
+
+Typically this would return -Infinity but that cannot be stored or serialized so null is returned
+```ts
+-1 => atanh() // outputs null
+```
+
+### `cbrt`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the cube root of a number
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+64 => cbrt() // outputs 4
+```
+
+```ts
+1 => cbrt() // outputs 1
+```
+
+### `ceil`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Rounds a number up to the next largest integer
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+0.95 => ceil() // outputs 1
+```
+
+```ts
+0.1 => ceil() // outputs 1
+```
+
+```ts
+-7.004 => ceil() // outputs -7
+```
+
+### `clz32`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the number of leading zero bits in the 32-bit binary representation of a number
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+1 => clz32() // outputs 31
+```
+
+```ts
+1000 => clz32() // outputs 22
+```
+
+```ts
+4 => clz32() // outputs 29
+```
+
+### `cos`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the cosine of the specified angle, which must be specified in radians
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+0 => cos() // outputs 1
+```
+
+```ts
+3.141592653589793 => cos() // outputs -1
+```
+
+```ts
+6.283185307179586 => cos() // outputs 1
+```
+
+### `cosh`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the hyperbolic cosine of a number, that can be expressed using the constant e
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+0 => cosh() // outputs 1
+```
+
+```ts
+3.141592653589793 => cosh() // outputs 11.591953275521519
+```
+
 ### `divide`
 
 **Type:** `FIELD_TRANSFORM`
@@ -298,9 +456,258 @@ Must be represented in a Language Tags (BCP 47)
 2 => divideValues() // outputs 2
 ```
 
+### `exp`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns a number representing `e^x`, where `e` is Euler's number and `x` is the argument
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+0 => exp() // outputs 1
+```
+
+```ts
+1 => exp() // outputs 2.718281828459045
+```
+
+### `expm1`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns a number representing `e^x - 1`, where `e` is Euler's number and `x` is the argument.
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+0 => expm1() // outputs 0
+```
+
+```ts
+1 => expm1() // outputs 1.718281828459045
+```
+
+### `floor`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Rounds a number down to the next largest integer
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+0.95 => floor() // outputs 0
+```
+
+```ts
+0.1 => floor() // outputs 0
+```
+
+```ts
+-7.004 => floor() // outputs -8
+```
+
+### `fround`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the nearest 32-bit single precision float representation of the given number
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+5.5 => fround() // outputs 5.5
+```
+
+```ts
+-5.05 => fround() // outputs -5.050000190734863
+```
+
+### `hypot`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the square root of the sum of squares of the given arguments. If at least one of the arguments cannot be converted to a number, null is returned
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+[3, 4] => hypot() // outputs 5
+```
+
+```ts
+[5, 12] => hypot() // outputs 13
+```
+
+```ts
+[3, 4, null, 5] => hypot() // outputs 7.0710678118654755
+```
+
+```ts
+null => hypot() // outputs null
+```
+
+### `log`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the natural logarithm (base e) of the given number. If the number is negative, null is returned
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+1 => log() // outputs 0
+```
+
+```ts
+10 => log() // outputs 2.302585092994046
+```
+
+```ts
+-1 => log() // outputs null
+```
+
+### `log1p`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the natural logarithm (base e) of 1 plus the given number. If the number is less than -1, null is returned.
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+1 => log1p() // outputs 0.6931471805599453
+```
+
+```ts
+0 => log1p() // outputs 0
+```
+
+Typically this would return -Infinity but that cannot be stored or serialized so null is returned
+```ts
+-1 => log1p() // outputs null
+```
+
+Typically this would return NaN but that cannot be stored or serialized so null is returned
+```ts
+-2 => log1p() // outputs null
+```
+
+### `log2`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the base 2 logarithm of the given number. If the number is negative, null is returned
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+2 => log2() // outputs 1
+```
+
+Typically this would return -Infinity but that cannot be stored or serialized so null is returned
+```ts
+0 => log2() // outputs null
+```
+
+```ts
+-2 => log2() // outputs null
+```
+
+### `log10`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the base 10 logarithm of the given number. If the number is negative, null is returned
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+10 => log10() // outputs 1
+```
+
+Typically this would return -Infinity but that cannot be stored or serialized so null is returned
+```ts
+0 => log10() // outputs null
+```
+
+```ts
+-2 => log10() // outputs null
+```
+
+### `minValues`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Get the minimum value in an array, this requires an array to function correctly
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+[100, 10] => minValues() // outputs 10
+```
+
+```ts
+[10] => minValues() // outputs 10
+```
+
+```ts
+[10, 100000, 2] => minValues() // outputs 2
+```
+
+```ts
+[[10, null], 100000, [2], null] => minValues() // outputs 2
+```
+
+```ts
+2 => minValues() // outputs 2
+```
+
 ### `modulus`
 
 **Type:** `FIELD_TRANSFORM`
+**Aliases:** `mod`
 
 > Calculate the modulus from the specified value
 
@@ -390,6 +797,174 @@ Must be represented in a Language Tags (BCP 47)
 2 => multiplyValues() // outputs 2
 ```
 
+### `pow`
+
+**Type:** `FIELD_TRANSFORM`
+**Aliases:** `power`
+
+> Returns a number representing the given base taken to the power of the given exponent
+
+#### Arguments
+
+ - **exp**: (required) `Integer` - The exponent used to raise the base
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+7 => pow(exp: 3) // outputs 343
+```
+
+```ts
+4 => pow(exp: 0.5) // outputs 2
+```
+
+### `random`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Generate a random number between a given range
+
+#### Arguments
+
+ - **min**: (required) `Number` - The minimum value in the range
+
+ - **max**: (required) `Number` - The maximum value in the range
+
+#### Examples
+
+```ts
+1 => random(min: 1, max: 1) // outputs 1
+```
+
+### `round`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the value of a number rounded to the nearest integer.
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+0.95 => round() // outputs 1
+```
+
+```ts
+0.1 => round() // outputs 0
+```
+
+```ts
+-7.004 => round() // outputs -7
+```
+
+### `sign`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns a number representing the sign of the given argument:
+>- If the argument is positive, returns 1
+>- If the argument is negative, returns -1
+>- If the argument is positive zero, returns 0
+>- If the argument is negative zero, returns -0
+>- Otherwise, null is returned
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+3 => sign() // outputs 1
+```
+
+```ts
+-3 => sign() // outputs -1
+```
+
+```ts
+0 => sign() // outputs 0
+```
+
+### `sin`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the sine of the given number
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+0 => sin() // outputs 0
+```
+
+```ts
+1 => sin() // outputs 0.8414709848078965
+```
+
+```ts
+1.5707963267948966 => sin() // outputs 1
+```
+
+### `sinh`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the hyperbolic sine of a number, that can be expressed using the constant e
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+0 => sinh() // outputs 0
+```
+
+```ts
+1 => sinh() // outputs 1.1752011936438014
+```
+
+```ts
+-1 => sinh() // outputs -1.1752011936438014
+```
+
+### `sqrt`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the square root of a number
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+9 => sqrt() // outputs 3
+```
+
+```ts
+2 => sqrt() // outputs 1.4142135623730951
+```
+
+```ts
+-1 => sqrt() // outputs null
+```
+
 ### `subtract`
 
 **Type:** `FIELD_TRANSFORM`
@@ -452,6 +1027,42 @@ Must be represented in a Language Tags (BCP 47)
 
 ```ts
 2 => subtractValues() // outputs 2
+```
+
+### `tan`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the tangent of a number
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+1 => tan() // outputs 1.5574077246549023
+```
+
+### `tanh`
+
+**Type:** `FIELD_TRANSFORM`
+
+> Returns the hyperbolic tangent of a number
+
+#### Accepts
+
+- `Number`
+
+#### Examples
+
+```ts
+-1 => tanh() // outputs -0.7615941559557649
+```
+
+```ts
+0 => tanh() // outputs 0
 ```
 
 ### `toCelsius`

--- a/packages/data-mate/scripts/docs.js
+++ b/packages/data-mate/scripts/docs.js
@@ -103,7 +103,7 @@ function generateFunctionDoc(fnDef) {
 
 **Type:** \`${fnDef.type}\`
 ${generateAliases(fnDef)}
-> ${firstToUpper(fnDef.description)}`.trim(),
+> ${firstToUpper(fnDef.description).split('\n').join('\n>')}`.trim(),
         ...generateArgDocs(fnDef),
         ...generateAccepts(fnDef),
         ...generateExamples(fnDef, fnDef.examples)

--- a/packages/data-mate/src/function-configs/numeric/abs.ts
+++ b/packages/data-mate/src/function-configs/numeric/abs.ts
@@ -1,4 +1,3 @@
-import { toFloatOrThrow } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -6,6 +5,7 @@ import {
     FunctionDefinitionType,
     FunctionDefinitionCategory,
 } from '../interfaces';
+import { runMathFn } from './utils';
 
 export const absConfig: FieldTransformConfig = {
     name: 'abs',
@@ -26,14 +26,10 @@ export const absConfig: FieldTransformConfig = {
         }
     ],
     create() {
-        return abs;
+        return runMathFn(Math.abs);
     },
     accepts: [
         FieldType.Number,
     ],
     argument_schema: {},
 };
-
-function abs(num: unknown): number {
-    return Math.abs(toFloatOrThrow(num));
-}

--- a/packages/data-mate/src/function-configs/numeric/acos.ts
+++ b/packages/data-mate/src/function-configs/numeric/acos.ts
@@ -1,4 +1,3 @@
-import { toFloatOrThrow } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -6,6 +5,7 @@ import {
     FunctionDefinitionType,
     FunctionDefinitionCategory,
 } from '../interfaces';
+import { runMathFn } from './utils';
 
 export const acosConfig: FieldTransformConfig = {
     name: 'acos',
@@ -26,7 +26,7 @@ export const acosConfig: FieldTransformConfig = {
         }
     ],
     create() {
-        return acos;
+        return runMathFn(Math.acos);
     },
     accepts: [
         FieldType.Number,
@@ -41,11 +41,3 @@ export const acosConfig: FieldTransformConfig = {
         };
     }
 };
-
-function acos(num: unknown): number|null {
-    const value = Math.acos(toFloatOrThrow(num));
-    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
-        return null;
-    }
-    return value;
-}

--- a/packages/data-mate/src/function-configs/numeric/acos.ts
+++ b/packages/data-mate/src/function-configs/numeric/acos.ts
@@ -42,6 +42,10 @@ export const acosConfig: FieldTransformConfig = {
     }
 };
 
-function acos(num: unknown): number {
-    return Math.acos(toFloatOrThrow(num));
+function acos(num: unknown): number|null {
+    const value = Math.acos(toFloatOrThrow(num));
+    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
+        return null;
+    }
+    return value;
 }

--- a/packages/data-mate/src/function-configs/numeric/acosh.ts
+++ b/packages/data-mate/src/function-configs/numeric/acosh.ts
@@ -1,4 +1,3 @@
-import { toFloatOrThrow } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -6,6 +5,7 @@ import {
     FunctionDefinitionType,
     FunctionDefinitionCategory,
 } from '../interfaces';
+import { runMathFn } from './utils';
 
 export const acoshConfig: FieldTransformConfig = {
     name: 'acosh',
@@ -33,11 +33,14 @@ export const acoshConfig: FieldTransformConfig = {
             field: 'testField',
             input: 0,
             fails: true,
-            output: 'Expected value greater than or equal to 0, got 0'
+            output: 'Expected value greater than 0, got 0'
         }
     ],
     create() {
-        return acosh;
+        return runMathFn(Math.acosh, (num) => {
+            if (num > 0) return;
+            throw new TypeError(`Expected value greater than 0, got ${num}`);
+        });
     },
     accepts: [
         FieldType.Number,
@@ -52,15 +55,3 @@ export const acoshConfig: FieldTransformConfig = {
         };
     }
 };
-
-function acosh(num: unknown): number|null {
-    const float = toFloatOrThrow(num);
-    if (float < 1) {
-        throw new TypeError(`Expected value greater than or equal to 0, got ${float}`);
-    }
-    const value = Math.acosh(float);
-    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
-        return null;
-    }
-    return value;
-}

--- a/packages/data-mate/src/function-configs/numeric/asin.ts
+++ b/packages/data-mate/src/function-configs/numeric/asin.ts
@@ -1,4 +1,3 @@
-import { toFloatOrThrow } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -6,6 +5,7 @@ import {
     FunctionDefinitionType,
     FunctionDefinitionCategory,
 } from '../interfaces';
+import { runMathFn } from './utils';
 
 export const asinConfig: FieldTransformConfig = {
     name: 'asin',
@@ -26,18 +26,10 @@ export const asinConfig: FieldTransformConfig = {
         }
     ],
     create() {
-        return asin;
+        return runMathFn(Math.asin);
     },
     accepts: [
         FieldType.Number,
     ],
     argument_schema: {},
 };
-
-function asin(num: unknown): number|null {
-    const value = Math.asin(toFloatOrThrow(num));
-    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
-        return null;
-    }
-    return value;
-}

--- a/packages/data-mate/src/function-configs/numeric/asin.ts
+++ b/packages/data-mate/src/function-configs/numeric/asin.ts
@@ -34,6 +34,10 @@ export const asinConfig: FieldTransformConfig = {
     argument_schema: {},
 };
 
-function asin(num: unknown): number {
-    return Math.asin(toFloatOrThrow(num));
+function asin(num: unknown): number|null {
+    const value = Math.asin(toFloatOrThrow(num));
+    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
+        return null;
+    }
+    return value;
 }

--- a/packages/data-mate/src/function-configs/numeric/asinh.ts
+++ b/packages/data-mate/src/function-configs/numeric/asinh.ts
@@ -42,6 +42,10 @@ export const asinhConfig: FieldTransformConfig = {
     }
 };
 
-function asinh(num: unknown): number {
-    return Math.asinh(toFloatOrThrow(num));
+function asinh(num: unknown): number|null {
+    const value = Math.asinh(toFloatOrThrow(num));
+    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
+        return null;
+    }
+    return value;
 }

--- a/packages/data-mate/src/function-configs/numeric/asinh.ts
+++ b/packages/data-mate/src/function-configs/numeric/asinh.ts
@@ -1,4 +1,3 @@
-import { toFloatOrThrow } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -6,6 +5,7 @@ import {
     FunctionDefinitionType,
     FunctionDefinitionCategory,
 } from '../interfaces';
+import { runMathFn } from './utils';
 
 export const asinhConfig: FieldTransformConfig = {
     name: 'asinh',
@@ -26,7 +26,7 @@ export const asinhConfig: FieldTransformConfig = {
         }
     ],
     create() {
-        return asinh;
+        return runMathFn(Math.asinh);
     },
     accepts: [
         FieldType.Number,
@@ -41,11 +41,3 @@ export const asinhConfig: FieldTransformConfig = {
         };
     }
 };
-
-function asinh(num: unknown): number|null {
-    const value = Math.asinh(toFloatOrThrow(num));
-    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
-        return null;
-    }
-    return value;
-}

--- a/packages/data-mate/src/function-configs/numeric/atan.ts
+++ b/packages/data-mate/src/function-configs/numeric/atan.ts
@@ -42,6 +42,10 @@ export const atanConfig: FieldTransformConfig = {
     }
 };
 
-function atan(num: unknown): number {
-    return Math.atan(toFloatOrThrow(num));
+function atan(num: unknown): number|null {
+    const value = Math.atan(toFloatOrThrow(num));
+    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
+        return null;
+    }
+    return value;
 }

--- a/packages/data-mate/src/function-configs/numeric/atan.ts
+++ b/packages/data-mate/src/function-configs/numeric/atan.ts
@@ -1,4 +1,3 @@
-import { toFloatOrThrow } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -6,6 +5,7 @@ import {
     FunctionDefinitionType,
     FunctionDefinitionCategory,
 } from '../interfaces';
+import { runMathFn } from './utils';
 
 export const atanConfig: FieldTransformConfig = {
     name: 'atan',
@@ -26,7 +26,7 @@ export const atanConfig: FieldTransformConfig = {
         }
     ],
     create() {
-        return atan;
+        return runMathFn(Math.atan);
     },
     accepts: [
         FieldType.Number,
@@ -41,11 +41,3 @@ export const atanConfig: FieldTransformConfig = {
         };
     }
 };
-
-function atan(num: unknown): number|null {
-    const value = Math.atan(toFloatOrThrow(num));
-    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
-        return null;
-    }
-    return value;
-}

--- a/packages/data-mate/src/function-configs/numeric/atan2.ts
+++ b/packages/data-mate/src/function-configs/numeric/atan2.ts
@@ -1,0 +1,90 @@
+import { FieldType } from '@terascope/types';
+import { getTypeOf, isNumberLike, toFloatOrThrow } from '@terascope/utils';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+
+export const atan2Config: FieldTransformConfig = {
+    name: 'atan2',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.FULL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns the angle in the plane (in radians) between the positive x-axis and the ray from (0,0) to the point (x,y), for atan2(y,x)',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte, array: true } }
+            },
+            field: 'testField',
+            input: [15, 90],
+            output: 1.4056476493802699
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte, array: true } }
+            },
+            field: 'testField',
+            input: [90, 15],
+            output: 0.16514867741462683
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte, array: true } }
+            },
+            field: 'testField',
+            input: [-90, null],
+            fails: true,
+            output: 'Expected (x, y) coordinates, got [-90,null] (Array)'
+        }
+    ],
+    create() {
+        return atan2;
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                array: false,
+                type: FieldType.Float
+            }
+        };
+    }
+};
+
+function atan2(input: unknown): number|null {
+    if (input == null) return null;
+
+    const [x, y] = getCoordinates(input);
+
+    const value = Math.atan2(y, x);
+    if (value === Number.NEGATIVE_INFINITY
+        || value === Number.POSITIVE_INFINITY
+        || Number.isNaN(value)) {
+        return null;
+    }
+    return value;
+}
+
+function getCoordinates(input: unknown): [x: number, y: number] {
+    if (
+        !Array.isArray(input)
+        || input.length !== 2
+        || !(isNumberLike(input[0]) && isNumberLike(input[1]))
+    ) {
+        throw new TypeError(`Expected (x, y) coordinates, got ${JSON.stringify(input)} (${getTypeOf(input)})`);
+    }
+    return [toFloatOrThrow(input[0]), toFloatOrThrow(input[1])];
+}

--- a/packages/data-mate/src/function-configs/numeric/atanh.ts
+++ b/packages/data-mate/src/function-configs/numeric/atanh.ts
@@ -1,4 +1,3 @@
-import { toFloatOrThrow } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -6,6 +5,7 @@ import {
     FunctionDefinitionType,
     FunctionDefinitionCategory,
 } from '../interfaces';
+import { runMathFn } from './utils';
 
 export const atanhConfig: FieldTransformConfig = {
     name: 'atanh',
@@ -37,7 +37,7 @@ export const atanhConfig: FieldTransformConfig = {
         }
     ],
     create() {
-        return atanh;
+        return runMathFn(Math.atanh);
     },
     accepts: [
         FieldType.Number,
@@ -52,11 +52,3 @@ export const atanhConfig: FieldTransformConfig = {
         };
     }
 };
-
-function atanh(num: unknown): number|null {
-    const value = Math.atanh(toFloatOrThrow(num));
-    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
-        return null;
-    }
-    return value;
-}

--- a/packages/data-mate/src/function-configs/numeric/atanh.ts
+++ b/packages/data-mate/src/function-configs/numeric/atanh.ts
@@ -7,12 +7,12 @@ import {
     FunctionDefinitionCategory,
 } from '../interfaces';
 
-export const acoshConfig: FieldTransformConfig = {
-    name: 'acosh',
+export const atanhConfig: FieldTransformConfig = {
+    name: 'atanh',
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Returns the hyperbolic arc-cosine of a given number. If given a number less than 1, it will throw.',
+    description: 'Returns the arctangent (in radians) of the given number',
     examples: [
         {
             args: {},
@@ -21,8 +21,8 @@ export const acoshConfig: FieldTransformConfig = {
                 fields: { testField: { type: FieldType.Float } }
             },
             field: 'testField',
-            input: 1,
-            output: 0
+            input: 0.5,
+            output: 0.5493061443340548
         },
         {
             args: {},
@@ -31,13 +31,13 @@ export const acoshConfig: FieldTransformConfig = {
                 fields: { testField: { type: FieldType.Float } }
             },
             field: 'testField',
-            input: 0,
-            fails: true,
-            output: 'Expected value greater than or equal to 0, got 0'
+            input: -1,
+            output: null,
+            description: 'Typically this would return -Infinity but that cannot be stored or serialized so null is returned'
         }
     ],
     create() {
-        return acosh;
+        return atanh;
     },
     accepts: [
         FieldType.Number,
@@ -47,18 +47,14 @@ export const acoshConfig: FieldTransformConfig = {
         return {
             field_config: {
                 ...field_config,
-                type: FieldType.Float
+                type: FieldType.Number
             }
         };
     }
 };
 
-function acosh(num: unknown): number|null {
-    const float = toFloatOrThrow(num);
-    if (float < 1) {
-        throw new TypeError(`Expected value greater than or equal to 0, got ${float}`);
-    }
-    const value = Math.acosh(float);
+function atanh(num: unknown): number|null {
+    const value = Math.atanh(toFloatOrThrow(num));
     if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
         return null;
     }

--- a/packages/data-mate/src/function-configs/numeric/cbrt.ts
+++ b/packages/data-mate/src/function-configs/numeric/cbrt.ts
@@ -1,0 +1,57 @@
+import { toFloatOrThrow } from '@terascope/utils';
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+
+export const cbrtConfig: FieldTransformConfig = {
+    name: 'cbrt',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns the cube root of a number',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: 64,
+            output: 4
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: 1,
+            output: 1
+        }
+    ],
+    create() {
+        return cbrt;
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Number
+            }
+        };
+    }
+};
+
+function cbrt(num: unknown): number {
+    return Math.cbrt(toFloatOrThrow(num));
+}

--- a/packages/data-mate/src/function-configs/numeric/cbrt.ts
+++ b/packages/data-mate/src/function-configs/numeric/cbrt.ts
@@ -52,6 +52,10 @@ export const cbrtConfig: FieldTransformConfig = {
     }
 };
 
-function cbrt(num: unknown): number {
-    return Math.cbrt(toFloatOrThrow(num));
+function cbrt(num: unknown): number|null {
+    const value = Math.cbrt(toFloatOrThrow(num));
+    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
+        return null;
+    }
+    return value;
 }

--- a/packages/data-mate/src/function-configs/numeric/cbrt.ts
+++ b/packages/data-mate/src/function-configs/numeric/cbrt.ts
@@ -1,4 +1,3 @@
-import { toFloatOrThrow } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -6,6 +5,7 @@ import {
     FunctionDefinitionType,
     FunctionDefinitionCategory,
 } from '../interfaces';
+import { runMathFn } from './utils';
 
 export const cbrtConfig: FieldTransformConfig = {
     name: 'cbrt',
@@ -36,7 +36,7 @@ export const cbrtConfig: FieldTransformConfig = {
         }
     ],
     create() {
-        return cbrt;
+        return runMathFn(Math.cbrt);
     },
     accepts: [
         FieldType.Number,
@@ -51,11 +51,3 @@ export const cbrtConfig: FieldTransformConfig = {
         };
     }
 };
-
-function cbrt(num: unknown): number|null {
-    const value = Math.cbrt(toFloatOrThrow(num));
-    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
-        return null;
-    }
-    return value;
-}

--- a/packages/data-mate/src/function-configs/numeric/ceil.ts
+++ b/packages/data-mate/src/function-configs/numeric/ceil.ts
@@ -1,0 +1,67 @@
+import { toFloatOrThrow } from '@terascope/utils';
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+
+export const ceilConfig: FieldTransformConfig = {
+    name: 'ceil',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Rounds a number up to the next largest integer',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: 0.95,
+            output: 1
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: 0.10,
+            output: 1
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: -7.004,
+            output: -7
+        }
+    ],
+    create() {
+        return ceil;
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Integer
+            }
+        };
+    }
+};
+
+function ceil(num: unknown): number {
+    return Math.ceil(toFloatOrThrow(num));
+}

--- a/packages/data-mate/src/function-configs/numeric/ceil.ts
+++ b/packages/data-mate/src/function-configs/numeric/ceil.ts
@@ -1,4 +1,3 @@
-import { toFloatOrThrow } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -6,6 +5,7 @@ import {
     FunctionDefinitionType,
     FunctionDefinitionCategory,
 } from '../interfaces';
+import { runMathFn } from './utils';
 
 export const ceilConfig: FieldTransformConfig = {
     name: 'ceil',
@@ -46,7 +46,7 @@ export const ceilConfig: FieldTransformConfig = {
         }
     ],
     create() {
-        return ceil;
+        return runMathFn(Math.ceil);
     },
     accepts: [
         FieldType.Number,
@@ -61,7 +61,3 @@ export const ceilConfig: FieldTransformConfig = {
         };
     }
 };
-
-function ceil(num: unknown): number {
-    return Math.ceil(toFloatOrThrow(num));
-}

--- a/packages/data-mate/src/function-configs/numeric/clz32.ts
+++ b/packages/data-mate/src/function-configs/numeric/clz32.ts
@@ -1,0 +1,67 @@
+import { toFloatOrThrow } from '@terascope/utils';
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+
+export const clz32Config: FieldTransformConfig = {
+    name: 'clz32',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns the number of leading zero bits in the 32-bit binary representation of a number',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 1,
+            output: 31
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Integer } }
+            },
+            field: 'testField',
+            input: 1000,
+            output: 22
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: 4,
+            output: 29
+        }
+    ],
+    create() {
+        return clz32;
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Byte
+            }
+        };
+    }
+};
+
+function clz32(num: unknown): number {
+    return Math.clz32(toFloatOrThrow(num));
+}

--- a/packages/data-mate/src/function-configs/numeric/clz32.ts
+++ b/packages/data-mate/src/function-configs/numeric/clz32.ts
@@ -1,4 +1,3 @@
-import { toFloatOrThrow } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -6,6 +5,7 @@ import {
     FunctionDefinitionType,
     FunctionDefinitionCategory,
 } from '../interfaces';
+import { runMathFn } from './utils';
 
 export const clz32Config: FieldTransformConfig = {
     name: 'clz32',
@@ -46,7 +46,7 @@ export const clz32Config: FieldTransformConfig = {
         }
     ],
     create() {
-        return clz32;
+        return runMathFn(Math.clz32);
     },
     accepts: [
         FieldType.Number,
@@ -61,7 +61,3 @@ export const clz32Config: FieldTransformConfig = {
         };
     }
 };
-
-function clz32(num: unknown): number {
-    return Math.clz32(toFloatOrThrow(num));
-}

--- a/packages/data-mate/src/function-configs/numeric/cos.ts
+++ b/packages/data-mate/src/function-configs/numeric/cos.ts
@@ -1,0 +1,67 @@
+import { toFloatOrThrow } from '@terascope/utils';
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+
+export const cosConfig: FieldTransformConfig = {
+    name: 'cos',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns the cosine of the specified angle, which must be specified in radians',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 0,
+            output: 1
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: Math.PI,
+            output: -1
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: 2 * Math.PI,
+            output: 1
+        }
+    ],
+    create() {
+        return cos;
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Float
+            }
+        };
+    }
+};
+
+function cos(num: unknown): number {
+    return Math.cos(toFloatOrThrow(num));
+}

--- a/packages/data-mate/src/function-configs/numeric/cos.ts
+++ b/packages/data-mate/src/function-configs/numeric/cos.ts
@@ -62,6 +62,10 @@ export const cosConfig: FieldTransformConfig = {
     }
 };
 
-function cos(num: unknown): number {
-    return Math.cos(toFloatOrThrow(num));
+function cos(num: unknown): number|null {
+    const value = Math.cos(toFloatOrThrow(num));
+    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
+        return null;
+    }
+    return value;
 }

--- a/packages/data-mate/src/function-configs/numeric/cos.ts
+++ b/packages/data-mate/src/function-configs/numeric/cos.ts
@@ -1,4 +1,3 @@
-import { toFloatOrThrow } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -6,6 +5,7 @@ import {
     FunctionDefinitionType,
     FunctionDefinitionCategory,
 } from '../interfaces';
+import { runMathFn } from './utils';
 
 export const cosConfig: FieldTransformConfig = {
     name: 'cos',
@@ -46,7 +46,7 @@ export const cosConfig: FieldTransformConfig = {
         }
     ],
     create() {
-        return cos;
+        return runMathFn(Math.cos);
     },
     accepts: [
         FieldType.Number,
@@ -61,11 +61,3 @@ export const cosConfig: FieldTransformConfig = {
         };
     }
 };
-
-function cos(num: unknown): number|null {
-    const value = Math.cos(toFloatOrThrow(num));
-    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
-        return null;
-    }
-    return value;
-}

--- a/packages/data-mate/src/function-configs/numeric/cosh.ts
+++ b/packages/data-mate/src/function-configs/numeric/cosh.ts
@@ -1,4 +1,3 @@
-import { toFloatOrThrow } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -6,6 +5,7 @@ import {
     FunctionDefinitionType,
     FunctionDefinitionCategory,
 } from '../interfaces';
+import { runMathFn } from './utils';
 
 export const coshConfig: FieldTransformConfig = {
     name: 'cosh',
@@ -36,7 +36,7 @@ export const coshConfig: FieldTransformConfig = {
         }
     ],
     create() {
-        return cosh;
+        return runMathFn(Math.cosh);
     },
     accepts: [
         FieldType.Number,
@@ -51,11 +51,3 @@ export const coshConfig: FieldTransformConfig = {
         };
     }
 };
-
-function cosh(num: unknown): number|null {
-    const value = Math.cosh(toFloatOrThrow(num));
-    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
-        return null;
-    }
-    return value;
-}

--- a/packages/data-mate/src/function-configs/numeric/cosh.ts
+++ b/packages/data-mate/src/function-configs/numeric/cosh.ts
@@ -1,0 +1,57 @@
+import { toFloatOrThrow } from '@terascope/utils';
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+
+export const coshConfig: FieldTransformConfig = {
+    name: 'cosh',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns the hyperbolic cosine of a number, that can be expressed using the constant e',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 0,
+            output: 1
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: Math.PI,
+            output: 11.591953275521519
+        }
+    ],
+    create() {
+        return cosh;
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Float
+            }
+        };
+    }
+};
+
+function cosh(num: unknown): number {
+    return Math.cosh(toFloatOrThrow(num));
+}

--- a/packages/data-mate/src/function-configs/numeric/cosh.ts
+++ b/packages/data-mate/src/function-configs/numeric/cosh.ts
@@ -52,6 +52,10 @@ export const coshConfig: FieldTransformConfig = {
     }
 };
 
-function cosh(num: unknown): number {
-    return Math.cosh(toFloatOrThrow(num));
+function cosh(num: unknown): number|null {
+    const value = Math.cosh(toFloatOrThrow(num));
+    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
+        return null;
+    }
+    return value;
 }

--- a/packages/data-mate/src/function-configs/numeric/exp.ts
+++ b/packages/data-mate/src/function-configs/numeric/exp.ts
@@ -1,4 +1,3 @@
-import { toFloatOrThrow } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -6,6 +5,7 @@ import {
     FunctionDefinitionType,
     FunctionDefinitionCategory,
 } from '../interfaces';
+import { runMathFn } from './utils';
 
 export const expConfig: FieldTransformConfig = {
     name: 'exp',
@@ -36,7 +36,7 @@ export const expConfig: FieldTransformConfig = {
         }
     ],
     create() {
-        return exp;
+        return runMathFn(Math.exp);
     },
     accepts: [
         FieldType.Number,
@@ -51,11 +51,3 @@ export const expConfig: FieldTransformConfig = {
         };
     }
 };
-
-function exp(num: unknown): number|null {
-    const value = Math.exp(toFloatOrThrow(num));
-    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
-        return null;
-    }
-    return value;
-}

--- a/packages/data-mate/src/function-configs/numeric/exp.ts
+++ b/packages/data-mate/src/function-configs/numeric/exp.ts
@@ -1,0 +1,61 @@
+import { toFloatOrThrow } from '@terascope/utils';
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+
+export const expConfig: FieldTransformConfig = {
+    name: 'exp',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns a number representing `e^x`, where `e` is Euler\'s number and `x` is the argument',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 0,
+            output: 1
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: 1,
+            output: 2.718281828459045
+        }
+    ],
+    create() {
+        return exp;
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Float
+            }
+        };
+    }
+};
+
+function exp(num: unknown): number|null {
+    const value = Math.exp(toFloatOrThrow(num));
+    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
+        return null;
+    }
+    return value;
+}

--- a/packages/data-mate/src/function-configs/numeric/expm1.ts
+++ b/packages/data-mate/src/function-configs/numeric/expm1.ts
@@ -1,0 +1,61 @@
+import { toFloatOrThrow } from '@terascope/utils';
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+
+export const expm1Config: FieldTransformConfig = {
+    name: 'expm1',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns a number representing `e^x - 1`, where `e` is Euler\'s number and `x` is the argument.',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 0,
+            output: 0
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: 1,
+            output: 1.718281828459045
+        }
+    ],
+    create() {
+        return expm1;
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Float
+            }
+        };
+    }
+};
+
+function expm1(num: unknown): number|null {
+    const value = Math.expm1(toFloatOrThrow(num));
+    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
+        return null;
+    }
+    return value;
+}

--- a/packages/data-mate/src/function-configs/numeric/expm1.ts
+++ b/packages/data-mate/src/function-configs/numeric/expm1.ts
@@ -1,4 +1,3 @@
-import { toFloatOrThrow } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -6,6 +5,7 @@ import {
     FunctionDefinitionType,
     FunctionDefinitionCategory,
 } from '../interfaces';
+import { runMathFn } from './utils';
 
 export const expm1Config: FieldTransformConfig = {
     name: 'expm1',
@@ -36,7 +36,7 @@ export const expm1Config: FieldTransformConfig = {
         }
     ],
     create() {
-        return expm1;
+        return runMathFn(Math.expm1);
     },
     accepts: [
         FieldType.Number,
@@ -51,11 +51,3 @@ export const expm1Config: FieldTransformConfig = {
         };
     }
 };
-
-function expm1(num: unknown): number|null {
-    const value = Math.expm1(toFloatOrThrow(num));
-    if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
-        return null;
-    }
-    return value;
-}

--- a/packages/data-mate/src/function-configs/numeric/floor.ts
+++ b/packages/data-mate/src/function-configs/numeric/floor.ts
@@ -1,0 +1,63 @@
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+import { runMathFn } from './utils';
+
+export const floorConfig: FieldTransformConfig = {
+    name: 'floor',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Rounds a number down to the next largest integer',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: 0.95,
+            output: 0
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: 0.10,
+            output: 0
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: -7.004,
+            output: -8
+        }
+    ],
+    create() {
+        return runMathFn(Math.floor);
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Integer
+            }
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/numeric/fround.ts
+++ b/packages/data-mate/src/function-configs/numeric/fround.ts
@@ -1,0 +1,53 @@
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+import { runMathFn } from './utils';
+
+export const froundConfig: FieldTransformConfig = {
+    name: 'fround',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns the nearest 32-bit single precision float representation of the given number',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: 5.5,
+            output: 5.5
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: -5.05,
+            output: -5.050000190734863
+        },
+    ],
+    create() {
+        return runMathFn(Math.fround);
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Float
+            }
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/numeric/hypot.ts
+++ b/packages/data-mate/src/function-configs/numeric/hypot.ts
@@ -1,0 +1,100 @@
+import { FieldType } from '@terascope/types';
+import {
+    toFloatOrThrow
+} from '@terascope/utils';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+
+export const hypotConfig: FieldTransformConfig = {
+    name: 'hypot',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.FULL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns the square root of the sum of squares of the given arguments. If at least one of the arguments cannot be converted to a number, null is returned',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte, array: true } }
+            },
+            field: 'testField',
+            input: [3, 4],
+            output: 5
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte, array: true } }
+            },
+            field: 'testField',
+            input: [5, 12],
+            output: 13
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte, array: true } }
+            },
+            field: 'testField',
+            input: [3, 4, null, 5],
+            output: 7.0710678118654755
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte, array: true } }
+            },
+            field: 'testField',
+            input: null,
+            output: null
+        }
+    ],
+    create() {
+        return function _hypot(input): number|null {
+            if (input == null) return null;
+
+            const numbers = getNumericValues(input);
+
+            const value = Math.hypot(...numbers);
+            if (value === Number.NEGATIVE_INFINITY
+                || value === Number.POSITIVE_INFINITY
+                || Number.isNaN(value)) {
+                return null;
+            }
+            return value;
+        };
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                array: false,
+                type: FieldType.Float
+            }
+        };
+    }
+};
+
+function getNumericValues(input: unknown): number[] {
+    if (input == null) return [];
+    if (Array.isArray(input)) {
+        let numbers: number[] = [];
+        for (const value of input) {
+            numbers = numbers.concat(getNumericValues(value));
+        }
+        return numbers;
+    }
+    return [toFloatOrThrow(input)];
+}

--- a/packages/data-mate/src/function-configs/numeric/index.ts
+++ b/packages/data-mate/src/function-configs/numeric/index.ts
@@ -25,6 +25,10 @@ import { isGreaterThanOrEqualToConfig } from './isGreaterThanOrEqual';
 import { isLessThanConfig } from './isLessThan';
 import { isLessThanOrEqualToConfig } from './isLessThanOrEqual';
 import { isOddConfig } from './isOdd';
+import { logConfig } from './log';
+import { log10Config } from './log10';
+import { log1pConfig } from './log1p';
+import { log2Config } from './log2';
 import { modulusConfig } from './modulus';
 import { multiplyConfig } from './multiply';
 import { multiplyValuesConfig } from './multiplyValues';
@@ -62,6 +66,10 @@ export const numericRepository = {
     isLessThan: isLessThanConfig,
     isLessThanOrEqualTo: isLessThanOrEqualToConfig,
     isOdd: isOddConfig,
+    log: logConfig,
+    log1p: log1pConfig,
+    log2: log2Config,
+    log10: log10Config,
     modulus: modulusConfig,
     multiply: multiplyConfig,
     multiplyValues: multiplyValuesConfig,

--- a/packages/data-mate/src/function-configs/numeric/index.ts
+++ b/packages/data-mate/src/function-configs/numeric/index.ts
@@ -34,8 +34,14 @@ import { multiplyConfig } from './multiply';
 import { multiplyValuesConfig } from './multiplyValues';
 import { powConfig } from './pow';
 import { roundConfig } from './round';
+import { signConfig } from './sign';
+import { sinConfig } from './sin';
+import { sinhConfig } from './sinh';
+import { sqrtConfig } from './sqrt';
 import { subtractConfig } from './subtract';
 import { subtractValuesConfig } from './subtractValues';
+import { tanConfig } from './tan';
+import { tanhConfig } from './tanh';
 import { toCelsiusConfig } from './toCelsius';
 import { toFahrenheitConfig } from './toFahrenheit';
 import { toPrecisionConfig } from './toPrecision';
@@ -77,8 +83,14 @@ export const numericRepository = {
     multiplyValues: multiplyValuesConfig,
     pow: powConfig,
     round: roundConfig,
+    sign: signConfig,
+    sin: sinConfig,
+    sinh: sinhConfig,
+    sqrt: sqrtConfig,
     subtract: subtractConfig,
     subtractValues: subtractValuesConfig,
+    tan: tanConfig,
+    tanh: tanhConfig,
     toCelsius: toCelsiusConfig,
     toFahrenheit: toFahrenheitConfig,
     toPrecision: toPrecisionConfig,

--- a/packages/data-mate/src/function-configs/numeric/index.ts
+++ b/packages/data-mate/src/function-configs/numeric/index.ts
@@ -16,6 +16,8 @@ import { divideConfig } from './divide';
 import { divideValuesConfig } from './divideValues';
 import { expConfig } from './exp';
 import { expm1Config } from './expm1';
+import { floorConfig } from './floor';
+import { froundConfig } from './fround';
 import { inNumberRangeConfig } from './inNumberRange';
 import { isEvenConfig } from './isEven';
 import { isGreaterThanConfig } from './isGreaterThan';
@@ -51,6 +53,8 @@ export const numericRepository = {
     divideValues: divideValuesConfig,
     exp: expConfig,
     expm1: expm1Config,
+    floor: floorConfig,
+    fround: froundConfig,
     inNumberRange: inNumberRangeConfig,
     isEven: isEvenConfig,
     isGreaterThan: isGreaterThanConfig,

--- a/packages/data-mate/src/function-configs/numeric/index.ts
+++ b/packages/data-mate/src/function-configs/numeric/index.ts
@@ -29,6 +29,7 @@ import { logConfig } from './log';
 import { log10Config } from './log10';
 import { log1pConfig } from './log1p';
 import { log2Config } from './log2';
+import { minValuesConfig } from './minValues';
 import { modulusConfig } from './modulus';
 import { multiplyConfig } from './multiply';
 import { multiplyValuesConfig } from './multiplyValues';
@@ -78,6 +79,7 @@ export const numericRepository = {
     log1p: log1pConfig,
     log2: log2Config,
     log10: log10Config,
+    minValues: minValuesConfig,
     modulus: modulusConfig,
     multiply: multiplyConfig,
     multiplyValues: multiplyValuesConfig,

--- a/packages/data-mate/src/function-configs/numeric/index.ts
+++ b/packages/data-mate/src/function-configs/numeric/index.ts
@@ -32,6 +32,8 @@ import { log2Config } from './log2';
 import { modulusConfig } from './modulus';
 import { multiplyConfig } from './multiply';
 import { multiplyValuesConfig } from './multiplyValues';
+import { powConfig } from './pow';
+import { roundConfig } from './round';
 import { subtractConfig } from './subtract';
 import { subtractValuesConfig } from './subtractValues';
 import { toCelsiusConfig } from './toCelsius';
@@ -73,6 +75,8 @@ export const numericRepository = {
     modulus: modulusConfig,
     multiply: multiplyConfig,
     multiplyValues: multiplyValuesConfig,
+    pow: powConfig,
+    round: roundConfig,
     subtract: subtractConfig,
     subtractValues: subtractValuesConfig,
     toCelsius: toCelsiusConfig,

--- a/packages/data-mate/src/function-configs/numeric/index.ts
+++ b/packages/data-mate/src/function-configs/numeric/index.ts
@@ -14,6 +14,8 @@ import { cosConfig } from './cos';
 import { coshConfig } from './cosh';
 import { divideConfig } from './divide';
 import { divideValuesConfig } from './divideValues';
+import { expConfig } from './exp';
+import { expm1Config } from './expm1';
 import { inNumberRangeConfig } from './inNumberRange';
 import { isEvenConfig } from './isEven';
 import { isGreaterThanConfig } from './isGreaterThan';
@@ -47,6 +49,8 @@ export const numericRepository = {
     cosh: coshConfig,
     divide: divideConfig,
     divideValues: divideValuesConfig,
+    exp: expConfig,
+    expm1: expm1Config,
     inNumberRange: inNumberRangeConfig,
     isEven: isEvenConfig,
     isGreaterThan: isGreaterThanConfig,

--- a/packages/data-mate/src/function-configs/numeric/index.ts
+++ b/packages/data-mate/src/function-configs/numeric/index.ts
@@ -34,6 +34,7 @@ import { modulusConfig } from './modulus';
 import { multiplyConfig } from './multiply';
 import { multiplyValuesConfig } from './multiplyValues';
 import { powConfig } from './pow';
+import { randomConfig } from './random';
 import { roundConfig } from './round';
 import { signConfig } from './sign';
 import { sinConfig } from './sin';
@@ -84,6 +85,7 @@ export const numericRepository = {
     multiply: multiplyConfig,
     multiplyValues: multiplyValuesConfig,
     pow: powConfig,
+    random: randomConfig,
     round: roundConfig,
     sign: signConfig,
     sin: sinConfig,

--- a/packages/data-mate/src/function-configs/numeric/index.ts
+++ b/packages/data-mate/src/function-configs/numeric/index.ts
@@ -6,6 +6,11 @@ import { addValuesConfig } from './addValues';
 import { asinConfig } from './asin';
 import { asinhConfig } from './asinh';
 import { atanConfig } from './atan';
+import { cbrtConfig } from './cbrt';
+import { ceilConfig } from './ceil';
+import { clz32Config } from './clz32';
+import { cosConfig } from './cos';
+import { coshConfig } from './cosh';
 import { divideConfig } from './divide';
 import { divideValuesConfig } from './divideValues';
 import { inNumberRangeConfig } from './inNumberRange';
@@ -32,6 +37,11 @@ export const numericRepository = {
     addValues: addValuesConfig,
     asin: asinConfig,
     asinh: asinhConfig,
+    cbrt: cbrtConfig,
+    ceil: ceilConfig,
+    clz32: clz32Config,
+    cos: cosConfig,
+    cosh: coshConfig,
     atan: atanConfig,
     divide: divideConfig,
     divideValues: divideValuesConfig,

--- a/packages/data-mate/src/function-configs/numeric/index.ts
+++ b/packages/data-mate/src/function-configs/numeric/index.ts
@@ -6,6 +6,7 @@ import { addValuesConfig } from './addValues';
 import { asinConfig } from './asin';
 import { asinhConfig } from './asinh';
 import { atanConfig } from './atan';
+import { atan2Config } from './atan2';
 import { atanhConfig } from './atanh';
 import { cbrtConfig } from './cbrt';
 import { ceilConfig } from './ceil';
@@ -18,6 +19,7 @@ import { expConfig } from './exp';
 import { expm1Config } from './expm1';
 import { floorConfig } from './floor';
 import { froundConfig } from './fround';
+import { hypotConfig } from './hypot';
 import { inNumberRangeConfig } from './inNumberRange';
 import { isEvenConfig } from './isEven';
 import { isGreaterThanConfig } from './isGreaterThan';
@@ -57,6 +59,7 @@ export const numericRepository = {
     asin: asinConfig,
     asinh: asinhConfig,
     atan: atanConfig,
+    atan2: atan2Config,
     atanh: atanhConfig,
     cbrt: cbrtConfig,
     ceil: ceilConfig,
@@ -69,6 +72,7 @@ export const numericRepository = {
     expm1: expm1Config,
     floor: floorConfig,
     fround: froundConfig,
+    hypot: hypotConfig,
     inNumberRange: inNumberRangeConfig,
     isEven: isEvenConfig,
     isGreaterThan: isGreaterThanConfig,

--- a/packages/data-mate/src/function-configs/numeric/index.ts
+++ b/packages/data-mate/src/function-configs/numeric/index.ts
@@ -6,6 +6,7 @@ import { addValuesConfig } from './addValues';
 import { asinConfig } from './asin';
 import { asinhConfig } from './asinh';
 import { atanConfig } from './atan';
+import { atanhConfig } from './atanh';
 import { cbrtConfig } from './cbrt';
 import { ceilConfig } from './ceil';
 import { clz32Config } from './clz32';
@@ -37,12 +38,13 @@ export const numericRepository = {
     addValues: addValuesConfig,
     asin: asinConfig,
     asinh: asinhConfig,
+    atan: atanConfig,
+    atanh: atanhConfig,
     cbrt: cbrtConfig,
     ceil: ceilConfig,
     clz32: clz32Config,
     cos: cosConfig,
     cosh: coshConfig,
-    atan: atanConfig,
     divide: divideConfig,
     divideValues: divideValuesConfig,
     inNumberRange: inNumberRangeConfig,

--- a/packages/data-mate/src/function-configs/numeric/log.ts
+++ b/packages/data-mate/src/function-configs/numeric/log.ts
@@ -7,18 +7,18 @@ import {
 } from '../interfaces';
 import { runMathFn } from './utils';
 
-export const acoshConfig: FieldTransformConfig = {
-    name: 'acosh',
+export const logConfig: FieldTransformConfig = {
+    name: 'log',
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Returns the hyperbolic arc-cosine of a given number. If given a number less than 1, null will be returned',
+    description: 'Returns the natural logarithm (base e) of the given number. If the number is negative, null is returned',
     examples: [
         {
             args: {},
             config: {
                 version: 1,
-                fields: { testField: { type: FieldType.Float } }
+                fields: { testField: { type: FieldType.Byte } }
             },
             field: 'testField',
             input: 1,
@@ -28,16 +28,25 @@ export const acoshConfig: FieldTransformConfig = {
             args: {},
             config: {
                 version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 10,
+            output: 2.302585092994046
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
                 fields: { testField: { type: FieldType.Float } }
             },
             field: 'testField',
-            input: 0,
-            output: null,
-            description: 'Since this function doesn\'t work with numbers <=0, null will be returned'
-        }
+            input: -1,
+            output: null
+        },
     ],
     create() {
-        return runMathFn(Math.acosh);
+        return runMathFn(Math.log);
     },
     accepts: [
         FieldType.Number,

--- a/packages/data-mate/src/function-configs/numeric/log10.ts
+++ b/packages/data-mate/src/function-configs/numeric/log10.ts
@@ -7,22 +7,33 @@ import {
 } from '../interfaces';
 import { runMathFn } from './utils';
 
-export const acoshConfig: FieldTransformConfig = {
-    name: 'acosh',
+export const log10Config: FieldTransformConfig = {
+    name: 'log10',
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Returns the hyperbolic arc-cosine of a given number. If given a number less than 1, null will be returned',
+    description: 'Returns the base 10 logarithm of the given number. If the number is negative, null is returned',
     examples: [
         {
             args: {},
             config: {
                 version: 1,
-                fields: { testField: { type: FieldType.Float } }
+                fields: { testField: { type: FieldType.Byte } }
             },
             field: 'testField',
-            input: 1,
-            output: 0
+            input: 10,
+            output: 1
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 0,
+            output: null,
+            description: 'Typically this would return -Infinity but that cannot be stored or serialized so null is returned'
         },
         {
             args: {},
@@ -31,13 +42,12 @@ export const acoshConfig: FieldTransformConfig = {
                 fields: { testField: { type: FieldType.Float } }
             },
             field: 'testField',
-            input: 0,
-            output: null,
-            description: 'Since this function doesn\'t work with numbers <=0, null will be returned'
-        }
+            input: -2,
+            output: null
+        },
     ],
     create() {
-        return runMathFn(Math.acosh);
+        return runMathFn(Math.log10);
     },
     accepts: [
         FieldType.Number,

--- a/packages/data-mate/src/function-configs/numeric/log1p.ts
+++ b/packages/data-mate/src/function-configs/numeric/log1p.ts
@@ -1,0 +1,75 @@
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+import { runMathFn } from './utils';
+
+export const log1pConfig: FieldTransformConfig = {
+    name: 'log1p',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns the natural logarithm (base e) of 1 plus the given number. If the number is less than -1, null is returned.',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 1,
+            output: 0.6931471805599453
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 0,
+            output: 0,
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: -1,
+            output: null,
+            description: 'Typically this would return -Infinity but that cannot be stored or serialized so null is returned'
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: -2,
+            output: null,
+            description: 'Typically this would return NaN but that cannot be stored or serialized so null is returned'
+        },
+    ],
+    create() {
+        return runMathFn(Math.log1p);
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Float
+            }
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/numeric/log2.ts
+++ b/packages/data-mate/src/function-configs/numeric/log2.ts
@@ -7,22 +7,33 @@ import {
 } from '../interfaces';
 import { runMathFn } from './utils';
 
-export const acoshConfig: FieldTransformConfig = {
-    name: 'acosh',
+export const log2Config: FieldTransformConfig = {
+    name: 'log2',
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Returns the hyperbolic arc-cosine of a given number. If given a number less than 1, null will be returned',
+    description: 'Returns the base 2 logarithm of the given number. If the number is negative, null is returned',
     examples: [
         {
             args: {},
             config: {
                 version: 1,
-                fields: { testField: { type: FieldType.Float } }
+                fields: { testField: { type: FieldType.Byte } }
             },
             field: 'testField',
-            input: 1,
-            output: 0
+            input: 2,
+            output: 1
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 0,
+            output: null,
+            description: 'Typically this would return -Infinity but that cannot be stored or serialized so null is returned'
         },
         {
             args: {},
@@ -31,13 +42,12 @@ export const acoshConfig: FieldTransformConfig = {
                 fields: { testField: { type: FieldType.Float } }
             },
             field: 'testField',
-            input: 0,
-            output: null,
-            description: 'Since this function doesn\'t work with numbers <=0, null will be returned'
-        }
+            input: -2,
+            output: null
+        },
     ],
     create() {
-        return runMathFn(Math.acosh);
+        return runMathFn(Math.log2);
     },
     accepts: [
         FieldType.Number,

--- a/packages/data-mate/src/function-configs/numeric/maxValues.ts
+++ b/packages/data-mate/src/function-configs/numeric/maxValues.ts
@@ -1,0 +1,114 @@
+import { isBigInt, isNumber, toFloatOrThrow } from '@terascope/utils';
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig, FunctionDefinitionType,
+    ProcessMode, DataTypeFieldAndChildren, FunctionDefinitionCategory
+} from '../interfaces';
+
+function maxValuesReducer(
+    acc: number|null,
+    curr: (number|bigint|null)[]|(number|bigint|null)
+): number|null {
+    const currValue = (Array.isArray(curr) ? maxValuesFn(curr) : curr);
+    if (currValue == null) return acc;
+    if (acc == null) return toFloatOrThrow(currValue);
+    if (acc >= currValue) return acc;
+    return toFloatOrThrow(currValue);
+}
+
+function maxValuesFn(value: unknown): bigint|number|null {
+    if (isNumber(value) || isBigInt(value)) return value;
+    if (!Array.isArray(value)) return null;
+
+    return value.reduce(maxValuesReducer, null);
+}
+
+export const maxValuesConfig: FieldTransformConfig = {
+    name: 'maxValues',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.FULL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Get the maximum value in an array, this requires an array to function correctly',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte, array: true } }
+            },
+            field: 'testField',
+            input: [100, 10],
+            output: 100
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte, array: true } }
+            },
+            field: 'testField',
+            input: [10],
+            output: 10
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: {
+                    testField: { type: FieldType.Tuple },
+                    'testField.0': { type: FieldType.Byte, array: true },
+                    'testField.1': { type: FieldType.Integer },
+                    'testField.2': { type: FieldType.Long }
+                }
+            },
+            field: 'testField',
+            input: [10, 100000, 2],
+            output: 100000
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: {
+                    testField: { type: FieldType.Tuple },
+                    'testField.0': { type: FieldType.Byte, array: true },
+                    'testField.1': { type: FieldType.Integer },
+                    'testField.2': { type: FieldType.Long, array: true },
+                    'testField.3': { type: FieldType.Short }
+                }
+            },
+            field: 'testField',
+            input: [[10, null], 100000, [2], null],
+            output: 100000
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: {
+                    testField: { type: FieldType.Byte },
+                }
+            },
+            field: 'testField',
+            input: 2,
+            output: 2
+        }
+    ],
+    create() {
+        return maxValuesFn;
+    },
+    argument_schema: {},
+    accepts: [FieldType.Number],
+    output_type(inputConfig: DataTypeFieldAndChildren): DataTypeFieldAndChildren {
+        const { field_config } = inputConfig;
+
+        return {
+            field_config: {
+                ...field_config,
+                array: false,
+                type: FieldType.Number
+            },
+            child_config: undefined
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/numeric/minValues.ts
+++ b/packages/data-mate/src/function-configs/numeric/minValues.ts
@@ -1,0 +1,114 @@
+import { isBigInt, isNumber, toFloatOrThrow } from '@terascope/utils';
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig, FunctionDefinitionType,
+    ProcessMode, DataTypeFieldAndChildren, FunctionDefinitionCategory
+} from '../interfaces';
+
+function minValuesReducer(
+    acc: number|null,
+    curr: (number|bigint|null)[]|(number|bigint|null)
+): number|null {
+    const currValue = (Array.isArray(curr) ? minValuesFn(curr) : curr);
+    if (currValue == null) return acc;
+    if (acc == null) return toFloatOrThrow(currValue);
+    if (acc <= currValue) return acc;
+    return toFloatOrThrow(currValue);
+}
+
+function minValuesFn(value: unknown): bigint|number|null {
+    if (isNumber(value) || isBigInt(value)) return value;
+    if (!Array.isArray(value)) return null;
+
+    return value.reduce(minValuesReducer, null);
+}
+
+export const minValuesConfig: FieldTransformConfig = {
+    name: 'minValues',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.FULL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Get the minimum value in an array, this requires an array to function correctly',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte, array: true } }
+            },
+            field: 'testField',
+            input: [100, 10],
+            output: 10
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte, array: true } }
+            },
+            field: 'testField',
+            input: [10],
+            output: 10
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: {
+                    testField: { type: FieldType.Tuple },
+                    'testField.0': { type: FieldType.Byte, array: true },
+                    'testField.1': { type: FieldType.Integer },
+                    'testField.2': { type: FieldType.Long }
+                }
+            },
+            field: 'testField',
+            input: [10, 100000, 2],
+            output: 2
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: {
+                    testField: { type: FieldType.Tuple },
+                    'testField.0': { type: FieldType.Byte, array: true },
+                    'testField.1': { type: FieldType.Integer },
+                    'testField.2': { type: FieldType.Long, array: true },
+                    'testField.3': { type: FieldType.Short }
+                }
+            },
+            field: 'testField',
+            input: [[10, null], 100000, [2], null],
+            output: 2
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: {
+                    testField: { type: FieldType.Byte },
+                }
+            },
+            field: 'testField',
+            input: 2,
+            output: 2
+        }
+    ],
+    create() {
+        return minValuesFn;
+    },
+    argument_schema: {},
+    accepts: [FieldType.Number],
+    output_type(inputConfig: DataTypeFieldAndChildren): DataTypeFieldAndChildren {
+        const { field_config } = inputConfig;
+
+        return {
+            field_config: {
+                ...field_config,
+                array: false,
+                type: FieldType.Number
+            },
+            child_config: undefined
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/numeric/modulus.ts
+++ b/packages/data-mate/src/function-configs/numeric/modulus.ts
@@ -18,6 +18,7 @@ function isLargeNumberType(type: FieldType|undefined) {
 
 export const modulusConfig: FieldTransformConfig<ModulusArgs> = {
     name: 'modulus',
+    aliases: ['mod'],
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,

--- a/packages/data-mate/src/function-configs/numeric/pow.ts
+++ b/packages/data-mate/src/function-configs/numeric/pow.ts
@@ -1,0 +1,66 @@
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+import { runMathFn } from './utils';
+
+export interface PowerArgs {
+    readonly exp: number;
+}
+
+export const powConfig: FieldTransformConfig<PowerArgs> = {
+    name: 'pow',
+    aliases: ['power'],
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns a number representing the given base taken to the power of the given exponent',
+    examples: [
+        {
+            args: { exp: 3 },
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 7,
+            output: 343
+        },
+        {
+            args: { exp: 0.5 },
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 4,
+            output: 2
+        }
+    ],
+    create({ exp }) {
+        // eslint-disable-next-line no-restricted-properties
+        return runMathFn(Math.pow, exp);
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {
+        exp: {
+            type: FieldType.Integer,
+            array: false,
+            description: 'The exponent used to raise the base'
+        },
+    },
+    required_arguments: ['exp'],
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Number
+            }
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/numeric/random.ts
+++ b/packages/data-mate/src/function-configs/numeric/random.ts
@@ -1,0 +1,63 @@
+import { random } from '@terascope/utils';
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+    DataTypeFieldAndChildren,
+} from '../interfaces';
+
+export interface RandomArgs {
+    readonly min: number;
+    readonly max: number;
+}
+
+export const randomConfig: FieldTransformConfig<RandomArgs> = {
+    name: 'random',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Generate a random number between a given range',
+    examples: [{
+        args: { min: 1, max: 1 },
+        config: {
+            version: 1,
+            fields: { testField: { type: FieldType.Byte } }
+        },
+        field: 'testField',
+        input: 1,
+        output: 1
+    }],
+    create({ min, max }) {
+        return function _random() {
+            return random(min, max);
+        };
+    },
+    accepts: [],
+    argument_schema: {
+        min: {
+            type: FieldType.Number,
+            array: false,
+            description: 'The minimum value in the range'
+        },
+        max: {
+            type: FieldType.Number,
+            array: false,
+            description: 'The maximum value in the range'
+        }
+    },
+    required_arguments: ['min', 'max'],
+    output_type(inputConfig: DataTypeFieldAndChildren): DataTypeFieldAndChildren {
+        const { field_config } = inputConfig;
+
+        return {
+            field_config: {
+                ...field_config,
+                array: false,
+                type: FieldType.Number
+            },
+            child_config: undefined
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/numeric/round.ts
+++ b/packages/data-mate/src/function-configs/numeric/round.ts
@@ -1,0 +1,63 @@
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+import { runMathFn } from './utils';
+
+export const roundConfig: FieldTransformConfig = {
+    name: 'round',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns the value of a number rounded to the nearest integer.',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: 0.95,
+            output: 1
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: 0.10,
+            output: 0
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: -7.004,
+            output: -7
+        }
+    ],
+    create() {
+        return runMathFn(Math.round);
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Integer
+            }
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/numeric/sign.ts
+++ b/packages/data-mate/src/function-configs/numeric/sign.ts
@@ -1,0 +1,68 @@
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+import { runMathFn } from './utils';
+
+export const signConfig: FieldTransformConfig = {
+    name: 'sign',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: `Returns a number representing the sign of the given argument:
+- If the argument is positive, returns 1
+- If the argument is negative, returns -1
+- If the argument is positive zero, returns 0
+- If the argument is negative zero, returns -0
+- Otherwise, null is returned`,
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 3,
+            output: 1
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Integer } }
+            },
+            field: 'testField',
+            input: -3,
+            output: -1
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: 0,
+            output: 0
+        }
+    ],
+    create() {
+        return runMathFn(Math.sign);
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Byte
+            }
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/numeric/sin.ts
+++ b/packages/data-mate/src/function-configs/numeric/sin.ts
@@ -1,0 +1,63 @@
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+import { runMathFn } from './utils';
+
+export const sinConfig: FieldTransformConfig = {
+    name: 'sin',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns the sine of the given number',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 0,
+            output: 0
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Integer } }
+            },
+            field: 'testField',
+            input: 1,
+            output: 0.8414709848078965
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: Math.PI / 2,
+            output: 1
+        }
+    ],
+    create() {
+        return runMathFn(Math.sin);
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Float
+            }
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/numeric/sinh.ts
+++ b/packages/data-mate/src/function-configs/numeric/sinh.ts
@@ -1,0 +1,63 @@
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+import { runMathFn } from './utils';
+
+export const sinhConfig: FieldTransformConfig = {
+    name: 'sinh',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns the hyperbolic sine of a number, that can be expressed using the constant e',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 0,
+            output: 0
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Integer } }
+            },
+            field: 'testField',
+            input: 1,
+            output: 1.1752011936438014
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: -1,
+            output: -1.1752011936438014
+        }
+    ],
+    create() {
+        return runMathFn(Math.sinh);
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Float
+            }
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/numeric/sqrt.ts
+++ b/packages/data-mate/src/function-configs/numeric/sqrt.ts
@@ -1,0 +1,63 @@
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+import { runMathFn } from './utils';
+
+export const sqrtConfig: FieldTransformConfig = {
+    name: 'sqrt',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns the square root of a number',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 9,
+            output: 3
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Integer } }
+            },
+            field: 'testField',
+            input: 2,
+            output: 1.4142135623730951
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Float } }
+            },
+            field: 'testField',
+            input: -1,
+            output: null
+        }
+    ],
+    create() {
+        return runMathFn(Math.sqrt);
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Float
+            }
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/numeric/tan.ts
+++ b/packages/data-mate/src/function-configs/numeric/tan.ts
@@ -1,0 +1,43 @@
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+import { runMathFn } from './utils';
+
+export const tanConfig: FieldTransformConfig = {
+    name: 'tan',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns the tangent of a number',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 1,
+            output: 1.5574077246549023
+        }
+    ],
+    create() {
+        return runMathFn(Math.tan);
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Float
+            }
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/numeric/tanh.ts
+++ b/packages/data-mate/src/function-configs/numeric/tanh.ts
@@ -1,0 +1,53 @@
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    FunctionDefinitionCategory,
+} from '../interfaces';
+import { runMathFn } from './utils';
+
+export const tanhConfig: FieldTransformConfig = {
+    name: 'tanh',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.NUMERIC,
+    description: 'Returns the hyperbolic tangent of a number',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: -1,
+            output: -0.7615941559557649
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Byte } }
+            },
+            field: 'testField',
+            input: 0,
+            output: 0
+        }
+    ],
+    create() {
+        return runMathFn(Math.tanh);
+    },
+    accepts: [
+        FieldType.Number,
+    ],
+    argument_schema: {},
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.Float
+            }
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/numeric/utils.ts
+++ b/packages/data-mate/src/function-configs/numeric/utils.ts
@@ -2,14 +2,14 @@ import { toFloatOrThrow } from '@terascope/utils';
 
 export function runMathFn(
     fn: (num: number) => number,
-    validate?: (num: number) => void
 ): (input: unknown) => number|null {
     return function _mathFn(input) {
         const num = toFloatOrThrow(input);
-        validate && validate(num);
 
         const value = fn(num);
-        if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
+        if (value === Number.NEGATIVE_INFINITY
+            || value === Number.POSITIVE_INFINITY
+            || Number.isNaN(value)) {
             return null;
         }
         return value;

--- a/packages/data-mate/src/function-configs/numeric/utils.ts
+++ b/packages/data-mate/src/function-configs/numeric/utils.ts
@@ -1,0 +1,17 @@
+import { toFloatOrThrow } from '@terascope/utils';
+
+export function runMathFn(
+    fn: (num: number) => number,
+    validate?: (num: number) => void
+): (input: unknown) => number|null {
+    return function _mathFn(input) {
+        const num = toFloatOrThrow(input);
+        validate && validate(num);
+
+        const value = fn(num);
+        if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
+            return null;
+        }
+        return value;
+    };
+}

--- a/packages/data-mate/src/function-configs/numeric/utils.ts
+++ b/packages/data-mate/src/function-configs/numeric/utils.ts
@@ -1,12 +1,12 @@
 import { toFloatOrThrow } from '@terascope/utils';
 
-export function runMathFn(
-    fn: (num: number) => number,
-): (input: unknown) => number|null {
+export function runMathFn<T extends(num: number, ...args: number[]) => number>(
+    fn: T,
+    ...extra: number[]): (input: unknown) => number|null {
     return function _mathFn(input) {
         const num = toFloatOrThrow(input);
 
-        const value = fn(num);
+        const value = fn(num, ...extra);
         if (value === Number.NEGATIVE_INFINITY
             || value === Number.POSITIVE_INFINITY
             || Number.isNaN(value)) {


### PR DESCRIPTION
- [x] Add `atan2`
- [x] Add `atanh`
- [x] Add `cbrt`
- [x] Add `ceil`
- [x] Add `clz32`
- [x] Add `cos`
- [x] Add `cosh`
- [x] Add `exp`
- [x] Add `expm1`
- [x] Add `floor`
- [x] Add `fround`
- [x] Add `hypot`
- [x] :x: Add `imul` (this doesn't make sense since it a performance optimization for 32 bit integers)
- [x] Add `log`
- [x] Add `log10`
- [x] Add `log1p`
- [x] Add `log2`
- [x] Add `maxValues`
- [x] Add `minValues`
- [x] Add `pow`
- [x] Add `random`
- [x] Add `round`
- [x] Add `sign`
- [x] Add `sin`
- [x] Add `sinh`
- [x] Add `sqrt`
- [x] Add `tan`
- [x] Add `tanh`
