### PR TITLE
Faster getHashCodeFrom

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.34.0",
+    "version": "0.34.1",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -29,9 +29,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.32.0",
+        "@terascope/data-types": "^0.32.1",
         "@terascope/types": "^0.10.1",
-        "@terascope/utils": "^0.42.0",
+        "@terascope/utils": "^0.42.1",
         "date-fns": "^2.23.0",
         "ip-bigint": "^3.0.3",
         "ip6addr": "^0.2.3",
@@ -43,7 +43,7 @@
         "uuid": "^8.3.2",
         "valid-url": "^1.0.9",
         "validator": "^13.6.0",
-        "xlucene-parser": "^0.40.0"
+        "xlucene-parser": "^0.40.1"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.2",

--- a/packages/data-mate/src/data-frame/utils.ts
+++ b/packages/data-mate/src/data-frame/utils.ts
@@ -3,7 +3,6 @@ import {
     DataTypeConfig, ReadonlyDataTypeConfig,
     DataTypeFields, DataTypeVersion
 } from '@terascope/types';
-import { md5 } from '@terascope/utils';
 import { Builder, getBuildersForConfig } from '../builder';
 import { Column, KeyAggFn } from '../column';
 
@@ -191,7 +190,7 @@ export function makeKeyForRow<T extends Record<string, any>>(
 
     return {
         row,
-        key: groupKey.length > 35 ? md5(groupKey) : groupKey,
+        key: groupKey,
     };
 }
 

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.32.0",
+    "version": "0.32.1",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.1",
-        "@terascope/utils": "^0.42.0",
+        "@terascope/utils": "^0.42.1",
         "graphql": "^15.5.0",
         "lodash": "^4.17.21",
         "yargs": "^17.1.1"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.23.0",
+    "version": "2.23.1",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.42.0",
+        "@terascope/utils": "^0.42.1",
         "bluebird": "^3.7.2"
     },
     "devDependencies": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.56.0",
+    "version": "0.56.1",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,13 +24,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.34.0",
-        "@terascope/data-types": "^0.32.0",
+        "@terascope/data-mate": "^0.34.1",
+        "@terascope/data-types": "^0.32.1",
         "@terascope/types": "^0.10.1",
-        "@terascope/utils": "^0.42.0",
+        "@terascope/utils": "^0.42.1",
         "ajv": "^6.12.6",
         "uuid": "^8.3.2",
-        "xlucene-translator": "^0.24.0"
+        "xlucene-translator": "^0.24.1"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.1",

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.21.0",
+    "version": "0.21.1",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.42.0",
+        "@terascope/utils": "^0.42.1",
         "chalk": "^4.1.2",
         "lodash": "^4.17.21",
         "yeoman-generator": "^4.13.0",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.54.0",
+    "version": "0.54.1",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.42.0",
+        "@terascope/utils": "^0.42.1",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^8.3.2"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.43.0",
+    "version": "0.43.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@lerna/query-graph": "^4.0.0",
-        "@terascope/utils": "^0.42.0",
+        "@terascope/utils": "^0.42.1",
         "codecov": "^3.8.3",
         "execa": "^5.1.0",
         "fs-extra": "^9.1.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.35.0",
+    "version": "0.35.1",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.42.0",
+        "@terascope/utils": "^0.42.1",
         "aws-sdk": "^2.874.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.15",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.46.0",
+    "version": "0.46.1",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.7.7",
-        "@terascope/utils": "^0.42.0",
+        "@terascope/utils": "^0.42.1",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.0",
         "easy-table": "^1.1.1",
@@ -51,7 +51,7 @@
         "pretty-bytes": "^5.6.0",
         "prompts": "^2.4.1",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.42.0",
+        "teraslice-client-js": "^0.42.1",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.3",
         "yargs": "^17.1.1",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.42.0",
+    "version": "0.42.1",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.54.0",
+        "@terascope/job-components": "^0.54.1",
         "auto-bind": "^4.0.0",
         "got": "^11.8.2"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/utils": "^0.42.0",
+        "@terascope/utils": "^0.42.1",
         "ms": "^2.1.3",
         "nanoid": "^3.1.25",
         "p-event": "^4.2.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.54.0"
+        "@terascope/job-components": "^0.54.1"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.54.0"
+        "@terascope/job-components": "^0.54.1"
     },
     "engines": {
         "node": "^12.20.0 || >=14.17.0",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.31.0",
+    "version": "0.31.1",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.23.0",
-        "@terascope/utils": "^0.42.0"
+        "@terascope/elasticsearch-api": "^2.23.1",
+        "@terascope/utils": "^0.42.1"
     },
     "engines": {
         "node": "^12.20.0 || >=14.17.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^9.1.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.54.0"
+        "@terascope/job-components": "^0.54.1"
     },
     "peerDependencies": {
-        "@terascope/job-components": "^0.54.0"
+        "@terascope/job-components": "^0.54.1"
     },
     "engines": {
         "node": "^12.20.0 || >=14.17.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.23.0",
-        "@terascope/job-components": "^0.54.0",
-        "@terascope/teraslice-messaging": "^0.25.0",
-        "@terascope/utils": "^0.42.0",
+        "@terascope/elasticsearch-api": "^2.23.1",
+        "@terascope/job-components": "^0.54.1",
+        "@terascope/teraslice-messaging": "^0.25.1",
+        "@terascope/utils": "^0.42.1",
         "async-mutex": "^0.3.1",
         "barbe": "^3.0.16",
         "body-parser": "^1.19.0",
@@ -61,7 +61,7 @@
         "semver": "^7.3.5",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.35.0",
+        "terafoundation": "^0.35.1",
         "uuid": "^8.3.2"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.63.0",
+    "version": "0.63.1",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.34.0",
+        "@terascope/data-mate": "^0.34.1",
         "@terascope/types": "^0.10.1",
-        "@terascope/utils": "^0.42.0",
+        "@terascope/utils": "^0.42.1",
         "awesome-phonenumber": "^2.57.0",
         "graphlib": "^2.1.8",
         "is-ip": "^3.1.0",

--- a/packages/utils/bench/getHashCodeFrom-suite.js
+++ b/packages/utils/bench/getHashCodeFrom-suite.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const { Suite } = require('./helpers');
+const { getHashCodeFrom } = require('../dist/src');
+
+const run = async () => {
+    const str6 = Array.from({ length: 6 }, () => 'a').join('');
+    const str26 = Array.from({ length: 26 }, () => 'a').join('');
+    const str36 = Array.from({ length: 36 }, () => 'a').join('');
+    const singleObj = { a: 1 };
+    const multiObj = {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4,
+        e: 5,
+        f: 6,
+        g: 7
+    };
+    const arrSingleObj = [singleObj];
+    const arrMultiObj = [multiObj];
+
+    const multiArrSingleObj = Array.from({ length: 5 }, () => singleObj);
+    const multiArrMultiObj = Array.from({ length: 5 }, () => multiObj);
+
+    return Suite('getHashCodeFrom')
+        .add('with a 6 character string', {
+            fn() {
+                getHashCodeFrom(str6);
+            }
+        })
+        .add('with a 26 character string', {
+            fn() {
+                getHashCodeFrom(str26);
+            }
+        })
+        .add('with a 36 character string', {
+            fn() {
+                getHashCodeFrom(str36);
+            }
+        })
+        .add('with a single property object', {
+            fn() {
+                getHashCodeFrom(singleObj);
+            }
+        })
+        .add('with a multiple property object', {
+            fn() {
+                getHashCodeFrom(multiObj);
+            }
+        })
+        .add('with an array with a single property object', {
+            fn() {
+                getHashCodeFrom(arrSingleObj);
+            }
+        })
+        .add('with an array with a multiple property object', {
+            fn() {
+                getHashCodeFrom(arrMultiObj);
+            }
+        })
+        .add('with a multi-item array with a single prop obj', {
+            fn() {
+                getHashCodeFrom(multiArrSingleObj);
+            }
+        })
+        .add('with a multi-item array with a multi-prop obj', {
+            fn() {
+                getHashCodeFrom(multiArrMultiObj);
+            }
+        })
+        .run({
+            async: true,
+            initCount: 2,
+            maxTime: 20,
+        });
+};
+
+if (require.main === module) {
+    run().then((suite) => {
+        suite.on('complete', () => {});
+    });
+} else {
+    module.exports = run;
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.42.0",
+    "version": "0.42.1",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/field-type.ts
+++ b/packages/utils/src/field-type.ts
@@ -9,8 +9,9 @@ import { isIPRangeOrThrow, isIPOrThrow } from './ip';
 import { toEpochMSOrThrow } from './dates';
 import { toBooleanOrThrow } from './booleans';
 import {
-    isValidateNumberType, toBigIntOrThrow, toFloatOrThrow,
-    toNumberOrThrow, bigIntToJSON, toIntegerOrThrow
+    isValidateNumberType, toBigIntOrThrow,
+    toNumberOrThrow, toIntegerOrThrow,
+    toFloatOrThrow,
 } from './numbers';
 import { toGeoJSONOrThrow, parseGeoPoint } from './geo';
 import { hasOwn } from './objects';
@@ -106,12 +107,14 @@ function _mapToString(input: any): string {
 }
 
 function _getHashCodeFrom(value: unknown): string {
-    if (value == null) return '~';
-    if (typeof value === 'bigint') return `|${bigIntToJSON(value)}`;
+    if (value == null) return '';
 
-    return typeof value === 'object'
-        ? _mapToString(value)
-        : primitiveToString(value);
+    const typeOf = typeof value;
+    return typeOf + (
+        typeOf === 'object'
+            ? _mapToString(value)
+            : value
+    );
 }
 
 /**
@@ -119,7 +122,8 @@ function _getHashCodeFrom(value: unknown): string {
  * the value doesn't explode the memory but the also need to
  * worry about using md5 too much
 */
-const MAX_STRING_LENGTH_BEFORE_MD5 = 1024;
+export const MAX_STRING_LENGTH_BEFORE_MD5 = 1024;
+
 /**
  * Generate a unique hash code from a value, this is
  * not a guarantee but it is close enough for doing

--- a/packages/utils/src/field-type.ts
+++ b/packages/utils/src/field-type.ts
@@ -118,9 +118,10 @@ function _getHashCodeFrom(value: unknown): string {
 }
 
 /**
- * If we has a hash a really long value we want to ensure that
- * the value doesn't explode the memory but the also need to
- * worry about using md5 too much
+ * If we have a hash that is a long value we want to ensure that
+ * the value doesn't explode the memory since we may be using
+ * that value as a key. So when a string exceeds this specified
+ * length we can reduce its length to 35 characters by using md5
 */
 export const MAX_STRING_LENGTH_BEFORE_MD5 = 1024;
 

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.40.0",
+    "version": "0.40.1",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.1",
-        "@terascope/utils": "^0.42.0",
+        "@terascope/utils": "^0.42.1",
         "netmask": "^2.0.2"
     },
     "devDependencies": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.24.0",
+    "version": "0.24.1",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,8 +29,8 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.1",
-        "@terascope/utils": "^0.42.0",
-        "xlucene-parser": "^0.40.0"
+        "@terascope/utils": "^0.42.1",
+        "xlucene-parser": "^0.40.1"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.42.0"
+        "@terascope/utils": "^0.42.1"
     },
     "devDependencies": {
         "@terascope/types": "^0.10.1"


### PR DESCRIPTION
Improve the performance of `getHashCodeFrom` by relying less on md5 and extra function calls. I think this also reduces the likelihood of collisions. We used `md5` when the string length was greater than 35 characters, I changed that to `1024`.