### PR TITLE
Teraslice cli asset error message improvement

### DIFF
--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.44.6",
+    "version": "0.44.7",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"

--- a/packages/teraslice-cli/src/cmds/assets/deploy.ts
+++ b/packages/teraslice-cli/src/cmds/assets/deploy.ts
@@ -120,7 +120,11 @@ export = {
             try {
                 assetPath = await asset.download(cliConfig.assetDir, cliConfig.args.quiet);
             } catch (err) {
-                reply.fatal(`Unable to download ${cliConfig.args.asset}, you can download a prerelease asset by specifying its version.\n\nExample:\n\t${cliConfig.args.asset}@v1.2.3`);
+                if (!asset.version) {
+                    reply.fatal(`Unable to download ${cliConfig.args.asset}, you can download a prerelease asset by specifying its version.\n\nExample:\n\t${cliConfig.args.asset}@v1.2.3`);
+                } else {
+                    reply.fatal(`Unable to download ${cliConfig.args.asset} asset: ${err.stack}`);
+                }
                 return;
             }
         } else if (cliConfig.args.build || assetJsonExists) {

--- a/packages/teraslice-cli/src/cmds/assets/deploy.ts
+++ b/packages/teraslice-cli/src/cmds/assets/deploy.ts
@@ -120,7 +120,7 @@ export = {
             try {
                 assetPath = await asset.download(cliConfig.assetDir, cliConfig.args.quiet);
             } catch (err) {
-                reply.fatal(`Unable to download ${cliConfig.args.asset} asset: ${err.stack}`);
+                reply.fatal(`Unable to download ${cliConfig.args.asset}, you can download a prerelease asset by specifying its version.\n\nExample:\n\t${cliConfig.args.asset}@v1.2.3`);
                 return;
             }
         } else if (cliConfig.args.build || assetJsonExists) {


### PR DESCRIPTION
I improve the error message to give the user a clue that the problem may be that there is not a released asset that matches their request, and they can specify the version if they want.