### PR TITLE
Fix no tests in ts-scripts

### DIFF
--- a/e2e/test/download-assets.js
+++ b/e2e/test/download-assets.js
@@ -79,11 +79,7 @@ function filterRelease(release) {
 
 function filterAsset(asset) {
     // if it includes the bundle choose that
-    if (asset.name.includes(`node-${nodeVersion}-bundle.zip`)) {
-        return true;
-    }
-    const mustContain = `node-${nodeVersion}-linux-x64.zip`;
-    return asset.name.includes(mustContain);
+    return asset.name.includes(`node-${nodeVersion}-bundle.zip`);
 }
 
 function listAssets() {

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.29.3",
+    "version": "0.29.4",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -29,9 +29,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.30.3",
+        "@terascope/data-types": "^0.30.4",
         "@terascope/types": "^0.10.0",
-        "@terascope/utils": "^0.40.3",
+        "@terascope/utils": "^0.40.4",
         "date-fns": "^2.22.1",
         "ip-bigint": "^3.0.3",
         "ip6addr": "^0.2.3",
@@ -43,7 +43,7 @@
         "uuid": "^8.3.2",
         "valid-url": "^1.0.9",
         "validator": "^13.6.0",
-        "xlucene-parser": "^0.37.3"
+        "xlucene-parser": "^0.37.4"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.2",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.30.3",
+    "version": "0.30.4",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.0",
-        "@terascope/utils": "^0.40.3",
+        "@terascope/utils": "^0.40.4",
         "graphql": "^15.5.0",
         "lodash": "^4.17.21",
         "yargs": "^17.0.1"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.21.3",
+    "version": "2.21.4",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.40.3",
+        "@terascope/utils": "^0.40.4",
         "bluebird": "^3.7.2"
     },
     "devDependencies": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.51.3",
+    "version": "0.51.4",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,13 +24,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.29.3",
-        "@terascope/data-types": "^0.30.3",
+        "@terascope/data-mate": "^0.29.4",
+        "@terascope/data-types": "^0.30.4",
         "@terascope/types": "^0.10.0",
-        "@terascope/utils": "^0.40.3",
+        "@terascope/utils": "^0.40.4",
         "ajv": "^6.12.6",
         "uuid": "^8.3.2",
-        "xlucene-translator": "^0.21.3"
+        "xlucene-translator": "^0.21.4"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.0",

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.19.3",
+    "version": "0.19.4",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.40.3",
+        "@terascope/utils": "^0.40.4",
         "chalk": "^4.1.1",
         "lodash": "^4.17.21",
         "yeoman-generator": "^4.13.0",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.52.3",
+    "version": "0.52.4",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.40.3",
+        "@terascope/utils": "^0.40.4",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^8.3.2"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.38.3",
+    "version": "0.38.4",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^4.0.0",
-        "@terascope/utils": "^0.40.3",
+        "@terascope/utils": "^0.40.4",
         "codecov": "^3.8.2",
         "execa": "^5.1.0",
         "fs-extra": "^9.1.0",

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -72,6 +72,8 @@ export const MAX_PROJECTS_PER_BATCH = toIntegerOrThrow(process.env.MAX_PROJECTS_
 const reportCov = process.env.REPORT_COVERAGE || `${isCI}`;
 export const REPORT_COVERAGE = toBoolean(reportCov);
 
-export const JEST_MAX_WORKERS = process.env.JEST_MAX_WORKERS || undefined;
+export const JEST_MAX_WORKERS = process.env.JEST_MAX_WORKERS
+    ? toIntegerOrThrow(process.env.JEST_MAX_WORKERS)
+    : undefined;
 
 export const NPM_DEFAULT_REGISTRY = 'https://registry.npmjs.org/';

--- a/packages/scripts/src/helpers/test-runner/utils.ts
+++ b/packages/scripts/src/helpers/test-runner/utils.ts
@@ -41,8 +41,8 @@ export function getArgs(options: TestOptions): ArgsMap {
         args.runInBand = '';
     } else {
         args.silent = '';
-        if (config.JEST_MAX_WORKERS) {
-            args.maxWorkers = config.JEST_MAX_WORKERS;
+        if (config.JEST_MAX_WORKERS != null) {
+            args.maxWorkers = String(config.JEST_MAX_WORKERS);
         }
     }
 

--- a/packages/scripts/src/helpers/test-runner/utils.ts
+++ b/packages/scripts/src/helpers/test-runner/utils.ts
@@ -25,7 +25,6 @@ const logger = debugLogger('ts-scripts:cmd:test');
 export function getArgs(options: TestOptions): ArgsMap {
     const args: ArgsMap = {};
     args.forceExit = '';
-    args.passWithNoTests = '';
     args.coverage = 'true';
     if (config.FORCE_COLOR === '1') {
         args.color = '';

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.33.3",
+    "version": "0.33.4",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.40.3",
+        "@terascope/utils": "^0.40.4",
         "aws-sdk": "^2.874.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.15",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.44.3",
+    "version": "0.44.4",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.7.7",
-        "@terascope/utils": "^0.40.3",
+        "@terascope/utils": "^0.40.4",
         "chalk": "^4.1.1",
         "cli-table3": "^0.6.0",
         "easy-table": "^1.1.1",
@@ -49,7 +49,7 @@
         "pretty-bytes": "^5.6.0",
         "prompts": "^2.4.1",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.40.3",
+        "teraslice-client-js": "^0.40.4",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.3",
         "yargs": "^17.0.1",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.40.3",
+    "version": "0.40.4",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.52.3",
+        "@terascope/job-components": "^0.52.4",
         "auto-bind": "^4.0.0",
         "got": "^11.8.2"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.23.3",
+    "version": "0.23.4",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/utils": "^0.40.3",
+        "@terascope/utils": "^0.40.4",
         "ms": "^2.1.3",
         "nanoid": "^3.1.21",
         "p-event": "^4.2.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.52.3"
+        "@terascope/job-components": "^0.52.4"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.52.3"
+        "@terascope/job-components": "^0.52.4"
     },
     "engines": {
         "node": "^12.20.0 || >=14.17.0",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.29.3",
+    "version": "0.29.4",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.21.3",
-        "@terascope/utils": "^0.40.3"
+        "@terascope/elasticsearch-api": "^2.21.4",
+        "@terascope/utils": "^0.40.4"
     },
     "engines": {
         "node": "^12.20.0 || >=14.17.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^9.1.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.52.3"
+        "@terascope/job-components": "^0.52.4"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.52.3"
+        "@terascope/job-components": "^0.52.4"
     },
     "engines": {
         "node": "^12.20.0 || >=14.17.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.21.3",
-        "@terascope/job-components": "^0.52.3",
-        "@terascope/teraslice-messaging": "^0.23.3",
-        "@terascope/utils": "^0.40.3",
+        "@terascope/elasticsearch-api": "^2.21.4",
+        "@terascope/job-components": "^0.52.4",
+        "@terascope/teraslice-messaging": "^0.23.4",
+        "@terascope/utils": "^0.40.4",
         "async-mutex": "^0.3.1",
         "barbe": "^3.0.16",
         "body-parser": "^1.19.0",
@@ -61,7 +61,7 @@
         "semver": "^7.3.5",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.33.3",
+        "terafoundation": "^0.33.4",
         "uuid": "^8.3.2"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.58.3",
+    "version": "0.58.4",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.29.3",
+        "@terascope/data-mate": "^0.29.4",
         "@terascope/types": "^0.10.0",
-        "@terascope/utils": "^0.40.3",
+        "@terascope/utils": "^0.40.4",
         "awesome-phonenumber": "^2.53.0",
         "graphlib": "^2.1.8",
         "is-ip": "^3.1.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.40.3",
+    "version": "0.40.4",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/dates.ts
+++ b/packages/utils/src/dates.ts
@@ -2,37 +2,35 @@ import validator from 'validator';
 import parser from 'datemath-parser';
 import parseDate from 'date-fns/parse';
 import formatDate from 'date-fns/lightFormat';
-import {
-    differenceInMilliseconds,
-    differenceInSeconds,
-    differenceInMinutes,
-    differenceInHours,
-    differenceInDays,
-    differenceInCalendarDays,
-    differenceInBusinessDays,
-    differenceInWeeks,
-    differenceInCalendarISOWeeks,
-    differenceInMonths,
-    differenceInCalendarMonths,
-    differenceInQuarters,
-    differenceInCalendarQuarters,
-    differenceInYears,
-    differenceInCalendarYears,
-    differenceInCalendarISOWeekYears,
-    differenceInISOWeekYears,
-    intervalToDuration,
-    formatISODuration,
-    isFuture as _isFuture,
-    isPast as _isPast,
-    isLeapYear as _isLeapYear,
-    isToday as _isToday,
-    isTomorrow as _isTomorrow,
-    isYesterday as _isYesterday,
-    add,
-    sub,
-    isBefore as _isBefore,
-    isAfter as _isAfter
-} from 'date-fns';
+import differenceInMilliseconds from 'date-fns/differenceInMilliseconds';
+import differenceInSeconds from 'date-fns/differenceInSeconds';
+import differenceInMinutes from 'date-fns/differenceInMinutes';
+import differenceInHours from 'date-fns/differenceInHours';
+import differenceInDays from 'date-fns/differenceInDays';
+import differenceInCalendarDays from 'date-fns/differenceInCalendarDays';
+import differenceInBusinessDays from 'date-fns/differenceInBusinessDays';
+import differenceInWeeks from 'date-fns/differenceInWeeks';
+import differenceInCalendarISOWeeks from 'date-fns/differenceInCalendarISOWeeks';
+import differenceInCalendarISOWeekYears from 'date-fns/differenceInCalendarISOWeekYears';
+import differenceInMonths from 'date-fns/differenceInMonths';
+import differenceInCalendarMonths from 'date-fns/differenceInCalendarMonths';
+import differenceInQuarters from 'date-fns/differenceInQuarters';
+import differenceInCalendarQuarters from 'date-fns/differenceInCalendarQuarters';
+import differenceInYears from 'date-fns/differenceInYears';
+import differenceInCalendarYears from 'date-fns/differenceInCalendarYears';
+import differenceInISOWeekYears from 'date-fns/differenceInISOWeekYears';
+import intervalToDuration from 'date-fns/intervalToDuration';
+import formatISODuration from 'date-fns/formatISODuration';
+import _isFuture from 'date-fns/isFuture';
+import _isPast from 'date-fns/isPast';
+import _isLeapYear from 'date-fns/isLeapYear';
+import _isToday from 'date-fns/isToday';
+import _isTomorrow from 'date-fns/isTomorrow';
+import _isYesterday from 'date-fns/isYesterday';
+import add from 'date-fns/add';
+import sub from 'date-fns/sub';
+import _isBefore from 'date-fns/isBefore';
+import _isAfter from 'date-fns/isAfter';
 import {
     DateFormat,
     ISO8601DateSegment,
@@ -40,7 +38,7 @@ import {
     DateInputTypes,
     GetTimeBetweenArgs
 } from '@terascope/types';
-import { getTimezoneOffset as tzOffset } from 'date-fns-tz';
+import tzOffset from 'date-fns-tz/getTimezoneOffset';
 import { getTypeOf } from './deps';
 import {
     bigIntToJSON, isNumber, toInteger, isInteger, inNumberRange

--- a/packages/utils/src/event-loop.ts
+++ b/packages/utils/src/event-loop.ts
@@ -68,7 +68,7 @@ export class EventLoop {
             this.checkedInDiff = now - this.checkedIn;
             this.checkedIn = now;
             if (this.blocked) {
-                this.logger.debug(`* EVENT LOOP IS PROBABLY BLOCKED (${toHumanTime(this.checkedInDiff)} diff) *`);
+                this.logger?.warn(`* EVENT LOOP IS PROBABLY BLOCKED (${toHumanTime(this.checkedInDiff)} diff) *`);
             }
         }, this.heartbeat);
 

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.37.3",
+    "version": "0.37.4",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.0",
-        "@terascope/utils": "^0.40.3",
+        "@terascope/utils": "^0.40.4",
         "netmask": "^2.0.2"
     },
     "devDependencies": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.21.3",
+    "version": "0.21.4",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,8 +29,8 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.0",
-        "@terascope/utils": "^0.40.3",
-        "xlucene-parser": "^0.37.3"
+        "@terascope/utils": "^0.40.4",
+        "xlucene-parser": "^0.37.4"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.40.3"
+        "@terascope/utils": "^0.40.4"
     },
     "devDependencies": {
         "@terascope/types": "^0.10.0"


### PR DESCRIPTION
- Only download the bundled assets in the e2e tests - this should speed them up
- Fix validation of `JEST_MAX_WORKERS` env
- Don't allow the tests to pass if none ran
- Fixes to EventLoop when logger gets deferenced
- Make tree shaking a little easier when requiring date-fns

Closes https://github.com/terascope/teraslice/issues/2819