### PR TITLE
DataFrame improvements

### DIFF
--- a/packages/data-mate/bench/data-frame-deserialize-suite.js
+++ b/packages/data-mate/bench/data-frame-deserialize-suite.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { timesIter } = require('@terascope/utils');
+const fs = require('fs');
+const path = require('path');
+const { Suite } = require('./helpers');
+const { DataFrame } = require('./src');
+
+const _dfJSON = fs.readFileSync(path.join(__dirname, './fixtures/data.dfjson'));
+
+const run = async () => {
+    const suite = Suite('DataFrame#deserialize');
+    let df = await DataFrame.deserialize(_dfJSON);
+    df = df.appendAll(timesIter(10, () => df));
+    const dfJSONStr = df.serialize();
+
+    suite.add('with string', {
+        defer: true,
+        fn(deferred) {
+            DataFrame.deserialize(dfJSONStr)
+                .then(
+                    () => deferred.resolve(),
+                    deferred.reject
+                );
+        }
+    });
+
+    const dfJSONBuffer = Buffer.from(dfJSONStr);
+    suite.add('with Buffer', {
+        defer: true,
+        fn(deferred) {
+            DataFrame.deserialize(dfJSONBuffer)
+                .then(
+                    () => deferred.resolve(),
+                    deferred.reject
+                );
+        }
+    });
+
+    return suite.run({
+        async: true,
+        initCount: 4,
+        minSamples: 2,
+        maxTime: 30,
+    });
+};
+if (require.main === module) {
+    run().then((suite) => {
+        suite.on('complete', () => {});
+    });
+} else {
+    module.exports = run;
+}

--- a/packages/data-mate/bench/src.js
+++ b/packages/data-mate/bench/src.js
@@ -1,4 +1,3 @@
 'use strict';
 
 module.exports = require('../dist/src');
-// module.exports = require(`${process.env.HOME}/tmp/data-mate/node_modules/@terascope/data-mate`);

--- a/packages/data-mate/bench/src.js
+++ b/packages/data-mate/bench/src.js
@@ -1,3 +1,4 @@
 'use strict';
 
 module.exports = require('../dist/src');
+// module.exports = require(`${process.env.HOME}/tmp/data-mate/node_modules/@terascope/data-mate`);

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.32.0",
+    "version": "0.33.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -22,7 +22,8 @@ import {
     concatColumnsToColumns, createColumnsWithIndices,
     distributeRowsToColumns, getSortedColumnsByValueCount,
     isEmptyRow, makeKeyForRow, makeUniqueRowBuilder,
-    processFieldFilter
+    processFieldFilter,
+    splitOnNewLineIterator
 } from './utils';
 import { Builder, getBuildersForConfig } from '../builder';
 import {
@@ -124,7 +125,7 @@ export class DataFrame<
         R extends Record<string, unknown> = Record<string, any>,
     >(data: Buffer|string): Promise<DataFrame<R>> {
         return DataFrame.deserializeIterator(
-            data.toString('utf8').split('\n')
+            splitOnNewLineIterator(data)
         );
     }
 

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -507,7 +507,6 @@ export class DataFrame<
         const len = this.size;
         let returning = len;
         const builders = getBuildersForConfig<T>(this.config, len);
-        const columns = new Map(this.columns.map((col) => [col.name, col]));
 
         const sortedColumns = getSortedColumnsByValueCount(this.columns);
         for (let i = 0; i < len; i++) {
@@ -515,7 +514,7 @@ export class DataFrame<
                 returning--;
             } else {
                 for (const [name, builder] of builders) {
-                    builder.append(columns.get(name)!.vector.get(i));
+                    builder.append(this.getColumnOrThrow(name).vector.get(i));
                 }
             }
         }
@@ -526,7 +525,7 @@ export class DataFrame<
             // @ts-expect-error data is readonly
             builder.data = builder.data
                 .resize(returning);
-            return columns.get(name)!.fork(builder.toVector());
+            return this.getColumnOrThrow(name).fork(builder.toVector());
         }));
     }
 
@@ -601,9 +600,8 @@ export class DataFrame<
         const buckets = new Set<string>();
         const keyAggs = new Map<keyof T, KeyAggFn>();
 
-        const columns = new Map(this.columns.map((col) => [col.name, col]));
         for (const name of fields) {
-            const column = columns.get(name)!;
+            const column = this.getColumnOrThrow(name);
             if (column) {
                 keyAggs.set(column.name, makeUniqueKeyAgg(
                     column.vector, serializeOptions
@@ -618,9 +616,9 @@ export class DataFrame<
             buckets,
             (name, i) => {
                 if (!serializeOptions) {
-                    return columns.get(name)!.vector.get(i);
+                    return this.getColumnOrThrow(name).vector.get(i);
                 }
-                return columns.get(name)!.vector.get(
+                return this.getColumnOrThrow(name).vector.get(
                     i, true, serializeOptions
                 );
             }
@@ -637,7 +635,7 @@ export class DataFrame<
             // @ts-expect-error data is readonly
             builder.data = builder.data
                 .resize(buckets.size);
-            return columns.get(name)!.fork(builder.toVector());
+            return this.getColumnOrThrow(name).fork(builder.toVector());
         }));
     }
 

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -91,7 +91,7 @@ export class DataFrame<
 
         for await (const row of data) {
             // ensure empty rows don't get passed along
-            if (!row.length || row.toString() === '\n') continue;
+            if (row.length <= 1) continue;
 
             index++;
             if (index === 0) {

--- a/packages/data-mate/src/data-frame/utils.ts
+++ b/packages/data-mate/src/data-frame/utils.ts
@@ -218,3 +218,37 @@ export function isEmptyRow(columns: readonly Column<any, any>[], row: number): b
     }
     return true;
 }
+
+export function splitOnNewLineIterator(data: Buffer|string): Iterable<Buffer|string> {
+    if (typeof data === 'string') {
+        return splitStringOnNewLineIterator(data);
+    }
+    return splitBufferOnNewLineIterator(data);
+}
+
+function* splitStringOnNewLineIterator(data: string): Iterable<string> {
+    let startIndex = 0;
+
+    while (true) {
+        const newLineIndex = data.indexOf('\n', startIndex);
+        // if this return -1 we are done
+        if (newLineIndex === -1) return;
+
+        yield data.slice(startIndex, newLineIndex + 1);
+        startIndex = newLineIndex + 1;
+    }
+}
+
+const NEW_LINE_BYTE_CODE = 10;
+function* splitBufferOnNewLineIterator(data: Buffer): Iterable<Buffer> {
+    let startIndex = 0;
+
+    while (true) {
+        const newLineIndex = data.indexOf(NEW_LINE_BYTE_CODE, startIndex);
+        // if this return -1 we are done
+        if (newLineIndex === -1) return;
+
+        yield data.slice(startIndex, newLineIndex + 1);
+        startIndex = newLineIndex + 1;
+    }
+}

--- a/packages/data-mate/src/data-frame/utils.ts
+++ b/packages/data-mate/src/data-frame/utils.ts
@@ -228,13 +228,18 @@ export function splitOnNewLineIterator(data: Buffer|string): Iterable<Buffer|str
 
 function* splitStringOnNewLineIterator(data: string): Iterable<string> {
     let startIndex = 0;
+    let isEndSlice = false;
 
     while (true) {
-        const newLineIndex = data.indexOf('\n', startIndex);
-        // if this return -1 we are done
-        if (newLineIndex === -1) return;
+        let newLineIndex = data.indexOf('\n', startIndex);
 
-        yield data.slice(startIndex, newLineIndex + 1);
+        if (newLineIndex === -1) {
+            if (isEndSlice) return;
+            isEndSlice = true;
+            newLineIndex = data.length;
+        }
+
+        yield data.slice(startIndex, newLineIndex);
         startIndex = newLineIndex + 1;
     }
 }
@@ -242,13 +247,18 @@ function* splitStringOnNewLineIterator(data: string): Iterable<string> {
 const NEW_LINE_BYTE_CODE = 10;
 function* splitBufferOnNewLineIterator(data: Buffer): Iterable<Buffer> {
     let startIndex = 0;
+    let isEndSlice = false;
 
     while (true) {
-        const newLineIndex = data.indexOf(NEW_LINE_BYTE_CODE, startIndex);
-        // if this return -1 we are done
-        if (newLineIndex === -1) return;
+        let newLineIndex = data.indexOf(NEW_LINE_BYTE_CODE, startIndex);
 
-        yield data.slice(startIndex, newLineIndex + 1);
+        if (newLineIndex === -1) {
+            if (isEndSlice) return;
+            isEndSlice = true;
+            newLineIndex = data.length;
+        }
+
+        yield data.subarray(startIndex, newLineIndex);
         startIndex = newLineIndex + 1;
     }
 }

--- a/packages/data-mate/src/vector/Vector.ts
+++ b/packages/data-mate/src/vector/Vector.ts
@@ -139,14 +139,14 @@ export abstract class Vector<T = unknown> {
      * Check to see there are any nil values stored in the Vector
     */
     hasNilValues(): boolean {
-        return this.data.some((data) => data.values.size !== data.values.length);
+        return this.data.some((data) => data.hasNilValues());
     }
 
     /**
      * Get the number of non-nil values in the Vector
     */
     countValues(): number {
-        return this.data.reduce((acc, data) => acc + data.values.size, 0);
+        return this.data.reduce((acc, data) => acc + data.countValues(), 0);
     }
 
     /**
@@ -154,7 +154,7 @@ export abstract class Vector<T = unknown> {
     */
     isEmpty(): boolean {
         if (this.size === 0) return true;
-        return this.data.every((data) => data.values.size === 0);
+        return this.data.every((data) => data.isEmpty());
     }
 
     /**
@@ -164,7 +164,7 @@ export abstract class Vector<T = unknown> {
     * values(): IterableIterator<[index: number, value: T]> {
         let offset = 0;
         for (const data of this.data) {
-            for (const [i, v] of data.values) {
+            for (const [i, v] of data.entries()) {
                 yield [offset + i, v];
             }
             offset += data.size;
@@ -200,7 +200,7 @@ export abstract class Vector<T = unknown> {
         let offset = 0;
 
         for (const data of this.data) {
-            for (const [index, value] of data.values) {
+            for (const [index, value] of data.entries()) {
                 const hash = getHash(value);
                 if (!hashes.has(hash)) {
                     hashes.add(hash);
@@ -222,7 +222,7 @@ export abstract class Vector<T = unknown> {
         const getHash = this.data[0].isPrimitive ? (v: unknown) => v : getHashCodeFrom;
 
         for (const data of this.data) {
-            for (const value of data.values.values()) {
+            for (const value of data.values()) {
                 const hash = getHash(value);
                 if (!hashes.has(hash)) {
                     hashes.add(hash);
@@ -279,7 +279,7 @@ export abstract class Vector<T = unknown> {
     has(index: number): boolean {
         const found = this.findDataWithIndex(index);
         if (!found) return false;
-        return found[0].values.has(found[1]);
+        return found[0].has(found[1]);
     }
 
     /**

--- a/packages/data-mate/test/data-spec.ts
+++ b/packages/data-mate/test/data-spec.ts
@@ -19,7 +19,7 @@ describe('Data', () => {
             });
 
             it('should have the correct values', () => {
-                expect(readable._values).toStrictEqual(values.filter(isNotNil));
+                expect(Array.from(readable.values())).toStrictEqual(values.filter(isNotNil));
             });
 
             it('should be able to get all of the values', () => {
@@ -37,7 +37,7 @@ describe('Data', () => {
             });
 
             it('should have the correct values', () => {
-                expect(readable._values).toStrictEqual(values.filter(isNotNil));
+                expect(Array.from(readable.values())).toStrictEqual(values.filter(isNotNil));
             });
 
             it('should be able to get all of the values', () => {
@@ -61,7 +61,7 @@ describe('Data', () => {
             });
 
             it('should have the correct values', () => {
-                expect(readable._values).toStrictEqual(values.filter(isNotNil));
+                expect(Array.from(readable.values())).toStrictEqual(values.filter(isNotNil));
             });
 
             it('should be able to get all of the values', () => {
@@ -127,7 +127,7 @@ describe('Data', () => {
             });
 
             it('should have the correct values', () => {
-                expect(readable._values).toStrictEqual(values.filter(isNotNil));
+                expect(Array.from(readable.values())).toStrictEqual(values.filter(isNotNil));
             });
 
             it('should be able to get all of the values', () => {
@@ -177,7 +177,7 @@ describe('Data', () => {
         });
 
         it('should have the correct values', () => {
-            expect(readable._values).toStrictEqual(values.filter(isNotNil));
+            expect(Array.from(readable.values())).toStrictEqual(values.filter(isNotNil));
         });
 
         it('should be able to get all of the values', () => {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.54.0",
+    "version": "0.55.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.32.0",
+        "@terascope/data-mate": "^0.33.0",
         "@terascope/data-types": "^0.31.0",
         "@terascope/types": "^0.10.1",
         "@terascope/utils": "^0.41.0",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.61.0",
+    "version": "0.62.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.32.0",
+        "@terascope/data-mate": "^0.33.0",
         "@terascope/types": "^0.10.1",
         "@terascope/utils": "^0.41.0",
         "awesome-phonenumber": "^2.57.0",


### PR DESCRIPTION
- Improve data frame deserialize performance (not much)
- Use `getColumnOrThrow` in more places to utilize the cache
- Hide the internal storage for Vector data so we can change how it is being stored in the future