### PR TITLE
Allow passing in a parsed xLucene query to DataFrame.search

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.29.4",
+    "version": "0.30.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -43,7 +43,7 @@
         "uuid": "^8.3.2",
         "valid-url": "^1.0.9",
         "validator": "^13.6.0",
-        "xlucene-parser": "^0.37.4"
+        "xlucene-parser": "^0.38.0"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.2",

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -5,6 +5,7 @@ import {
     DataTypeFields, DataTypeFieldConfig,
     xLuceneVariables,
 } from '@terascope/types';
+import { Node as xLuceneNode } from 'xlucene-parser';
 import {
     DataEntity, TSError,
     getTypeOf, isFunction,
@@ -408,8 +409,12 @@ export class DataFrame<
     /**
      * Search the DataFrame using an xLucene query
     */
-    search(query: string, variables?: xLuceneVariables): DataFrame<T> {
-        const matcher = buildSearchMatcherForQuery(this, query, variables);
+    search(
+        query: string,
+        variables?: xLuceneVariables,
+        _overrideParsedQuery?: xLuceneNode,
+    ): DataFrame<T> {
+        const matcher = buildSearchMatcherForQuery(this, query, variables, _overrideParsedQuery);
         return this.filterBy(matcher);
     }
 

--- a/packages/data-mate/src/data-frame/search-utils.ts
+++ b/packages/data-mate/src/data-frame/search-utils.ts
@@ -8,9 +8,15 @@ import type { DataFrame } from './DataFrame';
 export function buildSearchMatcherForQuery(
     frame: DataFrame<any>,
     query: string,
-    variables?: xLuceneVariables
+    variables?: xLuceneVariables,
+    _overrideParsedQuery?: p.Node
 ): BooleanCB {
-    const parser = new p.Parser(query, { type_config: frameToXluceneConfig(frame) });
+    const parser = new p.Parser(
+        query,
+        { type_config: frameToXluceneConfig(frame) },
+        _overrideParsedQuery
+    );
+
     if (variables) {
         return buildLogicFn(
             parser.resolveVariables(variables),

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.51.5",
+    "version": "0.52.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.29.4",
+        "@terascope/data-mate": "^0.30.0",
         "@terascope/data-types": "^0.30.4",
         "@terascope/types": "^0.10.0",
         "@terascope/utils": "^0.40.4",

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -30,7 +30,7 @@
         "@terascope/utils": "^0.40.4",
         "ajv": "^6.12.6",
         "uuid": "^8.3.2",
-        "xlucene-translator": "^0.21.4"
+        "xlucene-translator": "^0.22.0"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.0",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.58.4",
+    "version": "0.59.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.29.4",
+        "@terascope/data-mate": "^0.30.0",
         "@terascope/types": "^0.10.0",
         "@terascope/utils": "^0.40.4",
         "awesome-phonenumber": "^2.54.0",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.37.4",
+    "version": "0.38.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-parser/src/cached-parser.ts
+++ b/packages/xlucene-parser/src/cached-parser.ts
@@ -1,4 +1,4 @@
-import { ParserOptions } from './interfaces';
+import { ParserOptions, Node } from './interfaces';
 import { Parser } from './parser';
 
 type Cached = Map<string, Parser>;
@@ -9,7 +9,7 @@ export class CachedParser {
         _cache.set(this, new Map());
     }
 
-    make(query: string, options?: ParserOptions): Parser {
+    make(query: string, options?: ParserOptions, _overrideParsedQuery?: Node): Parser {
         const typeConfigKey = options?.type_config ? JSON.stringify(options.type_config) : '';
         const key = `${query}${typeConfigKey}`;
 
@@ -17,7 +17,7 @@ export class CachedParser {
         const cachedParser = cached.get(key);
         if (cachedParser) return cachedParser;
 
-        const parsed = new Parser(query, options);
+        const parsed = new Parser(query, options, _overrideParsedQuery);
         cached.set(key, parsed);
         return parsed;
     }

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.21.4",
+    "version": "0.22.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -30,7 +30,7 @@
     "dependencies": {
         "@terascope/types": "^0.10.0",
         "@terascope/utils": "^0.40.4",
-        "xlucene-parser": "^0.37.4"
+        "xlucene-parser": "^0.38.0"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xlucene-translator/src/query-access/query-access.ts
+++ b/packages/xlucene-translator/src/query-access/query-access.ts
@@ -74,7 +74,7 @@ export class QueryAccess<T extends ts.AnyObject = ts.AnyObject> {
      *
      * @returns a restricted xlucene query
      */
-    private _restrict(q: string): p.Parser {
+    private _restrict(q: string, _overrideParsedQuery?: p.Node): p.Parser {
         let parser: p.Parser;
 
         const parserOptions: p.ParserOptions = {
@@ -82,7 +82,7 @@ export class QueryAccess<T extends ts.AnyObject = ts.AnyObject> {
         };
 
         try {
-            parser = this._parser.make(q, parserOptions);
+            parser = this._parser.make(q, parserOptions, _overrideParsedQuery);
         } catch (err) {
             throw new ts.TSError(err, {
                 reason: 'Query could not be parsed',
@@ -180,7 +180,8 @@ export class QueryAccess<T extends ts.AnyObject = ts.AnyObject> {
      */
     async restrictSearchQuery(
         query: string,
-        opts: i.RestrictSearchQueryOptions = {}
+        opts: i.RestrictSearchQueryOptions = {},
+        _overrideParsedQuery?: p.Node
     ): Promise<es.SearchParams> {
         const {
             params: _params = {},
@@ -195,7 +196,7 @@ export class QueryAccess<T extends ts.AnyObject = ts.AnyObject> {
         }
         const params = { ..._params };
 
-        const parser = this._restrict(query);
+        const parser = this._restrict(query, _overrideParsedQuery);
 
         await ts.pImmediate();
 


### PR DESCRIPTION
- Add support for using a cached xLucene query in DataFrame.search
- bump: (minor) @terascope/data-mate@0.30.0, elasticsearch-store@0.52.0
