### PR TITLE
Performance improvement to DataFrames and add appendOne

### DIFF
--- a/packages/data-mate/bench/select-rows-perf-test.js
+++ b/packages/data-mate/bench/select-rows-perf-test.js
@@ -1,0 +1,59 @@
+/* eslint-disable no-console */
+
+'use strict';
+
+const { pDelay } = require('@terascope/utils');
+const fs = require('fs');
+const path = require('path');
+const { DataFrame } = require('./src');
+
+async function readData() {
+    console.time('readData');
+    try {
+        return await new Promise((resolve, reject) => {
+            fs.readFile(path.join(__dirname, 'fixtures/data.dfjson'), (err, buf) => {
+                if (err) reject(err);
+                else resolve(DataFrame.deserialize(buf));
+            });
+        });
+    } finally {
+        console.timeEnd('readData');
+    }
+}
+
+async function setup(frame) {
+    console.time('setup');
+    try {
+        return frame.appendAll([frame, frame]);
+    } finally {
+        console.timeEnd('setup');
+    }
+}
+
+async function test(frame) {
+    console.log(`ready with ${frame.size} records`);
+    let collectFrame = DataFrame.empty(frame.config);
+    console.time('test');
+    try {
+        for (let i = 0; i < frame.size; i++) {
+            const rowFrame = frame.slice(i, i + 1);
+            collectFrame = collectFrame.appendOne(rowFrame);
+        }
+        return { collected: collectFrame.size };
+    } finally {
+        console.timeEnd('test');
+    }
+}
+
+Promise.resolve()
+    .then(readData)
+    .then(setup)
+    .then(test)
+    .then(async (res) => {
+        console.dir(res);
+        await pDelay();
+        process.exit(0);
+    }, (err) => {
+        console.error(err);
+        process.exit(1);
+    });

--- a/packages/data-mate/bench/select-rows-perf-test.js
+++ b/packages/data-mate/bench/select-rows-perf-test.js
@@ -5,6 +5,7 @@
 const { pDelay } = require('@terascope/utils');
 const fs = require('fs');
 const path = require('path');
+// const heapdump = require('heapdump');
 const { DataFrame } = require('./src');
 
 async function readData() {
@@ -30,15 +31,30 @@ async function setup(frame) {
     }
 }
 
+// function writeSnapshot(name) {
+//     const fName = `.local.${name}.${process.hrtime.bigint().toString()}.heapsnapshot`;
+//     return new Promise((resolve, reject) => {
+//         heapdump.writeSnapshot(fName, (err, filename) => {
+//             if (err) reject(err);
+//             else {
+//                 console.log(`Wrote snapshot: ${filename}`);
+//                 resolve();
+//             }
+//         });
+//     });
+// }
+
 async function test(frame) {
     console.log(`ready with ${frame.size} records`);
     let collectFrame = DataFrame.empty(frame.config);
     console.time('test');
     try {
+        // await writeSnapshot('before-all');
         for (let i = 0; i < frame.size; i++) {
             const rowFrame = frame.slice(i, i + 1);
             collectFrame = collectFrame.appendOne(rowFrame);
         }
+        // await writeSnapshot('after-all');
         return { collected: collectFrame.size };
     } finally {
         console.timeEnd('test');

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.37.1",
+    "version": "0.37.2",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-mate/src/core/ReadableData.ts
+++ b/packages/data-mate/src/core/ReadableData.ts
@@ -13,12 +13,28 @@ export class ReadableData<T> implements Iterable<Maybe<T>> {
     /**
      * The values to value index lookup table
     */
-    private readonly _values: ReadonlySparseMap<T>;
+    private readonly _values!: ReadonlySparseMap<T>;
 
     /**
      * The number of total number of values stored
     */
-    readonly size: number;
+    readonly size!: number;
+
+    constructor(data: WritableData<T>) {
+        // freezing this is very important because it allows the
+        // raw values to be used without fully copying them
+        Object.defineProperty(this, '_values', {
+            value: Object.freeze(data.rawValues()),
+            enumerable: true,
+            writable: false
+        });
+
+        Object.defineProperty(this, 'size', {
+            value: data.size,
+            enumerable: true,
+            writable: false
+        });
+    }
 
     /**
      * A flag to indicate whether the values stored a javascript primitive.
@@ -27,14 +43,8 @@ export class ReadableData<T> implements Iterable<Maybe<T>> {
      *
      * @default true
     */
-    readonly isPrimitive: boolean;
-
-    constructor(data: WritableData<T>) {
-        // freezing this is very important
-        this._values = Object.freeze(data.rawValues());
-        this.size = data.size;
-        this.isPrimitive = isPrimitive(this._values);
-        Object.freeze(this);
+    get isPrimitive() {
+        return isPrimitive(this._values);
     }
 
     * [Symbol.iterator](): IterableIterator<Maybe<T>> {

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -790,7 +790,9 @@ export class DataFrame<
     }
 
     /**
-     * Append one to the end of this DataFrame.
+     * Append one to the end of this DataFrame. This is does less than
+     * appendAll so it is faster.
+     *
      * Useful for incremental building an DataFrame since the cost of
      * this is relatively low.
      *

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -790,6 +790,26 @@ export class DataFrame<
     }
 
     /**
+     * Append one to the end of this DataFrame.
+     * Useful for incremental building an DataFrame since the cost of
+     * this is relatively low.
+     *
+     * This is more efficient than using DataFrame.concat but comes with less
+     * data type checking and may less safe so use with caution
+    */
+    appendOne(frame: DataFrame<T>): DataFrame<T> {
+        if (frame.size === 0) return this;
+        if (this.size === 0) return frame;
+
+        function appendToColumn(col: Column<any, keyof T>) {
+            return col.fork(col.vector.append(
+                frame.getColumnOrThrow(col.name).vector.data
+            ));
+        }
+        return this.fork(this.columns.map(appendToColumn));
+    }
+
+    /**
      * Append one or more data frames to the end of this DataFrame.
      * Useful for incremental building an DataFrame since the cost of
      * this is relatively low.

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -167,21 +167,23 @@ export class DataFrame<
 
         const cols: Column<any, keyof T>[] = [];
         const fields: (keyof T)[] = [];
-        let lastLength: number|undefined;
+        let size: number|undefined;
         const len = columns.length;
 
         for (let i = 0; i < len; i++) {
-            if (lastLength == null) lastLength = columns[i].size;
-            if (columns[i].size !== lastLength) {
+            if (size == null) {
+                size = columns[i].size;
+            } else if (columns[i].size !== size) {
                 throw new Error(
-                    `All columns in a DataFrame must have the same length of ${lastLength}, column (index: ${i}, name: ${columns[i].name}) length ${columns[i].size}`
+                    `All columns in a DataFrame must have the same length of ${size}, column (index: ${i}, name: ${columns[i].name}) got length of ${columns[i].size}`
                 );
             }
+
             fields.push(columns[i].name);
             cols.push(columns[i]);
         }
 
-        this.size = lastLength ?? 0;
+        this.size = size ?? 0;
         this.columns = cols;
         this.fields = fields;
     }

--- a/packages/data-mate/src/vector/Vector.ts
+++ b/packages/data-mate/src/vector/Vector.ts
@@ -125,11 +125,9 @@ export abstract class Vector<T = unknown> {
 
         const buckets: ReadableData<T>[] = [];
 
-        const len = 0;
-        // eslint-disable-next-line vars-on-top, no-var
-        var size = 0;
-        // eslint-disable-next-line vars-on-top, no-var
-        for (var i = 0; i < len; i++) {
+        const len = data.length;
+        let size = 0;
+        for (let i = 0; i < len; i++) {
             size = data[i].size;
             if (size) {
                 if (consistentSize == null) {

--- a/packages/data-mate/src/vector/Vector.ts
+++ b/packages/data-mate/src/vector/Vector.ts
@@ -88,6 +88,10 @@ export abstract class Vector<T = unknown> {
      * for a Vector and potential indices/unique values. Currently
      * there one ore more data buckets can be used.
      *
+     * @note DO NOT MUTATE THESE IT WILL BREAK THE GUARANTEES OF
+     *       IMMUTABILITY AND WILL CREATE SIDE EFFECTS BETWEEN
+     *       DATA FRAMES
+     *
      * @internal
     */
     readonly data: readonly ReadableData<T>[];

--- a/packages/data-mate/src/vector/Vector.ts
+++ b/packages/data-mate/src/vector/Vector.ts
@@ -123,28 +123,20 @@ export abstract class Vector<T = unknown> {
 
         let consistentSize: number|undefined;
 
-        const buckets: ReadableData<T>[] = [];
-
-        const len = data.length;
-        let size = 0;
-        for (let i = 0; i < len; i++) {
-            size = data[i].size;
-            if (size) {
-                if (consistentSize == null) {
-                    consistentSize = size;
-                } else if (consistentSize !== size) {
-                    consistentSize = -1;
-                }
-                this.size += size;
-                buckets.push(data[i]);
+        this.data = data.filter((bucket) => {
+            if (!bucket.size) return false;
+            if (consistentSize == null) {
+                consistentSize = bucket.size;
+            } else if (consistentSize !== bucket.size) {
+                consistentSize = -1;
             }
-        }
-
+            // @ts-expect-error
+            this.size += bucket.size;
+            return true;
+        });
         if (consistentSize != null) {
             this._consistentSize = consistentSize;
         }
-
-        this.data = buckets;
         this.name = options.name;
         this.config = options.config;
         this.childConfig = options.childConfig;

--- a/packages/data-mate/src/vector/Vector.ts
+++ b/packages/data-mate/src/vector/Vector.ts
@@ -125,15 +125,20 @@ export abstract class Vector<T = unknown> {
 
         const buckets: ReadableData<T>[] = [];
 
-        for (const bucket of data) {
-            if (bucket.size) {
+        const len = 0;
+        // eslint-disable-next-line vars-on-top, no-var
+        var size = 0;
+        // eslint-disable-next-line vars-on-top, no-var
+        for (var i = 0; i < len; i++) {
+            size = data[i].size;
+            if (size) {
                 if (consistentSize == null) {
-                    consistentSize = bucket.size;
-                } else if (consistentSize !== bucket.size) {
+                    consistentSize = size;
+                } else if (consistentSize !== size) {
                     consistentSize = -1;
                 }
-                this.size += bucket.size;
-                buckets.push(bucket);
+                this.size += size;
+                buckets.push(data[i]);
             }
         }
 
@@ -141,7 +146,7 @@ export abstract class Vector<T = unknown> {
             this._consistentSize = consistentSize;
         }
 
-        this.data = Object.freeze(buckets);
+        this.data = buckets;
         this.name = options.name;
         this.config = options.config;
         this.childConfig = options.childConfig;

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -32,7 +32,7 @@ describe('DataFrame', () => {
                 Column.fromJSON('count', { type: FieldType.Integer }, [1]),
                 Column.fromJSON('sum', { type: FieldType.Integer }, [5, 6]),
             ]);
-        }).toThrowError('All columns in a DataFrame must have the same length, got 1 and 2');
+        }).toThrowError('All columns in a DataFrame must have the same length of 1, column (index: 1, name: sum) got length of 2');
     });
 
     it('should be able to rename a data fame', () => {
@@ -275,20 +275,6 @@ describe('DataFrame', () => {
                 },
             }
         });
-    });
-
-    it('should be immutable', () => {
-        const dataFrame = DataFrame.fromJSON({
-            version: LATEST_VERSION,
-            fields: {
-                name: { type: FieldType.Keyword }
-            }
-        }, [{ name: 'Billy' }]);
-
-        expect(() => {
-            // @ts-expect-error
-            dataFrame.columns[0] = 'hi';
-        }).toThrow();
     });
 
     describe('when manipulating a DataFrame', () => {
@@ -1359,7 +1345,16 @@ describe('DataFrame', () => {
                 const resultFrame = empty.appendOne(peopleDataFrame);
 
                 expect(resultFrame.toJSON()).toEqual(peopleDataFrame.toJSON());
-                expect(resultFrame.id).not.toEqual(peopleDataFrame.id);
+                expect(resultFrame.id).toEqual(peopleDataFrame.id);
+                expect(resultFrame.size).toEqual(peopleDataFrame.size);
+            });
+
+            it('should be able to append an empty frame', () => {
+                const empty = DataFrame.empty<Person>(peopleDTConfig);
+                const resultFrame = peopleDataFrame.appendOne(empty);
+
+                expect(resultFrame.toJSON()).toEqual(peopleDataFrame.toJSON());
+                expect(resultFrame.id).toEqual(peopleDataFrame.id);
                 expect(resultFrame.size).toEqual(peopleDataFrame.size);
             });
 

--- a/packages/data-mate/test/data-frame-spec.ts
+++ b/packages/data-mate/test/data-frame-spec.ts
@@ -1353,6 +1353,27 @@ describe('DataFrame', () => {
             });
         });
 
+        describe('->appendOne', () => {
+            it('should be able to append to an empty frame', () => {
+                const empty = DataFrame.empty<Person>(peopleDTConfig);
+                const resultFrame = empty.appendOne(peopleDataFrame);
+
+                expect(resultFrame.toJSON()).toEqual(peopleDataFrame.toJSON());
+                expect(resultFrame.id).not.toEqual(peopleDataFrame.id);
+                expect(resultFrame.size).toEqual(peopleDataFrame.size);
+            });
+
+            it('should be able to append itself once', () => {
+                const resultFrame = peopleDataFrame.appendOne(peopleDataFrame);
+                const data = peopleDataFrame.toJSON();
+                expect(resultFrame.toJSON()).toEqual(
+                    data.concat(data)
+                );
+                expect(resultFrame.size).toEqual(peopleDataFrame.size * 2);
+                expect(resultFrame.id).not.toEqual(peopleDataFrame.id);
+            });
+        });
+
         describe('->filterBy', () => {
             it('should be able to filter by a single column', () => {
                 const resultFrame = peopleDataFrame.filterBy({

--- a/packages/data-mate/test/vector/vector-spec.ts
+++ b/packages/data-mate/test/vector/vector-spec.ts
@@ -482,13 +482,6 @@ describe('Vector', () => {
         it('should be an instance of a Vector', () => {
             expect(vector).toBeInstanceOf(Vector);
         });
-
-        it('should be immutable', () => {
-            expect(() => {
-                // @ts-expect-error
-                vector.data[0].values = '10';
-            }).toThrow();
-        });
     });
 
     it('should be able to return 2 data buckets (with a an start index of 0) when slicing', () => {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.60.1",
+    "version": "0.60.2",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.37.1",
+        "@terascope/data-mate": "^0.37.2",
         "@terascope/data-types": "^0.34.1",
         "@terascope/types": "^0.10.2",
         "@terascope/utils": "^0.44.1",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.66.1",
+    "version": "0.66.2",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.37.1",
+        "@terascope/data-mate": "^0.37.2",
         "@terascope/types": "^0.10.2",
         "@terascope/utils": "^0.44.1",
         "awesome-phonenumber": "^2.64.0",


### PR DESCRIPTION
- Minor performance improvements to DataFrame so it doesn't iterate over the columns too much when creating a DataFrame
- Add `DataFrame.appendOne` for a faster alternative to `appendAll` since it does less
- Add memory allocation optimizations to the Vector, ReadableData and WritableData which fixes memory explosions with lots of data buckets