### PR TITLE
Add generic encode and misc fixes

### DIFF
--- a/docs/packages/data-mate/functions.md
+++ b/docs/packages/data-mate/functions.md
@@ -3600,9 +3600,9 @@ hello: "i am an object" => isString() // outputs null
 
 #### Arguments
 
- - **hash**:  `String` - Which has hashing algorithm to use, defaults to sha256
+ - **hash**:  `String` - Which hashing algorithm to use, defaults to sha256
 
- - **digest**:  `String` - Which has digest to use, may be set to either "base64" or "hex", defaults to "hex"
+ - **digest**:  `String` - Which hash digest to use, may be set to either "base64" or "hex", defaults to "hex"
 
 #### Accepts
 
@@ -3627,7 +3627,7 @@ hashing algorithm defaults to sha256, and digest defaults to hex
 
 #### Arguments
 
- - **digest**:  `String` - Which has digest to use, may be set to either "base64" or "hex", defaults to "hex"
+ - **digest**:  `String` - Which hash digest to use, may be set to either "base64" or "hex", defaults to "hex"
 
 #### Accepts
 

--- a/packages/data-mate/src/column/aggregations.ts
+++ b/packages/data-mate/src/column/aggregations.ts
@@ -3,7 +3,7 @@ import {
 } from '@terascope/utils';
 import { Maybe, ISO8601DateSegment } from '@terascope/types';
 import {
-    Vector, VectorType, getNumericValues, SerializeOptions, DateVector
+    Vector, VectorType, getNumericValues, SerializeOptions
 } from '../vector';
 import { getHashCodeFrom } from '../core';
 
@@ -189,8 +189,7 @@ function makeDateAgg(trimDateFn: (input: unknown) => number): MakeKeyAggFn {
             if (value == null) return { key: undefined, value };
 
             return {
-                key: `${trimDateFn((vector as DateVector)
-                    .valueToJSON(value))}`,
+                key: `${trimDateFn(value)}`,
                 value,
             };
         };

--- a/packages/data-mate/src/function-configs/object/equals.ts
+++ b/packages/data-mate/src/function-configs/object/equals.ts
@@ -1,4 +1,4 @@
-import { isDeepEqual } from '@terascope/utils';
+import { isDeepEqualFP } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldValidateConfig, ProcessMode, FunctionDefinitionType, FunctionDefinitionCategory
@@ -15,7 +15,7 @@ export const equalsConfig: FieldValidateConfig<EqualsArgs> = {
     category: FunctionDefinitionCategory.OBJECT,
     description: 'Checks to see if input matches the value',
     create({ value }) {
-        return (input: unknown) => isDeepEqual(input, value);
+        return isDeepEqualFP(value);
     },
     accepts: [],
     argument_schema: {

--- a/packages/data-mate/src/function-configs/object/equals.ts
+++ b/packages/data-mate/src/function-configs/object/equals.ts
@@ -1,4 +1,4 @@
-import { isSame } from '@terascope/utils';
+import { isDeepEqual } from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import {
     FieldValidateConfig, ProcessMode, FunctionDefinitionType, FunctionDefinitionCategory
@@ -15,7 +15,7 @@ export const equalsConfig: FieldValidateConfig<EqualsArgs> = {
     category: FunctionDefinitionCategory.OBJECT,
     description: 'Checks to see if input matches the value',
     create({ value }) {
-        return (input: unknown) => isSame(input, value);
+        return (input: unknown) => isDeepEqual(input, value);
     },
     accepts: [],
     argument_schema: {

--- a/packages/data-mate/src/function-configs/string/encode-utils.ts
+++ b/packages/data-mate/src/function-configs/string/encode-utils.ts
@@ -1,0 +1,26 @@
+import { createHash, BinaryToTextEncoding } from 'crypto';
+import { primitiveToString } from '@terascope/utils';
+
+export function bufferEncode(bufferEncoding: BufferEncoding) {
+    return function _bufferEncode(input: unknown): string {
+        return Buffer.from(primitiveToString(input)).toString(bufferEncoding);
+    };
+}
+
+export function cryptoEncode(hash: string, digest: BinaryToTextEncoding) {
+    return function _cryptoEncode(input: unknown): string {
+        return createHash(hash).update(primitiveToString(input)).digest(digest);
+    };
+}
+
+export function encodeURL(input: unknown): string {
+    return encodeURIComponent(primitiveToString(input));
+}
+
+export function encodeAny(
+    algo: string, digest?: BinaryToTextEncoding
+): (input: unknown) => string {
+    if (algo === 'url') return encodeURL;
+    if (algo === 'base64' || algo === 'hex') return bufferEncode(algo);
+    return cryptoEncode(algo, digest ?? 'hex');
+}

--- a/packages/data-mate/src/function-configs/string/encode.ts
+++ b/packages/data-mate/src/function-configs/string/encode.ts
@@ -101,12 +101,12 @@ export const encodeConfig: FieldTransformConfig<EncodeConfig> = {
         algo: {
             type: FieldType.String,
             array: false,
-            description: 'Which has hashing algorithm to use'
+            description: 'Which hashing algorithm to use'
         },
         digest: {
             type: FieldType.String,
             array: false,
-            description: 'Which has digest to use, may be set to either "base64" or "hex", defaults to "hex". '
+            description: 'Which hash digest to use, may be set to either "base64" or "hex", defaults to "hex". '
             + 'Only used when algorithm is not base64, hex, or url'
         }
     },

--- a/packages/data-mate/src/function-configs/string/encode.ts
+++ b/packages/data-mate/src/function-configs/string/encode.ts
@@ -1,0 +1,125 @@
+import { BinaryToTextEncoding } from 'crypto';
+import { FieldType } from '@terascope/types';
+import {
+    FieldTransformConfig,
+    ProcessMode,
+    FunctionDefinitionType,
+    DataTypeFieldAndChildren,
+    FunctionDefinitionCategory
+} from '../interfaces';
+import { encodeAny } from './encode-utils';
+
+export interface EncodeConfig {
+    algo: string;
+    digest?: BinaryToTextEncoding;
+}
+
+export const encodeConfig: FieldTransformConfig<EncodeConfig> = {
+    name: 'encode',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.INDIVIDUAL_VALUES,
+    category: FunctionDefinitionCategory.STRING,
+    description: 'Converts a value to a hash using a specified algorithm',
+    examples: [
+        {
+            args: { algo: 'sha256' },
+            config: {
+                version: 1,
+                fields: {
+                    testField: {
+                        type: FieldType.String
+                    }
+                }
+            },
+            field: 'testField',
+            input: '{ "some": "data" }',
+            output: 'e43e698b8ee20f09ae4257e81d7c8ac5074cdda2a8aef8d6c00dbbe5b404f7e5',
+            description: 'Hashing algorithm defaults to 256, and digest defaults to hex'
+        },
+        {
+            args: { algo: 'md5' },
+            config: {
+                version: 1,
+                fields: {
+                    testField: {
+                        type: FieldType.String
+                    }
+                }
+            },
+            field: 'testField',
+            input: '{ "some": "data" }',
+            output: '7e33b72a611da99c7e9013dd44dbbdad',
+        },
+        {
+            args: { algo: 'url' },
+            config: {
+                version: 1,
+                fields: {
+                    testField: {
+                        type: FieldType.String
+                    }
+                }
+            },
+            field: 'testField',
+            input: 'google.com?q=HELLO AND GOODBYE',
+            output: 'google.com%3Fq%3DHELLO%20AND%20GOODBYE'
+        },
+        {
+            args: { algo: 'base64' },
+            config: {
+                version: 1,
+                fields: {
+                    testField: {
+                        type: FieldType.String
+                    }
+                }
+            },
+            field: 'testField',
+            input: 'HELLO AND GOODBYE',
+            output: 'SEVMTE8gQU5EIEdPT0RCWUU='
+        },
+        {
+            args: { algo: 'sha1', digest: 'base64' },
+            config: {
+                version: 1,
+                fields: {
+                    testField: {
+                        type: FieldType.String
+                    }
+                }
+            },
+            field: 'testField',
+            input: '{ "some": "data" }',
+            output: '6MsUBHluumd5onY3fM6ZpQKjZIE=',
+        }
+    ],
+    create({ algo, digest }) {
+        return encodeAny(algo, digest);
+    },
+    accepts: [FieldType.String],
+    argument_schema: {
+        algo: {
+            type: FieldType.String,
+            array: false,
+            description: 'Which has hashing algorithm to use'
+        },
+        digest: {
+            type: FieldType.String,
+            array: false,
+            description: 'Which has digest to use, may be set to either "base64" or "hex", defaults to "hex". '
+            + 'Only used when algorithm is not base64, hex, or url'
+        }
+    },
+    required_arguments: ['algo'],
+    output_type(inputConfig: DataTypeFieldAndChildren): DataTypeFieldAndChildren {
+        const { field_config, child_config } = inputConfig;
+
+        return {
+            field_config: {
+                ...field_config,
+                type: FieldType.String
+            },
+            child_config
+        };
+    }
+};

--- a/packages/data-mate/src/function-configs/string/encodeBase64.ts
+++ b/packages/data-mate/src/function-configs/string/encodeBase64.ts
@@ -6,6 +6,7 @@ import {
     DataTypeFieldAndChildren,
     FunctionDefinitionCategory
 } from '../interfaces';
+import { bufferEncode } from './encode-utils';
 
 export const encodeBase64Config: FieldTransformConfig = {
     name: 'encodeBase64',
@@ -30,7 +31,7 @@ export const encodeBase64Config: FieldTransformConfig = {
         }
     ],
     create() {
-        return (input: unknown) => encodeBase64(input as string);
+        return bufferEncode('base64');
     },
     accepts: [FieldType.String],
     output_type(inputConfig: DataTypeFieldAndChildren): DataTypeFieldAndChildren {
@@ -45,7 +46,3 @@ export const encodeBase64Config: FieldTransformConfig = {
         };
     },
 };
-
-export function encodeBase64(input: string): string {
-    return Buffer.from(input as string).toString('base64');
-}

--- a/packages/data-mate/src/function-configs/string/encodeHex.ts
+++ b/packages/data-mate/src/function-configs/string/encodeHex.ts
@@ -6,6 +6,7 @@ import {
     DataTypeFieldAndChildren,
     FunctionDefinitionCategory
 } from '../interfaces';
+import { bufferEncode } from './encode-utils';
 
 export const encodeHexConfig: FieldTransformConfig = {
     name: 'encodeHex',
@@ -30,7 +31,7 @@ export const encodeHexConfig: FieldTransformConfig = {
         }
     ],
     create() {
-        return (input: unknown) => Buffer.from(input as string).toString('hex');
+        return bufferEncode('hex');
     },
     accepts: [FieldType.String],
     output_type(inputConfig: DataTypeFieldAndChildren): DataTypeFieldAndChildren {

--- a/packages/data-mate/src/function-configs/string/encodeSHA.ts
+++ b/packages/data-mate/src/function-configs/string/encodeSHA.ts
@@ -62,12 +62,12 @@ export const encodeSHAConfig: FieldTransformConfig<EncodeSHAConfig> = {
         hash: {
             type: FieldType.String,
             array: false,
-            description: 'Which has hashing algorithm to use, defaults to sha256'
+            description: 'Which hashing algorithm to use, defaults to sha256'
         },
         digest: {
             type: FieldType.String,
             array: false,
-            description: 'Which has digest to use, may be set to either "base64" or "hex", defaults to "hex"'
+            description: 'Which hash digest to use, may be set to either "base64" or "hex", defaults to "hex"'
         }
     },
     validate_arguments({ hash }) {

--- a/packages/data-mate/src/function-configs/string/encodeSHA1.ts
+++ b/packages/data-mate/src/function-configs/string/encodeSHA1.ts
@@ -1,4 +1,4 @@
-import crypto, { BinaryToTextEncoding } from 'crypto';
+import { BinaryToTextEncoding } from 'crypto';
 import { FieldType } from '@terascope/types';
 import {
     FieldTransformConfig,
@@ -7,12 +7,13 @@ import {
     DataTypeFieldAndChildren,
     FunctionDefinitionCategory
 } from '../interfaces';
+import { cryptoEncode } from './encode-utils';
 
 export interface EncodeSHA1Config {
-    digest?: string;
+    digest?: BinaryToTextEncoding;
 }
 
-const defaultDigest = 'hex';
+const defaultDigest: BinaryToTextEncoding = 'hex';
 
 export const encodeSHA1Config: FieldTransformConfig<EncodeSHA1Config> = {
     name: 'encodeSHA1',
@@ -52,7 +53,7 @@ export const encodeSHA1Config: FieldTransformConfig<EncodeSHA1Config> = {
         }
     ],
     create({ digest = defaultDigest } = {}) {
-        return (input: unknown) => encodeSHA1(input, digest as BinaryToTextEncoding);
+        return cryptoEncode('sha1', digest);
     },
     accepts: [FieldType.String],
     argument_schema: {
@@ -73,7 +74,3 @@ export const encodeSHA1Config: FieldTransformConfig<EncodeSHA1Config> = {
         };
     }
 };
-
-export function encodeSHA1(input: unknown, digest: BinaryToTextEncoding = defaultDigest): string {
-    return crypto.createHash('sha1').update(input as string).digest(digest);
-}

--- a/packages/data-mate/src/function-configs/string/encodeSHA1.ts
+++ b/packages/data-mate/src/function-configs/string/encodeSHA1.ts
@@ -60,7 +60,7 @@ export const encodeSHA1Config: FieldTransformConfig<EncodeSHA1Config> = {
         digest: {
             type: FieldType.String,
             array: false,
-            description: 'Which has digest to use, may be set to either "base64" or "hex", defaults to "hex"'
+            description: 'Which hash digest to use, may be set to either "base64" or "hex", defaults to "hex"'
         }
     },
     output_type(inputConfig: DataTypeFieldAndChildren): DataTypeFieldAndChildren {

--- a/packages/data-mate/src/function-configs/string/encodeURL.ts
+++ b/packages/data-mate/src/function-configs/string/encodeURL.ts
@@ -6,6 +6,7 @@ import {
     DataTypeFieldAndChildren,
     FunctionDefinitionCategory
 } from '../interfaces';
+import { encodeURL } from './encode-utils';
 
 export const encodeURLConfig: FieldTransformConfig = {
     name: 'encodeURL',
@@ -30,7 +31,7 @@ export const encodeURLConfig: FieldTransformConfig = {
         }
     ],
     create() {
-        return (input: unknown) => encodeURIComponent(input as string);
+        return encodeURL;
     },
     accepts: [FieldType.String],
     output_type(inputConfig: DataTypeFieldAndChildren): DataTypeFieldAndChildren {

--- a/packages/data-mate/src/function-configs/string/index.ts
+++ b/packages/data-mate/src/function-configs/string/index.ts
@@ -26,6 +26,7 @@ import { isPostalCodeConfig } from './isPostalCode';
 import { isStringConfig } from './isString';
 import { isURLConfig } from './isURL';
 import { isUUIDConfig } from './isUUID';
+import { joinConfig } from './join';
 import { reverseConfig } from './reverse';
 import { splitConfig } from './split';
 import { startsWithConfig } from './startsWith';
@@ -72,6 +73,7 @@ export const stringRepository = {
     isString: isStringConfig,
     isURL: isURLConfig,
     isUUID: isUUIDConfig,
+    join: joinConfig,
     reverse: reverseConfig,
     split: splitConfig,
     startsWith: startsWithConfig,

--- a/packages/data-mate/src/function-configs/string/index.ts
+++ b/packages/data-mate/src/function-configs/string/index.ts
@@ -2,6 +2,7 @@ import { containsConfig } from './contains';
 import { decodeBase64Config } from './decodeBase64';
 import { decodeHexConfig } from './decodeHex';
 import { decodeURLConfig } from './decodeURL';
+import { encodeConfig } from './encode';
 import { encodeBase64Config } from './encodeBase64';
 import { encodeHexConfig } from './encodeHex';
 import { encodeSHAConfig } from './encodeSHA';
@@ -49,6 +50,7 @@ export const stringRepository = {
     decodeBase64: decodeBase64Config,
     decodeHex: decodeHexConfig,
     decodeURL: decodeURLConfig,
+    encode: encodeConfig,
     encodeBase64: encodeBase64Config,
     encodeHex: encodeHexConfig,
     encodeSHA: encodeSHAConfig,

--- a/packages/data-mate/src/function-configs/string/join.ts
+++ b/packages/data-mate/src/function-configs/string/join.ts
@@ -1,0 +1,107 @@
+import { FieldType } from '@terascope/types';
+import { isNotNil } from '@terascope/utils';
+import {
+    FieldTransformConfig, ProcessMode, FunctionDefinitionType,
+    FunctionDefinitionExample, FunctionDefinitionCategory
+} from '../interfaces';
+
+export interface JoinArgs {
+    delimiter?: string;
+}
+
+const examples: FunctionDefinitionExample<JoinArgs>[] = [
+    {
+        args: {},
+        config: {
+            version: 1,
+            fields: {
+                testField: {
+                    type: FieldType.String, array: true
+                }
+            }
+        },
+        field: 'testField',
+        input: ['a', ' ', 's', 't', 'r', 'i', 'n', 'g'],
+        output: 'a string',
+    },
+    {
+        args: { delimiter: ',' },
+        config: {
+            version: 1,
+            fields: {
+                testField: {
+                    type: FieldType.String, array: true
+                }
+            }
+        },
+        field: 'testField',
+        input: ['a string', 'found'],
+        output: 'a string,found',
+    },
+    {
+        args: { delimiter: ' - ' },
+        config: {
+            version: 1,
+            fields: {
+                testField: {
+                    type: FieldType.String, array: true
+                }
+            }
+        },
+        field: 'testField',
+        input: ['a', 'stri', 'ng'],
+        output: 'a - stri - ng',
+    },
+    {
+        args: { delimiter: ' ' },
+        config: {
+            version: 1,
+            fields: {
+                testField: {
+                    type: FieldType.String, array: true
+                }
+            }
+        },
+        field: 'testField',
+        input: 'a string',
+        output: 'a string',
+    },
+];
+
+export const joinConfig: FieldTransformConfig<JoinArgs> = {
+    name: 'join',
+    type: FunctionDefinitionType.FIELD_TRANSFORM,
+    process_mode: ProcessMode.FULL_VALUES,
+    category: FunctionDefinitionCategory.STRING,
+    description: 'Converts an array of string values joins by the delimiter provided',
+    examples,
+    create({ delimiter = '' }) {
+        return joinFn(delimiter);
+    },
+    accepts: [FieldType.String],
+    argument_schema: {
+        delimiter: {
+            type: FieldType.String,
+            array: false,
+            description: 'The char to join the strings'
+        }
+    },
+    output_type({ field_config }) {
+        return {
+            field_config: {
+                ...field_config,
+                array: false,
+            }
+        };
+    }
+};
+
+function joinFn(delimiter: string): (input: unknown) => string|null {
+    return function _join(input) {
+        if (input == null) return null;
+        if (!Array.isArray(input)) {
+            return String(input);
+        }
+        return input.filter(isNotNil).join(delimiter);
+    };
+}

--- a/packages/data-mate/src/validations/field-validator.ts
+++ b/packages/data-mate/src/validations/field-validator.ts
@@ -919,11 +919,11 @@ export function equals(input: unknown, _parentContext: unknown, args: { value: s
     if (!args.value) throw new Error('A value must provided with the input');
 
     if (isArray(input)) {
-        const fn = (data: any) => ts.isSame(data, args.value);
+        const fn = (data: any) => ts.isDeepEqual(data, args.value);
         return _lift(fn, input, _parentContext);
     }
 
-    return ts.isSame(input, args.value);
+    return ts.isDeepEqual(input, args.value);
 }
 
 /**

--- a/packages/job-components/src/operations/convict-schema.ts
+++ b/packages/job-components/src/operations/convict-schema.ts
@@ -3,7 +3,7 @@ import {
     has,
     get,
     toString,
-    isSame
+    isDeepEqual
 } from '@terascope/utils';
 import SchemaCore, { OpType } from './core/schema-core';
 import {
@@ -82,7 +82,7 @@ export default abstract class ConvictSchema<T extends Record<string, any>, S = a
 
             for (const [key, value] of Object.entries(apiConfig)) {
                 const configVal = get(config, key);
-                if (has(config, key) && !isSame(configVal, value)) {
+                if (has(config, key) && !isDeepEqual(configVal, value)) {
                     mixedValues[key] = [toString(configVal), toString(value)];
                 }
             }

--- a/packages/utils/src/equality.ts
+++ b/packages/utils/src/equality.ts
@@ -1,13 +1,77 @@
+import _isEqualWith from 'lodash/isEqualWith';
+import { isDataEntity } from './entities/utils';
+
 /**
- * Verify that two values are the same (uses a reference check)
+ * Verify that two values are the same (uses a reference check).
+ * Similar to === except two NaNs is considered the same
+ * For deep equality use isDeepEqual
 */
-export function isEqual<T>(value: T, input: unknown): input is T {
-    return value === input || Object.is(value, input);
+export function isEqual<T>(target: T, input: unknown): input is T;
+export function isEqual<T extends unknown>(target: T, input: unknown): boolean;
+export function isEqual<T>(target: T, input: unknown): input is T {
+    return input === target || (Number.isNaN(target) && Number.isNaN(input));
 }
 
 /**
  * A functional version of isEqual
 */
-export function isEqualFP<T>(value: T): (input: unknown) => input is T {
-    return isEqual.bind(isEqual, value) as (input: unknown) => input is T;
+export function isEqualFP<T>(target: T): (input: unknown) => input is T;
+export function isEqualFP<T extends unknown>(target: T): (input: unknown) => boolean;
+export function isEqualFP<T>(target: T): (input: T) => input is T {
+    return isEqual.bind(isEqual, target) as (input: T) => input is T;
 }
+
+/**
+ * Compares two values and returns a boolean if they are the same.
+ * Arrays are compared using original sorting, while object key ordering
+ * doesn't matter.
+ *
+ * @example
+        isDeepEqual({ key1: 1, key2: 2 }, { key2: 2, key1: 1 }) === true;
+        isDeepEqual(null, null) === true;
+        isDeepEqual(undefined, undefined) === true;
+        isDeepEqual(NaN, NaN) === true;
+        isDeepEqual(3, 3) === true
+        isDeepEqual('hello', 'hello') === true
+        isDeepEqual([1, 2, 3], [1, 2, 3]) === true
+        isDeepEqual([{ some: 'obj' }], [{ some: 'obj' }]) === true
+
+        isDeepEqual(undefined, null) === false;
+        isDeepEqual([1, 2, 3], [1, 3, 2]) === false
+        isDeepEqual([1, 2, 3], [1, 2, undefined, 3]) === false
+        isDeepEqual(true, 'true') === false;
+*/
+export function isDeepEqual<T>(target: T, input: unknown): input is T;
+export function isDeepEqual<T extends unknown>(target: T, input: unknown): boolean;
+export function isDeepEqual<T>(target: T, input: unknown): target is T {
+    return _isEqualWith(input, target, _isEqualCustomizer);
+}
+
+function _isEqualCustomizer(objValue: unknown, otherObject: unknown): boolean|undefined {
+    const aIsEntity = isDataEntity(objValue);
+    const bIsEntity = isDataEntity(otherObject);
+
+    if (aIsEntity && bIsEntity) {
+        return isDeepEqual(Object.assign({}, objValue), Object.assign({}, otherObject));
+    }
+    if (aIsEntity && !bIsEntity) {
+        return isDeepEqual(Object.assign({}, objValue), otherObject);
+    }
+    if (!aIsEntity && bIsEntity) {
+        return isDeepEqual(Object.assign({}, objValue), otherObject);
+    }
+}
+
+/**
+ * A functional version of isDeepEqual
+*/
+export function isDeepEqualFP<T>(target: T): (input: unknown) => input is T;
+export function isDeepEqualFP<T extends unknown>(target: T): (input: unknown) => boolean;
+export function isDeepEqualFP<T>(target: unknown): (input: T) => input is T {
+    return isDeepEqual.bind(isDeepEqual, target) as (input: T) => input is T;
+}
+
+/**
+ * @deprecated use isDeepEqual instead
+*/
+export const isSame = isDeepEqual;

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -191,48 +191,6 @@ export function getField<T, P extends keyof T, V>(
 }
 
 /**
- * Compares two values and returns a boolean if they are the same.
- * Object keys are sorted before comparison, arrays are NOT sorted and
- * are compared value for value
- *
- * @example
-        isSame({ key1: 1, key2: 2 }, { key2: 2, key1: 1 }) === true;
-        isSame(null, null) === true;
-        isSame(undefined, undefined) === true;
-        isSame(NaN, NaN) === true;
-        isSame(3, 3) === true
-        isSame('hello', 'hello') === true
-        isSame([1, 2, 3], [1, 2, 3]) === true
-        isSame([{ some: 'obj' }], [{ some: 'obj' }]) === true
-
-        isSame(undefined, null) === false;
-        isSame([1, 2, 3], [1, 3, 2]) === false
-        isSame([1, 2, 3], [1, 2, undefined, 3]) === false
-        isSame(true, 'true') === false;
-*/
-export function isSame(input: unknown, target: unknown): boolean {
-    if (input === target || Object.is(input, target)) return true;
-    if (isObjectEntity(input)) {
-        if (isObjectEntity(target)) {
-            const sortedInput = sortKeys(input as Record<string, unknown>, { deep: true });
-            const sortedTarget = sortKeys(target as Record<string, unknown>, { deep: true });
-            return JSON.stringify(sortedInput) === JSON.stringify(sortedTarget);
-        }
-        return false;
-    }
-
-    if (isArrayLike(input)) {
-        if (isArrayLike(target)) {
-            if (input.length !== target.length) return false;
-            return input.every((val, index) => isSame(val, target[index]));
-        }
-        return false;
-    }
-
-    return false;
-}
-
-/**
  * Check if a object has property (and not included in the prototype)
  * Different from has since it doesn't deal with dot notation values.
 */

--- a/packages/utils/test/deps-spec.ts
+++ b/packages/utils/test/deps-spec.ts
@@ -1,12 +1,10 @@
 /* eslint-disable max-classes-per-file */
 import 'jest-extended';
 import { DataEntity } from '../src/entities';
-import { pDelay } from '../src/promises';
 import {
     getTypeOf,
     isPlainObject,
     cloneDeep,
-    pMap,
 } from '../src/deps';
 
 describe('Dependency Utils', () => {
@@ -176,38 +174,6 @@ describe('Dependency Utils', () => {
             output.value = 456;
             expect(output.value).toBe(456);
             expect(input.value).toBe(123);
-        });
-    });
-
-    describe('pMap', () => {
-        it('should be able to work without concurrency', () => {
-            const items: { int: number }[] = [{ int: 1 }, { int: 3 }];
-            return expect(pMap(items, (item) => {
-                item.int++;
-                return item;
-            })).resolves.toEqual([
-                { int: 2 }, { int: 4 }
-            ]);
-        });
-
-        it('should be able to work with a concurrency of 2', async () => {
-            const items: number[] = [1, 2, 3, 4, 5];
-            const start = Date.now();
-            const concurrency = 2;
-            const wait = 500;
-
-            const result = pMap(items, async (item, i) => {
-                const diff = Date.now() - start;
-                if (i % concurrency === 0) {
-                    await pDelay(wait);
-                }
-                return Math.floor(diff / wait) * wait;
-            }, {
-                concurrency
-            });
-            return expect(result).resolves.toEqual([
-                0, 0, 0, 500, 500
-            ]);
         });
     });
 });

--- a/packages/utils/test/equality-spec.ts
+++ b/packages/utils/test/equality-spec.ts
@@ -1,0 +1,73 @@
+import 'jest-extended';
+import {
+    isDeepEqual
+} from '../src/equality';
+import { DataEntity } from '../src';
+
+describe('Equality', () => {
+    describe('isDeepEqual', () => {
+        describe('when given an object', () => {
+            it('should return true if they are the same', () => {
+                const obj = { key1: 1, key2: 2 };
+                const obj2 = { key1: 1, key2: 2 };
+
+                expect(isDeepEqual(obj, obj2)).toBeTrue();
+            });
+
+            it('should return true if they are the same even with out of order keys', () => {
+                const obj = { key1: 1, key2: 2 };
+                const obj2 = { key2: 2, key1: 1 };
+
+                expect(isDeepEqual(obj, obj2)).toBeTrue();
+            });
+
+            it('should return true if they have same key/values even if other is DataEntity', () => {
+                const obj = { key1: 1, key2: 2 };
+
+                expect(isDeepEqual(obj, new DataEntity(obj))).toBeTrue();
+            });
+
+            it('should return true false when compared to anything else', () => {
+                const obj = { key1: 1, key2: 2 };
+
+                expect(isDeepEqual(obj, 'true')).toBeFalse();
+                expect(isDeepEqual(obj, null)).toBeFalse();
+                expect(isDeepEqual(obj, [1, 2])).toBeFalse();
+                expect(isDeepEqual(obj, [obj])).toBeFalse();
+            });
+        });
+
+        describe('when other values other than arrays and objects', () => {
+            it('should true if they are the same', () => {
+                expect(isDeepEqual(null, null)).toBeTrue();
+                expect(isDeepEqual(undefined, undefined)).toBeTrue();
+                expect(isDeepEqual(NaN, NaN)).toBeTrue();
+
+                expect(isDeepEqual('true', 'true')).toBeTrue();
+                expect(isDeepEqual('true', true)).toBeFalse();
+
+                expect(isDeepEqual(3, 3)).toBeTrue();
+                expect(isDeepEqual(3, 324)).toBeFalse();
+
+                expect(isDeepEqual(false, null)).toBeFalse();
+                expect(isDeepEqual(false, undefined)).toBeFalse();
+                expect(isDeepEqual(undefined, null)).toBeFalse();
+            });
+        });
+
+        describe('when given an array', () => {
+            it('should true if they are the same, order matters', () => {
+                expect(isDeepEqual([1, 2, 3], [1, 2, 3])).toBeTrue();
+                expect(isDeepEqual([1, 2, 3], [1, 2, undefined, 3])).toBeFalse();
+                expect(isDeepEqual([1, 2, 3], [1, 3, 2])).toBeFalse();
+
+                expect(isDeepEqual(['hello'], ['hello'])).toBeTrue();
+
+                expect(isDeepEqual(['hello', 3], ['hello', 3])).toBeTrue();
+
+                expect(isDeepEqual(['hello'], ['hello'])).toBeTrue();
+                expect(isDeepEqual([{ some: 'obj' }], [{ some: 'obj' }])).toBeTrue();
+            });
+        });
+    });
+});

--- a/packages/utils/test/objects-spec.ts
+++ b/packages/utils/test/objects-spec.ts
@@ -5,7 +5,6 @@ import {
     withoutNil,
     filterObject,
     isObjectEntity,
-    isSame
 } from '../src/objects';
 import { DataEntity } from '../src';
 
@@ -75,72 +74,6 @@ describe('Objects', () => {
         describe('when given an empty object', () => {
             it('should return nil', () => {
                 expect(getFirstKey({})).toBeNil();
-            });
-        });
-    });
-
-    describe('isSame', () => {
-        describe('when given an object', () => {
-            it('should return true if they are the same', () => {
-                const obj = { key1: 1, key2: 2 };
-                const obj2 = { key1: 1, key2: 2 };
-
-                expect(isSame(obj, obj2)).toBeTrue();
-            });
-
-            it('should return true if they are the same even with out of order keys', () => {
-                const obj = { key1: 1, key2: 2 };
-                const obj2 = { key2: 2, key1: 1 };
-
-                expect(isSame(obj, obj2)).toBeTrue();
-            });
-
-            it('should return true if they have same key/values even if other is DataEntity', () => {
-                const obj = { key1: 1, key2: 2 };
-
-                expect(isSame(obj, new DataEntity(obj))).toBeTrue();
-            });
-
-            it('should return true false when compared to anything else', () => {
-                const obj = { key1: 1, key2: 2 };
-
-                expect(isSame(obj, 'true')).toBeFalse();
-                expect(isSame(obj, null)).toBeFalse();
-                expect(isSame(obj, [1, 2])).toBeFalse();
-                expect(isSame(obj, [obj])).toBeFalse();
-            });
-        });
-
-        describe('when other values other than arrays and objects', () => {
-            it('should true if they are the same', () => {
-                expect(isSame(null, null)).toBeTrue();
-                expect(isSame(undefined, undefined)).toBeTrue();
-                expect(isSame(NaN, NaN)).toBeTrue();
-
-                expect(isSame('true', 'true')).toBeTrue();
-                expect(isSame('true', true)).toBeFalse();
-
-                expect(isSame(3, 3)).toBeTrue();
-                expect(isSame(3, 324)).toBeFalse();
-
-                expect(isSame(false, null)).toBeFalse();
-                expect(isSame(false, undefined)).toBeFalse();
-                expect(isSame(undefined, null)).toBeFalse();
-            });
-        });
-
-        describe('when given an array', () => {
-            it('should true if they are the same, order matters', () => {
-                expect(isSame([1, 2, 3], [1, 2, 3])).toBeTrue();
-                expect(isSame([1, 2, 3], [1, 2, undefined, 3])).toBeFalse();
-                expect(isSame([1, 2, 3], [1, 3, 2])).toBeFalse();
-
-                expect(isSame(['hello'], ['hello'])).toBeTrue();
-
-                expect(isSame(['hello', 3], ['hello', 3])).toBeTrue();
-
-                expect(isSame(['hello'], ['hello'])).toBeTrue();
-                expect(isSame([{ some: 'obj' }], [{ some: 'obj' }])).toBeTrue();
             });
         });
     });


### PR DESCRIPTION
- [x] Add generic `encode`
- [x] Add `join`
- [x] Add performance improvement to date aggregations
- [x] Rename `isSame` to `isDeepEqual`, put it in `packages/utils/src/equality` not `packages/utils/src/objects.ts`, and use the lodash `isEqual` since I don't think it worked correct with certain values. I made sure this wasn't a breaking change by adding an alias for `isSame`