### PR TITLE
release: (minor) teraslice@0.80.0

### DIFF
--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.56.4",
+    "version": "0.57.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.47.1",
+    "version": "0.48.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.48.4",
+    "version": "0.49.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -51,7 +51,7 @@
         "pretty-bytes": "^5.6.0",
         "prompts": "^2.4.2",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.44.4",
+        "teraslice-client-js": "^0.45.0",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.5",
         "yargs": "^17.4.0",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.44.4",
+    "version": "0.45.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.56.4",
+        "@terascope/job-components": "^0.57.0",
         "auto-bind": "^4.0.0",
         "got": "^11.8.3"
     },

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.56.4"
+        "@terascope/job-components": "^0.57.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.56.4"
+        "@terascope/job-components": ">=0.57.0"
     },
     "engines": {
         "node": "^12.22.0 || >=14.17.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^10.0.1"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.56.4"
+        "@terascope/job-components": "^0.57.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.56.4"
+        "@terascope/job-components": ">=0.57.0"
     },
     "engines": {
         "node": "^12.22.0 || >=14.17.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -38,7 +38,7 @@
     },
     "dependencies": {
         "@terascope/elasticsearch-api": "^3.2.0",
-        "@terascope/job-components": "^0.56.4",
+        "@terascope/job-components": "^0.57.0",
         "@terascope/teraslice-messaging": "^0.27.2",
         "@terascope/utils": "^0.44.2",
         "async-mutex": "^0.3.2",


### PR DESCRIPTION
bump: (minor) @terascope/job-components@0.57.0, teraslice-client-js@0.45.0

bump: (minor) teraslice-cli@0.49.0, @terascope/scripts@0.48.0