### PR TITLE
Documentation changes

### DIFF
--- a/packages/data-mate/src/function-configs/boolean/isBoolean.ts
+++ b/packages/data-mate/src/function-configs/boolean/isBoolean.ts
@@ -9,7 +9,7 @@ export const isBooleanConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.BOOLEAN,
-    description: 'Checks to see if input is a boolean',
+    description: 'Returns the input if it is a boolean, otherwise returns null',
     examples: [{
         args: {},
         config: {

--- a/packages/data-mate/src/function-configs/boolean/isBooleanLike.ts
+++ b/packages/data-mate/src/function-configs/boolean/isBooleanLike.ts
@@ -9,7 +9,7 @@ export const isBooleanLikeConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.BOOLEAN,
-    description: 'Checks to see if input is loosely like a boolean, these values should be compatible with toBoolean',
+    description: 'Returns the input if it can be converted to a boolean, otherwise returns null',
     examples: [{
         args: {},
         config: {

--- a/packages/data-mate/src/function-configs/boolean/toBoolean.ts
+++ b/packages/data-mate/src/function-configs/boolean/toBoolean.ts
@@ -53,7 +53,7 @@ export const toBooleanConfig: FieldTransformConfig = {
             },
             field: 'testField',
             input: null,
-            output: false
+            output: null
         }
     ],
     create() {

--- a/packages/data-mate/src/function-configs/boolean/toBoolean.ts
+++ b/packages/data-mate/src/function-configs/boolean/toBoolean.ts
@@ -13,7 +13,49 @@ export const toBooleanConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.BOOLEAN,
-    description: 'Converts a truthy or falsy value to boolean',
+    description: 'Converts the input into a boolean and returns the boolean value',
+    examples: [
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.String } }
+            },
+            field: 'testField',
+            input: 'TRUE',
+            output: true
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Number } }
+            },
+            field: 'testField',
+            input: 1,
+            output: true
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Number } }
+            },
+            field: 'testField',
+            input: 0,
+            output: false
+        },
+        {
+            args: {},
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.Any } }
+            },
+            field: 'testField',
+            input: null,
+            output: false
+        }
+    ],
     create() {
         return toBoolean;
     },

--- a/packages/data-mate/src/function-configs/date/addToDate.ts
+++ b/packages/data-mate/src/function-configs/date/addToDate.ts
@@ -44,7 +44,7 @@ export const addToDateConfig: FieldTransformConfig<AdjustDateArgs> = {
         field: 'testField',
         input: '2019-10-22T22:00:00.000Z',
         fails: true,
-        output: 'Expected at least either expr or years, months, weeks, days, hours, minutes, seconds or milliseconds'
+        output: 'Expected an expr or years, months, weeks, days, hours, minutes, seconds or milliseconds'
     }, {
         args: { expr: '1hr', months: 10 },
         config: {
@@ -107,7 +107,7 @@ For example, \`1h\` or \`1h+2m\``
         const argKeys = Object.keys(args);
 
         if (argKeys.length === 0) {
-            throw new Error('Expected at least either expr or years, months, weeks, days, hours, minutes, seconds or milliseconds');
+            throw new Error('Expected an expr or years, months, weeks, days, hours, minutes, seconds or milliseconds');
         }
 
         for (const argKey of argKeys) {

--- a/packages/data-mate/src/function-configs/date/addToDate.ts
+++ b/packages/data-mate/src/function-configs/date/addToDate.ts
@@ -14,7 +14,7 @@ export const addToDateConfig: FieldTransformConfig<AdjustDateArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Add time to a date expression or specific number of years, months, weeks, days, hours, minutes, seconds, or milliseconds',
+    description: 'Returns the input date plus a date expression or a specific number of years, months, weeks, days, hours, minutes, seconds, or milliseconds',
     examples: [{
         args: { expr: '10h+2m' },
         config: {

--- a/packages/data-mate/src/function-configs/date/addToDate.ts
+++ b/packages/data-mate/src/function-configs/date/addToDate.ts
@@ -14,7 +14,7 @@ export const addToDateConfig: FieldTransformConfig<AdjustDateArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Returns the input date plus a date expression or a specific number of years, months, weeks, days, hours, minutes, seconds, or milliseconds',
+    description: 'Returns the input date added to a date expression or a specific number of years, months, weeks, days, hours, minutes, seconds, or milliseconds',
     examples: [{
         args: { expr: '10h+2m' },
         config: {

--- a/packages/data-mate/src/function-configs/date/formatDate.ts
+++ b/packages/data-mate/src/function-configs/date/formatDate.ts
@@ -18,7 +18,7 @@ export const formatDateConfig: FieldTransformConfig<FormatDateArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Converts a date value to a formatted date string, when specifying the format it applies to the output value',
+    description: 'Converts a date value to a formatted date string.  Can specify the format with args to format the output value',
     examples: [{
         args: { format: 'yyyy-MM-dd' },
         config: {

--- a/packages/data-mate/src/function-configs/date/formatDate.ts
+++ b/packages/data-mate/src/function-configs/date/formatDate.ts
@@ -18,7 +18,7 @@ export const formatDateConfig: FieldTransformConfig<FormatDateArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Converts a date value to formatted date string, when specifying the format it applies to the output value',
+    description: 'Converts a date value to a formatted date string, when specifying the format it applies to the output value',
     examples: [{
         args: { format: 'yyyy-MM-dd' },
         config: {
@@ -77,7 +77,7 @@ export const formatDateConfig: FieldTransformConfig<FormatDateArgs> = {
             type: FieldType.String,
             description: `When the value is a string, this indicates the date string format.
 See https://date-fns.org/v2.16.1/docs/parse for more info.
-Default: iso_8601 for strings and epoch_millis for number`
+Default: iso_8601 for strings and epoch_millis for numbers`
         },
     },
     output_type(inputConfig, { format }) {

--- a/packages/data-mate/src/function-configs/date/getDate.ts
+++ b/packages/data-mate/src/function-configs/date/getDate.ts
@@ -9,7 +9,7 @@ export const getDateConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Returns the day of the month of the given date in UTC Time',
+    description: 'Returns the day of the month of the input date in UTC Time',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/date/getHours.ts
+++ b/packages/data-mate/src/function-configs/date/getHours.ts
@@ -9,7 +9,7 @@ export const getHoursConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Returns the hours of the given date in UTC Time',
+    description: 'Returns the hours of the input date in UTC Time',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/date/getMilliseconds.ts
+++ b/packages/data-mate/src/function-configs/date/getMilliseconds.ts
@@ -9,7 +9,7 @@ export const getMillisecondsConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Returns the milliseconds of the given date',
+    description: 'Returns the milliseconds of the input date',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/date/getMinutes.ts
+++ b/packages/data-mate/src/function-configs/date/getMinutes.ts
@@ -9,7 +9,7 @@ export const getMinutesConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Returns the minutes of the given date',
+    description: 'Returns the minutes of the input date in UTC time',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/date/getMonth.ts
+++ b/packages/data-mate/src/function-configs/date/getMonth.ts
@@ -9,7 +9,7 @@ export const getMonthConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Returns the month of the given date in UTC Time',
+    description: 'Returns the month of the input date in UTC Time',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/date/getSeconds.ts
+++ b/packages/data-mate/src/function-configs/date/getSeconds.ts
@@ -9,7 +9,7 @@ export const getSecondsConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Returns the seconds of the given date',
+    description: 'Returns the seconds of the input date',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/date/getTimeBetween.ts
+++ b/packages/data-mate/src/function-configs/date/getTimeBetween.ts
@@ -1,5 +1,10 @@
 import { FieldType } from '@terascope/types';
-import { getTimeBetween, GetTimeBetweenArgs } from '@terascope/utils';
+import {
+    getTimeBetween,
+    GetTimeBetweenArgs,
+    getDurationFunc,
+    joinList
+} from '@terascope/utils';
 import {
     ProcessMode, FunctionDefinitionType, FunctionDefinitionCategory, FieldTransformConfig
 } from '../interfaces';
@@ -9,10 +14,10 @@ export const getTimeBetweenConfig: FieldTransformConfig<GetTimeBetweenArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Returns time duration between input and start or end time.  Returns the duration as a number or in the ISO 8601 duration format',
+    description: 'Returns time duration as a number or ISO 8601 duration format between the input and start or end arg.',
     examples: [
         {
-            args: { start: '2021-05-10T10:00:00.000Z', format: 'milliseconds' },
+            args: { start: '2021-05-10T10:00:00.000Z', interval: 'milliseconds' },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Date } }
@@ -22,7 +27,7 @@ export const getTimeBetweenConfig: FieldTransformConfig<GetTimeBetweenArgs> = {
             output: 1000
         },
         {
-            args: { end: '2021-05-10T10:00:00.000Z', format: 'days' },
+            args: { end: '2021-05-10T10:00:00.000Z', interval: 'days' },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.String } }
@@ -32,7 +37,7 @@ export const getTimeBetweenConfig: FieldTransformConfig<GetTimeBetweenArgs> = {
             output: 1
         },
         {
-            args: { end: 1620764441001, format: 'seconds' },
+            args: { end: 1620764441001, interval: 'seconds' },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Number } }
@@ -40,29 +45,39 @@ export const getTimeBetweenConfig: FieldTransformConfig<GetTimeBetweenArgs> = {
             field: 'testField',
             input: 1620764440001,
             output: 1
+        },
+        {
+            args: { end: '2023-01-09T18:19:23.132Z', interval: 'ISO8601' },
+            config: {
+                version: 1,
+                fields: { testField: { type: FieldType.String } }
+            },
+            field: 'testField',
+            input: '2021-05-10T10:00:00.000Z',
+            output: 'P1Y7M30DT8H19M23S'
         }
     ],
     argument_schema: {
         start: {
             type: FieldType.Date,
-            description: 'Start time of time range, if start is after input will return a negative number'
+            description: 'Start time of time range, if start is after the input it will return a negative number'
         },
         end: {
             type: FieldType.Date,
-            description: 'End time of time range, if provided end is after input the return value will be negative'
+            description: 'End time of time range, if end is before the input it will return a negative number'
         },
-        format: {
+        interval: {
             type: FieldType.String,
-            description: 'The format of the return value'
+            description: `The interval of the return value.  Accepts ${joinList(Object.keys(getDurationFunc))} or use ISO8601 to get the return value in ISO-8601 duration format, see https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_duration_format.htm`
         }
     },
     create({ args }) {
         return (input: unknown) => getTimeBetween(input, args);
     },
-    required_arguments: ['format'],
+    required_arguments: ['interval'],
     accepts: [FieldType.Date, FieldType.String, FieldType.Number],
     validate_arguments({ start, end }: GetTimeBetweenArgs) {
-        if (start == null && end == null) {
+        if ((start == null && end == null) || (start != null && end != null)) {
             throw Error('Must provide a start or an end value');
         }
     },
@@ -70,7 +85,7 @@ export const getTimeBetweenConfig: FieldTransformConfig<GetTimeBetweenArgs> = {
         return {
             field_config: {
                 ...field_config,
-                type: FieldType.Number
+                type: FieldType.Number || FieldType.String
             }
         };
     }

--- a/packages/data-mate/src/function-configs/date/getTimeBetween.ts
+++ b/packages/data-mate/src/function-configs/date/getTimeBetween.ts
@@ -14,7 +14,7 @@ export const getTimeBetweenConfig: FieldTransformConfig<GetTimeBetweenArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Returns time duration as a number or ISO 8601 duration format between the input and start or end arg.',
+    description: 'Returns the time duration between the input value and start or end arg.  Can also select the interval and format with the args interval option.',
     examples: [
         {
             args: { start: '2021-05-10T10:00:00.000Z', interval: 'milliseconds' },

--- a/packages/data-mate/src/function-configs/date/getTimeBetween.ts
+++ b/packages/data-mate/src/function-configs/date/getTimeBetween.ts
@@ -81,12 +81,14 @@ export const getTimeBetweenConfig: FieldTransformConfig<GetTimeBetweenArgs> = {
             throw Error('Must provide a start or an end value');
         }
     },
-    output_type({ field_config }) {
+    output_type(inputConfig, { interval }) {
+        const { field_config } = inputConfig;
+
         return {
             field_config: {
                 ...field_config,
-                type: FieldType.Number || FieldType.String
-            }
+                type: interval === 'ISO8601' ? FieldType.String : FieldType.Number
+            },
         };
     }
 };

--- a/packages/data-mate/src/function-configs/date/getTimezoneOffset.ts
+++ b/packages/data-mate/src/function-configs/date/getTimezoneOffset.ts
@@ -17,7 +17,7 @@ export const getTimezoneOffsetConfig: FieldTransformConfig<GetTimezoneOffsetArgs
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
     description: `Given a date and timezone, it will return the offset from UTC in minutes.
-     This is more accurate than timezoneToOffset as it can better account for day lights saving time`,
+     This is more accurate than timezoneToOffset as it can better account for daylight saving time`,
     examples: [
         {
             args: { timezone: 'Africa/Accra' },

--- a/packages/data-mate/src/function-configs/date/getYear.ts
+++ b/packages/data-mate/src/function-configs/date/getYear.ts
@@ -9,7 +9,7 @@ export const getYearConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Returns the year of the given date in UTC Time',
+    description: 'Returns the year of the input date in UTC Time',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/date/isAfter.ts
+++ b/packages/data-mate/src/function-configs/date/isAfter.ts
@@ -13,7 +13,7 @@ export const isAfterConfig: FieldValidateConfig<IsAfterArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Checks if the input is after the arg date',
+    description: 'Returns the input if it is after the arg date, otherwise returns null',
     examples: [
         {
             args: { date: '2021-05-09T10:00:00.000Z' },

--- a/packages/data-mate/src/function-configs/date/isBefore.ts
+++ b/packages/data-mate/src/function-configs/date/isBefore.ts
@@ -13,7 +13,7 @@ export const isBeforeConfig: FieldValidateConfig<IsBeforeArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Checks if the input is before the arg date',
+    description: 'Returns the input if it is before the arg date, otherwise returns null',
     examples: [
         {
             args: { date: '2021-05-10T10:00:00.000Z' },

--- a/packages/data-mate/src/function-configs/date/isBetween.ts
+++ b/packages/data-mate/src/function-configs/date/isBetween.ts
@@ -14,7 +14,7 @@ export const isBetweenConfig: FieldValidateConfig<IsBetweenArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Checks if the input is before the arg date',
+    description: 'Returns the input if it is before the arg date, otherwise returns null',
     examples: [
         {
             args: { start: '2021-05-09T10:00:00.001Z', end: '2021-05-11T10:00:00.001Z' },

--- a/packages/data-mate/src/function-configs/date/isBetween.ts
+++ b/packages/data-mate/src/function-configs/date/isBetween.ts
@@ -14,7 +14,7 @@ export const isBetweenConfig: FieldValidateConfig<IsBetweenArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Returns the input if it is before the arg date, otherwise returns null',
+    description: 'Returns the input if it is between the args start and end dates, otherwise returns null',
     examples: [
         {
             args: { start: '2021-05-09T10:00:00.001Z', end: '2021-05-11T10:00:00.001Z' },

--- a/packages/data-mate/src/function-configs/date/isDate.ts
+++ b/packages/data-mate/src/function-configs/date/isDate.ts
@@ -14,7 +14,7 @@ export const isDateConfig: FieldValidateConfig<IsDateArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Checks to see if input is a valid date, if format is provided the format will also be validated',
+    description: 'Returns the input if it is a valid date, if format is provided the format will be applied to the validation.',
     examples: [{
         args: { format: 'yyyy-MM-dd' },
         config: {

--- a/packages/data-mate/src/function-configs/date/isEpoch.ts
+++ b/packages/data-mate/src/function-configs/date/isEpoch.ts
@@ -14,7 +14,7 @@ export const isEpochConfig: FieldValidateConfig<IsEpochArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Returns the input if it is a valid epoch timestamp. Accuracy is not guaranteed since it is just a number.',
+    description: 'Returns the input if it is a valid epoch timestamp. Accuracy is not guaranteed since any number could be a valid epoch timestamp.',
     examples: [{
         args: { },
         config: {

--- a/packages/data-mate/src/function-configs/date/isEpoch.ts
+++ b/packages/data-mate/src/function-configs/date/isEpoch.ts
@@ -14,7 +14,7 @@ export const isEpochConfig: FieldValidateConfig<IsEpochArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Checks to see if input is a valid epoch timestamp. Accuracy is not guaranteed since it is just a number.',
+    description: 'Returns the input if it is a valid epoch timestamp. Accuracy is not guaranteed since it is just a number.',
     examples: [{
         args: { },
         config: {

--- a/packages/data-mate/src/function-configs/date/isEpochMillis.ts
+++ b/packages/data-mate/src/function-configs/date/isEpochMillis.ts
@@ -13,7 +13,7 @@ export const isEpochMillisConfig: FieldValidateConfig<IsEpochMillisArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Checks to see if input is a valid epoch timestamp (in milliseconds). Accuracy is not guaranteed since it is just a number.',
+    description: 'Returns the input if it is a valid epoch timestamp (in milliseconds). Accuracy is not guaranteed since it is just a number.',
     examples: [{
         args: { },
         config: {

--- a/packages/data-mate/src/function-configs/date/isEpochMillis.ts
+++ b/packages/data-mate/src/function-configs/date/isEpochMillis.ts
@@ -13,7 +13,7 @@ export const isEpochMillisConfig: FieldValidateConfig<IsEpochMillisArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Returns the input if it is a valid epoch timestamp (in milliseconds). Accuracy is not guaranteed since it is just a number.',
+    description: 'Returns the input if it is a valid epoch timestamp (in milliseconds). Accuracy is not guaranteed since any number could be a valid epoch timestamp.',
     examples: [{
         args: { },
         config: {

--- a/packages/data-mate/src/function-configs/date/isFriday.ts
+++ b/packages/data-mate/src/function-configs/date/isFriday.ts
@@ -25,7 +25,7 @@ export const isFridayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Determines if the given date is on a Friday',
+    description: 'Returns the given date if it is on a Friday, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isFuture.ts
+++ b/packages/data-mate/src/function-configs/date/isFuture.ts
@@ -25,7 +25,7 @@ export const isFutureConfig: FieldValidateConfig = {
             output: '2121-05-09T10:00:00.000Z'
         },
     ],
-    description: 'Returns the the given date if it is in the future, otherwise returns null',
+    description: 'Returns the the input if it is in the future, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isFuture.ts
+++ b/packages/data-mate/src/function-configs/date/isFuture.ts
@@ -25,7 +25,7 @@ export const isFutureConfig: FieldValidateConfig = {
             output: '2121-05-09T10:00:00.000Z'
         },
     ],
-    description: 'Determines if the given date is in the future',
+    description: 'Returns the the given date if it is in the future, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isISO8601.ts
+++ b/packages/data-mate/src/function-configs/date/isISO8601.ts
@@ -10,7 +10,7 @@ export const isISO8601Config: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Checks to see if input is a valid epoch timestamp. Accuracy is not guaranteed since it is just a number.',
+    description: 'Returns the input if it is a valid ISO-8601 date, otherwise returns null',
     examples: [{
         args: {},
         config: {

--- a/packages/data-mate/src/function-configs/date/isLeapYear.ts
+++ b/packages/data-mate/src/function-configs/date/isLeapYear.ts
@@ -25,7 +25,7 @@ export const isLeapYearConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Returns the the given date if it is in a leap year, otherwise returns null',
+    description: 'Returns the the input if it is in a leap year, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isLeapYear.ts
+++ b/packages/data-mate/src/function-configs/date/isLeapYear.ts
@@ -25,7 +25,7 @@ export const isLeapYearConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Determines if the given date is in a leap year',
+    description: 'Returns the the given date if it is in a leap year, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isMonday.ts
+++ b/packages/data-mate/src/function-configs/date/isMonday.ts
@@ -25,7 +25,7 @@ export const isMondayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Returns the the given date if it is on a Monday',
+    description: 'Returns the the input if it is on a Monday',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isMonday.ts
+++ b/packages/data-mate/src/function-configs/date/isMonday.ts
@@ -25,7 +25,7 @@ export const isMondayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Determines if the given date is on a Monday',
+    description: 'Returns the the given date if it is on a Monday',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isPast.ts
+++ b/packages/data-mate/src/function-configs/date/isPast.ts
@@ -25,7 +25,7 @@ export const isPastConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Determines if the given date is in the past',
+    description: 'Returns the given date if it is in the past, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isPast.ts
+++ b/packages/data-mate/src/function-configs/date/isPast.ts
@@ -25,7 +25,7 @@ export const isPastConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Returns the given date if it is in the past, otherwise returns null',
+    description: 'Returns the input if it is in the past, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isSaturday.ts
+++ b/packages/data-mate/src/function-configs/date/isSaturday.ts
@@ -25,7 +25,7 @@ export const isSaturdayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Returns the given date if it is on a Saturday, otherwise returns null',
+    description: 'Returns the input if it is on a Saturday, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isSaturday.ts
+++ b/packages/data-mate/src/function-configs/date/isSaturday.ts
@@ -25,7 +25,7 @@ export const isSaturdayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Determines if the given date is on a Saturday',
+    description: 'Returns the given date if it is on a Saturday, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isSunday.ts
+++ b/packages/data-mate/src/function-configs/date/isSunday.ts
@@ -25,7 +25,7 @@ export const isSundayConfig: FieldValidateConfig = {
             output: 1620554400000
         },
     ],
-    description: 'Returns the given date if it is on a Sunday, otherwise returns null',
+    description: 'Returns the input if it is on a Sunday, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isSunday.ts
+++ b/packages/data-mate/src/function-configs/date/isSunday.ts
@@ -25,7 +25,7 @@ export const isSundayConfig: FieldValidateConfig = {
             output: 1620554400000
         },
     ],
-    description: 'Determines if the given date is on a Sunday',
+    description: 'Returns the given date if it is on a Sunday, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isThursday.ts
+++ b/packages/data-mate/src/function-configs/date/isThursday.ts
@@ -25,7 +25,7 @@ export const isThursdayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Returns the given date if it is on a Thursday, otherwise returns null',
+    description: 'Returns the input if it is on a Thursday, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isThursday.ts
+++ b/packages/data-mate/src/function-configs/date/isThursday.ts
@@ -25,7 +25,7 @@ export const isThursdayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Determines if the given date is on a Thursday',
+    description: 'Returns the given date if it is on a Thursday, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isToday.ts
+++ b/packages/data-mate/src/function-configs/date/isToday.ts
@@ -28,7 +28,7 @@ export const isTodayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Determines if the given date is on the same day (utc-time)',
+    description: 'Returns the given date if it is on the same day (utc-time), otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isToday.ts
+++ b/packages/data-mate/src/function-configs/date/isToday.ts
@@ -28,7 +28,7 @@ export const isTodayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Returns the given date if it is on the same day (utc-time), otherwise returns null',
+    description: 'Returns the input if it is on the same day (utc-time), otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isTomorrow.ts
+++ b/packages/data-mate/src/function-configs/date/isTomorrow.ts
@@ -32,7 +32,7 @@ export const isTomorrowConfig: FieldValidateConfig = {
             description: 'represents day after current time'
         },
     ],
-    description: 'Determines if the given date is on the next day (utc-time)',
+    description: 'Returns the given date if it is on the next day (utc-time), otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isTomorrow.ts
+++ b/packages/data-mate/src/function-configs/date/isTomorrow.ts
@@ -32,7 +32,7 @@ export const isTomorrowConfig: FieldValidateConfig = {
             description: 'represents day after current time'
         },
     ],
-    description: 'Returns the given date if it is on the next day (utc-time), otherwise returns null',
+    description: 'Returns the input if it is on the next day (utc-time), otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isTuesday.ts
+++ b/packages/data-mate/src/function-configs/date/isTuesday.ts
@@ -25,7 +25,7 @@ export const isTuesdayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Returns the given date if it is on a Tuesday, otherwise returns null',
+    description: 'Returns the input if it is on a Tuesday, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isTuesday.ts
+++ b/packages/data-mate/src/function-configs/date/isTuesday.ts
@@ -25,7 +25,7 @@ export const isTuesdayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Determines if the given date is on a Tuesday',
+    description: 'Returns the given date if it is on a Tuesday, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isWednesday.ts
+++ b/packages/data-mate/src/function-configs/date/isWednesday.ts
@@ -25,7 +25,7 @@ export const isWednesdayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Determines if the given date is on a Wednesday',
+    description: 'Returns the given date if it is on a Wednesday, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isWednesday.ts
+++ b/packages/data-mate/src/function-configs/date/isWednesday.ts
@@ -25,7 +25,7 @@ export const isWednesdayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Returns the given date if it is on a Wednesday, otherwise returns null',
+    description: 'Returns the input if it is on a Wednesday, otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isWeekday.ts
+++ b/packages/data-mate/src/function-configs/date/isWeekday.ts
@@ -39,7 +39,7 @@ export const isWeekdayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Determines if the given date is on a Weekday (Monday-Friday)',
+    description: 'Returns the given date if it is on a Weekday (Monday-Friday), otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isWeekday.ts
+++ b/packages/data-mate/src/function-configs/date/isWeekday.ts
@@ -39,7 +39,7 @@ export const isWeekdayConfig: FieldValidateConfig = {
             output: null
         },
     ],
-    description: 'Returns the given date if it is on a Weekday (Monday-Friday), otherwise returns null',
+    description: 'Returns the input if it is on a Weekday (Monday-Friday), otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isWeekend.ts
+++ b/packages/data-mate/src/function-configs/date/isWeekend.ts
@@ -39,7 +39,7 @@ export const isWeekendConfig: FieldValidateConfig = {
             output: '2021-05-08T10:00:00.000Z'
         },
     ],
-    description: 'Returns the given date if it is on a Weekend (Saturday-Sunday), otherwise returns null',
+    description: 'Returns the input if it is on a Weekend (Saturday-Sunday), otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isWeekend.ts
+++ b/packages/data-mate/src/function-configs/date/isWeekend.ts
@@ -39,7 +39,7 @@ export const isWeekendConfig: FieldValidateConfig = {
             output: '2021-05-08T10:00:00.000Z'
         },
     ],
-    description: 'Determines if the given date is on a Weekend (Saturday-Sunday)',
+    description: 'Returns the given date if it is on a Weekend (Saturday-Sunday), otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isYesterday.ts
+++ b/packages/data-mate/src/function-configs/date/isYesterday.ts
@@ -32,7 +32,7 @@ export const isYesterdayConfig: FieldValidateConfig = {
             description: 'represents day before current time'
         },
     ],
-    description: 'Returns the given date if it is on the day before (utc-time), otherwise returns null',
+    description: 'Returns the input if it is on the day before (utc-time), otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/isYesterday.ts
+++ b/packages/data-mate/src/function-configs/date/isYesterday.ts
@@ -32,7 +32,7 @@ export const isYesterdayConfig: FieldValidateConfig = {
             description: 'represents day before current time'
         },
     ],
-    description: 'Determines if the given date is on the day before (utc-time)',
+    description: 'Returns the given date if it is on the day before (utc-time), otherwise returns null',
     accepts: [
         FieldType.String, FieldType.Date, FieldType.Number
     ],

--- a/packages/data-mate/src/function-configs/date/lookupTimezone.ts
+++ b/packages/data-mate/src/function-configs/date/lookupTimezone.ts
@@ -45,7 +45,7 @@ export const lookupTimezoneConfig: FieldTransformConfig = {
             output: 'Europe/Paris',
         },
     ],
-    description: 'Takes in a geo point like entity and returns the timezone of its location',
+    description: 'Returns the timezone of a geo point\'s location.',
     create() {
         return (input: unknown) => {
             if (isNil(input)) return null;

--- a/packages/data-mate/src/function-configs/date/setDate.ts
+++ b/packages/data-mate/src/function-configs/date/setDate.ts
@@ -6,7 +6,7 @@ import {
     ProcessMode, FunctionDefinitionType, FunctionDefinitionCategory, FieldTransformConfig
 } from '../interfaces';
 
-export const setDateConfig: FieldTransformConfig<{ date: number }> = {
+export const setDateConfig: FieldTransformConfig<{ value: number }> = {
     name: 'setDate',
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
@@ -14,7 +14,7 @@ export const setDateConfig: FieldTransformConfig<{ date: number }> = {
     description: 'Set the day of the month of the input date',
     examples: [
         {
-            args: { date: 12 },
+            args: { value: 12 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.String } }
@@ -25,7 +25,7 @@ export const setDateConfig: FieldTransformConfig<{ date: number }> = {
             serialize_output: toISO8601
         },
         {
-            args: { date: 22 },
+            args: { value: 22 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Date } }
@@ -36,7 +36,7 @@ export const setDateConfig: FieldTransformConfig<{ date: number }> = {
             serialize_output: toISO8601
         },
         {
-            args: { date: 1 },
+            args: { value: 1 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Number } }
@@ -47,18 +47,18 @@ export const setDateConfig: FieldTransformConfig<{ date: number }> = {
             serialize_output: toISO8601
         }
     ],
-    create({ args: { date } }) {
-        return setDate(date);
+    create({ args: { value } }) {
+        return setDate(value);
     },
     argument_schema: {
-        date: {
+        value: {
             type: FieldType.Number,
             description: 'Value to set day of the month to, must be between 1 and 31'
         }
     },
-    validate_arguments: ({ date }) => {
-        if (!isInteger(date)
-            || !inNumberRange(date, { min: 1, max: 31, inclusive: true })) {
+    validate_arguments: ({ value }) => {
+        if (!isInteger(value)
+            || !inNumberRange(value, { min: 1, max: 31, inclusive: true })) {
             throw Error('Invalid argument "date", must be an integer between 1 and 31');
         }
     },

--- a/packages/data-mate/src/function-configs/date/setDate.ts
+++ b/packages/data-mate/src/function-configs/date/setDate.ts
@@ -11,7 +11,7 @@ export const setDateConfig: FieldTransformConfig<{ value: number }> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Set the day of the month of the input date',
+    description: 'Returns in the input date with the day of the month set to the args value.',
     examples: [
         {
             args: { value: 12 },

--- a/packages/data-mate/src/function-configs/date/setDate.ts
+++ b/packages/data-mate/src/function-configs/date/setDate.ts
@@ -11,7 +11,7 @@ export const setDateConfig: FieldTransformConfig<{ value: number }> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Returns in the input date with the day of the month set to the args value.',
+    description: 'Returns the input date with the day of the month set to the args value.',
     examples: [
         {
             args: { value: 12 },
@@ -62,7 +62,7 @@ export const setDateConfig: FieldTransformConfig<{ value: number }> = {
             throw Error('Invalid argument "date", must be an integer between 1 and 31');
         }
     },
-    required_arguments: ['date'],
+    required_arguments: ['value'],
     accepts: [FieldType.Date, FieldType.String, FieldType.Number],
     output_type({ field_config }) {
         return {

--- a/packages/data-mate/src/function-configs/date/setHours.ts
+++ b/packages/data-mate/src/function-configs/date/setHours.ts
@@ -6,7 +6,7 @@ import {
     ProcessMode, FunctionDefinitionType, FunctionDefinitionCategory, FieldTransformConfig
 } from '../interfaces';
 
-export const setHoursConfig: FieldTransformConfig<{ hours: number }> = {
+export const setHoursConfig: FieldTransformConfig<{ value: number }> = {
     name: 'setHours',
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
@@ -14,7 +14,7 @@ export const setHoursConfig: FieldTransformConfig<{ hours: number }> = {
     description: 'Set the hours of the input date',
     examples: [
         {
-            args: { hours: 12 },
+            args: { value: 12 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.String } }
@@ -25,7 +25,7 @@ export const setHoursConfig: FieldTransformConfig<{ hours: number }> = {
             serialize_output: toISO8601
         },
         {
-            args: { hours: 22 },
+            args: { value: 22 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Date } }
@@ -36,7 +36,7 @@ export const setHoursConfig: FieldTransformConfig<{ hours: number }> = {
             serialize_output: toISO8601
         },
         {
-            args: { hours: 1 },
+            args: { value: 1 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Number } }
@@ -47,8 +47,8 @@ export const setHoursConfig: FieldTransformConfig<{ hours: number }> = {
             serialize_output: toISO8601
         }
     ],
-    create({ args: { hours } }) {
-        return setHours(hours);
+    create({ args: { value } }) {
+        return setHours(value);
     },
     argument_schema: {
         hours: {
@@ -56,9 +56,9 @@ export const setHoursConfig: FieldTransformConfig<{ hours: number }> = {
             description: 'Value to set hours to, must be between 0 and 23'
         }
     },
-    validate_arguments: ({ hours }) => {
-        if (!isInteger(hours)
-            || !inNumberRange(hours, { min: 0, max: 23, inclusive: true })) {
+    validate_arguments: ({ value }) => {
+        if (!isInteger(value)
+            || !inNumberRange(value, { min: 0, max: 23, inclusive: true })) {
             throw Error('Invalid argument "hours", must be an integer between 0 and 23');
         }
     },

--- a/packages/data-mate/src/function-configs/date/setHours.ts
+++ b/packages/data-mate/src/function-configs/date/setHours.ts
@@ -62,7 +62,7 @@ export const setHoursConfig: FieldTransformConfig<{ value: number }> = {
             throw Error('Invalid argument "hours", must be an integer between 0 and 23');
         }
     },
-    required_arguments: ['hours'],
+    required_arguments: ['value'],
     accepts: [FieldType.Date, FieldType.String, FieldType.Number],
     output_type({ field_config }) {
         return {

--- a/packages/data-mate/src/function-configs/date/setHours.ts
+++ b/packages/data-mate/src/function-configs/date/setHours.ts
@@ -11,7 +11,7 @@ export const setHoursConfig: FieldTransformConfig<{ value: number }> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Set the hours of the input date',
+    description: 'Returns the input date with the hours set to the args value.',
     examples: [
         {
             args: { value: 12 },

--- a/packages/data-mate/src/function-configs/date/setMilliseconds.ts
+++ b/packages/data-mate/src/function-configs/date/setMilliseconds.ts
@@ -11,7 +11,7 @@ export const setMillisecondsConfig: FieldTransformConfig<{ value: number }> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Set the milliseconds of the input date',
+    description: 'Returns the input date with the milliseconds set to the args value.',
     examples: [
         {
             args: { value: 392 },

--- a/packages/data-mate/src/function-configs/date/setMilliseconds.ts
+++ b/packages/data-mate/src/function-configs/date/setMilliseconds.ts
@@ -6,7 +6,7 @@ import {
     ProcessMode, FunctionDefinitionType, FunctionDefinitionCategory, FieldTransformConfig
 } from '../interfaces';
 
-export const setMillisecondsConfig: FieldTransformConfig<{ milliseconds: number }> = {
+export const setMillisecondsConfig: FieldTransformConfig<{ value: number }> = {
     name: 'setMilliseconds',
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
@@ -14,7 +14,7 @@ export const setMillisecondsConfig: FieldTransformConfig<{ milliseconds: number 
     description: 'Set the milliseconds of the input date',
     examples: [
         {
-            args: { milliseconds: 392 },
+            args: { value: 392 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.String } }
@@ -25,7 +25,7 @@ export const setMillisecondsConfig: FieldTransformConfig<{ milliseconds: number 
             serialize_output: toISO8601
         },
         {
-            args: { milliseconds: 483 },
+            args: { value: 483 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Date } }
@@ -36,7 +36,7 @@ export const setMillisecondsConfig: FieldTransformConfig<{ milliseconds: number 
             serialize_output: toISO8601
         },
         {
-            args: { milliseconds: 1 },
+            args: { value: 1 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Number } }
@@ -47,22 +47,22 @@ export const setMillisecondsConfig: FieldTransformConfig<{ milliseconds: number 
             serialize_output: toISO8601
         }
     ],
-    create({ args: { milliseconds } }) {
-        return setMilliseconds(milliseconds);
+    create({ args: { value } }) {
+        return setMilliseconds(value);
     },
     argument_schema: {
-        milliseconds: {
+        value: {
             type: FieldType.Number,
             description: 'Value to set milliseconds to, must be between 0 and 999'
         }
     },
-    validate_arguments: ({ milliseconds }) => {
-        if (!isInteger(milliseconds)
-            || !inNumberRange(milliseconds, { min: 0, max: 999, inclusive: true })) {
-            throw Error('Invalid argument "milliseconds", must be an integer between 0 and 999');
+    validate_arguments: ({ value }) => {
+        if (!isInteger(value)
+            || !inNumberRange(value, { min: 0, max: 999, inclusive: true })) {
+            throw Error('Invalid argument "value", must be an integer between 0 and 999');
         }
     },
-    required_arguments: ['milliseconds'],
+    required_arguments: ['value'],
     accepts: [FieldType.Date, FieldType.String, FieldType.Number],
     output_type({ field_config }) {
         return {

--- a/packages/data-mate/src/function-configs/date/setMinutes.ts
+++ b/packages/data-mate/src/function-configs/date/setMinutes.ts
@@ -6,7 +6,7 @@ import {
     ProcessMode, FunctionDefinitionType, FunctionDefinitionCategory, FieldTransformConfig
 } from '../interfaces';
 
-export const setMinutesConfig: FieldTransformConfig<{ minutes: number }> = {
+export const setMinutesConfig: FieldTransformConfig<{ value: number }> = {
     name: 'setMinutes',
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
@@ -14,7 +14,7 @@ export const setMinutesConfig: FieldTransformConfig<{ minutes: number }> = {
     description: 'Set the minutes of the input date',
     examples: [
         {
-            args: { minutes: 12 },
+            args: { value: 12 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.String } }
@@ -25,7 +25,7 @@ export const setMinutesConfig: FieldTransformConfig<{ minutes: number }> = {
             serialize_output: toISO8601
         },
         {
-            args: { minutes: 22 },
+            args: { value: 22 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Date } }
@@ -36,7 +36,7 @@ export const setMinutesConfig: FieldTransformConfig<{ minutes: number }> = {
             serialize_output: toISO8601
         },
         {
-            args: { minutes: 1 },
+            args: { value: 1 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Number } }
@@ -47,22 +47,22 @@ export const setMinutesConfig: FieldTransformConfig<{ minutes: number }> = {
             serialize_output: toISO8601
         }
     ],
-    create({ args: { minutes } }) {
-        return setMinutes(minutes);
+    create({ args: { value } }) {
+        return setMinutes(value);
     },
     argument_schema: {
-        minutes: {
+        value: {
             type: FieldType.Number,
             description: 'Value to set minutes to, must be between 0 and 59'
         }
     },
-    validate_arguments: ({ minutes }) => {
-        if (!isInteger(minutes)
-            || !inNumberRange(minutes, { min: 0, max: 59, inclusive: true })) {
-            throw Error('Invalid argument "minutes", must be an integer between 0 and 59');
+    validate_arguments: ({ value }) => {
+        if (!isInteger(value)
+            || !inNumberRange(value, { min: 0, max: 59, inclusive: true })) {
+            throw Error('Invalid argument "value", must be an integer between 0 and 59');
         }
     },
-    required_arguments: ['minutes'],
+    required_arguments: ['value'],
     accepts: [FieldType.Date, FieldType.String, FieldType.Number],
     output_type({ field_config }) {
         return {

--- a/packages/data-mate/src/function-configs/date/setMinutes.ts
+++ b/packages/data-mate/src/function-configs/date/setMinutes.ts
@@ -11,7 +11,7 @@ export const setMinutesConfig: FieldTransformConfig<{ value: number }> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Set the minutes of the input date',
+    description: 'Returns the input date with the minutes set to the args value.',
     examples: [
         {
             args: { value: 12 },

--- a/packages/data-mate/src/function-configs/date/setMonth.ts
+++ b/packages/data-mate/src/function-configs/date/setMonth.ts
@@ -11,7 +11,7 @@ export const setMonthConfig: FieldTransformConfig<{ value: number }> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Set the month of the input month',
+    description: 'Returns the input date with the month set to the args value.',
     examples: [
         {
             args: { value: 12 },

--- a/packages/data-mate/src/function-configs/date/setMonth.ts
+++ b/packages/data-mate/src/function-configs/date/setMonth.ts
@@ -6,7 +6,7 @@ import {
     ProcessMode, FunctionDefinitionType, FunctionDefinitionCategory, FieldTransformConfig
 } from '../interfaces';
 
-export const setMonthConfig: FieldTransformConfig<{ month: number }> = {
+export const setMonthConfig: FieldTransformConfig<{ value: number }> = {
     name: 'setMonth',
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
@@ -14,7 +14,7 @@ export const setMonthConfig: FieldTransformConfig<{ month: number }> = {
     description: 'Set the month of the input month',
     examples: [
         {
-            args: { month: 12 },
+            args: { value: 12 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.String } }
@@ -25,7 +25,7 @@ export const setMonthConfig: FieldTransformConfig<{ month: number }> = {
             serialize_output: toISO8601
         },
         {
-            args: { month: 2 },
+            args: { value: 2 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Date } }
@@ -36,7 +36,7 @@ export const setMonthConfig: FieldTransformConfig<{ month: number }> = {
             serialize_output: toISO8601
         },
         {
-            args: { month: 1 },
+            args: { value: 1 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Number } }
@@ -47,22 +47,22 @@ export const setMonthConfig: FieldTransformConfig<{ month: number }> = {
             serialize_output: toISO8601
         }
     ],
-    create({ args: { month } }) {
-        return setMonth(month);
+    create({ args: { value } }) {
+        return setMonth(value);
     },
     argument_schema: {
-        month: {
+        value: {
             type: FieldType.Number,
-            description: 'Value to set month to, must be between 1 and 12'
+            description: 'Value to set value to, must be between 1 and 12'
         }
     },
-    validate_arguments: ({ month }) => {
-        if (!isInteger(month)
-            || !inNumberRange(month, { min: 1, max: 12, inclusive: true })) {
-            throw Error('Invalid argument "month", must be an integer between 1 and 12');
+    validate_arguments: ({ value }) => {
+        if (!isInteger(value)
+            || !inNumberRange(value, { min: 1, max: 12, inclusive: true })) {
+            throw Error('Invalid argument "value", must be an integer between 1 and 12');
         }
     },
-    required_arguments: ['month'],
+    required_arguments: ['value'],
     accepts: [FieldType.Date, FieldType.String, FieldType.Number],
     output_type({ field_config }) {
         return {

--- a/packages/data-mate/src/function-configs/date/setSeconds.ts
+++ b/packages/data-mate/src/function-configs/date/setSeconds.ts
@@ -6,7 +6,7 @@ import {
     ProcessMode, FunctionDefinitionType, FunctionDefinitionCategory, FieldTransformConfig
 } from '../interfaces';
 
-export const setSecondsConfig: FieldTransformConfig<{ seconds: number }> = {
+export const setSecondsConfig: FieldTransformConfig<{ value: number }> = {
     name: 'setSeconds',
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
@@ -14,7 +14,7 @@ export const setSecondsConfig: FieldTransformConfig<{ seconds: number }> = {
     description: 'Set the seconds of the input date',
     examples: [
         {
-            args: { seconds: 12 },
+            args: { value: 12 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.String } }
@@ -25,7 +25,7 @@ export const setSecondsConfig: FieldTransformConfig<{ seconds: number }> = {
             serialize_output: toISO8601
         },
         {
-            args: { seconds: 22 },
+            args: { value: 22 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Date } }
@@ -36,7 +36,7 @@ export const setSecondsConfig: FieldTransformConfig<{ seconds: number }> = {
             serialize_output: toISO8601
         },
         {
-            args: { seconds: 1 },
+            args: { value: 1 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Number } }
@@ -47,22 +47,22 @@ export const setSecondsConfig: FieldTransformConfig<{ seconds: number }> = {
             serialize_output: toISO8601
         }
     ],
-    create({ args: { seconds } }) {
-        return setSeconds(seconds);
+    create({ args: { value } }) {
+        return setSeconds(value);
     },
     argument_schema: {
-        seconds: {
+        value: {
             type: FieldType.Number,
             description: 'Value to set seconds to, must be between 0 and 59'
         }
     },
-    validate_arguments: ({ seconds }) => {
-        if (!isInteger(seconds)
-            || !inNumberRange(seconds, { min: 0, max: 59, inclusive: true })) {
-            throw Error('Invalid arguments "seconds", must be an integer between 0 and 59');
+    validate_arguments: ({ value }) => {
+        if (!isInteger(value)
+            || !inNumberRange(value, { min: 0, max: 59, inclusive: true })) {
+            throw Error('Invalid arguments "value", must be an integer between 0 and 59');
         }
     },
-    required_arguments: ['seconds'],
+    required_arguments: ['value'],
     accepts: [FieldType.Date, FieldType.String, FieldType.Number],
     output_type({ field_config }) {
         return {

--- a/packages/data-mate/src/function-configs/date/setSeconds.ts
+++ b/packages/data-mate/src/function-configs/date/setSeconds.ts
@@ -11,7 +11,7 @@ export const setSecondsConfig: FieldTransformConfig<{ value: number }> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Set the seconds of the input date',
+    description: 'Returns the input date with the seconds set to the args value.',
     examples: [
         {
             args: { value: 12 },

--- a/packages/data-mate/src/function-configs/date/setTimezone.ts
+++ b/packages/data-mate/src/function-configs/date/setTimezone.ts
@@ -14,7 +14,7 @@ export const setTimezoneConfig: FieldTransformConfig<{ timezone: number|string }
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Set the timezone for the date value',
+    description: 'Returns the input date with the timezone set to the args value.',
     examples: [
         {
             args: { timezone: 420 }, // 'America/Phoenix' },

--- a/packages/data-mate/src/function-configs/date/setTimezone.ts
+++ b/packages/data-mate/src/function-configs/date/setTimezone.ts
@@ -14,7 +14,7 @@ export const setTimezoneConfig: FieldTransformConfig<{ timezone: number|string }
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Set the timezone on for the date value',
+    description: 'Set the timezone for the date value',
     examples: [
         {
             args: { timezone: 420 }, // 'America/Phoenix' },
@@ -45,14 +45,14 @@ export const setTimezoneConfig: FieldTransformConfig<{ timezone: number|string }
     argument_schema: {
         timezone: {
             type: FieldType.Any,
-            description: 'Value to set day of the month to, must be between 1 and 31'
+            description: 'Value to set timezone to in minutes or timezone name.  Offset must be between -1440 and 1440'
         }
     },
     required_arguments: ['timezone'],
     validate_arguments({ timezone }) {
         if (isNumber(timezone)) {
             if (timezone >= -1440 && timezone <= 1440) return;
-            throw new Error('Expected timezone offset to be between -1440 and -1440');
+            throw new Error('Expected timezone offset to be between -1440 and 1440');
         }
         if (isString(timezone)) return;
 

--- a/packages/data-mate/src/function-configs/date/setYear.ts
+++ b/packages/data-mate/src/function-configs/date/setYear.ts
@@ -4,7 +4,7 @@ import {
     ProcessMode, FunctionDefinitionType, FunctionDefinitionCategory, FieldTransformConfig
 } from '../interfaces';
 
-export const setYearConfig: FieldTransformConfig<{ year: number }> = {
+export const setYearConfig: FieldTransformConfig<{ value: number }> = {
     name: 'setYear',
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
@@ -12,7 +12,7 @@ export const setYearConfig: FieldTransformConfig<{ year: number }> = {
     description: 'Set the year of the input date',
     examples: [
         {
-            args: { year: 2024 },
+            args: { value: 2024 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.String } }
@@ -23,7 +23,7 @@ export const setYearConfig: FieldTransformConfig<{ year: number }> = {
             serialize_output: toISO8601
         },
         {
-            args: { year: 1984 },
+            args: { value: 1984 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Date } }
@@ -34,7 +34,7 @@ export const setYearConfig: FieldTransformConfig<{ year: number }> = {
             serialize_output: toISO8601
         },
         {
-            args: { year: 2001 },
+            args: { value: 2001 },
             config: {
                 version: 1,
                 fields: { testField: { type: FieldType.Number } }
@@ -45,21 +45,21 @@ export const setYearConfig: FieldTransformConfig<{ year: number }> = {
             serialize_output: toISO8601
         }
     ],
-    create({ args: { year } }) {
-        return setYear(year);
+    create({ args: { value } }) {
+        return setYear(value);
     },
     argument_schema: {
-        year: {
+        value: {
             type: FieldType.Number,
             description: 'Value to set year to, must be an integer'
         }
     },
-    validate_arguments: ({ year }) => {
-        if (!isInteger(year)) {
-            throw Error('Invalid argument "year", must be an integer');
+    validate_arguments: ({ value }) => {
+        if (!isInteger(value)) {
+            throw Error('Invalid argument "value", must be an integer');
         }
     },
-    required_arguments: ['year'],
+    required_arguments: ['value'],
     accepts: [FieldType.Date, FieldType.String, FieldType.Number],
     output_type(inputConfig) {
         const { field_config } = inputConfig;

--- a/packages/data-mate/src/function-configs/date/setYear.ts
+++ b/packages/data-mate/src/function-configs/date/setYear.ts
@@ -9,7 +9,7 @@ export const setYearConfig: FieldTransformConfig<{ value: number }> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Set the year of the input date',
+    description: 'Returns the input date with the year set to the args value.',
     examples: [
         {
             args: { value: 2024 },

--- a/packages/data-mate/src/function-configs/date/subtractFromDate.ts
+++ b/packages/data-mate/src/function-configs/date/subtractFromDate.ts
@@ -44,7 +44,7 @@ export const subtractFromDateConfig: FieldTransformConfig<AdjustDateArgs> = {
         field: 'testField',
         input: '2019-10-22T22:00:00.000Z',
         fails: true,
-        output: 'Expected at least either expr or years, months, weeks, days, hours, minutes, seconds or milliseconds'
+        output: 'Expected an expr or years, months, weeks, days, hours, minutes, seconds or milliseconds'
     }, {
         args: { expr: '1hr', months: 10 },
         config: {

--- a/packages/data-mate/src/function-configs/date/subtractFromDate.ts
+++ b/packages/data-mate/src/function-configs/date/subtractFromDate.ts
@@ -70,35 +70,35 @@ For example, \`1h\` or \`1h+2m\``
         },
         years: {
             type: FieldType.Integer,
-            description: 'The number of years from subtract from the date. This cannot be specified with expr'
+            description: 'The number of years to subtract from the date. This cannot be specified with expr'
         },
         months: {
             type: FieldType.Integer,
-            description: 'The number of months from subtract from the date. This cannot be specified with expr'
+            description: 'The number of months to subtract from the date. This cannot be specified with expr'
         },
         weeks: {
             type: FieldType.Integer,
-            description: 'The number of weeks from subtract from the date. This cannot be specified with expr'
+            description: 'The number of weeks to subtract from the date. This cannot be specified with expr'
         },
         days: {
             type: FieldType.Integer,
-            description: 'The number of days from subtract from the date. This cannot be specified with expr'
+            description: 'The number of days to subtract from the date. This cannot be specified with expr'
         },
         hours: {
             type: FieldType.Integer,
-            description: 'The number of hours from subtract from the date. This cannot be specified with expr'
+            description: 'The number of hours to subtract from the date. This cannot be specified with expr'
         },
         minutes: {
             type: FieldType.Integer,
-            description: 'The number of minutes from subtract from the date. This cannot be specified with expr'
+            description: 'The number of minutes to subtract from the date. This cannot be specified with expr'
         },
         seconds: {
             type: FieldType.Integer,
-            description: 'The number of seconds from subtract from the date. This cannot be specified with expr'
+            description: 'The number of seconds to subtract from the date. This cannot be specified with expr'
         },
         milliseconds: {
             type: FieldType.Integer,
-            description: 'The number of milliseconds from subtract from the date. This cannot be specified with expr'
+            description: 'The number of milliseconds to subtract from the date. This cannot be specified with expr'
         }
     },
     validate_arguments(args) {
@@ -107,7 +107,7 @@ For example, \`1h\` or \`1h+2m\``
         const argKeys = Object.keys(args);
 
         if (argKeys.length === 0) {
-            throw new Error('Expected at least either expr or years, months, weeks, days, hours, minutes, seconds or milliseconds');
+            throw new Error('Expected an expr or years, months, weeks, days, hours, minutes, seconds or milliseconds');
         }
 
         for (const argKey of argKeys) {

--- a/packages/data-mate/src/function-configs/date/subtractFromDate.ts
+++ b/packages/data-mate/src/function-configs/date/subtractFromDate.ts
@@ -14,7 +14,7 @@ export const subtractFromDateConfig: FieldTransformConfig<AdjustDateArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Subtract time from a date expression or specific number of years, months, weeks, days, hours, minutes, seconds, or milliseconds',
+    description: 'Returns the input date minus the date expression or a specific number of years, months, weeks, days, hours, minutes, seconds, or milliseconds',
     examples: [{
         args: { expr: '10h+2m' },
         config: {

--- a/packages/data-mate/src/function-configs/date/timezoneToOffset.ts
+++ b/packages/data-mate/src/function-configs/date/timezoneToOffset.ts
@@ -14,7 +14,7 @@ export const timezoneToOffsetConfig: FieldTransformConfig = {
     category: FunctionDefinitionCategory.DATE,
     description: `Given a timezone, it will return the offset from UTC in minutes.
      This uses current server time as the reference for a date, so results may vary
-     depending on daylight savings time adjustments`,
+     depending on daylight saving time adjustments`,
     create() {
         return timezoneToOffset;
     },
@@ -23,7 +23,6 @@ export const timezoneToOffsetConfig: FieldTransformConfig = {
     ],
     output_type(inputConfig) {
         const { field_config } = inputConfig;
-
         return {
             field_config: {
                 ...field_config,

--- a/packages/data-mate/src/function-configs/date/toDate.ts
+++ b/packages/data-mate/src/function-configs/date/toDate.ts
@@ -16,7 +16,7 @@ export const toDateConfig: FieldTransformConfig<ToDateArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.DATE,
-    description: 'Converts a value to a date value, when specifying the format it applies to the input value',
+    description: 'Converts a value to a date value, specify a format to apply it to the input value',
     examples: [{
         args: { format: 'yyyy-MM-dd' },
         config: {

--- a/packages/data-mate/src/function-configs/geo/geoContains.ts
+++ b/packages/data-mate/src/function-configs/geo/geoContains.ts
@@ -109,7 +109,7 @@ export const geoContainsConfig: FieldValidateConfig<GeoContainsArgs> = {
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.GEO,
     examples,
-    description: 'Validates that geo-like data completely "contains" the value argument. The interiors of both geo entities must intersect, and the argument geo-entity must not exceed the bounds of the geo data being compared',
+    description: 'Returns the input if it contains the value argument, otherwise returns null. The interiors of both geo entities must intersect, and the argument geo-entity must not exceed the bounds of the input geo-entity',
     create({ args: { value } }) {
         return geoContainsFP(value);
     },
@@ -124,7 +124,7 @@ export const geoContainsConfig: FieldValidateConfig<GeoContainsArgs> = {
     argument_schema: {
         value: {
             type: FieldType.Any,
-            description: 'The geo input that must be "contained" by other geo-like data'
+            description: 'The geo value used to check if it is contained by the input'
         }
     },
     required_arguments: ['value'],

--- a/packages/data-mate/src/function-configs/geo/geoContainsPoint.ts
+++ b/packages/data-mate/src/function-configs/geo/geoContainsPoint.ts
@@ -88,7 +88,7 @@ const examples: FunctionDefinitionExample<GeoContainsPointArgs>[] = [
                 [[20, 20], [20, 40], [40, 40], [40, 20], [20, 20]]
             ]
         },
-        description: 'this verifies that point is within a polygon with holes '
+        description: 'point is within a polygon with holes '
     },
     {
         args: { point: '15, 15' },
@@ -102,7 +102,7 @@ const examples: FunctionDefinitionExample<GeoContainsPointArgs>[] = [
             type: GeoShapeType.Point,
             coordinates: [15, 15]
         },
-        description: 'this verifies that point can match against a geo-shape point '
+        description: 'point can match against a geo-shape point '
     },
 ];
 
@@ -112,7 +112,7 @@ export const geoContainsPointConfig: FieldValidateConfig<GeoContainsPointArgs> =
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.GEO,
     examples,
-    description: 'Checks to see if a geo input contains the given point',
+    description: 'Returns the input if it contains the geo-point, otherwise returns null',
     create({ args: { point } }) {
         return geoContainsFP(point);
     },
@@ -120,7 +120,7 @@ export const geoContainsPointConfig: FieldValidateConfig<GeoContainsPointArgs> =
     argument_schema: {
         point: {
             type: FieldType.Any,
-            description: 'The point used to see if it is within the given geo-shape, if geo-shape is a point, it checks if they are the same'
+            description: 'The point used to see if it is within the input geo-shape. If the input geo-shape is a point, it checks if they are the same'
         }
     },
     required_arguments: ['point'],

--- a/packages/data-mate/src/function-configs/geo/geoDisjoint.ts
+++ b/packages/data-mate/src/function-configs/geo/geoDisjoint.ts
@@ -78,7 +78,7 @@ export const geoDisjointConfig: FieldValidateConfig<GeoDisjointArgs> = {
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.GEO,
     examples,
-    description: 'Validates that geo-like data does not have any intersection (overlap) with the geoInput argument',
+    description: 'Returns the input if it does not have any intersection (overlap) with the argument value, otherwise returns null',
     create({ args: { value } }) {
         return geoDisjointFP(value);
     },
@@ -93,7 +93,7 @@ export const geoDisjointConfig: FieldValidateConfig<GeoDisjointArgs> = {
     argument_schema: {
         value: {
             type: FieldType.Any,
-            description: 'The geo input used to validate that no intersection exists with other geo-like data'
+            description: 'The geo value used to validate that no intersection exists with the input geo-entity'
         }
     },
     required_arguments: ['value'],

--- a/packages/data-mate/src/function-configs/geo/geoIntersects.ts
+++ b/packages/data-mate/src/function-configs/geo/geoIntersects.ts
@@ -79,7 +79,7 @@ export const geoIntersectsConfig: FieldValidateConfig<GeoIntersectsArgs> = {
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.GEO,
     examples,
-    description: 'Validates that geo-like data when compared to the argument has overlap between the two',
+    description: 'Returns the input if it has at least one point in common with the argument value, otherwise returns null',
     create({ args: { value } }) {
         return geoIntersectsFP(value);
     },
@@ -94,7 +94,7 @@ export const geoIntersectsConfig: FieldValidateConfig<GeoIntersectsArgs> = {
     argument_schema: {
         value: {
             type: FieldType.Any,
-            description: 'The geo input used to validate intersection with other geo-like data'
+            description: 'The geo value used to compare with the input geo-entity'
         }
     },
     required_arguments: ['value'],

--- a/packages/data-mate/src/function-configs/geo/geoPointWithinRange.ts
+++ b/packages/data-mate/src/function-configs/geo/geoPointWithinRange.ts
@@ -37,7 +37,7 @@ export const geoPointWithinRangeConfig: FieldValidateConfig<GeoPointWithinRangeA
             output: null,
         },
     ],
-    description: 'Checks to see if input geo-point is within range of the point and distance values provided',
+    description: 'Returns the input if it is within range of the point and distance argument values, otherwise returns null.  Creates a geo circle based on the argument values and checks if the input is within the circle',
     create({ args: { point, distance } }) {
         return geoPointWithinRangeFP(point, distance);
     },
@@ -52,12 +52,12 @@ export const geoPointWithinRangeConfig: FieldValidateConfig<GeoPointWithinRangeA
     argument_schema: {
         point: {
             type: FieldType.Any,
-            description: 'The geo-point used to compare to other points'
+            description: 'The geo-point used as the center of the geo circle.'
         },
         distance: {
             type: FieldType.String,
-            description: `The range from the point that will provide a positive result.
-              It combines the number as well as the unit of measurement (ie 110km, 20in, 100yards).
+            description: `Value of the radius of the geo-circle.
+              It combines the number and the unit of measurement (ie 110km, 20in, 100yards).
                 Possible units are as follows: ${joinList(Object.keys(GEO_DISTANCE_UNITS), ', ')}
             `.trim()
         }

--- a/packages/data-mate/src/function-configs/geo/geoPointWithinRange.ts
+++ b/packages/data-mate/src/function-configs/geo/geoPointWithinRange.ts
@@ -37,7 +37,7 @@ export const geoPointWithinRangeConfig: FieldValidateConfig<GeoPointWithinRangeA
             output: null,
         },
     ],
-    description: 'Returns the input if it is within range of the point and distance argument values, otherwise returns null.  Creates a geo circle based on the argument values and checks if the input is within the circle',
+    description: 'Returns the input if it\'s distance to the args point is less then or equal to the args distance.',
     create({ args: { point, distance } }) {
         return geoPointWithinRangeFP(point, distance);
     },

--- a/packages/data-mate/src/function-configs/geo/geoRelation.ts
+++ b/packages/data-mate/src/function-configs/geo/geoRelation.ts
@@ -101,7 +101,7 @@ export const geoRelationConfig: FieldValidateConfig<GeoRelationArgs> = {
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.GEO,
     examples,
-    description: `Compares geo inputs to any geo-like data based off the relation specified (defaults to "${GeoShapeRelation.Within}"`,
+    description: `Returns the input if it relates, as specified in the relation argument, to the argument value (defaults to "${GeoShapeRelation.Within}"), otherwise returns null`,
     create({ args: { value, relation = GeoShapeRelation.Within } }) {
         return geoRelationFP(value, relation);
     },
@@ -116,11 +116,11 @@ export const geoRelationConfig: FieldValidateConfig<GeoRelationArgs> = {
     argument_schema: {
         value: {
             type: FieldType.Any,
-            description: 'The geo input used to compare to other geo entities'
+            description: 'The geo value used to compare to the input geo-entity'
         },
         relation: {
             type: FieldType.String,
-            description: `How the geo input should relate the data, defaults to "within" : ${joinList(Object.values(GeoShapeRelation), ', ')}
+            description: `How the geo input should relate the argument value, defaults to "within" : ${joinList(Object.values(GeoShapeRelation), ', ')}
             `.trim()
         }
     },

--- a/packages/data-mate/src/function-configs/geo/geoWithin.ts
+++ b/packages/data-mate/src/function-configs/geo/geoWithin.ts
@@ -132,7 +132,7 @@ export const geoWithinConfig: FieldValidateConfig<GeoWithinArgs> = {
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.GEO,
     examples,
-    description: 'Validates that geo-like data is completely "within" the argument. The interiors of both geo entities must intersect, and the geo data  must not exceed the bounds of the geo argument',
+    description: 'Returns the input if it is completely within the argument geo-value. The interiors of both geo entities must intersect and the geo data must not exceed the bounds of the geo argument.  Otherwise returns null',
     create({ args: { value } }) {
         return geoWithinFP(value);
     },
@@ -147,7 +147,7 @@ export const geoWithinConfig: FieldValidateConfig<GeoWithinArgs> = {
     argument_schema: {
         value: {
             type: FieldType.Any,
-            description: 'The geo input used to compare to other geo entities'
+            description: 'The geo value used to compare the input value to.'
         }
     },
     required_arguments: ['value'],

--- a/packages/data-mate/src/function-configs/geo/inGeoBoundingBox.ts
+++ b/packages/data-mate/src/function-configs/geo/inGeoBoundingBox.ts
@@ -41,7 +41,7 @@ export const inGeoBoundingBoxConfig: FieldValidateConfig<PointInBoundingBoxArgs>
             output: { type: 'Point', coordinates: [-112, 33] },
         },
     ],
-    description: 'Checks to see if input is within the geo bounding-box',
+    description: 'Returns the input if it is within the geo bounding box, otherwise returns null',
     create({ args: { top_left, bottom_right } }) {
         return inGeoBoundingBoxFP(top_left, bottom_right);
     },

--- a/packages/data-mate/src/function-configs/geo/isGeoJSON.ts
+++ b/packages/data-mate/src/function-configs/geo/isGeoJSON.ts
@@ -12,7 +12,7 @@ export const isGeoJSONConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.GEO,
-    description: 'Checks if value is a GeoJSON object',
+    description: 'Returns the input if it is a GeoJSON object, otherwise returns null',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/geo/isGeoPoint.ts
+++ b/packages/data-mate/src/function-configs/geo/isGeoPoint.ts
@@ -12,7 +12,7 @@ export const isGeoPointConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.GEO,
-    description: 'Checks if value is parsable to geo-point',
+    description: 'Returns the input if it is parsable to a geo-point, otherwise returns null',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/geo/isGeoShapeMultiPolygon.ts
+++ b/packages/data-mate/src/function-configs/geo/isGeoShapeMultiPolygon.ts
@@ -55,7 +55,7 @@ export const isGeoShapeMultiPolygonConfig: FieldValidateConfig = {
             },
         }
     ],
-    description: 'Checks to see if input is a valid geo-json multi-polygon',
+    description: 'Returns the input if it is a valid geo-json multi-polygon, otherwise returns null',
     create() {
         return isGeoShapeMultiPolygon;
     },

--- a/packages/data-mate/src/function-configs/geo/isGeoShapePoint.ts
+++ b/packages/data-mate/src/function-configs/geo/isGeoShapePoint.ts
@@ -45,7 +45,7 @@ export const isGeoShapePointConfig: FieldValidateConfig = {
             output: null,
         }
     ],
-    description: 'Checks to see if input is a valid geo-json point',
+    description: 'Returns the input if it is a valid geo-json point, otherwise returns null',
     create() {
         return isGeoShapePoint;
     },

--- a/packages/data-mate/src/function-configs/geo/isGeoShapePolygon.ts
+++ b/packages/data-mate/src/function-configs/geo/isGeoShapePolygon.ts
@@ -45,7 +45,7 @@ export const isGeoShapePolygonConfig: FieldValidateConfig = {
             output: null,
         }
     ],
-    description: 'Checks to see if input is a valid geo-json polygon',
+    description: 'Return the input if it is a valid geo-json polygon, otherwise returns null',
     create() {
         return isGeoShapePolygon;
     },

--- a/packages/data-mate/src/function-configs/geo/toGeoJSON.ts
+++ b/packages/data-mate/src/function-configs/geo/toGeoJSON.ts
@@ -62,7 +62,7 @@ export const toGeoJSONConfig: FieldTransformConfig = {
             }
         },
     ],
-    description: 'Converts a geo-point or list of geo-points to its geoJSON counterpart as well as make sure any geo-shape input is formatted correctly. If geo-points are provided only a simple geoJSON point or polygon will be made, there is currently no support for multi-polygon construction or polygon/multipolygon with holes',
+    description: 'Converts a geo-point or a list of geo-points to geoJSON. Only supports geoJSON points or simple polygons, there is currently no support for multi-polygons or polygons/ multipolygons with holes',
     create() {
         return (input: unknown) => {
             if (isNil(input)) return null;

--- a/packages/data-mate/src/function-configs/geo/toGeoPoint.ts
+++ b/packages/data-mate/src/function-configs/geo/toGeoPoint.ts
@@ -45,7 +45,7 @@ export const toGeoPointConfig: FieldTransformConfig = {
             fails: true
         },
     ],
-    description: 'Converts a value to a geo-point',
+    description: 'Converts the input to a geo-point',
     create() {
         return (input: unknown) => {
             if (isNil(input)) return null;

--- a/packages/data-mate/src/function-configs/ip/extractMappedIPV4.ts
+++ b/packages/data-mate/src/function-configs/ip/extractMappedIPV4.ts
@@ -26,7 +26,7 @@ export const extractMappedIPV4Config: FieldTransformConfig = {
             output: '122.168.5.18',
         }
     ],
-    description: 'Extracts a mapped IPv4 address from an IPv6 address',
+    description: 'Extracts a mapped IPv4 address from an IPv6 address and returns the IPv4 address',
     create() { return extractMappedIPV4; },
     accepts: [FieldType.String, FieldType.IP],
     output_type({ field_config }) {

--- a/packages/data-mate/src/function-configs/ip/inIPRange.ts
+++ b/packages/data-mate/src/function-configs/ip/inIPRange.ts
@@ -46,7 +46,7 @@ export const inIPRangeConfig: FieldValidateConfig = {
             output: null,
         }
     ],
-    description: 'Returns the input if the ip is within the given range, inclusive.  Accepts min, max or cidr notation for the ip range.  Function accepts min without a max and vice versa.',
+    description: 'Returns the input if the ip is within the given range, inclusive.  Accepts min, max or cidr notation for the ip range, also accepts min without a max and vice versa.',
     create({ args }) {
         return (input: unknown) => inIPRange(input, args);
     },

--- a/packages/data-mate/src/function-configs/ip/inIPRange.ts
+++ b/packages/data-mate/src/function-configs/ip/inIPRange.ts
@@ -46,7 +46,7 @@ export const inIPRangeConfig: FieldValidateConfig = {
             output: null,
         }
     ],
-    description: 'Checks if the ip is within a range, inclusive.  Accepts min, max or cidr notation for the ip range.  Function accepts min without a max and vice versa.',
+    description: 'Returns the input if the ip is within the given range, inclusive.  Accepts min, max or cidr notation for the ip range.  Function accepts min without a max and vice versa.',
     create({ args }) {
         return (input: unknown) => inIPRange(input, args);
     },

--- a/packages/data-mate/src/function-configs/ip/intToIP.ts
+++ b/packages/data-mate/src/function-configs/ip/intToIP.ts
@@ -37,7 +37,7 @@ export const intToIPConfig: FieldTransformConfig<IntToIPArgs> = {
         }
     },
     accepts: [FieldType.String, FieldType.Number],
-    description: 'Converts an integer to an ip address, must provide the version of the returned ip address',
+    description: 'Converts an integer to an ip address, must provide the version of the returned ip address.',
     create({ args: { version } }) {
         return (input: unknown) => intToIP(input, toString(version));
     },

--- a/packages/data-mate/src/function-configs/ip/isCIDR.ts
+++ b/packages/data-mate/src/function-configs/ip/isCIDR.ts
@@ -40,7 +40,7 @@ export const isCIDRConfig: FieldValidateConfig = {
             output: null,
         }
     ],
-    description: 'Checks if the input is a valid ipv4 or ipv6 ip address in CIDR notation',
+    description: 'Returns the input if it is a valid ipv4 or ipv6 ip address in CIDR notation, otherwise returns null',
     create() { return isCIDR; },
     accepts: [FieldType.String, FieldType.IPRange],
 };

--- a/packages/data-mate/src/function-configs/ip/isIP.ts
+++ b/packages/data-mate/src/function-configs/ip/isIP.ts
@@ -47,7 +47,7 @@ export const isIPConfig: FieldValidateConfig = {
             output: null,
         },
     ],
-    description: 'Checks if the input is a valid ipv4 or ipv6 ip address.  Accepts dot notation for ipv4 addresses and hexadecimal separated by colons for ipv6 addresses',
+    description: 'Returns the input if it is a valid ipv4 or ipv6 ip address.  Accepts dot notation for ipv4 addresses and hexadecimal separated by colons for ipv6 addresses',
     create() { return isIP; },
     accepts: [FieldType.String, FieldType.IP]
 };

--- a/packages/data-mate/src/function-configs/ip/isIPV4.ts
+++ b/packages/data-mate/src/function-configs/ip/isIPV4.ts
@@ -40,7 +40,7 @@ export const isIPV4Config: FieldValidateConfig = {
             output: null,
         },
     ],
-    description: 'Checks if the input is a valid ipv4 address in dot notation.',
+    description: 'Returns the input if it is a valid ipv4 address in dot notation, otherwise returns null',
     create() { return isIPV4; },
     accepts: [FieldType.String, FieldType.IP],
 };

--- a/packages/data-mate/src/function-configs/ip/isIPV6.ts
+++ b/packages/data-mate/src/function-configs/ip/isIPV6.ts
@@ -47,7 +47,7 @@ export const isIPV6Config: FieldValidateConfig = {
             output: null,
         },
     ],
-    description: 'Checks if the input is a valid ipv6 ip address in hexadecimal separated by colons format',
+    description: 'Returns the input if it is a valid ipv6 ip address in hexadecimal separated by colons format, otherwise returns null.',
     create() { return isIPV6; },
     accepts: [FieldType.String, FieldType.IP],
 };

--- a/packages/data-mate/src/function-configs/ip/isMappedIPV4.ts
+++ b/packages/data-mate/src/function-configs/ip/isMappedIPV4.ts
@@ -47,7 +47,7 @@ export const isMappedIPV4Config: FieldValidateConfig = {
             output: null,
         },
     ],
-    description: 'Checks if the input is an ipv4 address mapped to an ipv6 address',
+    description: 'Returns the input if it is an ipv4 address mapped to an ipv6 address, otherwise returns null',
     create() { return isMappedIPV4; },
     accepts: [FieldType.String, FieldType.IP],
 };

--- a/packages/data-mate/src/function-configs/ip/isNonRoutableIP.ts
+++ b/packages/data-mate/src/function-configs/ip/isNonRoutableIP.ts
@@ -47,7 +47,7 @@ export const isNonRoutableIPConfig: FieldValidateConfig = {
             output: null,
         },
     ],
-    description: 'Checks if the input is a non-routable ip address, handles ipv6 and ipv4 address.  Non-routable ip ranges are private, uniqueLocal, loopback, unspecified, carrierGradeNat, linkLocal, reserved, rfc6052, teredo, 6to4, broadcast',
+    description: 'Returns the input if it is a non-routable ip address, handles ipv6 and ipv4 address.  Non-routable ip ranges are private, uniqueLocal, loopback, unspecified, carrierGradeNat, linkLocal, reserved, rfc6052, teredo, 6to4, or broadcast',
     create() { return isNonRoutableIP; },
     accepts: [FieldType.String, FieldType.IP],
 };

--- a/packages/data-mate/src/function-configs/ip/isNonRoutableIP.ts
+++ b/packages/data-mate/src/function-configs/ip/isNonRoutableIP.ts
@@ -47,7 +47,7 @@ export const isNonRoutableIPConfig: FieldValidateConfig = {
             output: null,
         },
     ],
-    description: 'Returns the input if it is a non-routable ip address, handles ipv6 and ipv4 address.  Non-routable ip ranges are private, uniqueLocal, loopback, unspecified, carrierGradeNat, linkLocal, reserved, rfc6052, teredo, 6to4, or broadcast',
+    description: 'Returns the input if it is a non-routable ip address, handles ipv6 and ipv4 address. See https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml and https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml',
     create() { return isNonRoutableIP; },
     accepts: [FieldType.String, FieldType.IP],
 };

--- a/packages/data-mate/src/function-configs/ip/isRoutableIP.ts
+++ b/packages/data-mate/src/function-configs/ip/isRoutableIP.ts
@@ -47,7 +47,7 @@ export const isRoutableIPConfig: FieldValidateConfig = {
             output: null,
         },
     ],
-    description: 'Checks if the input is a routable ipv4 or ipv6 address.  Routable ranges are defined as anything that is not in the following ip ranges: private, uniqueLocal, loopback, unspecified, carrierGradeNat, linkLocal, reserved, rfc6052, teredo, 6to4, or broadcast',
+    description: 'Returns the input if it is a routable ipv4 or ipv6 address.  Routable ranges are defined as anything that is not in the following ip ranges: private, uniqueLocal, loopback, unspecified, carrierGradeNat, linkLocal, reserved, rfc6052, teredo, 6to4, or broadcast',
     create() { return isRoutableIP; },
     accepts: [FieldType.String, FieldType.IP],
 };

--- a/packages/data-mate/src/function-configs/ip/isRoutableIP.ts
+++ b/packages/data-mate/src/function-configs/ip/isRoutableIP.ts
@@ -47,7 +47,7 @@ export const isRoutableIPConfig: FieldValidateConfig = {
             output: null,
         },
     ],
-    description: 'Returns the input if it is a routable ipv4 or ipv6 address.  Routable ranges are defined as anything that is not in the following ip ranges: private, uniqueLocal, loopback, unspecified, carrierGradeNat, linkLocal, reserved, rfc6052, teredo, 6to4, or broadcast',
+    description: 'Returns the input if it is a routable ipv4 or ipv6 address.  See https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml and https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml',
     create() { return isRoutableIP; },
     accepts: [FieldType.String, FieldType.IP],
 };

--- a/packages/data-mate/src/function-configs/ip/toCIDR.ts
+++ b/packages/data-mate/src/function-configs/ip/toCIDR.ts
@@ -50,7 +50,7 @@ export const toCIDRConfig: FieldTransformConfig<ToCIDRArgs> = {
     argument_schema: {
         suffix: {
             type: FieldType.Any,
-            description: 'suffix must be between 0 and 32 for IPv4 address and 0 and 128 for IPv6 addresses'
+            description: 'Suffix must be between 0 and 32 for IPv4 address and 0 and 128 for IPv6 addresses'
         }
     },
     required_arguments: ['suffix'],
@@ -61,6 +61,6 @@ export const toCIDRConfig: FieldTransformConfig<ToCIDRArgs> = {
             if (asInt >= 0 && asInt <= 128) return;
         }
 
-        throw Error('suffix must be between 0 and 32 for IPv4 address and 0 and 128 for IPv6 addresses');
+        throw Error('Suffix must be between 0 and 32 for IPv4 address and 0 and 128 for IPv6 addresses');
     }
 };

--- a/packages/data-mate/src/function-configs/json/parseJSON.ts
+++ b/packages/data-mate/src/function-configs/json/parseJSON.ts
@@ -30,7 +30,7 @@ export const parseJSONConfig: FieldTransformConfig<ParseJSONArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.JSON,
-    description: 'Parses a JSON string, constructing the value or object described by the string',
+    description: 'Parses a JSON string and returns the value or object according to the arg options.',
     create() {
         return (input: unknown) => {
             if (isNil(input)) return null;

--- a/packages/data-mate/src/function-configs/json/parseJSON.ts
+++ b/packages/data-mate/src/function-configs/json/parseJSON.ts
@@ -54,7 +54,7 @@ export const parseJSONConfig: FieldTransformConfig<ParseJSONArgs> = {
         },
         locale: {
             type: FieldType.String,
-            description: `Specify the locale for the field (only compatible with some field types).  Must be a BCP 47 Language Tag`
+            description: 'Specify the locale for the field (only compatible with some field types).  Must be a BCP 47 Language Tag'
         },
 
         indexed: {

--- a/packages/data-mate/src/function-configs/json/parseJSON.ts
+++ b/packages/data-mate/src/function-configs/json/parseJSON.ts
@@ -30,7 +30,7 @@ export const parseJSONConfig: FieldTransformConfig<ParseJSONArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.JSON,
-    description: 'parses a JSON string, constructing the value or object described by the string',
+    description: 'Parses a JSON string, constructing the value or object described by the string',
     create() {
         return (input: unknown) => {
             if (isNil(input)) return null;
@@ -39,7 +39,6 @@ export const parseJSONConfig: FieldTransformConfig<ParseJSONArgs> = {
     },
     accepts: [FieldType.String],
     argument_schema: {
-
         type: {
             type: FieldType.String,
             description: 'The type of field, defaults to Any, you may need to specify the type for better execution optimization'
@@ -51,26 +50,25 @@ export const parseJSONConfig: FieldTransformConfig<ParseJSONArgs> = {
 
         description: {
             type: FieldType.Text,
-            description: 'A new description for the field'
+            description: 'Set the description for the field'
         },
         locale: {
             type: FieldType.String,
-            description: `Specify the locale for the field (only compatible with some field types).
-Must be represented in a Language Tags (BCP 47)`
+            description: `Specify the locale for the field (only compatible with some field types).  Must be a BCP 47 Language Tag`
         },
 
         indexed: {
             type: FieldType.Boolean,
-            description: 'Specifies whether the field is index in elasticsearch (Only type Object currently support this)'
+            description: 'Specifies whether the field is indexed in elasticsearch (Only type Object currently support this)'
         },
 
         format: {
             type: FieldType.String,
-            description: 'The format for the field. Currently only Date field support it.'
+            description: 'The format for the field. Currently only supported by Date fields.'
         },
         is_primary_date: {
             type: FieldType.Boolean,
-            description: 'used to denote naming of timeseries indicies, and if any search/join queries off of this field should use a date searching algorithm'
+            description: 'Used to denote naming of timeseries indicies, and if any search/join queries off of this field should use a date searching algorithm'
         },
         time_resolution: {
             type: FieldType.String,

--- a/packages/data-mate/src/function-configs/json/setDefault.ts
+++ b/packages/data-mate/src/function-configs/json/setDefault.ts
@@ -20,7 +20,7 @@ export const setDefaultConfig: FieldTransformConfig<SetDefaultArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.JSON,
-    description: 'Replace missing values in a column with a constant value',
+    description: 'Replaces missing values in a column with a constant value',
     examples: [
         {
             args: { value: 'example' },

--- a/packages/data-mate/src/function-configs/json/toJSON.ts
+++ b/packages/data-mate/src/function-configs/json/toJSON.ts
@@ -15,7 +15,7 @@ export const toJSONConfig: FieldTransformConfig = {
     name: 'toJSON',
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.FULL_VALUES,
-    description: 'converts whole input to JSON format',
+    description: 'Converts whole input to JSON format',
     category: FunctionDefinitionCategory.JSON,
     examples: [
         {

--- a/packages/data-mate/src/function-configs/numeric/abs.ts
+++ b/packages/data-mate/src/function-configs/numeric/abs.ts
@@ -12,7 +12,7 @@ export const absConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Returns the absolute value of a number. That is, it returns x if x is positive or zero, and the negation of x if x is negative',
+    description: 'Returns the absolute value of a number.',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/acosh.ts
+++ b/packages/data-mate/src/function-configs/numeric/acosh.ts
@@ -12,7 +12,7 @@ export const acoshConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Returns the hyperbolic arc-cosine of a given number. If given a number less than 1, null will be returned',
+    description: 'Returns the hyperbolic arc-cosine of a given number. If given the number is less than 1, returns null.',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/add.ts
+++ b/packages/data-mate/src/function-configs/numeric/add.ts
@@ -21,7 +21,7 @@ export const addConfig: FieldTransformConfig<AddArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Add a numeric value to another',
+    description: 'Returns the sum of the input and the args value.',
     examples: [
         {
             args: { value: 1 },

--- a/packages/data-mate/src/function-configs/numeric/addValues.ts
+++ b/packages/data-mate/src/function-configs/numeric/addValues.ts
@@ -27,7 +27,7 @@ export const addValuesConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Add the values with a given field, this requires an array to function correctly',
+    description: 'Adds the values with a given field, this requires an array to function correctly',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/cosh.ts
+++ b/packages/data-mate/src/function-configs/numeric/cosh.ts
@@ -12,7 +12,7 @@ export const coshConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Returns the hyperbolic cosine of a number, that can be expressed using the constant e',
+    description: 'Returns the hyperbolic cosine of a number that can be expressed using the constant e',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/divide.ts
+++ b/packages/data-mate/src/function-configs/numeric/divide.ts
@@ -21,7 +21,7 @@ export const divideConfig: FieldTransformConfig<DivideArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Divide a numeric value',
+    description: 'Returns the quotient from the input divided by the args value.',
     examples: [
         {
             args: { value: 5 },
@@ -68,7 +68,7 @@ export const divideConfig: FieldTransformConfig<DivideArgs> = {
         value: {
             type: FieldType.Number,
             array: false,
-            description: 'Value to divide against the input'
+            description: 'Value to divide into the input'
         }
     },
     required_arguments: ['value']

--- a/packages/data-mate/src/function-configs/numeric/divide.ts
+++ b/packages/data-mate/src/function-configs/numeric/divide.ts
@@ -21,7 +21,7 @@ export const divideConfig: FieldTransformConfig<DivideArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'divide a numeric value',
+    description: 'Divide a numeric value',
     examples: [
         {
             args: { value: 5 },

--- a/packages/data-mate/src/function-configs/numeric/divideValues.ts
+++ b/packages/data-mate/src/function-configs/numeric/divideValues.ts
@@ -27,7 +27,7 @@ export const divideValuesConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Divide the values with a given field, this requires an array to function correctly',
+    description: 'Divides the values with a given field, this requires an array to function correctly',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/floor.ts
+++ b/packages/data-mate/src/function-configs/numeric/floor.ts
@@ -12,7 +12,7 @@ export const floorConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Rounds a number down to the next largest integer',
+    description: 'Rounds a number down to the previous largest integer',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/inNumberRange.ts
+++ b/packages/data-mate/src/function-configs/numeric/inNumberRange.ts
@@ -12,7 +12,7 @@ export const inNumberRangeConfig: FieldValidateConfig<InNumberRangeArg> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Checks if a number is within a given min and max value, optionally inclusive or exclusive',
+    description: 'Checks if a number is within a given min and max value, arg option for inclusive or exclusive',
     examples: [
         {
             args: { min: 100, max: 110 },
@@ -65,12 +65,12 @@ export const inNumberRangeConfig: FieldValidateConfig<InNumberRangeArg> = {
         min: {
             type: FieldType.Number,
             array: false,
-            description: 'The maximum value allowed in the range, defaults to Negative Infinity'
+            description: 'The minimum value allowed in the range, defaults to Negative Infinity'
         },
         max: {
             type: FieldType.Number,
             array: false,
-            description: 'The minimum value allowed in the range, defaults to Positive Infinity'
+            description: 'The maximum value allowed in the range, defaults to Positive Infinity'
         },
         inclusive: {
             type: FieldType.Boolean,

--- a/packages/data-mate/src/function-configs/numeric/inNumberRange.ts
+++ b/packages/data-mate/src/function-configs/numeric/inNumberRange.ts
@@ -12,7 +12,7 @@ export const inNumberRangeConfig: FieldValidateConfig<InNumberRangeArg> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Checks if a number is within a given min and max value, arg option for inclusive or exclusive',
+    description: 'Returns the input if it is within the given min and max values, arg option for inclusive or exclusive',
     examples: [
         {
             args: { min: 100, max: 110 },

--- a/packages/data-mate/src/function-configs/numeric/isEven.ts
+++ b/packages/data-mate/src/function-configs/numeric/isEven.ts
@@ -11,7 +11,7 @@ export const isEvenConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Check if a number is even',
+    description: 'Returns the input if it is an even number.',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/isGreaterThan.ts
+++ b/packages/data-mate/src/function-configs/numeric/isGreaterThan.ts
@@ -15,7 +15,7 @@ export const isGreaterThanConfig: FieldValidateConfig<GreaterThanArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Check if a number is greater than the specified value',
+    description: 'Returns the input if it is greater than the args value',
     examples: [
         {
             args: { value: 100 },

--- a/packages/data-mate/src/function-configs/numeric/isGreaterThanOrEqual.ts
+++ b/packages/data-mate/src/function-configs/numeric/isGreaterThanOrEqual.ts
@@ -15,7 +15,7 @@ export const isGreaterThanOrEqualToConfig: FieldValidateConfig<GreaterThanOrEqua
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Check if a number is greater than or equal to the specified value',
+    description: 'Returns the input if it is greater than or equal to the args value',
     examples: [
         {
             args: { value: 100 },

--- a/packages/data-mate/src/function-configs/numeric/isLessThan.ts
+++ b/packages/data-mate/src/function-configs/numeric/isLessThan.ts
@@ -15,7 +15,7 @@ export const isLessThanConfig: FieldValidateConfig<LessThanArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Check if a number is less than the specified value',
+    description: 'Returns the input if it is a number less than the args value',
     examples: [
         {
             args: { value: 100 },

--- a/packages/data-mate/src/function-configs/numeric/isLessThanOrEqual.ts
+++ b/packages/data-mate/src/function-configs/numeric/isLessThanOrEqual.ts
@@ -15,7 +15,7 @@ export const isLessThanOrEqualToConfig: FieldValidateConfig<LessThanOrEqualToArg
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Check if a number is less than or equal to the specified value',
+    description: 'Returns the input if it is a number less than or equal to the args value',
     examples: [
         {
             args: { value: 100 },

--- a/packages/data-mate/src/function-configs/numeric/isOdd.ts
+++ b/packages/data-mate/src/function-configs/numeric/isOdd.ts
@@ -11,7 +11,7 @@ export const isOddConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Check if a number is odd',
+    description: 'Returns the input if it is an odd number',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/maxValues.ts
+++ b/packages/data-mate/src/function-configs/numeric/maxValues.ts
@@ -28,7 +28,7 @@ export const maxValuesConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Get the maximum value in an array, this requires an array to function correctly',
+    description: 'Returns the maximum value in an array, this requires an array to function correctly',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/minValues.ts
+++ b/packages/data-mate/src/function-configs/numeric/minValues.ts
@@ -28,7 +28,7 @@ export const minValuesConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Get the minimum value in an array, this requires an array to function correctly',
+    description: 'Returns the minimum value in an array, this requires an array to function correctly',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/modulus.ts
+++ b/packages/data-mate/src/function-configs/numeric/modulus.ts
@@ -79,7 +79,7 @@ export const modulusConfig: FieldTransformConfig<ModulusArgs> = {
         value: {
             type: FieldType.Number,
             array: false,
-            description: 'Divisor value used to determine the modulus.'
+            description: 'Value to divide into the input.'
         }
     },
     required_arguments: ['value']

--- a/packages/data-mate/src/function-configs/numeric/modulus.ts
+++ b/packages/data-mate/src/function-configs/numeric/modulus.ts
@@ -22,7 +22,7 @@ export const modulusConfig: FieldTransformConfig<ModulusArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Calculate the modulus from the specified value',
+    description: 'Returns the modulus from the input divided by the args value.',
     examples: [
         {
             args: { value: 2 },
@@ -79,7 +79,7 @@ export const modulusConfig: FieldTransformConfig<ModulusArgs> = {
         value: {
             type: FieldType.Number,
             array: false,
-            description: 'How much to modulus'
+            description: 'Divisor value used to determine the modulus.'
         }
     },
     required_arguments: ['value']

--- a/packages/data-mate/src/function-configs/numeric/multiply.ts
+++ b/packages/data-mate/src/function-configs/numeric/multiply.ts
@@ -65,7 +65,7 @@ export const multiplyConfig: FieldTransformConfig<MultiplyArgs> = {
         value: {
             type: FieldType.Number,
             array: false,
-            description: 'Value to multiply against the input'
+            description: 'Value to multiply the input by'
         }
     },
     required_arguments: ['value']

--- a/packages/data-mate/src/function-configs/numeric/multiply.ts
+++ b/packages/data-mate/src/function-configs/numeric/multiply.ts
@@ -21,7 +21,7 @@ export const multiplyConfig: FieldTransformConfig<MultiplyArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Multiply a numeric value',
+    description: 'Returns the product of the input multiplied by the args value',
     examples: [{
         args: { value: 5 },
         config: {

--- a/packages/data-mate/src/function-configs/numeric/multiplyValues.ts
+++ b/packages/data-mate/src/function-configs/numeric/multiplyValues.ts
@@ -27,7 +27,7 @@ export const multiplyValuesConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Multiply the values with a given field, this requires an array to function correctly',
+    description: 'Multiplies the values with a given field, this requires an array to function correctly',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/pow.ts
+++ b/packages/data-mate/src/function-configs/numeric/pow.ts
@@ -17,7 +17,7 @@ export const powConfig: FieldTransformConfig<PowerArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Returns a number representing the given base taken to the power of the given exponent',
+    description: 'Returns a number representing the input value taken to the power of the args exp value',
     examples: [
         {
             args: { exp: 3 },

--- a/packages/data-mate/src/function-configs/numeric/random.ts
+++ b/packages/data-mate/src/function-configs/numeric/random.ts
@@ -18,7 +18,7 @@ export const randomConfig: FieldTransformConfig<RandomArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Returns a random number between a given range',
+    description: 'Returns a random number between the args min and max values.',
     examples: [{
         args: { min: 1, max: 1 },
         config: {

--- a/packages/data-mate/src/function-configs/numeric/random.ts
+++ b/packages/data-mate/src/function-configs/numeric/random.ts
@@ -18,7 +18,7 @@ export const randomConfig: FieldTransformConfig<RandomArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Generate a random number between a given range',
+    description: 'Returns a random number between a given range',
     examples: [{
         args: { min: 1, max: 1 },
         config: {

--- a/packages/data-mate/src/function-configs/numeric/setPrecision.ts
+++ b/packages/data-mate/src/function-configs/numeric/setPrecision.ts
@@ -21,7 +21,7 @@ export const setPrecisionConfig: FieldTransformConfig<ToPrecisionArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Returns a truncated number to nth decimal places. The values will skip rounding if truncate: true is specified',
+    description: 'Returns a truncated number to the nth decimal places. The values will skip rounding if truncate: true is specified',
     examples: [
         {
             args: { digits: 1, truncate: false },

--- a/packages/data-mate/src/function-configs/numeric/sign.ts
+++ b/packages/data-mate/src/function-configs/numeric/sign.ts
@@ -12,7 +12,7 @@ export const signConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: `Returns a number representing the sign of the given argument:
+    description: `Returns a number representing the sign of the input value:
 - If the argument is positive, returns 1
 - If the argument is negative, returns -1
 - If the argument is positive zero, returns 0

--- a/packages/data-mate/src/function-configs/numeric/sin.ts
+++ b/packages/data-mate/src/function-configs/numeric/sin.ts
@@ -12,7 +12,7 @@ export const sinConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Returns the sine of the given number',
+    description: 'Returns the sine of the input value',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/sinh.ts
+++ b/packages/data-mate/src/function-configs/numeric/sinh.ts
@@ -12,7 +12,7 @@ export const sinhConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Returns the hyperbolic sine of a number, that can be expressed using the constant e',
+    description: 'Returns the hyperbolic sine of the input, that can be expressed using the constant e',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/sqrt.ts
+++ b/packages/data-mate/src/function-configs/numeric/sqrt.ts
@@ -12,7 +12,7 @@ export const sqrtConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Returns the square root of a number',
+    description: 'Returns the square root of the input',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/subtract.ts
+++ b/packages/data-mate/src/function-configs/numeric/subtract.ts
@@ -21,7 +21,7 @@ export const subtractConfig: FieldTransformConfig<SubtractArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Subtract a numeric value',
+    description: 'Returns the result of subtracting the args value from the input value',
     examples: [
         {
             args: { value: 1 },

--- a/packages/data-mate/src/function-configs/numeric/subtractValues.ts
+++ b/packages/data-mate/src/function-configs/numeric/subtractValues.ts
@@ -27,7 +27,7 @@ export const subtractValuesConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Subtract the values with a given field, this requires an array to function correctly',
+    description: 'Subtracts the values with a given field, this requires an array to function correctly',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/numeric/toCelsius.ts
+++ b/packages/data-mate/src/function-configs/numeric/toCelsius.ts
@@ -14,7 +14,7 @@ export const toCelsiusConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Convert a fahrenheit value to celsius',
+    description: 'Converts a fahrenheit value to the equivalent celsius value',
     examples: [
         {
             args: { },

--- a/packages/data-mate/src/function-configs/numeric/toCelsius.ts
+++ b/packages/data-mate/src/function-configs/numeric/toCelsius.ts
@@ -14,7 +14,7 @@ export const toCelsiusConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Converts a fahrenheit value to the equivalent celsius value',
+    description: 'Returns the equivalent celsius value from the fahrenheit input.',
     examples: [
         {
             args: { },

--- a/packages/data-mate/src/function-configs/numeric/toFahrenheit.ts
+++ b/packages/data-mate/src/function-configs/numeric/toFahrenheit.ts
@@ -14,7 +14,7 @@ export const toFahrenheitConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Converts a celsius value to the equivalent fahrenheit value',
+    description: 'Returns the equivalent fahrenheit value from the celsius input.',
     examples: [
         {
             args: { },

--- a/packages/data-mate/src/function-configs/numeric/toFahrenheit.ts
+++ b/packages/data-mate/src/function-configs/numeric/toFahrenheit.ts
@@ -14,7 +14,7 @@ export const toFahrenheitConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.NUMERIC,
-    description: 'Convert a celsius value to fahrenheit',
+    description: 'Converts a celsius value to the equivalent fahrenheit value',
     examples: [
         {
             args: { },

--- a/packages/data-mate/src/function-configs/object/equals.ts
+++ b/packages/data-mate/src/function-configs/object/equals.ts
@@ -59,7 +59,7 @@ export const equalsConfig: FieldValidateConfig<EqualsArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.OBJECT,
-    description: 'Checks to see if input matches the value',
+    description: 'Returns the input if it matches the args value',
     examples,
     create({ args: { value } }) {
         return isDeepEqualFP(value);

--- a/packages/data-mate/src/function-configs/object/equals.ts
+++ b/packages/data-mate/src/function-configs/object/equals.ts
@@ -59,7 +59,7 @@ export const equalsConfig: FieldValidateConfig<EqualsArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.OBJECT,
-    description: 'Returns the input if it matches the args value',
+    description: 'Returns the input if it matches the args value, otherwise returns null.',
     examples,
     create({ args: { value } }) {
         return isDeepEqualFP(value);

--- a/packages/data-mate/src/function-configs/object/isEmpty.ts
+++ b/packages/data-mate/src/function-configs/object/isEmpty.ts
@@ -39,7 +39,7 @@ export const isEmptyConfig: FieldValidateConfig<EmptyArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.OBJECT,
-    description: 'Returns the input if it is empty',
+    description: 'Returns the input if it is empty, otherwise returns null.',
     examples,
     accepts: [],
     create({ args: { ignoreWhitespace } }) {

--- a/packages/data-mate/src/function-configs/object/isEmpty.ts
+++ b/packages/data-mate/src/function-configs/object/isEmpty.ts
@@ -39,7 +39,7 @@ export const isEmptyConfig: FieldValidateConfig<EmptyArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.OBJECT,
-    description: 'Checks to see if input is empty',
+    description: 'Returns the input if it is empty',
     examples,
     accepts: [],
     create({ args: { ignoreWhitespace } }) {

--- a/packages/data-mate/src/function-configs/string/contains.ts
+++ b/packages/data-mate/src/function-configs/string/contains.ts
@@ -13,7 +13,7 @@ export const containsConfig: FieldValidateConfig<ContainsArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Returns the input string if it contains the args substring value. This operations is case-sensitive',
+    description: 'Returns the input string if it contains the args substring value, otherwise returns null. This operations is case-sensitive',
     examples: [
         {
             args: { substr: 'ample' },

--- a/packages/data-mate/src/function-configs/string/contains.ts
+++ b/packages/data-mate/src/function-configs/string/contains.ts
@@ -13,7 +13,7 @@ export const containsConfig: FieldValidateConfig<ContainsArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Checks to see if string contains substring. This operations is case-sensitive',
+    description: 'Returns the input string if it contains the args substring value. This operations is case-sensitive',
     examples: [
         {
             args: { substr: 'ample' },

--- a/packages/data-mate/src/function-configs/string/decodeBase64.ts
+++ b/packages/data-mate/src/function-configs/string/decodeBase64.ts
@@ -12,7 +12,7 @@ export const decodeBase64Config: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Returns the base64-decoded version of the source string',
+    description: 'Returns the base64-decoded version of the input string',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/string/decodeBase64.ts
+++ b/packages/data-mate/src/function-configs/string/decodeBase64.ts
@@ -12,7 +12,7 @@ export const decodeBase64Config: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Converts a base64 hash back to its value',
+    description: 'Returns the base64-decoded version of the source string',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/string/decodeHex.ts
+++ b/packages/data-mate/src/function-configs/string/decodeHex.ts
@@ -12,7 +12,7 @@ export const decodeHexConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Converts a hexadecimal hash back to its value',
+    description: 'Returns a hexadecimal-decoded version of the source string',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/string/decodeHex.ts
+++ b/packages/data-mate/src/function-configs/string/decodeHex.ts
@@ -12,7 +12,7 @@ export const decodeHexConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Returns a hexadecimal-decoded version of the source string',
+    description: 'Returns the hexadecimal-decoded version of the input string',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/string/decodeURL.ts
+++ b/packages/data-mate/src/function-configs/string/decodeURL.ts
@@ -12,7 +12,7 @@ export const decodeURLConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Returns a url-decoded version of the source string',
+    description: 'Returns the url-decoded version of the input string',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/string/decodeURL.ts
+++ b/packages/data-mate/src/function-configs/string/decodeURL.ts
@@ -12,7 +12,7 @@ export const decodeURLConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'decodes a URL encoded value',
+    description: 'Returns a url-decoded version of the source string',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/string/encode.ts
+++ b/packages/data-mate/src/function-configs/string/encode.ts
@@ -19,7 +19,7 @@ export const encodeConfig: FieldTransformConfig<EncodeConfig> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Converts a value to a hash using a specified algorithm',
+    description: 'Returns a hashed version of the source string.  The hashing algorithm and digest must be specified in the args.',
     examples: [
         {
             args: { algo: 'sha256' },
@@ -101,12 +101,12 @@ export const encodeConfig: FieldTransformConfig<EncodeConfig> = {
         algo: {
             type: FieldType.String,
             array: false,
-            description: 'Which hashing algorithm to use'
+            description: 'The hashing algorithm applied to the input.'
         },
         digest: {
             type: FieldType.String,
             array: false,
-            description: 'Which hash digest to use, may be set to either "base64" or "hex", defaults to "hex". '
+            description: 'The hash digest applied to the input, may be set to either "base64" or "hex", defaults to "hex". '
             + 'Only used when algorithm is not base64, hex, or url'
         }
     },

--- a/packages/data-mate/src/function-configs/string/encode.ts
+++ b/packages/data-mate/src/function-configs/string/encode.ts
@@ -19,7 +19,7 @@ export const encodeConfig: FieldTransformConfig<EncodeConfig> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Returns a hashed version of the source string.  The hashing algorithm and digest must be specified in the args.',
+    description: 'Returns a hashed version of the input string.  The hashing algorithm and digest must be specified in the args.',
     examples: [
         {
             args: { algo: 'sha256' },

--- a/packages/data-mate/src/function-configs/string/encodeBase64.ts
+++ b/packages/data-mate/src/function-configs/string/encodeBase64.ts
@@ -13,7 +13,7 @@ export const encodeBase64Config: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Converts value to a base64 hash',
+    description: 'Returns a base64 hashed version of the input string',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/string/encodeHex.ts
+++ b/packages/data-mate/src/function-configs/string/encodeHex.ts
@@ -13,7 +13,7 @@ export const encodeHexConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Converts value to a hexadecimal hash',
+    description: 'Returns a hexadecimal hashed version of the input string.',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/string/encodeSHA.ts
+++ b/packages/data-mate/src/function-configs/string/encodeSHA.ts
@@ -22,7 +22,7 @@ export const encodeSHAConfig: FieldTransformConfig<EncodeSHAConfig> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Converts to a SHA encoded value',
+    description: 'Returns a SHA encoded version of the input string',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/string/encodeSHA.ts
+++ b/packages/data-mate/src/function-configs/string/encodeSHA.ts
@@ -22,7 +22,7 @@ export const encodeSHAConfig: FieldTransformConfig<EncodeSHAConfig> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Returns a SHA encoded version of the input string',
+    description: 'Returns a SHA encoded version of the input string.  Specify the hash algorithm and digest with the args options.',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/string/encodeSHA1.ts
+++ b/packages/data-mate/src/function-configs/string/encodeSHA1.ts
@@ -19,7 +19,7 @@ export const encodeSHA1Config: FieldTransformConfig<EncodeSHA1Config> = {
     name: 'encodeSHA1',
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
-    description: 'Converts to a SHA1 encoded value',
+    description: 'Returns a SHA1 encoded version of the input value',
     category: FunctionDefinitionCategory.STRING,
     examples: [
         {
@@ -35,7 +35,7 @@ export const encodeSHA1Config: FieldTransformConfig<EncodeSHA1Config> = {
             field: 'testField',
             input: '{ "some": "data" }',
             output: 'e8cb1404796eba6779a276377cce99a502a36481',
-            description: 'If digest is not provided, it defaults to hex'
+            description: 'If the digest is not provided, it defaults to hex'
         },
         {
             args: { digest: 'base64' },
@@ -60,7 +60,7 @@ export const encodeSHA1Config: FieldTransformConfig<EncodeSHA1Config> = {
         digest: {
             type: FieldType.String,
             array: false,
-            description: 'Which hash digest to use, may be set to either "base64" or "hex", defaults to "hex"'
+            description: 'Hash digest to used, may be set to either "base64" or "hex", defaults to "hex"'
         }
     },
     output_type(inputConfig: DataTypeFieldAndChildren): DataTypeFieldAndChildren {

--- a/packages/data-mate/src/function-configs/string/encodeURL.ts
+++ b/packages/data-mate/src/function-configs/string/encodeURL.ts
@@ -13,7 +13,7 @@ export const encodeURLConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Returns the URL encoded version of the input value',
+    description: 'Returns a URL encoded version of the input value',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/string/encodeURL.ts
+++ b/packages/data-mate/src/function-configs/string/encodeURL.ts
@@ -13,7 +13,7 @@ export const encodeURLConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'URL encodes a value',
+    description: 'Returns the URL encoded version of the input value',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/string/endsWith.ts
+++ b/packages/data-mate/src/function-configs/string/endsWith.ts
@@ -44,14 +44,14 @@ export const endsWithConfig: FieldValidateConfig<EndsWithArgs> = {
             output: 'other word'
         },
     ],
-    description: 'Validation that determines whether or not a string ends with another string. This is case-sensitive.',
+    description: 'Returns the input if it ends with the args value string, otherwise returns null. This is case-sensitive.',
     create({ args: { value } }) {
         return endsWithFP(value);
     },
     argument_schema: {
         value: {
             type: FieldType.String,
-            description: 'The value that must match at the end of the input string '
+            description: 'The value compared to the end of the input string '
         }
     },
     accepts: [FieldType.String],

--- a/packages/data-mate/src/function-configs/string/extract.ts
+++ b/packages/data-mate/src/function-configs/string/extract.ts
@@ -63,7 +63,7 @@ export const extractConfig: FieldTransformConfig<ExtractArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     category: FunctionDefinitionCategory.STRING,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
-    description: 'Extract values from strings',
+    description: 'Returns an extracted substring or an array of substrings from the input string',
     create({ args }) {
         return _extract(args);
     },

--- a/packages/data-mate/src/function-configs/string/isAlpha.ts
+++ b/packages/data-mate/src/function-configs/string/isAlpha.ts
@@ -74,14 +74,14 @@ export const isAlphaConfig: FieldValidateConfig<AlphaLocale> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Checks to see if input is a string composed of only alphabetical characters',
+    description: 'Returns the input if it is a string composed of only alphabetical characters, otherwise returns null.',
     create({ args: { locale } }) {
         return (input: unknown) => isAlpha(input, locale as validator.AlphaLocale);
     },
     argument_schema: {
         locale: {
             type: FieldType.String,
-            description: 'Specify locale to check for valid alphabetical characters, defaults to en-US if not provided'
+            description: 'Specify the locale to check for valid alphabetical characters, defaults to en-US if not provided'
         }
     },
     examples,

--- a/packages/data-mate/src/function-configs/string/isAlphaNumeric.ts
+++ b/packages/data-mate/src/function-configs/string/isAlphaNumeric.ts
@@ -74,7 +74,7 @@ export const isAlphaNumericConfig: FieldValidateConfig<AlphaNumericLocale> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Checks to see if input is a string composed of only alpha-numeric characters',
+    description: 'Returns the input if it is a string composed of only alpha-numeric characters, otherwise returns null.',
     create({ args: { locale } }) {
         return (input: unknown) => isAlphaNumeric(input, locale as validator.AlphanumericLocale);
     },

--- a/packages/data-mate/src/function-configs/string/isBase64.ts
+++ b/packages/data-mate/src/function-configs/string/isBase64.ts
@@ -56,7 +56,7 @@ export const isBase64Config: FieldValidateConfig = {
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
     examples,
-    description: 'Checks to see if input is a valid base64 string',
+    description: 'Returns the input if it is a valid base64 string, otherwise returns null.',
     create() { return isBase64; },
     accepts: [FieldType.String],
 };

--- a/packages/data-mate/src/function-configs/string/isCountryCode.ts
+++ b/packages/data-mate/src/function-configs/string/isCountryCode.ts
@@ -84,7 +84,7 @@ export const isCountryCodeConfig: FieldValidateConfig = {
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
     examples,
-    description: 'Checks to see if input is a valid ISO 3166-1 alpha-2 country code',
+    description: 'Returns the input if it is a valid ISO 3166-1 alpha-2 country code, otherwise returns null.',
     create() { return isCountryCode; },
     accepts: [FieldType.String]
 };

--- a/packages/data-mate/src/function-configs/string/isEmail.ts
+++ b/packages/data-mate/src/function-configs/string/isEmail.ts
@@ -139,7 +139,7 @@ export const isEmailConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Returns the input if it is a valid email format, otherwise returns null.',
+    description: 'Returns the input if it is a valid email formatted string, otherwise returns null.',
     examples,
     create() { return isEmail; },
     accepts: [FieldType.String],

--- a/packages/data-mate/src/function-configs/string/isEmail.ts
+++ b/packages/data-mate/src/function-configs/string/isEmail.ts
@@ -139,7 +139,7 @@ export const isEmailConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Checks to see if input is an email',
+    description: 'Returns the input if it is a valid email format, otherwise returns null.',
     examples,
     create() { return isEmail; },
     accepts: [FieldType.String],

--- a/packages/data-mate/src/function-configs/string/isFQDN.ts
+++ b/packages/data-mate/src/function-configs/string/isFQDN.ts
@@ -111,7 +111,7 @@ export const isFQDNConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Checks to see if input is a fully qualified domain name',
+    description: 'Returns the input if it is a fully qualified domain name, otherwise returns null.',
     examples,
     create() { return isFQDN; },
     accepts: [FieldType.String],

--- a/packages/data-mate/src/function-configs/string/isHash.ts
+++ b/packages/data-mate/src/function-configs/string/isHash.ts
@@ -46,7 +46,7 @@ export const isHashConfig: FieldValidateConfig<IsHashArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Checks to see if input is a hash',
+    description: 'Returns the input if it is a hashed value, otherwise returns null.',
     examples: [
         {
             args: { algo: 'sha256' },
@@ -73,7 +73,7 @@ export const isHashConfig: FieldValidateConfig<IsHashArgs> = {
         algo: {
             type: FieldType.String,
             array: false,
-            description: 'Which algorithm to check values against'
+            description: 'The hashing algorithm to check values against'
         }
     },
     required_arguments: ['algo'],

--- a/packages/data-mate/src/function-configs/string/isISDN.ts
+++ b/packages/data-mate/src/function-configs/string/isISDN.ts
@@ -73,7 +73,7 @@ export const isISDNConfig: FieldValidateConfig<ISDNCountry> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Checks to see if input is a valid phone number.  If the country arg is not provided then it is processed as an international formatted phone number',
+    description: 'Returns the input if it is a valid phone number.  If the country arg is not provided then it is processed as an international formatted phone number',
     create({ args: { country } }) {
         return (input: unknown) => isISDN(input, country);
     },

--- a/packages/data-mate/src/function-configs/string/isLength.ts
+++ b/packages/data-mate/src/function-configs/string/isLength.ts
@@ -17,7 +17,7 @@ export const isLengthConfig: FieldValidateConfig<LengthArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Checks to see if input either matches a certain length, or is within a range',
+    description: 'Returns the input if it either matches a certain length, or is within a range.  Otherwise returns null.',
     accepts: [FieldType.String],
     examples: [
         {
@@ -63,7 +63,7 @@ export const isLengthConfig: FieldValidateConfig<LengthArgs> = {
         size: {
             type: FieldType.Number,
             array: false,
-            description: "The value's length must exact match this parameter if specified"
+            description: "The value's length must equal this parameter if specified"
         },
         min: {
             type: FieldType.Number,
@@ -74,7 +74,7 @@ export const isLengthConfig: FieldValidateConfig<LengthArgs> = {
         max: {
             type: FieldType.Number,
             array: false,
-            description: "The value's length must be lesser than or equal to this parameter if specified"
+            description: "The value's length must be less than or equal to this parameter if specified"
         }
     },
     validate_arguments({ min, max, size }) {

--- a/packages/data-mate/src/function-configs/string/isLength.ts
+++ b/packages/data-mate/src/function-configs/string/isLength.ts
@@ -17,7 +17,7 @@ export const isLengthConfig: FieldValidateConfig<LengthArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Returns the input if it either matches a certain length, or is within a range.  Otherwise returns null.',
+    description: 'Returns the input if it either matches a certain length, or is within the specified range.  Otherwise returns null.',
     accepts: [FieldType.String],
     examples: [
         {

--- a/packages/data-mate/src/function-configs/string/isMACAddress.ts
+++ b/packages/data-mate/src/function-configs/string/isMACAddress.ts
@@ -90,7 +90,7 @@ export const isMACAddressConfig: FieldValidateConfig<IsMacArgs> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Checks to see if input is a valid mac address',
+    description: 'Returns the input if it is a valid mac address, otherwise returns null.',
     examples,
     create({ args: { delimiter } }) {
         return (input: unknown) => isString(input)

--- a/packages/data-mate/src/function-configs/string/isMACAddress.ts
+++ b/packages/data-mate/src/function-configs/string/isMACAddress.ts
@@ -100,7 +100,7 @@ export const isMACAddressConfig: FieldValidateConfig<IsMacArgs> = {
     argument_schema: {
         delimiter: {
             type: FieldType.String,
-            description: `Specify delimiter character for mac address format, may be set to one of ${joinList(delimiterOptions)}`,
+            description: `Specify delimiter character for the mac address format, may be set to one of ${joinList(delimiterOptions)}`,
         }
     },
     required_arguments: [],

--- a/packages/data-mate/src/function-configs/string/isMIMEType.ts
+++ b/packages/data-mate/src/function-configs/string/isMIMEType.ts
@@ -72,5 +72,5 @@ export const isMIMETypeConfig: FieldValidateConfig = {
     examples,
     accepts: [FieldType.String],
     create() { return isMIMEType; },
-    description: 'Checks to see if input is a valid Media or MIME (Multipurpose Internet Mail Extensions) Type',
+    description: 'Returns the input if it is a valid Media or MIME (Multipurpose Internet Mail Extensions) Type, otherwise returns null.',
 };

--- a/packages/data-mate/src/function-configs/string/isPhoneNumberLike.ts
+++ b/packages/data-mate/src/function-configs/string/isPhoneNumberLike.ts
@@ -84,7 +84,7 @@ export const isPhoneNumberLikeConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'A simplified phone number check that returns the input if it has the basic requirements of a phone number, otherwise returns null.',
+    description: 'A simplified phone number check that returns the input if it has the basic requirements of a phone number, otherwise returns null.  Useful if the phone number\'s country is not known',
     examples,
     create() { return isPhoneNumberLike; },
     accepts: [

--- a/packages/data-mate/src/function-configs/string/isPhoneNumberLike.ts
+++ b/packages/data-mate/src/function-configs/string/isPhoneNumberLike.ts
@@ -84,7 +84,7 @@ export const isPhoneNumberLikeConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Checks to see if input looks like a phone number',
+    description: 'A simplified phone number check that returns the input if it has the basic requirements of a phone number, otherwise returns null.',
     examples,
     create() { return isPhoneNumberLike; },
     accepts: [

--- a/packages/data-mate/src/function-configs/string/isPort.ts
+++ b/packages/data-mate/src/function-configs/string/isPort.ts
@@ -70,7 +70,7 @@ export const isPortConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Returns the input it it is a valid port, otherwise returns null.',
+    description: 'Returns the input it it is a valid TCP or UDP port, otherwise returns null.',
     examples,
     create() { return isPort; },
     accepts: [

--- a/packages/data-mate/src/function-configs/string/isPort.ts
+++ b/packages/data-mate/src/function-configs/string/isPort.ts
@@ -70,7 +70,7 @@ export const isPortConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Checks to see if input is a valid port',
+    description: 'Returns the input it it is a valid port, otherwise returns null.',
     examples,
     create() { return isPort; },
     accepts: [

--- a/packages/data-mate/src/function-configs/string/isPostalCode.ts
+++ b/packages/data-mate/src/function-configs/string/isPostalCode.ts
@@ -74,7 +74,7 @@ export const isPostalCodeConfig: FieldValidateConfig<PostalCodeLocale> = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Checks to see if input is a valid postal code',
+    description: 'Returns the input if it is a valid postal code, otherwise returns null.',
     examples,
     create({ args: { locale } }) {
         return (input: unknown) => isPostalCode(input, locale as validator.PostalCodeLocale);
@@ -82,7 +82,7 @@ export const isPostalCodeConfig: FieldValidateConfig<PostalCodeLocale> = {
     argument_schema: {
         locale: {
             type: FieldType.String,
-            description: 'Specify locale to check for postal code, defaults to any if locale is not provided'
+            description: 'Specify the locale to check for valid postal codes in specific regions, defaults to any if locale is not provided'
         }
     },
     accepts: [

--- a/packages/data-mate/src/function-configs/string/isString.ts
+++ b/packages/data-mate/src/function-configs/string/isString.ts
@@ -46,7 +46,7 @@ export const isStringConfig: FieldValidateConfig = {
             output: ['12345', 'some more stuff'],
         },
     ],
-    description: 'Checks to see if input is a string',
+    description: 'Returns the input if it is is a string, otherwise returns null.',
     create() { return isString; },
     accepts: [FieldType.String],
 };

--- a/packages/data-mate/src/function-configs/string/isURL.ts
+++ b/packages/data-mate/src/function-configs/string/isURL.ts
@@ -68,7 +68,7 @@ export const isURLConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Checks to see if input is a string',
+    description: 'Returns the input if it is a valid url string, otherwise returns null.',
     examples,
     create() { return isURL; },
     accepts: [FieldType.String]

--- a/packages/data-mate/src/function-configs/string/isUUID.ts
+++ b/packages/data-mate/src/function-configs/string/isUUID.ts
@@ -48,7 +48,7 @@ export const isUUIDConfig: FieldValidateConfig = {
     type: FunctionDefinitionType.FIELD_VALIDATION,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Checks to see if input is a UUID',
+    description: 'Returns the input if it is a valid UUID, otherwise returns null.',
     examples,
     create() { return isUUID; },
     accepts: [FieldType.String]

--- a/packages/data-mate/src/function-configs/string/join.ts
+++ b/packages/data-mate/src/function-configs/string/join.ts
@@ -73,7 +73,7 @@ export const joinConfig: FieldTransformConfig<JoinArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.FULL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Converts an array of string values joins by the delimiter provided',
+    description: 'Returns a string from an array of values joined by the delimiter.',
     examples,
     create({ args: { delimiter = '' } }) {
         return joinFn(delimiter);

--- a/packages/data-mate/src/function-configs/string/replaceLiteral.ts
+++ b/packages/data-mate/src/function-configs/string/replaceLiteral.ts
@@ -32,7 +32,7 @@ export const replaceLiteralConfig: FieldTransformConfig<ReplaceLiteralArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Replaces the searched value with the replace value',
+    description: 'Returns a string with the searched value replaced by the replace value',
     examples,
     create({ args: { replace, search } }) {
         return (input: unknown) => replaceFn(input as string, search, replace);
@@ -47,7 +47,7 @@ export const replaceLiteralConfig: FieldTransformConfig<ReplaceLiteralArgs> = {
         replace: {
             type: FieldType.String,
             array: false,
-            description: 'the value that will replace what is set in search'
+            description: 'The value that will replace what is set in search'
         }
     },
     required_arguments: ['search', 'replace']

--- a/packages/data-mate/src/function-configs/string/replaceLiteral.ts
+++ b/packages/data-mate/src/function-configs/string/replaceLiteral.ts
@@ -42,7 +42,7 @@ export const replaceLiteralConfig: FieldTransformConfig<ReplaceLiteralArgs> = {
         search: {
             type: FieldType.String,
             array: false,
-            description: 'The word that will be replaced'
+            description: 'The characters that will be replaced'
         },
         replace: {
             type: FieldType.String,

--- a/packages/data-mate/src/function-configs/string/replaceRegex.ts
+++ b/packages/data-mate/src/function-configs/string/replaceRegex.ts
@@ -50,7 +50,7 @@ export const replaceLRegexConfig: FieldTransformConfig<ReplaceRegexArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'This function replaces chars in a string based off the regex value provided',
+    description: 'Returns a string with the characters matched by the regex replaced with the args replace value',
     create({
         args: {
             replace,
@@ -72,7 +72,7 @@ export const replaceLRegexConfig: FieldTransformConfig<ReplaceRegexArgs> = {
         replace: {
             type: FieldType.String,
             array: false,
-            description: 'the value that will replace what is found by the regex'
+            description: 'The value that will replace what is found by the regex'
         },
         ignoreCase: {
             type: FieldType.Boolean,

--- a/packages/data-mate/src/function-configs/string/reverse.ts
+++ b/packages/data-mate/src/function-configs/string/reverse.ts
@@ -53,7 +53,7 @@ export const reverseConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'reverses the string value',
+    description: 'Returns the input string with its characters in reverse order.',
     examples,
     create() {
         return _reverse;

--- a/packages/data-mate/src/function-configs/string/split.ts
+++ b/packages/data-mate/src/function-configs/string/split.ts
@@ -45,7 +45,7 @@ export const splitConfig: FieldTransformConfig<SplitArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Converts a string to an array of characters split by the delimiter provided, defaults to splitting up every char',
+    description: 'Returns an array based off the input split by the args delimiter, defaults to splitting each character',
     examples,
     create({ args: { delimiter = '' } }) {
         return splitFn(delimiter);

--- a/packages/data-mate/src/function-configs/string/split.ts
+++ b/packages/data-mate/src/function-configs/string/split.ts
@@ -45,7 +45,7 @@ export const splitConfig: FieldTransformConfig<SplitArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Returns an array based off the input split by the args delimiter, defaults to splitting each character',
+    description: 'Returns an array based off the input split by the args delimiter, defaults to splitting by each character',
     examples,
     create({ args: { delimiter = '' } }) {
         return splitFn(delimiter);

--- a/packages/data-mate/src/function-configs/string/startsWith.ts
+++ b/packages/data-mate/src/function-configs/string/startsWith.ts
@@ -51,7 +51,7 @@ export const startsWithConfig: FieldValidateConfig<StartsWithArgs> = {
             output: null
         },
     ],
-    description: 'Validation that determines whether or not a string begins with another string. This is case-sensitive.',
+    description: 'Returns the input if it begins with the args value string. This is case-sensitive.',
     create({ args: { value } }) {
         return startsWithFP(value);
     },

--- a/packages/data-mate/src/function-configs/string/toISDN.ts
+++ b/packages/data-mate/src/function-configs/string/toISDN.ts
@@ -53,7 +53,7 @@ export const toISDNConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Parses a string or number to a fully validated phone number',
+    description: 'Converts the input to the ISDN format, if it is a valid phone number.  Otherwise returns null.',
     examples,
     create() {
         return (input: unknown) => parsePhoneNumber(input as string);

--- a/packages/data-mate/src/function-configs/string/toKebabCase.ts
+++ b/packages/data-mate/src/function-configs/string/toKebabCase.ts
@@ -12,7 +12,7 @@ export const toKebabCaseConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Converts on ore more words into a single word joined by dashes',
+    description: 'Converts one or more words into a single word joined by dashes',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/string/toString.ts
+++ b/packages/data-mate/src/function-configs/string/toString.ts
@@ -45,7 +45,7 @@ export const toStringConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Converts input values to strings',
+    description: 'Converts the input value to a string.  If the input is an array each array item will be converted to a string.',
     examples,
     create({ inputConfig }) {
         if (inputConfig?.field_config.type === FieldType.Date) {

--- a/packages/data-mate/src/function-configs/string/toTitleCase.ts
+++ b/packages/data-mate/src/function-configs/string/toTitleCase.ts
@@ -12,7 +12,7 @@ export const toTitleCaseConfig: FieldTransformConfig = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Converts one or more words into a whitespace separated word with each word starting with a capital letter',
+    description: 'Converts one or more words into a whitespace separated string with each word starting with a capital letter',
     examples: [
         {
             args: {},

--- a/packages/data-mate/src/function-configs/string/trimStart.ts
+++ b/packages/data-mate/src/function-configs/string/trimStart.ts
@@ -50,7 +50,7 @@ export const trimStartConfig: FieldTransformConfig<TrimStartArgs> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Trims whitespace or characters from start of a string',
+    description: 'Trims whitespace or characters from the start of a string',
     examples,
     create({ args: { chars } }) {
         return trimStartFP(chars);

--- a/packages/data-mate/src/function-configs/string/truncate.ts
+++ b/packages/data-mate/src/function-configs/string/truncate.ts
@@ -16,7 +16,7 @@ export const truncateConfig: FieldTransformConfig<TruncateConfig> = {
     type: FunctionDefinitionType.FIELD_TRANSFORM,
     process_mode: ProcessMode.INDIVIDUAL_VALUES,
     category: FunctionDefinitionCategory.STRING,
-    description: 'Limits the size of string to a specific length, if the length is greater than the specified size, the excess is removed',
+    description: 'Limits the size of the input string to a specific length, if the length is greater than the specified size, the excess is removed',
     examples: [
         {
             args: { size: 4 },

--- a/packages/types/src/dates.ts
+++ b/packages/types/src/dates.ts
@@ -8,7 +8,7 @@ export enum ISO8601DateSegment {
     yearly = 'yearly',
 }
 
-export type TimeBetweenFormats = 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days' | 'calendarDays' | 'businessDays' | 'weeks' | 'calendarWeeks' | 'months' | 'calendarMonths' | 'quarters' | 'calendarQuarters' | 'years' | 'calendarYears' | 'calendarISOWeekYears' | 'ISOWeekYears' | 'ISODuration';
+export type TimeBetweenIntervals = 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days' | 'calendarDays' | 'businessDays' | 'weeks' | 'calendarWeeks' | 'months' | 'calendarMonths' | 'quarters' | 'calendarQuarters' | 'years' | 'calendarYears' | 'calendarISOWeekYears' | 'ISOWeekYears' | 'ISO8601';
 
 /**
  * A storage format for a date tuple, the first time is the

--- a/packages/utils/src/dates.ts
+++ b/packages/utils/src/dates.ts
@@ -36,7 +36,7 @@ import {
 import {
     DateFormat,
     ISO8601DateSegment,
-    TimeBetweenFormats,
+    TimeBetweenIntervals,
     DateTuple
 } from '@terascope/types';
 import { getTimezoneOffset as tzOffset } from 'date-fns-tz';
@@ -415,7 +415,7 @@ export function formatDateValue(
     return toISO8601(value);
 }
 
-const _getDurationFunc = {
+export const getDurationFunc = {
     milliseconds: differenceInMilliseconds,
     seconds: differenceInSeconds,
     minutes: differenceInMinutes,
@@ -438,14 +438,14 @@ const _getDurationFunc = {
 export interface GetTimeBetweenArgs {
     start?: Date | string | number;
     end?: Date | string | number;
-    format: TimeBetweenFormats;
+    interval: TimeBetweenIntervals;
 }
 
 export function getTimeBetween(
     input: unknown,
     args: GetTimeBetweenArgs
 ): string | number {
-    const { format, start, end } = args;
+    const { interval, start, end } = args;
 
     if (start == null && end == null) {
         throw Error('Must provide a start or an end argument');
@@ -471,14 +471,14 @@ export function getTimeBetween(
         throw Error('Could not parse date values into dates');
     }
 
-    if (format === 'ISODuration') {
+    if (interval === 'ISO8601') {
         return formatISODuration(intervalToDuration({
             start: date1,
             end: date2
         }));
     }
 
-    return _getDurationFunc[format](date2, date1);
+    return getDurationFunc[interval](date2, date1);
 }
 
 /**

--- a/packages/utils/test/dates-spec.ts
+++ b/packages/utils/test/dates-spec.ts
@@ -128,7 +128,7 @@ describe('date utils', () => {
             ['2021-05-10T10:00:00.000Z', '2019-05-10T11:01:33.192Z', 'calendarYears', 2],
             ['2021-05-10T10:00:00.000Z', '2019-05-10T11:01:33.192Z', 'calendarISOWeekYears', 2],
             ['2021-05-10T10:00:00.000Z', '2019-05-10T11:01:33.192Z', 'ISOWeekYears', 1],
-            ['2021-05-10T10:00:00.000Z', '2010-01-09T11:01:33.192Z', 'ISODuration', 'P11Y4M0DT22H58M26S']
+            ['2021-05-10T10:00:00.000Z', '2010-01-09T11:01:33.192Z', 'ISO8601', 'P11Y4M0DT22H58M26S']
         ])('should return duration between %p and %p, in %p as %p for start values', (input, start, interval, expected) => {
             const args: { start: any, interval: any } = { start, interval };
 
@@ -153,7 +153,7 @@ describe('date utils', () => {
             ['2021-05-10T10:00:00.000Z', '2024-05-10T11:01:33.192Z', 'calendarYears', 3],
             ['2021-05-10T10:00:00.000Z', '2028-05-10T11:01:33.192Z', 'calendarISOWeekYears', 7],
             ['2021-05-10T10:00:00.000Z', '2024-05-10T11:01:33.192Z', 'ISOWeekYears', 3],
-            ['2021-05-10T10:00:00.000Z', '2023-01-09T18:19:23.132Z', 'ISODuration', 'P1Y7M30DT8H19M23S']
+            ['2021-05-10T10:00:00.000Z', '2023-01-09T18:19:23.132Z', 'ISO8601', 'P1Y7M30DT8H19M23S']
         ])('should return duration between %p and %p, in %p as %p for end values', (input, end, interval, expected) => {
             const args: { end: any, interval: any } = { end, interval };
 

--- a/packages/utils/test/dates-spec.ts
+++ b/packages/utils/test/dates-spec.ts
@@ -129,8 +129,8 @@ describe('date utils', () => {
             ['2021-05-10T10:00:00.000Z', '2019-05-10T11:01:33.192Z', 'calendarISOWeekYears', 2],
             ['2021-05-10T10:00:00.000Z', '2019-05-10T11:01:33.192Z', 'ISOWeekYears', 1],
             ['2021-05-10T10:00:00.000Z', '2010-01-09T11:01:33.192Z', 'ISODuration', 'P11Y4M0DT22H58M26S']
-        ])('should return duration between %p and %p, in %p as %p for start values', (input, start, format, expected) => {
-            const args: { start: any, format: any } = { start, format };
+        ])('should return duration between %p and %p, in %p as %p for start values', (input, start, interval, expected) => {
+            const args: { start: any, interval: any } = { start, interval };
 
             expect(getTimeBetween(input, args)).toBe(expected);
         });
@@ -154,8 +154,8 @@ describe('date utils', () => {
             ['2021-05-10T10:00:00.000Z', '2028-05-10T11:01:33.192Z', 'calendarISOWeekYears', 7],
             ['2021-05-10T10:00:00.000Z', '2024-05-10T11:01:33.192Z', 'ISOWeekYears', 3],
             ['2021-05-10T10:00:00.000Z', '2023-01-09T18:19:23.132Z', 'ISODuration', 'P1Y7M30DT8H19M23S']
-        ])('should return duration between %p and %p, in %p as %p for end values', (input, end, format, expected) => {
-            const args: { end: any, format: any } = { end, format };
+        ])('should return duration between %p and %p, in %p as %p for end values', (input, end, interval, expected) => {
+            const args: { end: any, interval: any } = { end, interval };
 
             expect(getTimeBetween(input, args)).toBe(expected);
         });
@@ -167,24 +167,24 @@ describe('date utils', () => {
             [1620764444501, '2028-05-10', 'milliseconds', 220765155499],
             [1620764444501, '05/10/2028 UTC', 'milliseconds', 220765155499],
             [new Date(1620764444501), new Date('2028-05-10T11:01:33.192Z'), 'milliseconds', 220804848691],
-        ])('should return duration between %p and %p, in %p as %p for different date formats', (input, end, format, expected) => {
-            const args: { end: any, format: any } = { end, format };
+        ])('should return duration between %p and %p, in %p as %p for different date intervals', (input, end, interval, expected) => {
+            const args: { end: any, interval: any } = { end, interval };
 
             expect(getTimeBetween(input, args)).toBe(expected);
         });
 
         it('should throw if end and start are missing', () => {
-            expect(() => { getTimeBetween('2021-05-10T10:00:00.000Z', { format: 'seconds' }); })
+            expect(() => { getTimeBetween('2021-05-10T10:00:00.000Z', { interval: 'seconds' }); })
                 .toThrowError('Must provide a start or an end argument');
         });
 
         it('should throw if input is an invalid date', () => {
-            expect(() => { getTimeBetween('bad date', { start: 1715472000000, format: 'seconds' }); })
+            expect(() => { getTimeBetween('bad date', { start: 1715472000000, interval: 'seconds' }); })
                 .toThrowError('Could not parse date values into dates');
         });
 
         it('should throw if start or end arg is an invalid date', () => {
-            expect(() => { getTimeBetween('1715472000000', { start: 'bad date', format: 'seconds' }); })
+            expect(() => { getTimeBetween('1715472000000', { start: 'bad date', interval: 'seconds' }); })
                 .toThrowError('Could not parse date values into dates');
         });
     });


### PR DESCRIPTION
* Tried to use same verbiage for functions
    * basic formula was `Returns x if y` where applicable
* Tried to simplify where obvious 
* Found some typos, there are probably more
* Focused on the function descriptions and args
* Changed all the `set` date function arg to `value` instead of `second` or `year`, etc...