### PR TITLE
Expand bulk request API in IndexStore to support upserts with scripts

### DIFF
--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.59.0",
+    "version": "0.60.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/elasticsearch-store/src/cluster.ts
+++ b/packages/elasticsearch-store/src/cluster.ts
@@ -1,7 +1,11 @@
 import type { Client, NodesInfoParams, NodesStatsParams } from 'elasticsearch';
 
-/** Get Cluster Metadata and Stats */
-export default class Cluster {
+/**
+ * Get Cluster Metadata and Stats
+ *
+ * @todo this is not complete
+*/
+export class Cluster {
     readonly client: Client;
 
     constructor(client: Client) {

--- a/packages/elasticsearch-store/src/index-manager.ts
+++ b/packages/elasticsearch-store/src/index-manager.ts
@@ -8,7 +8,7 @@ const _loggers = new WeakMap<IndexConfig<any>, ts.Logger>();
 /**
  * Manage Elasticsearch Indices
  */
-export default class IndexManager {
+export class IndexManager {
     readonly client: es.Client;
     readonly esVersion: number;
     enableIndexMutations: boolean;

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -3,7 +3,7 @@ import * as ts from '@terascope/utils';
 import { JoinBy } from '@terascope/data-mate';
 import { QueryAccess, RestrictOptions } from 'xlucene-translator';
 import { v4 as uuid } from 'uuid';
-import IndexStore, { AnyInput } from './index-store';
+import { IndexStore, AnyInput } from './index-store';
 import * as utils from './utils';
 import * as i from './interfaces';
 
@@ -11,7 +11,7 @@ import * as i from './interfaces';
  * An high-level, opinionated, abstract class
  * for an elasticsearch DataType, with a CRUD-like interface
  */
-export default abstract class IndexModel<T extends i.IndexModelRecord> extends IndexStore<T> {
+export abstract class IndexModel<T extends i.IndexModelRecord> extends IndexStore<T> {
     readonly name: string;
     readonly logger: ts.Logger;
 

--- a/packages/elasticsearch-store/src/index.ts
+++ b/packages/elasticsearch-store/src/index.ts
@@ -1,11 +1,6 @@
-import Cluster from './cluster';
-import IndexManager from './index-manager';
-import IndexModel from './index-model';
-import IndexStore from './index-store';
-
 export * from './utils';
+export * from './cluster';
+export * from './index-manager';
+export * from './index-model';
+export * from './index-store';
 export * from './interfaces';
-
-export {
-    Cluster, IndexManager, IndexModel, IndexStore
-};


### PR DESCRIPTION
- [x] Expand the bulk request API in the `IndexStore` to support upserts with scripts
- [x] Fix the support reducing duplicates bulk requests by record key to avoid certain issues with bulk requests