### PR TITLE
fix async client use with docker images

### DIFF
--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.61.1",
+    "version": "0.61.2",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.38.1",
+    "version": "0.38.2",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -33,7 +33,7 @@
         "bunyan": "^1.8.15",
         "convict": "^4.4.1",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^0.61.1",
+        "elasticsearch-store": "^0.61.2",
         "js-yaml": "^4.1.0",
         "mongoose": "~5.11.12",
         "nanoid": "^3.3.2",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -61,7 +61,7 @@
         "semver": "^7.3.6",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.38.1",
+        "terafoundation": "^0.38.2",
         "uuid": "^8.3.2"
     },
     "devDependencies": {


### PR DESCRIPTION
es7 client would throw if using a docker image < 7.13 if elasticsearch. This is is because the client checks for the tagline, version, build_flavor, and headers (x-elastic-product) to verify that it is their product and not something else. 

Since the current opensearch library is backwards compatible with < 7.13, I am opting to use that for those version, and anything greater will use native elasticsearch client as the server should be compliant with their requirements.

I tested this against docker images to verify as this bug did not come up since all my local tests use elasticsearch itself, or docker images of v6 in teraslice. In the next major change to teraslice I will try to include v7 version of tests as well