### PR TITLE
WIP: OpenSearch example

### DIFF
--- a/config/docker-teraslice-master.yml
+++ b/config/docker-teraslice-master.yml
@@ -4,6 +4,7 @@ terafoundation:
     connectors:
         elasticsearch:
             default:
+                apiVersion: "7.0"
                 host:
                     - "elasticsearch:9200"
         kafka:

--- a/config/docker-teraslice-worker.yml
+++ b/config/docker-teraslice-worker.yml
@@ -4,6 +4,7 @@ terafoundation:
     connectors:
         elasticsearch:
             default:
+                apiVersion: "7.0"
                 host:
                     - "elasticsearch:9200"
         kafka:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - ./autoload:/app/autoload:delegated
       - ./config:/app/config:delegated
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.5.4
+    image: opensearchproject/opensearch
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       interval: 15s
@@ -50,17 +50,15 @@ services:
       - "9200:9200"
       - "9300:9300"
     environment:
-      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - "OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g"
       - "network.host=0.0.0.0"
       - "http.port=9200"
-      - "transport.tcp.port=9300"
+      - "transport.port=9300"
       - "discovery.type=single-node"
-      - "xpack.security.enabled=false"
-      - "xpack.ml.enabled=false"
-      - "xpack.watcher.enabled=false"
       - "bootstrap.memory_lock=true"
+      - opendistro_security.disabled=true
     volumes:
-      - elasticsearch-data:/usr/share/elasticsearch/data
+      - elasticsearch-data:/usr/share/opensearch/data
     networks:
       - cluster
     ulimits:

--- a/e2e/test/cases/data/reindex-spec.js
+++ b/e2e/test/cases/data/reindex-spec.js
@@ -37,7 +37,7 @@ describe('reindex', () => {
         // as there are no records
         await misc.indexStats(specIndex).catch((errResponse) => {
             const reason = get(errResponse, 'body.error.reason');
-            expect(reason).toEqual('no such index');
+            expect(reason.substring(0, 13)).toEqual('no such index');
         });
     });
 

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -31,13 +31,11 @@ const services: Readonly<Record<Service, Readonly<DockerRunOptions>>> = {
             : undefined,
         ports: [`${config.ELASTICSEARCH_PORT}:${config.ELASTICSEARCH_PORT}`],
         env: {
-            ES_JAVA_OPTS: config.SERVICE_HEAP_OPTS,
+            OPENSEARCH_JAVA_OPTS: config.SERVICE_HEAP_OPTS,
             'network.host': '0.0.0.0',
             'http.port': config.ELASTICSEARCH_PORT,
             'discovery.type': 'single-node',
-            ...disableXPackSecurity && {
-                'xpack.security.enabled': 'false'
-            }
+            'opendistro_security.disabled': 'true'
         },
         network: config.DOCKER_NETWORK_NAME
     },


### PR DESCRIPTION
This PR is an example of what kind of changes are needed for OpenSearch.

For E2E tests to pass I set these env variables as well:
```
ELASTICSEARCH_API_VERSION=7.0
ELASTICSEARCH_DOCKER_IMAGE=opensearchproject/opensearch
ELASTICSEARCH_VERSION=1.0.0-beta1
```

```
yarn test
yarn run v1.22.10
$ ts-scripts test --suite e2e --
*  pending   building docker image terascope/teraslice:dev-local
[+] Building 1.8s (17/17) FINISHED                                                                                                                                                                                
 => [internal] load build definition from Dockerfile                                                                                                                                                         0.0s
 => => transferring dockerfile: 37B                                                                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                                                            0.0s
 => => transferring context: 35B                                                                                                                                                                             0.0s
 => [internal] load metadata for docker.io/terascope/node-base:14.17.0                                                                                                                                       1.4s
 => [internal] load build context                                                                                                                                                                            0.1s
 => => transferring context: 58.44kB                                                                                                                                                                         0.1s
 => [ 1/12] FROM docker.io/terascope/node-base:14.17.0@sha256:70e194a0d756eb38d934c97f5134f5d277a2fa11cda6bb4ba9fb1481ea09ac57                                                                               0.0s
 => CACHED [ 2/12] COPY package.json yarn.lock tsconfig.json .yarnrc /app/source/                                                                                                                            0.0s
 => CACHED [ 3/12] COPY .yarnclean.ci /app/source/.yarnclean                                                                                                                                                 0.0s
 => CACHED [ 4/12] COPY packages /app/source/packages                                                                                                                                                        0.0s
 => CACHED [ 5/12] COPY scripts /app/source/scripts                                                                                                                                                          0.0s
 => CACHED [ 6/12] RUN yarn --prod=false --silent --ignore-optional --frozen-lockfile     && yarn cache clean                                                                                                0.0s
 => CACHED [ 7/12] COPY types /app/source/types                                                                                                                                                              0.0s
 => CACHED [ 8/12] RUN yarn build                                                                                                                                                                            0.0s
 => CACHED [ 9/12] COPY service.js /app/source/                                                                                                                                                              0.0s
 => CACHED [10/12] RUN yarn     --prod=true     --silent     --frozen-lockfile     --skip-integrity-check     --ignore-scripts     && yarn cache clean                                                       0.0s
 => CACHED [11/12] RUN node -e "require('node-rdkafka')"                                                                                                                                                     0.0s
 => CACHED [12/12] RUN node -e "require('teraslice')"                                                                                                                                                        0.0s
 => exporting to image                                                                                                                                                                                       0.0s
 => => exporting layers                                                                                                                                                                                      0.0s
 => => writing image sha256:12ec3d26914807d3767daa1337860f2fc6f1f06b5c3a8068b0262772678fa146                                                                                                                 0.0s
 => => naming to docker.io/terascope/teraslice:dev-local                                                                                                                                                     0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
✔  success   built docker image terascope/teraslice:dev-local, took 3s
*  pending   starting elasticsearch@1.0.0-beta1 service...
*  pending   starting kafka@2.3 service...
✔  success   kafka@2.3 *might* be running at 192.168.1.195:49092, took 6s
✔  success   elasticsearch@1.0.0-beta1 is running at http://192.168.1.195:49200, took 1m
▶  test suite "e2e" Initialized timer...
Determining test suites to run...
▶  global setup Initialized timer...
⚠  warning   Deleting asset elasticsearch@v2.6.0 in-favor of existing v2.6.0 [non-bundle]
⚠  warning   Deleting asset kafka@v3.2.0 in-favor of existing v3.2.0 [non-bundle]
⚠  warning   Deleting asset standard@v0.11.0 in-favor of existing v0.11.0 [non-bundle]
ℹ  info      Autoload asset bundles: elasticsearch@v2.6.0 [bundle], kafka@v3.2.0 [bundle], standard@v0.11.0 [bundle]
*  pending   Bringing Docker environment up...
✔  success   Docker environment is good to go took 11s
*  pending   Waiting for Teraslice...
✔  success   Teraslice is ready to go with 3 nodes took 7s
*  pending   Generating example data...
ℹ  info      Generating ts_test_example-100 example data
ℹ  info      Generating ts_test_example-1000 example data
ℹ  info      Generated ts_test_example-1000 example data took 5s
ℹ  info      Generated ts_test_example-100 example data took 5s
✔  success   Data generation is done took 5s
◼  global setup Timer run for: 28.94s
 PASS   e2e  test/cases/data/recovery-spec.js (119.945 s)
  recovery
    ✓ can support different recovery mode cleanup=errors (13986 ms)
    ✓ can support different recovery mode cleanup=all (17201 ms)
    ✓ can support different recovery mode cleanup=pending (8335 ms)
    ✓ can support autorecovery (38650 ms)
    ✓ can support recovery without a cleanup type (38986 ms)

 PASS   e2e  test/cases/assets/simple-spec.js (46.277 s)
  assets
    ✓ after uploading an asset, it can be deleted (201 ms)
    ✓ uploading a bad asset returns an error (85 ms)
    ✓ after starting a job with a Type 1 asset specified by ID should eventually have all workers joined (9753 ms)
    ✓ after starting a job with a Type 2 asset specified by ID should eventually have all workers joined (13527 ms)
    ✓ can update an asset bundle and use the new asset (12012 ms)
    ✓ can directly ask for the new asset to be used (9257 ms)

 PASS   e2e  test/cases/cluster/state-spec.js (41.743 s)
  cluster state
    ✓ should match default configuration (18 ms)
    ✓ should update after adding and removing a worker node (8117 ms)
    ✓ should be correct for running job with 1 worker (21217 ms)
    ✓ should be correct for running job with 4 workers (11154 ms)

 PASS   e2e  test/cases/data/reindex-spec.js (51.504 s)
  reindex
    ✓ should work for simple case (8102 ms)
    ✓ should work when no data is returned with lucene query (5298 ms)
    ✓ should collect cluster level stats (7 ms)
    ✓ should support idempotency (12747 ms)
    ✓ should be able to recover and continue (24089 ms)

 PASS   e2e  test/cases/data/elasticsearch-bulk-spec.js (6.884 s)
  elasticsearch bulk
    ✓ should support multisend (5636 ms)

 PASS   e2e  test/cases/cluster/worker-allocation-spec.js (23.943 s)
  worker allocation
    ✓ with 1 worker (12664 ms)
    ✓ with 3 workers (11114 ms)

 PASS   e2e  test/cases/kafka/kafka-spec.js (20.626 s)
  kafka
    ✓ should be able to read and write from kafka (19472 ms)

 PASS   e2e  test/cases/cluster/job-state-spec.js (11.461 s)
  job state
    ✓ should cycle through after state changes with other jobs running (10242 ms)

 PASS   e2e  test/cases/cluster/api-spec.js (13.763 s)
  cluster api
    ✓ submitted jobs are not saved in validated form (2409 ms)
    ✓ should update job config (3528 ms)
    ✓ will not send lifecycle changes to executions that are not active (6701 ms)
    ✓ api end point /assets should return an array of json objects of asset metadata (29 ms)
    ✓ api end point /assets/assetName should return an array of json objects of asset metadata (17 ms)
    ✓ api end point /assets/assetName/version should return an array of json objects of asset metadata (14 ms)
    ✓ api end point /txt/assets should return a text table (31 ms)
    ✓ api end point /txt/assets/assetName should return a text table (18 ms)
    ✓ api end point /txt/assets/assetName/version should return a text table (15 ms)

 PASS   e2e  test/cases/validation/job-spec.js (9.244 s)
  job validation
    ✓ should be rejected with empty index selector index name (1382 ms)
    ✓ should be rejected with empty reader index name (1437 ms)
    ✓ should be rejected with slicers = 0 (1345 ms)
    ✓ should be rejected with slicers < 0 (1330 ms)
    ✓ should be rejected with negative workers == 0 (1380 ms)
    ✓ should be rejected with invalid lifecycle (1384 ms)
    ✓ should be rejected if empty (8 ms)

Test Suites: 1 skipped, 10 passed, 10 of 11 total
Tests:       4 skipped, 41 passed, 45 total
Snapshots:   0 total
Time:        345.91 s, estimated 359 s
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
◼  test suite "e2e" Timer run for: 413.55s
✔  success   All tests completed
✨  Done in 483.13s.
```