### PR TITLE
Improve object column performance

### DIFF
--- a/packages/data-mate/bench/build-column-perf-test.js
+++ b/packages/data-mate/bench/build-column-perf-test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { config, data } = require('./fixtures/data.json');
+const { Column } = require('./src');
+
+const name = 'results';
+const fieldConfig = config.fields[name];
+const values = data.map((row) => row[name]);
+
+const startRSS = process.memoryUsage().rss;
+// eslint-disable-next-line no-console
+console.log(`Building ${values.length} rows`,);
+
+console.time(`Built ${values.length} rows`);
+
+const column = Column.fromJSON(name, fieldConfig, values);
+console.timeEnd(`Built ${values.length} rows`);
+
+const endRSS = process.memoryUsage().rss;
+// eslint-disable-next-line no-console
+console.log('DONE', endRSS - startRSS);
+
+setTimeout(() => console.error('exiting...'), 5000);
+
+// this ensures it is kept in memory
+module.exports = column;

--- a/packages/data-mate/bench/build-column-suite.js
+++ b/packages/data-mate/bench/build-column-suite.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { getGroupedFields } = require('@terascope/data-types');
-const { FieldType } = require('@terascope/types');
 const { Suite } = require('./helpers');
 const { config, data } = require('./fixtures/data.json');
 const { Column } = require('./src');

--- a/packages/data-mate/bench/build-column-suite.js
+++ b/packages/data-mate/bench/build-column-suite.js
@@ -11,9 +11,6 @@ const run = async () => {
 
     for (const name of Object.keys(getGroupedFields(config.fields))) {
         const fieldConfig = config.fields[name];
-        // FIXME this is temporary
-        if (fieldConfig.type !== FieldType.Object) continue;
-
         const values = data.map((row) => row[name]);
         const fieldInfo = `${name} (${fieldConfig.type}${fieldConfig.array ? '[]' : ''})`;
         suite.add(fieldInfo, {

--- a/packages/data-mate/bench/build-column-suite.js
+++ b/packages/data-mate/bench/build-column-suite.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { getGroupedFields } = require('@terascope/data-types');
+const { FieldType } = require('@terascope/types');
 const { Suite } = require('./helpers');
 const { config, data } = require('./fixtures/data.json');
 const { Column } = require('./src');
@@ -10,6 +11,9 @@ const run = async () => {
 
     for (const name of Object.keys(getGroupedFields(config.fields))) {
         const fieldConfig = config.fields[name];
+        // FIXME this is temporary
+        if (fieldConfig.type !== FieldType.Object) continue;
+
         const values = data.map((row) => row[name]);
         const fieldInfo = `${name} (${fieldConfig.type}${fieldConfig.array ? '[]' : ''})`;
         suite.add(fieldInfo, {

--- a/packages/data-mate/bench/generate-data.js
+++ b/packages/data-mate/bench/generate-data.js
@@ -44,9 +44,6 @@ const dataTypeConfig = {
         alive: {
             type: FieldType.Boolean
         },
-        location: {
-            type: FieldType.GeoPoint
-        },
         metadata: {
             type: FieldType.Object
         },
@@ -64,6 +61,28 @@ const dataTypeConfig = {
         },
         'metadata.requests.last': {
             type: FieldType.Date,
+        },
+        location: {
+            type: FieldType.GeoPoint
+        },
+        results: {
+            type: FieldType.Object,
+            array: true
+        },
+        'results.type': {
+            type: FieldType.Keyword
+        },
+        'results.number_of_friends': {
+            type: FieldType.Integer
+        },
+        'results.requests': {
+            type: FieldType.Object,
+        },
+        'results.requests.total': {
+            type: FieldType.Integer,
+        },
+        'results.requests.last': {
+            type: FieldType.Date,
         }
     }
 };
@@ -73,6 +92,16 @@ const numRecords = 1000; // this will be doubled
 const year = new Date().getFullYear();
 let records = times(numRecords, () => {
     const age = chance.age();
+    function genMetadata() {
+        return {
+            type: age > 20 ? 'parent' : 'child',
+            number_of_friends: random(1, 2000),
+            requests: random(0, 20) ? {
+                total: random(10, maxInt),
+                last: chance.date().toISOString()
+            } : null,
+        };
+    }
     return {
         _key: chance.guid({ version: 4 }),
         name: chance.name(),
@@ -85,18 +114,8 @@ let records = times(numRecords, () => {
         }).toISOString(),
         address: randNull(chance.address),
         alive: chance.bool(),
-        location: random(0, 30) ? {
-            lat: chance.latitude(),
-            lon: chance.longitude(),
-        } : null,
-        metadata: random(0, 20) ? {
-            type: age > 20 ? 'parent' : 'child',
-            number_of_friends: random(1, 2000),
-            requests: random(0, 20) ? {
-                total: random(10, maxInt),
-                last: chance.date().toISOString()
-            } : null
-        } : null
+        metadata: random(0, 20) ? genMetadata() : null,
+        results: times(random(10, 200), genMetadata)
     };
 });
 

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.30.2",
+    "version": "0.30.3",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -29,9 +29,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.30.6",
+        "@terascope/data-types": "^0.30.7",
         "@terascope/types": "^0.10.1",
-        "@terascope/utils": "^0.40.6",
+        "@terascope/utils": "^0.40.7",
         "date-fns": "^2.23.0",
         "ip-bigint": "^3.0.3",
         "ip6addr": "^0.2.3",
@@ -43,7 +43,7 @@
         "uuid": "^8.3.2",
         "valid-url": "^1.0.9",
         "validator": "^13.6.0",
-        "xlucene-parser": "^0.38.2"
+        "xlucene-parser": "^0.38.3"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.2",

--- a/packages/data-mate/src/column/aggregations.ts
+++ b/packages/data-mate/src/column/aggregations.ts
@@ -1,11 +1,10 @@
 import {
-    isBigInt, toBigInt, trimISODateSegment
+    isBigInt, toBigInt, trimISODateSegment, getHashCodeFrom
 } from '@terascope/utils';
 import { Maybe, ISO8601DateSegment } from '@terascope/types';
 import {
     Vector, VectorType, getNumericValues, SerializeOptions
 } from '../vector';
-import { getHashCodeFrom } from '../core';
 
 export enum ValueAggregation {
     avg = 'avg',

--- a/packages/data-mate/src/core/interfaces.ts
+++ b/packages/data-mate/src/core/interfaces.ts
@@ -1,5 +1,3 @@
-export const HASH_CODE_SYMBOL = Symbol('__hash__');
-
 export const MAX_8BIT_INT = (2 ** 8) - 1;
 export const MAX_16BIT_INT = (2 ** 16) - 1;
 export const MAX_32BIT_INT = (2 ** 32) - 1;

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -10,8 +10,8 @@ import {
     DataEntity, TSError,
     getTypeOf, isFunction,
     isPlainObject, trimFP,
-    isInteger,
-    joinList
+    isInteger, joinList,
+    getHashCodeFrom, createHashCode
 } from '@terascope/utils';
 import {
     Column, KeyAggFn, makeUniqueKeyAgg
@@ -25,8 +25,8 @@ import {
 } from './utils';
 import { Builder, getBuildersForConfig } from '../builder';
 import {
-    createHashCode, FieldArg, flattenStringArg,
-    freezeArray, getFieldsFromArg, getHashCodeFrom,
+    FieldArg, flattenStringArg,
+    freezeArray, getFieldsFromArg,
     ReadableData,
     WritableData,
 } from '../core';

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -11,7 +11,7 @@ import {
     getTypeOf, isFunction,
     isPlainObject, trimFP,
     isInteger, joinList,
-    getHashCodeFrom, createHashCode
+    getHashCodeFrom
 } from '@terascope/utils';
 import {
     Column, KeyAggFn, makeUniqueKeyAgg
@@ -246,7 +246,7 @@ export class DataFrame<
             .sort()
             .join(':');
 
-        const id = createHashCode(long);
+        const id = getHashCodeFrom(long);
         this.#id = id;
         return id;
     }

--- a/packages/data-mate/src/data-frame/utils.ts
+++ b/packages/data-mate/src/data-frame/utils.ts
@@ -3,9 +3,9 @@ import {
     DataTypeConfig, ReadonlyDataTypeConfig,
     DataTypeFields, DataTypeVersion
 } from '@terascope/types';
+import { md5 } from '@terascope/utils';
 import { Builder, getBuildersForConfig } from '../builder';
 import { Column, KeyAggFn } from '../column';
-import { md5 } from '../core';
 
 export function buildRecords<T extends Record<string, any>>(
     builders: Map<keyof T, Builder<unknown>>,

--- a/packages/data-mate/src/vector/ListVector.ts
+++ b/packages/data-mate/src/vector/ListVector.ts
@@ -1,8 +1,7 @@
 import { AnyObject, FieldType, Maybe } from '@terascope/types';
-import { isNotNil } from '@terascope/utils';
+import { isNotNil, getHashCodeFrom } from '@terascope/utils';
 import { Vector, VectorOptions } from './Vector';
 import { DataBuckets, SerializeOptions, VectorType } from './interfaces';
-import { getHashCodeFrom } from '../core';
 
 export class ListVector<T = unknown> extends Vector<readonly Maybe<T>[]> {
     getComparableValue = undefined;

--- a/packages/data-mate/src/vector/Vector.ts
+++ b/packages/data-mate/src/vector/Vector.ts
@@ -4,8 +4,7 @@ import {
     ReadonlyDataTypeFields,
 } from '@terascope/types';
 import {
-    isPrimitiveValue, createHashCode,
-    HASH_CODE_SYMBOL, getHashCodeFrom
+    isPrimitiveValue, getHashCodeFrom,
 } from '@terascope/utils';
 import {
     ReadableData, freezeArray, WritableData
@@ -150,14 +149,6 @@ export abstract class Vector<T = unknown> {
             }
             offset += data.size;
         }
-    }
-
-    get [HASH_CODE_SYMBOL](): string {
-        if (this.#cachedHash) return this.#cachedHash;
-
-        const hash = createHashCode(this.toArray());
-        this.#cachedHash = hash;
-        return hash;
     }
 
     /**

--- a/packages/data-mate/src/vector/Vector.ts
+++ b/packages/data-mate/src/vector/Vector.ts
@@ -3,9 +3,12 @@ import {
     Maybe, SortOrder,
     ReadonlyDataTypeFields,
 } from '@terascope/types';
-import { isPrimitiveValue } from '@terascope/utils';
 import {
-    ReadableData, createHashCode, HASH_CODE_SYMBOL, getHashCodeFrom, freezeArray, WritableData
+    isPrimitiveValue, createHashCode,
+    HASH_CODE_SYMBOL, getHashCodeFrom
+} from '@terascope/utils';
+import {
+    ReadableData, freezeArray, WritableData
 } from '../core';
 import {
     DataBuckets, SerializeOptions, VectorType

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.30.6",
+    "version": "0.30.7",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.1",
-        "@terascope/utils": "^0.40.6",
+        "@terascope/utils": "^0.40.7",
         "graphql": "^15.5.0",
         "lodash": "^4.17.21",
         "yargs": "^17.0.1"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.21.6",
+    "version": "2.21.7",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.40.6",
+        "@terascope/utils": "^0.40.7",
         "bluebird": "^3.7.2"
     },
     "devDependencies": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.52.3",
+    "version": "0.52.4",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,13 +24,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.30.2",
-        "@terascope/data-types": "^0.30.6",
+        "@terascope/data-mate": "^0.30.3",
+        "@terascope/data-types": "^0.30.7",
         "@terascope/types": "^0.10.1",
-        "@terascope/utils": "^0.40.6",
+        "@terascope/utils": "^0.40.7",
         "ajv": "^6.12.6",
         "uuid": "^8.3.2",
-        "xlucene-translator": "^0.22.2"
+        "xlucene-translator": "^0.22.3"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.1",

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -15,7 +15,7 @@ export default abstract class IndexModel<T extends i.IndexModelRecord> extends I
     readonly name: string;
     readonly logger: ts.Logger;
 
-    private _uniqueFields: (keyof T)[];
+    private _uniqueFields: readonly (keyof T)[];
     private _sanitizeFields: i.SanitizeFields;
 
     constructor(

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.19.6",
+    "version": "0.19.7",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.40.6",
+        "@terascope/utils": "^0.40.7",
         "chalk": "^4.1.1",
         "lodash": "^4.17.21",
         "yeoman-generator": "^4.13.0",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.52.6",
+    "version": "0.52.7",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.40.6",
+        "@terascope/utils": "^0.40.7",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^8.3.2"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.38.6",
+    "version": "0.38.7",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^4.0.0",
-        "@terascope/utils": "^0.40.6",
+        "@terascope/utils": "^0.40.7",
         "codecov": "^3.8.3",
         "execa": "^5.1.0",
         "fs-extra": "^9.1.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.33.6",
+    "version": "0.33.7",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.40.6",
+        "@terascope/utils": "^0.40.7",
         "aws-sdk": "^2.874.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.15",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.44.8",
+    "version": "0.44.9",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.7.7",
-        "@terascope/utils": "^0.40.6",
+        "@terascope/utils": "^0.40.7",
         "chalk": "^4.1.1",
         "cli-table3": "^0.6.0",
         "easy-table": "^1.1.1",
@@ -51,7 +51,7 @@
         "pretty-bytes": "^5.6.0",
         "prompts": "^2.4.1",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.40.6",
+        "teraslice-client-js": "^0.40.7",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.3",
         "yargs": "^17.0.1",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.40.6",
+    "version": "0.40.7",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.52.6",
+        "@terascope/job-components": "^0.52.7",
         "auto-bind": "^4.0.0",
         "got": "^11.8.2"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.23.6",
+    "version": "0.23.7",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/utils": "^0.40.6",
+        "@terascope/utils": "^0.40.7",
         "ms": "^2.1.3",
         "nanoid": "^3.1.21",
         "p-event": "^4.2.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.52.6"
+        "@terascope/job-components": "^0.52.7"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.52.6"
+        "@terascope/job-components": "^0.52.7"
     },
     "engines": {
         "node": "^12.20.0 || >=14.17.0",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.29.6",
+    "version": "0.29.7",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.21.6",
-        "@terascope/utils": "^0.40.6"
+        "@terascope/elasticsearch-api": "^2.21.7",
+        "@terascope/utils": "^0.40.7"
     },
     "engines": {
         "node": "^12.20.0 || >=14.17.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^9.1.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.52.6"
+        "@terascope/job-components": "^0.52.7"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.52.6"
+        "@terascope/job-components": "^0.52.7"
     },
     "engines": {
         "node": "^12.20.0 || >=14.17.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.21.6",
-        "@terascope/job-components": "^0.52.6",
-        "@terascope/teraslice-messaging": "^0.23.6",
-        "@terascope/utils": "^0.40.6",
+        "@terascope/elasticsearch-api": "^2.21.7",
+        "@terascope/job-components": "^0.52.7",
+        "@terascope/teraslice-messaging": "^0.23.7",
+        "@terascope/utils": "^0.40.7",
         "async-mutex": "^0.3.1",
         "barbe": "^3.0.16",
         "body-parser": "^1.19.0",
@@ -61,7 +61,7 @@
         "semver": "^7.3.5",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.33.6",
+        "terafoundation": "^0.33.7",
         "uuid": "^8.3.2"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.59.2",
+    "version": "0.59.3",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.30.2",
+        "@terascope/data-mate": "^0.30.3",
         "@terascope/types": "^0.10.1",
-        "@terascope/utils": "^0.40.6",
+        "@terascope/utils": "^0.40.7",
         "awesome-phonenumber": "^2.54.0",
         "graphlib": "^2.1.8",
         "is-ip": "^3.1.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.40.6",
+    "version": "0.40.7",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -20,8 +20,8 @@ export function flattenDeep<T>(val: ListOfRecursiveArraysOrValues<T>): T[] {
 /** A simplified implementation of lodash castArray */
 export function castArray<T>(input: T|undefined|null|T[]): T[] {
     if (input == null) return [];
-    if (input instanceof Set) return [...input];
     if (isArrayLike(input)) return input;
+    if (input instanceof Set) return [...input];
     return [input];
 }
 
@@ -200,5 +200,5 @@ export function isTypedArray<T = TypedArray>(input: unknown): input is T {
  * Check if an input is an TypedArray or Array instance
 */
 export function isArrayLike<T = any[]>(input: unknown): input is T {
-    return isArray(input) || isTypedArray(input);
+    return Array.isArray(input) || isTypedArray(input);
 }

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -30,8 +30,8 @@ export function castArray<T>(input: T|undefined|null|T[]|(readonly T[])): T[] {
  * Any non-array value will be converted to an array
 */
 export function concat<T>(arr: T| T[], arr1?: T|T[]): readonly T[];
-export function concat<T>(arr: T| readonly T[], arr1?: T| readonly T[]): readonly T[];
-export function concat<T>(arr: T| readonly T[], arr1?: T|T[]): readonly T[];
+export function concat<T>(arr: readonly T[], arr1?: readonly T[]): readonly T[];
+export function concat<T>(arr: readonly T[], arr1?: T|T[]): readonly T[];
 export function concat<T>(arr: T|T[], arr1?: T|T[]): T[] {
     return uniq(
         castArray(arr)

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -18,17 +18,20 @@ export function flattenDeep<T>(val: ListOfRecursiveArraysOrValues<T>): T[] {
 }
 
 /** A simplified implementation of lodash castArray */
-export function castArray<T>(input: T|undefined|null|T[]): T[] {
+export function castArray<T>(input: T|undefined|null|T[]|(readonly T[])): T[] {
     if (input == null) return [];
     if (isArrayLike(input)) return input;
     if (input instanceof Set) return [...input];
-    return [input];
+    return [input as T];
 }
 
 /**
  * Concat and unique the items in the array
  * Any non-array value will be converted to an array
 */
+export function concat<T>(arr: T| T[], arr1?: T|T[]): readonly T[];
+export function concat<T>(arr: T| readonly T[], arr1?: T| readonly T[]): readonly T[];
+export function concat<T>(arr: T| readonly T[], arr1?: T|T[]): readonly T[];
 export function concat<T>(arr: T|T[], arr1?: T|T[]): T[] {
     return uniq(
         castArray(arr)
@@ -44,12 +47,12 @@ export function uniq<T>(arr: T[]|Set<T>): T[] {
 
 /** Sort an arr or set */
 export function sort<T>(
-    arr: T[]|Set<T>,
+    arr: T[]|(readonly T[])|Set<T>,
     compare?: (a: T, b: T) => number
 ): T[] {
     if (arr instanceof Set) return [...arr].sort(compare);
     if (isArrayLike(arr)) return arr.sort(compare);
-    return arr;
+    return arr as T[];
 }
 
 const numLike = {
@@ -122,21 +125,8 @@ export function* timesIter<T>(n: number, fn?: (index: number) => T): Iterable<nu
     }
 }
 
-/** Map an array faster without sparse array handling */
-export function fastMap<T, U>(arr: T[], fn: (val: T, index: number) => U): U[] {
-    const { length } = arr;
-    const result = Array(length);
-
-    let i = -1;
-    while (++i < length) {
-        result[i] = fn(arr[i], i);
-    }
-
-    return result;
-}
-
 /** Chunk an array into specific sizes */
-export function chunk<T>(dataArray: T[]|Set<T>, size: number): T[][] {
+export function chunk<T>(dataArray: T[]|Set<T>|readonly T[], size: number): T[][] {
     if (size < 1) return isArrayLike(dataArray) ? [dataArray] : [[...dataArray]];
     const results: T[][] = [];
     let chunked: T[] = [];
@@ -169,7 +159,7 @@ export function includes(input: unknown, key: string): boolean {
  * If the input is an array it will return the first item
  * else if it will return the input
  */
-export function getFirst<T>(input: T | T[]): T|undefined {
+export function getFirst<T>(input: T | T[]|(readonly T[])): T|undefined {
     return castArray(input)[0];
 }
 
@@ -177,7 +167,7 @@ export function getFirst<T>(input: T | T[]): T|undefined {
  * If the input is an array it will return the first item
  * else if it will return the input
  */
-export function getLast<T>(input: T | T[]): T|undefined {
+export function getLast<T>(input: T | T[]|(readonly T[])): T|undefined {
     return castArray(input).slice(-1)[0];
 }
 

--- a/packages/utils/src/functions.ts
+++ b/packages/utils/src/functions.ts
@@ -21,7 +21,13 @@ export function once<T extends((...args: any[]) => any)>(fn: T): (
     };
 }
 
-export function noop(..._args: any[]): any {}
+/**
+ * A simple function that does nothing but return the first
+ * argument
+*/
+export function noop(...args: any[]): any {
+    return args[0];
+}
 
 function _getArgCacheKey(args: any[]): string {
     const fixed = args.filter((a, i, arr) => {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.38.2",
+    "version": "0.38.3",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.1",
-        "@terascope/utils": "^0.40.6",
+        "@terascope/utils": "^0.40.7",
         "netmask": "^2.0.2"
     },
     "devDependencies": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.22.2",
+    "version": "0.22.3",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,8 +29,8 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.1",
-        "@terascope/utils": "^0.40.6",
-        "xlucene-parser": "^0.38.2"
+        "@terascope/utils": "^0.40.7",
+        "xlucene-parser": "^0.38.3"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "0.7.6",
+    "version": "0.7.7",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.40.6"
+        "@terascope/utils": "^0.40.7"
     },
     "devDependencies": {
         "@terascope/types": "^0.10.1"


### PR DESCRIPTION
- Removes the custom unique hash stuff that created way too much memory (this was the biggest performance again)
- Create building functions can be v8 inlined optimize
- No longer freeze objects stored in a column (we just need to be smart about not touching it)


Previously building a column with an object array took 4.451 seconds and used 688MiB of RAM. Now it takes 365ms and used 119 MiB of RAM.  So it uses over 5x less RAM previously required and is a 12x faster.