### PR TITLE
Make `RouteSenderAPI->send` return the number of affected records

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.36.2",
+    "version": "0.36.3",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -29,9 +29,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.33.2",
+        "@terascope/data-types": "^0.33.3",
         "@terascope/types": "^0.10.2",
-        "@terascope/utils": "^0.43.2",
+        "@terascope/utils": "^0.43.3",
         "@types/validator": "^13.6.6",
         "awesome-phonenumber": "^2.64.0",
         "date-fns": "^2.25.0",
@@ -46,7 +46,7 @@
         "uuid": "^8.3.2",
         "valid-url": "^1.0.9",
         "validator": "^13.7.0",
-        "xlucene-parser": "^0.41.2"
+        "xlucene-parser": "^0.41.3"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.2",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.33.2",
+    "version": "0.33.3",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.2",
-        "@terascope/utils": "^0.43.2",
+        "@terascope/utils": "^0.43.3",
         "graphql": "^14.7.0",
         "lodash": "^4.17.21",
         "yargs": "^17.2.0"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.24.2",
+    "version": "2.24.3",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.43.2",
+        "@terascope/utils": "^0.43.3",
         "bluebird": "^3.7.2"
     },
     "devDependencies": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.58.2",
+    "version": "0.58.3",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,14 +24,14 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.36.2",
-        "@terascope/data-types": "^0.33.2",
+        "@terascope/data-mate": "^0.36.3",
+        "@terascope/data-types": "^0.33.3",
         "@terascope/types": "^0.10.2",
-        "@terascope/utils": "^0.43.2",
+        "@terascope/utils": "^0.43.3",
         "@types/elasticsearch": "^5.0.39",
         "ajv": "^6.12.6",
         "uuid": "^8.3.2",
-        "xlucene-translator": "^0.25.2"
+        "xlucene-translator": "^0.25.3"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.1",

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.22.2",
+    "version": "0.22.3",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.43.2",
+        "@terascope/utils": "^0.43.3",
         "chalk": "^4.1.2",
         "lodash": "^4.17.21",
         "yeoman-generator": "^4.13.0",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.55.2",
+    "version": "0.55.3",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.43.2",
+        "@terascope/utils": "^0.43.3",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^8.3.2"

--- a/packages/job-components/src/interfaces/misc.ts
+++ b/packages/job-components/src/interfaces/misc.ts
@@ -1,9 +1,3 @@
-import { DataEntity } from '@terascope/utils';
-
-export interface RouteSenderAPI {
-    send(records: DataEntity[]): Promise<void>;
-    verify(route?: string): Promise<void>;
-}
 export interface APIFactoryRegistry<T, C> {
     get(name: string): T|undefined;
     getConfig(name: string): C|undefined;

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.45.2",
+    "version": "0.45.3",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "typescript": "~4.4.4"
     },
     "dependencies": {
-        "@terascope/utils": "^0.43.2",
+        "@terascope/utils": "^0.43.3",
         "codecov": "^3.8.3",
         "execa": "^5.1.0",
         "fs-extra": "^10.0.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.36.2",
+    "version": "0.36.3",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,7 +27,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.43.2",
+        "@terascope/utils": "^0.43.3",
         "aws-sdk": "^2.1011.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.15",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.47.2",
+    "version": "0.47.3",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.8.7",
-        "@terascope/utils": "^0.43.2",
+        "@terascope/utils": "^0.43.3",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.0",
         "easy-table": "^1.2.0",
@@ -51,7 +51,7 @@
         "pretty-bytes": "^5.6.0",
         "prompts": "^2.4.2",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.43.2",
+        "teraslice-client-js": "^0.43.3",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.5",
         "yargs": "^17.2.0",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.43.2",
+    "version": "0.43.3",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.55.2",
+        "@terascope/job-components": "^0.55.3",
         "auto-bind": "^4.0.0",
         "got": "^11.8.2"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.26.2",
+    "version": "0.26.3",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/utils": "^0.43.2",
+        "@terascope/utils": "^0.43.3",
         "ms": "^2.1.3",
         "nanoid": "^3.1.30",
         "p-event": "^4.2.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.55.2"
+        "@terascope/job-components": "^0.55.3"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.55.2"
+        "@terascope/job-components": ">=0.55.3"
     },
     "engines": {
         "node": "^12.22.0 || >=14.17.0",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.32.2",
+    "version": "0.32.3",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.24.2",
-        "@terascope/utils": "^0.43.2"
+        "@terascope/elasticsearch-api": "^2.24.3",
+        "@terascope/utils": "^0.43.3"
     },
     "engines": {
         "node": "^12.22.0 || >=14.17.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^10.0.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.55.2"
+        "@terascope/job-components": "^0.55.3"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.55.2"
+        "@terascope/job-components": ">=0.55.3"
     },
     "engines": {
         "node": "^12.22.0 || >=14.17.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.24.2",
-        "@terascope/job-components": "^0.55.2",
-        "@terascope/teraslice-messaging": "^0.26.2",
-        "@terascope/utils": "^0.43.2",
+        "@terascope/elasticsearch-api": "^2.24.3",
+        "@terascope/job-components": "^0.55.3",
+        "@terascope/teraslice-messaging": "^0.26.3",
+        "@terascope/utils": "^0.43.3",
         "async-mutex": "^0.3.2",
         "barbe": "^3.0.16",
         "body-parser": "^1.19.0",
@@ -61,7 +61,7 @@
         "semver": "^7.3.5",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.36.2",
+        "terafoundation": "^0.36.3",
         "uuid": "^8.3.2"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.65.2",
+    "version": "0.65.3",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.36.2",
+        "@terascope/data-mate": "^0.36.3",
         "@terascope/types": "^0.10.2",
-        "@terascope/utils": "^0.43.2",
+        "@terascope/utils": "^0.43.3",
         "awesome-phonenumber": "^2.64.0",
         "graphlib": "^2.1.8",
         "is-ip": "^3.1.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.43.2",
+    "version": "0.43.3",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/interfaces.ts
+++ b/packages/utils/src/interfaces.ts
@@ -1,3 +1,5 @@
+import type { DataEntity } from './entities/data-entity';
+
 export type {
     Omit,
     Overwrite,
@@ -18,3 +20,24 @@ export type {
     FilteredResult,
     Unpacked
 } from '@terascope/types';
+
+/**
+ * Used for sending data to particular index/topic/file/table in a storage system.
+ * This is used by the routed sender in the standard-assets
+*/
+export interface RouteSenderAPI {
+    /**
+     * Sends the records to the respective storage backend
+     *
+     * @returns the number of affected records/rows
+    */
+    send(records: Iterable<DataEntity>): Promise<number>;
+
+    /**
+     * This is used to verify and create an resources
+     * required for this particular route
+     *
+     * This is optional to implement
+    */
+    verify?(route?: string): Promise<void>;
+}

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.41.2",
+    "version": "0.41.3",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.2",
-        "@terascope/utils": "^0.43.2",
+        "@terascope/utils": "^0.43.3",
         "netmask": "^2.0.2"
     },
     "devDependencies": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.25.2",
+    "version": "0.25.3",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,9 +29,9 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.2",
-        "@terascope/utils": "^0.43.2",
+        "@terascope/utils": "^0.43.3",
         "@types/elasticsearch": "^5.0.39",
-        "xlucene-parser": "^0.41.2"
+        "xlucene-parser": "^0.41.3"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.43.2"
+        "@terascope/utils": "^0.43.3"
     },
     "devDependencies": {
         "@terascope/types": "^0.10.2"


### PR DESCRIPTION
- Make `RouteSenderAPI->send` return the number of affected records
- Make `RouteSenderAPI->send` accept an iterable so we can stream process records in the future
- Add comments to the interface
- Move the interface to utils so it can be defined without needing to import job-components, this is useful for some our api packages

These changes should be backwards compatible since the number of affected records can default to the number of input records