### PR TITLE
Breaking changes to `elasticsearch-api->buldSend` to fix retry support

### DIFF
--- a/docs/packages/elasticsearch-api/overview.md
+++ b/docs/packages/elasticsearch-api/overview.md
@@ -240,24 +240,7 @@ const name = 'logs_template';
 elasticsearch.putTemplate(template, name)
 ```
 
-### bulkSend [DEPRECATED]
-
-Uses the client bulk functionality with exponential back-off retries. Use bulkSendImproved instead
-
-Query requires:
-
-- data  (formatted to work with elasticsearch bulk queries)
-
-```js
-const elasticsearch = require('@terascope/elasticsearch-api')(client, logger, opConfig);
-elasticsearch.bulkSend(data)
-  .then(function(){
-      //all done sending data
-   });
-```
-
-
-### bulkSendImproved
+### bulkSend
 
 Uses the client bulk functionality with exponential back-off retries
 
@@ -267,7 +250,7 @@ Query requires:
 
 ```js
 const elasticsearch = require('@terascope/elasticsearch-api')(client, logger, opConfig);
-elasticsearch.bulkSendImproved([
+elasticsearch.bulkSend([
      {
         action: {
             index: { _index: 'some_index', _type: 'events', _id: 1 }

--- a/docs/packages/elasticsearch-api/overview.md
+++ b/docs/packages/elasticsearch-api/overview.md
@@ -240,9 +240,9 @@ const name = 'logs_template';
 elasticsearch.putTemplate(template, name)
 ```
 
-### bulkSend
+### bulkSend [DEPRECATED]
 
-Uses the client bulk functionality with exponential back-off retries
+Uses the client bulk functionality with exponential back-off retries. Use bulkSendImproved instead
 
 Query requires:
 
@@ -252,6 +252,35 @@ Query requires:
 const elasticsearch = require('@terascope/elasticsearch-api')(client, logger, opConfig);
 elasticsearch.bulkSend(data)
   .then(function(){
+      //all done sending data
+   });
+```
+
+
+### bulkSendImproved
+
+Uses the client bulk functionality with exponential back-off retries
+
+Query requires:
+
+- data  (formatted to work with elasticsearch bulk queries)
+
+```js
+const elasticsearch = require('@terascope/elasticsearch-api')(client, logger, opConfig);
+elasticsearch.bulkSendImproved([
+     {
+        action: {
+            index: { _index: 'some_index', _type: 'events', _id: 1 }
+        },
+        data: { title: 'foo' }
+    },
+    {
+        action: {
+            delete: { _index: 'some_index', _type: 'events', _id: 5 }
+        }
+    }
+])
+  .then(() => {
       //all done sending data
    });
 ```

--- a/packages/elasticsearch-api/index.js
+++ b/packages/elasticsearch-api/index.js
@@ -99,7 +99,7 @@ module.exports = function elasticsearchApi(client, logger, _opConfig) {
 
             function _runRequest() {
                 clientBase[endpoint](query)
-                    .then((result) => resolve(result))
+                    .then(resolve)
                     .catch(errHandler);
             }
 
@@ -374,22 +374,7 @@ module.exports = function elasticsearchApi(client, logger, _opConfig) {
             throw new Error(`Expected bulkSend to receive an array, got ${data} (${getTypeOf(data)})`);
         }
 
-        return new Promise((resolve, reject) => {
-            _bulkSend(data)
-                .then(resolve)
-                .catch((err) => {
-                    if (err) {
-                        reject(err);
-                        return;
-                    }
-                    reject(new TSError(err, {
-                        reason: 'bulk sender error',
-                        context: {
-                            connection,
-                        },
-                    }));
-                });
-        });
+        return Promise.resolve(_bulkSend(data));
     }
 
     function _warn(warnLogger, msg) {
@@ -771,7 +756,7 @@ module.exports = function elasticsearchApi(client, logger, _opConfig) {
                 let timeoutMs = delay - elapsed;
                 if (timeoutMs < 1) timeoutMs = 1;
 
-                setTimeout(resolve, timeoutMs);
+                setTimeout(resolve, timeoutMs, delay);
             }, reject);
         });
     }

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.25.0",
+    "version": "3.0.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "2.24.3",
+    "version": "2.25.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-api/test/api-spec.js
+++ b/packages/elasticsearch-api/test/api-spec.js
@@ -191,13 +191,17 @@ describe('elasticsearch-api', () => {
         const response = { took: 22, errors: false, items: results };
         if (bulkError) {
             response.errors = true;
-            response.items = results.body.map((obj, index) => {
-                Object.entries(obj).forEach(([key, value]) => {
-                    obj[key] = Object.assign(value, {
+            response.items = results.body.flatMap((obj, index) => {
+                if (!obj.index && !obj.update && !obj.create && !obj.delete) {
+                    // ignore the non-metadata objects
+                    return [];
+                }
+                Object.values(obj).forEach((value) => {
+                    Object.assign(value, {
                         error: { type: bulkError[index] || 'someType', reason: 'someReason' }
                     });
                 });
-                return obj;
+                return [obj];
             });
         }
         return response;
@@ -323,45 +327,26 @@ describe('elasticsearch-api', () => {
         expect(() => {
             api = esApi(client, logger);
         }).not.toThrow();
-        expect(api).toBeDefined();
         expect(typeof api).toEqual('object');
-        expect(api.search).toBeDefined();
         expect(typeof api.search).toEqual('function');
-        expect(api.count).toBeDefined();
         expect(typeof api.count).toEqual('function');
-        expect(api.get).toBeDefined();
         expect(typeof api.get).toEqual('function');
-        expect(api.index).toBeDefined();
         expect(typeof api.index).toEqual('function');
-        expect(api.indexWithId).toBeDefined();
         expect(typeof api.indexWithId).toEqual('function');
-        expect(api.create).toBeDefined();
         expect(typeof api.create).toEqual('function');
-        expect(api.update).toBeDefined();
         expect(typeof api.update).toEqual('function');
-        expect(api.remove).toBeDefined();
         expect(typeof api.remove).toEqual('function');
-        expect(api.version).toBeDefined();
         expect(typeof api.version).toEqual('function');
-        expect(api.putTemplate).toBeDefined();
         expect(typeof api.putTemplate).toEqual('function');
-        expect(api.bulkSend).toBeDefined();
         expect(typeof api.bulkSend).toEqual('function');
-        expect(api.nodeInfo).toBeDefined();
+        expect(typeof api.bulkSendImproved).toEqual('function');
         expect(typeof api.nodeInfo).toEqual('function');
-        expect(api.nodeStats).toBeDefined();
         expect(typeof api.nodeStats).toEqual('function');
-        expect(api.buildQuery).toBeDefined();
         expect(typeof api.buildQuery).toEqual('function');
-        expect(api.indexExists).toBeDefined();
         expect(typeof api.indexExists).toEqual('function');
-        expect(api.indexCreate).toBeDefined();
         expect(typeof api.indexCreate).toEqual('function');
-        expect(api.indexRefresh).toBeDefined();
         expect(typeof api.indexRefresh).toEqual('function');
-        expect(api.indexRecovery).toBeDefined();
         expect(typeof api.indexRecovery).toEqual('function');
-        expect(api.indexSetup).toBeDefined();
         expect(typeof api.indexSetup).toEqual('function');
     });
 
@@ -727,7 +712,7 @@ describe('elasticsearch-api', () => {
         return expect(results).toBeTruthy();
     });
 
-    it('can remove type from bulk send', async () => {
+    it('can remove type from bulkSend', async () => {
         const es7client = cloneDeep(client);
 
         es7client.transport._config = { apiVersion: '7.0' };
@@ -750,7 +735,7 @@ describe('elasticsearch-api', () => {
         });
     });
 
-    it('will not remove _type from record in a bulk send', async () => {
+    it('will not remove _type from record in a bulkSend', async () => {
         const es7client = cloneDeep(client);
 
         es7client.transport._config = { apiVersion: '7.0' };
@@ -773,7 +758,7 @@ describe('elasticsearch-api', () => {
         });
     });
 
-    it('will not err if no _type in es7 bulk request metadata', async () => {
+    it('will not err if no _type in es7 bulkSend request metadata', async () => {
         const es7client = cloneDeep(client);
 
         es7client.transport._config = { apiVersion: '7.0' };
@@ -823,6 +808,154 @@ describe('elasticsearch-api', () => {
         return expect(
             Promise.all([
                 api.bulkSend(myBulkData),
+                waitFor(20, () => {
+                    bulkError = false;
+                })
+            ])
+        ).rejects.toThrow(/some_thing_else--someReason/);
+    });
+
+    it('can call bulkSendImproved', async () => {
+        const api = esApi(client, logger);
+
+        const result = await api.bulkSendImproved([
+            {
+                action: {
+                    index: { _index: 'some_index', _type: 'events', _id: 1 }
+                },
+                data: { title: 'foo' }
+            },
+            {
+                action: {
+                    delete: { _index: 'some_index', _type: 'events', _id: 5 }
+                }
+            }
+        ]);
+        expect(bulkData).toEqual({
+            body: [
+                { index: { _index: 'some_index', _type: 'events', _id: 1 } },
+                { title: 'foo' },
+                { delete: { _index: 'some_index', _type: 'events', _id: 5 } }
+            ]
+        });
+        return expect(result).toBe(2);
+    });
+
+    it('can remove type from bulkSendImproved', async () => {
+        const es7client = cloneDeep(client);
+
+        es7client.transport._config = { apiVersion: '7.0' };
+
+        const api = esApi(es7client, logger);
+
+        await api.bulkSendImproved([{
+            action: {
+                index: { _index: 'some_index', _type: 'events', _id: 1 }
+            },
+            data: { title: 'foo' }
+        },
+        {
+            action: {
+                delete: { _index: 'some_index', _type: 'events', _id: 5 }
+            }
+        }]);
+        expect(bulkData).toEqual({
+            body: [
+                { index: { _index: 'some_index', _id: 1 } },
+                { title: 'foo' },
+                { delete: { _index: 'some_index', _id: 5 } }
+            ]
+        });
+    });
+
+    it('will not remove _type from record in a bulkSendImproved', async () => {
+        const es7client = cloneDeep(client);
+
+        es7client.transport._config = { apiVersion: '7.0' };
+
+        const api = esApi(es7client, logger);
+
+        await api.bulkSendImproved([{
+            action: {
+                delete: { _index: 'some_index', _type: 'events', _id: 5 }
+            },
+        },
+        {
+            action: {
+                index: { _index: 'some_index', _type: 'events', _id: 1 }
+            },
+            data: { title: 'foo', _type: 'doc', name: 'joe' }
+        }]);
+        expect(bulkData).toEqual({
+            body: [
+                { delete: { _index: 'some_index', _id: 5 } },
+                { index: { _index: 'some_index', _id: 1 } },
+                { title: 'foo', _type: 'doc', name: 'joe' }
+            ]
+        });
+    });
+
+    it('will not err if no _type in es7 bulkSendImproved request metadata', async () => {
+        const es7client = cloneDeep(client);
+
+        es7client.transport._config = { apiVersion: '7.0' };
+
+        const api = esApi(es7client, logger);
+
+        await api.bulkSendImproved([{
+            action: {
+                delete: { _index: 'some_index', _type: 'events', _id: 5 }
+            },
+        },
+        {
+            action: {
+                index: { _index: 'some_index', _type: 'events', _id: 1 }
+            },
+            data: { title: 'foo', _type: 'doc', name: 'joe' }
+        }]);
+
+        expect(bulkData).toEqual({
+            body: [
+                { delete: { _index: 'some_index', _id: 5 } },
+                { index: { _index: 'some_index', _id: 1 } },
+                { title: 'foo', _type: 'doc', name: 'joe' }
+            ]
+        });
+    });
+
+    it('can call bulkSendImproved with errors', async () => {
+        const api = esApi(client, logger);
+        const myBulkData = [{
+            action: {
+                index: { _index: 'some_index', _type: 'events', _id: 1 }
+            },
+            data: { title: 'foo' }
+        },
+        {
+            action: {
+                delete: { _index: 'some_index', _type: 'events', _id: 5 }
+            }
+        }];
+
+        bulkError = [
+            'es_rejected_execution_exception',
+            'es_rejected_execution_exception',
+            'es_rejected_execution_exception'
+        ];
+
+        const [results] = await Promise.all([
+            api.bulkSendImproved(myBulkData),
+            waitFor(20, () => {
+                bulkError = false;
+            })
+        ]);
+
+        expect(results).toBeTruthy();
+        bulkError = ['some_thing_else', 'some_thing_else', 'some_thing_else'];
+
+        return expect(
+            Promise.all([
+                api.bulkSendImproved(myBulkData),
                 waitFor(20, () => {
                     bulkError = false;
                 })

--- a/packages/elasticsearch-api/test/api-spec.js
+++ b/packages/elasticsearch-api/test/api-spec.js
@@ -339,7 +339,6 @@ describe('elasticsearch-api', () => {
         expect(typeof api.version).toEqual('function');
         expect(typeof api.putTemplate).toEqual('function');
         expect(typeof api.bulkSend).toEqual('function');
-        expect(typeof api.bulkSendImproved).toEqual('function');
         expect(typeof api.nodeInfo).toEqual('function');
         expect(typeof api.nodeStats).toEqual('function');
         expect(typeof api.buildQuery).toEqual('function');
@@ -702,123 +701,8 @@ describe('elasticsearch-api', () => {
 
     it('can call bulkSend', async () => {
         const api = esApi(client, logger);
-        const myBulkData = [
-            { index: { _index: 'some_index', _type: 'events', _id: 1 } },
-            { title: 'foo' },
-            { delete: { _index: 'some_index', _type: 'events', _id: 5 } }
-        ];
 
-        const results = await api.bulkSend(myBulkData);
-        return expect(results).toBeTruthy();
-    });
-
-    it('can remove type from bulkSend', async () => {
-        const es7client = cloneDeep(client);
-
-        es7client.transport._config = { apiVersion: '7.0' };
-
-        const api = esApi(es7client, logger);
-
-        const myBulkData = [
-            { index: { _index: 'some_index', _type: 'events', _id: 1 } },
-            { title: 'foo' },
-            { delete: { _index: 'some_index', _type: 'events', _id: 5 } }
-        ];
-
-        await api.bulkSend(myBulkData);
-        expect(bulkData).toEqual({
-            body: [
-                { index: { _index: 'some_index', _id: 1 } },
-                { title: 'foo' },
-                { delete: { _index: 'some_index', _id: 5 } }
-            ]
-        });
-    });
-
-    it('will not remove _type from record in a bulkSend', async () => {
-        const es7client = cloneDeep(client);
-
-        es7client.transport._config = { apiVersion: '7.0' };
-
-        const api = esApi(es7client, logger);
-
-        const myBulkData = [
-            { delete: { _index: 'some_index', _type: 'events', _id: 5 } },
-            { index: { _index: 'some_index', _type: 'events', _id: 1 } },
-            { title: 'foo', _type: 'doc', name: 'joe' }
-        ];
-
-        await api.bulkSend(myBulkData);
-        expect(bulkData).toEqual({
-            body: [
-                { delete: { _index: 'some_index', _id: 5 } },
-                { index: { _index: 'some_index', _id: 1 } },
-                { title: 'foo', _type: 'doc', name: 'joe' }
-            ]
-        });
-    });
-
-    it('will not err if no _type in es7 bulkSend request metadata', async () => {
-        const es7client = cloneDeep(client);
-
-        es7client.transport._config = { apiVersion: '7.0' };
-
-        const api = esApi(es7client, logger);
-
-        const myBulkData = [
-            { delete: { _index: 'some_index', _id: 5 } },
-            { index: { _index: 'some_index', _id: 1 } },
-            { title: 'foo', _type: 'doc', name: 'joe' }
-        ];
-
-        await api.bulkSend(myBulkData);
-        expect(bulkData).toEqual({
-            body: [
-                { delete: { _index: 'some_index', _id: 5 } },
-                { index: { _index: 'some_index', _id: 1 } },
-                { title: 'foo', _type: 'doc', name: 'joe' }
-            ]
-        });
-    });
-
-    it('can call bulkSend with errors', async () => {
-        const api = esApi(client, logger);
-        const myBulkData = [
-            { index: { _index: 'some_index', _type: 'events', _id: 1 } },
-            { title: 'foo' },
-            { delete: { _index: 'some_index', _type: 'events', _id: 5 } }
-        ];
-
-        bulkError = [
-            'es_rejected_execution_exception',
-            'es_rejected_execution_exception',
-            'es_rejected_execution_exception'
-        ];
-
-        const [results] = await Promise.all([
-            api.bulkSend(myBulkData),
-            waitFor(20, () => {
-                bulkError = false;
-            })
-        ]);
-
-        expect(results).toBeTruthy();
-        bulkError = ['some_thing_else', 'some_thing_else', 'some_thing_else'];
-
-        return expect(
-            Promise.all([
-                api.bulkSend(myBulkData),
-                waitFor(20, () => {
-                    bulkError = false;
-                })
-            ])
-        ).rejects.toThrow(/some_thing_else--someReason/);
-    });
-
-    it('can call bulkSendImproved', async () => {
-        const api = esApi(client, logger);
-
-        const result = await api.bulkSendImproved([
+        const result = await api.bulkSend([
             {
                 action: {
                     index: { _index: 'some_index', _type: 'events', _id: 1 }
@@ -841,14 +725,14 @@ describe('elasticsearch-api', () => {
         return expect(result).toBe(2);
     });
 
-    it('can remove type from bulkSendImproved', async () => {
+    it('can remove type from bulkSend', async () => {
         const es7client = cloneDeep(client);
 
         es7client.transport._config = { apiVersion: '7.0' };
 
         const api = esApi(es7client, logger);
 
-        await api.bulkSendImproved([{
+        await api.bulkSend([{
             action: {
                 index: { _index: 'some_index', _type: 'events', _id: 1 }
             },
@@ -868,14 +752,14 @@ describe('elasticsearch-api', () => {
         });
     });
 
-    it('will not remove _type from record in a bulkSendImproved', async () => {
+    it('will not remove _type from record in a bulkSend', async () => {
         const es7client = cloneDeep(client);
 
         es7client.transport._config = { apiVersion: '7.0' };
 
         const api = esApi(es7client, logger);
 
-        await api.bulkSendImproved([{
+        await api.bulkSend([{
             action: {
                 delete: { _index: 'some_index', _type: 'events', _id: 5 }
             },
@@ -895,14 +779,14 @@ describe('elasticsearch-api', () => {
         });
     });
 
-    it('will not err if no _type in es7 bulkSendImproved request metadata', async () => {
+    it('will not err if no _type in es7 bulkSend request metadata', async () => {
         const es7client = cloneDeep(client);
 
         es7client.transport._config = { apiVersion: '7.0' };
 
         const api = esApi(es7client, logger);
 
-        await api.bulkSendImproved([{
+        await api.bulkSend([{
             action: {
                 delete: { _index: 'some_index', _type: 'events', _id: 5 }
             },
@@ -923,7 +807,7 @@ describe('elasticsearch-api', () => {
         });
     });
 
-    it('can call bulkSendImproved with errors', async () => {
+    it('can call bulkSend with errors', async () => {
         const api = esApi(client, logger);
         const myBulkData = [{
             action: {
@@ -944,7 +828,7 @@ describe('elasticsearch-api', () => {
         ];
 
         const [results] = await Promise.all([
-            api.bulkSendImproved(myBulkData),
+            api.bulkSend(myBulkData),
             waitFor(20, () => {
                 bulkError = false;
             })
@@ -955,7 +839,7 @@ describe('elasticsearch-api', () => {
 
         return expect(
             Promise.all([
-                api.bulkSendImproved(myBulkData),
+                api.bulkSend(myBulkData),
                 waitFor(20, () => {
                     bulkError = false;
                 })

--- a/packages/elasticsearch-api/types/index.d.ts
+++ b/packages/elasticsearch-api/types/index.d.ts
@@ -29,17 +29,11 @@ declare namespace elasticsearchAPI {
         version: () => Promise<boolean>;
         putTemplate: (template: any, name: string) => Promise<any>;
         /**
-         * Bulk send actions to the server
-         *
-         * @deprecated use bulkSendImproved instead
-        */
-        bulkSend: (data: Record<string, any>[]) => Promise<any>;
-        /**
          * The new and improved bulk send with proper retry support
          *
          * @returns the number of affected rows
         */
-        bulkSendImproved: (data: BulkRecord[]) => Promise<number>;
+        bulkSend: (data: BulkRecord[]) => Promise<number>;
         nodeInfo: (query: any) => Promise<any>;
         nodeStats: (query: any) => Promise<any>;
         buildQuery: (opConfig: Config, msg: any) => es.SearchParams;

--- a/packages/elasticsearch-api/types/index.d.ts
+++ b/packages/elasticsearch-api/types/index.d.ts
@@ -28,7 +28,18 @@ declare namespace elasticsearchAPI {
         remove: (query: es.DeleteDocumentParams) => Promise<es.DeleteDocumentResponse>;
         version: () => Promise<boolean>;
         putTemplate: (template: any, name: string) => Promise<any>;
-        bulkSend: (data: any[]) => Promise<any>;
+        /**
+         * Bulk send actions to the server
+         *
+         * @deprecated use bulkSendImproved instead
+        */
+        bulkSend: (data: Record<string, any>[]) => Promise<any>;
+        /**
+         * The new and improved bulk send with proper retry support
+         *
+         * @returns the number of affected rows
+        */
+        bulkSendImproved: (data: BulkRecord[]) => Promise<number>;
         nodeInfo: (query: any) => Promise<any>;
         nodeStats: (query: any) => Promise<any>;
         buildQuery: (opConfig: Config, msg: any) => es.SearchParams;
@@ -40,5 +51,33 @@ declare namespace elasticsearchAPI {
         verifyClient: () => boolean;
         validateGeoParameters: (opConfig: any) => any;
         getESVersion: () => number;
+    }
+
+    /**
+     * This is used for improved bulk sending function
+    */
+    export interface BulkRecord {
+        action: AnyBulkAction;
+        data?: UpdateConfig | DataEntity;
+    }
+
+    /**
+     * This is used for improved bulk sending function
+    */
+    export interface AnyBulkAction  {
+        update?: Partial<BulkActionMetadata>;
+        index?: Partial<BulkActionMetadata>;
+        create?: Partial<BulkActionMetadata>;
+        delete?: Partial<BulkActionMetadata>;
+    }
+
+    /**
+     * This is used for improved bulk sending function
+    */
+    export interface BulkActionMetadata {
+        _index: string;
+        _type: string;
+        _id: string | number;
+        retry_on_conflict?: number;
     }
 }

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.25.0",
+        "@terascope/elasticsearch-api": "^3.0.0",
         "@terascope/utils": "^0.43.3"
     },
     "engines": {

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.32.3",
+    "version": "0.33.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.24.3",
+        "@terascope/elasticsearch-api": "^2.25.0",
         "@terascope/utils": "^0.43.3"
     },
     "engines": {

--- a/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
+++ b/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
@@ -5,7 +5,7 @@ import {
     chunk,
     pMap
 } from '@terascope/utils';
-import esApi, { Client } from '@terascope/elasticsearch-api';
+import esApi, { Client, BulkRecord } from '@terascope/elasticsearch-api';
 import { ESStateStorageConfig, MGetCacheResponse } from '../interfaces';
 import CachedStateStorage from '../cached-state-storage';
 
@@ -230,20 +230,17 @@ export default class ESCachedStateStorage {
         return this.es.mget(request);
     }
 
-    private _esBulkUpdatePrep(dataArray: DataEntity[]) {
-        const bulkRequest: ESBulkQuery[] = [];
-
-        for (const doc of dataArray) {
-            bulkRequest.push({
+    private _esBulkUpdatePrep(dataArray: DataEntity[]): BulkRecord[] {
+        return dataArray.map((doc) => ({
+            action: {
                 index: {
                     _index: this.index,
                     _type: this.type,
                     _id: this.getIdentifier(doc, '_key'),
                 },
-            }, doc);
-        }
-
-        return bulkRequest;
+            },
+            data: doc
+        }));
     }
 
     private async _esBulkUpdate(docArray: DataEntity[]): Promise<void> {
@@ -251,7 +248,7 @@ export default class ESCachedStateStorage {
 
         await pMap(chunked, (chunkedData) => {
             const bulkRequest = this._esBulkUpdatePrep(chunkedData);
-            return this.es.bulkSend(bulkRequest);
+            return this.es.bulkSendImproved(bulkRequest);
         }, {
             concurrency: this.concurrency
         });

--- a/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
+++ b/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
@@ -248,7 +248,7 @@ export default class ESCachedStateStorage {
 
         await pMap(chunked, (chunkedData) => {
             const bulkRequest = this._esBulkUpdatePrep(chunkedData);
-            return this.es.bulkSendImproved(bulkRequest);
+            return this.es.bulkSend(bulkRequest);
         }, {
             concurrency: this.concurrency
         });

--- a/packages/teraslice/lib/storage/analytics.js
+++ b/packages/teraslice/lib/storage/analytics.js
@@ -50,7 +50,7 @@ module.exports = async function analyticsService(context) {
                 time: stats.time[index],
                 memory: stats.memory[index],
             },
-            null,
+            'index',
             esIndex
         ));
 

--- a/packages/teraslice/lib/storage/backends/elasticsearch_store.js
+++ b/packages/teraslice/lib/storage/backends/elasticsearch_store.js
@@ -29,7 +29,7 @@ module.exports = function elasticsearchStorage(backendConfig) {
         recordType,
         idField,
         storageName,
-        bulkSize = 500,
+        bulkSize = 1000,
         fullResponse = false,
         logRecord = true,
         forceRefresh = true,
@@ -329,7 +329,10 @@ module.exports = function elasticsearchStorage(backendConfig) {
             }
         };
 
-        bulkQueue.push({ action, data: type === 'delete' ? undefined : record });
+        bulkQueue.push({
+            action,
+            data: type === 'delete' ? undefined : record
+        });
 
         // We only flush once enough records have accumulated for it to make sense.
         if (bulkQueue.length >= bulkSize) {
@@ -375,17 +378,7 @@ module.exports = function elasticsearchStorage(backendConfig) {
     }
 
     async function bulkSend(bulkRequest) {
-        const recordCount = (bulkRequest.length / 2);
-
-        await pRetry(async () => elasticsearch.bulkSend(bulkRequest), {
-            reason: `Failure to bulk create "${recordType}"`,
-            logError: logger.warn,
-            delay: isTest ? 100 : 1000,
-            backoff: 5,
-            retries: 100,
-        });
-
-        return recordCount;
+        return elasticsearch.bulkSend(bulkRequest);
     }
 
     async function _flush(shuttingDown = false) {

--- a/packages/teraslice/lib/storage/backends/elasticsearch_store.js
+++ b/packages/teraslice/lib/storage/backends/elasticsearch_store.js
@@ -377,7 +377,7 @@ module.exports = function elasticsearchStorage(backendConfig) {
     async function bulkSend(bulkRequest) {
         const recordCount = (bulkRequest.length / 2);
 
-        await pRetry(async () => elasticsearch.bulkSendImproved(bulkRequest), {
+        await pRetry(async () => elasticsearch.bulkSend(bulkRequest), {
             reason: `Failure to bulk create "${recordType}"`,
             logError: logger.warn,
             delay: isTest ? 100 : 1000,

--- a/packages/teraslice/lib/storage/backends/elasticsearch_store.js
+++ b/packages/teraslice/lib/storage/backends/elasticsearch_store.js
@@ -322,14 +322,14 @@ module.exports = function elasticsearchStorage(backendConfig) {
 
         const type = _type || 'index';
 
-        const indexRequest = {
+        const action = {
             [type]: {
                 _index: indexArg,
                 _type: recordType,
             }
         };
 
-        bulkQueue.push(indexRequest, record);
+        bulkQueue.push({ action, data: type === 'delete' ? undefined : record });
 
         // We only flush once enough records have accumulated for it to make sense.
         if (bulkQueue.length >= bulkSize) {
@@ -377,7 +377,7 @@ module.exports = function elasticsearchStorage(backendConfig) {
     async function bulkSend(bulkRequest) {
         const recordCount = (bulkRequest.length / 2);
 
-        await pRetry(async () => elasticsearch.bulkSend(bulkRequest), {
+        await pRetry(async () => elasticsearch.bulkSendImproved(bulkRequest), {
             reason: `Failure to bulk create "${recordType}"`,
             logError: logger.warn,
             delay: isTest ? 100 : 1000,

--- a/packages/teraslice/lib/storage/state.js
+++ b/packages/teraslice/lib/storage/state.js
@@ -73,7 +73,7 @@ async function stateStorage(context) {
                 data: record
             };
         });
-        return backend.bulkSendImproved(bulkRequest);
+        return backend.bulkSend(bulkRequest);
     }
 
     function _createSliceRecord(exId, slice, state, error) {

--- a/packages/teraslice/lib/storage/state.js
+++ b/packages/teraslice/lib/storage/state.js
@@ -60,18 +60,20 @@ async function stateStorage(context) {
     async function createSlices(exId, slices) {
         await waitForClient();
 
-        const bulkRequest = [];
-        for (const slice of slices) {
+        const bulkRequest = slices.map((slice) => {
             const { record, index } = _createSliceRecord(exId, slice, SliceState.pending);
-            bulkRequest.push({
-                index: {
-                    _index: index,
-                    _type: recordType,
-                    _id: record.slice_id,
+            return {
+                action: {
+                    index: {
+                        _index: index,
+                        _type: recordType,
+                        _id: record.slice_id,
+                    },
                 },
-            }, record);
-        }
-        return backend.bulkSend(bulkRequest);
+                data: record
+            };
+        });
+        return backend.bulkSendImproved(bulkRequest);
     }
 
     function _createSliceRecord(exId, slice, state, error) {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,7 +37,7 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.24.3",
+        "@terascope/elasticsearch-api": "^2.25.0",
         "@terascope/job-components": "^0.55.3",
         "@terascope/teraslice-messaging": "^0.26.3",
         "@terascope/utils": "^0.43.3",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,7 +37,7 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^2.25.0",
+        "@terascope/elasticsearch-api": "^3.0.0",
         "@terascope/job-components": "^0.55.3",
         "@terascope/teraslice-messaging": "^0.26.3",
         "@terascope/utils": "^0.43.3",

--- a/packages/teraslice/test/test.setup.js
+++ b/packages/teraslice/test/test.setup.js
@@ -3,4 +3,4 @@
 process.env.USE_DEBUG_LOGGER = 'true';
 
 // use a larger timeout
-jest.setTimeout(20 * 1000);
+jest.setTimeout(30 * 1000);


### PR DESCRIPTION
Makes breaking changes to the elasticsearch api `bulkSend` method so that the retries work correctly.