### PR TITLE
Allow scripts test suite to better run with asset directory structures

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.48.1",
+    "version": "0.49.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/interfaces.ts
+++ b/packages/scripts/src/helpers/interfaces.ts
@@ -51,6 +51,8 @@ export type PackageConfig = {
     testSuite?: string;
     allowBumpWhenPrivate?: boolean;
     linkToMain?: boolean;
+    root?: boolean
+    tests?: Record<string, Record<string, string[]>>
 };
 
 export enum Hook {
@@ -113,7 +115,8 @@ export type RootPackageInfo = {
 };
 
 export const AvailablePackageConfigKeys: readonly (keyof PackageConfig)[] = [
-    'enableTypedoc', 'testSuite', 'main', 'allowBumpWhenPrivate', 'linkToMain'
+    'enableTypedoc', 'testSuite', 'main', 'allowBumpWhenPrivate',
+    'linkToMain', 'root', 'tests'
 ];
 
 export type TSCommands = 'docs';

--- a/packages/scripts/src/helpers/packages.ts
+++ b/packages/scripts/src/helpers/packages.ts
@@ -77,9 +77,11 @@ export function listPackages(
         .filter((pkg): pkg is i.PackageInfo => pkg?.name != null);
 
     const sortedNames = getSortedPackages(packages);
+
     _packages = sortedNames.map((name) => (
         packages.find((pkg) => pkg.name === name)!
     ));
+
     return _packages;
 }
 
@@ -167,15 +169,6 @@ export function isMainPackage(pkgInfo: i.PackageInfo): boolean {
     return get(pkgInfo, 'terascope.main', false);
 }
 
-export function addPackageConfig(pkgInfo: i.PackageInfo): void {
-    for (const _key of Object.keys(pkgInfo.terascope)) {
-        const key = _key as (keyof i.PackageConfig);
-        if (!i.AvailablePackageConfigKeys.includes(key)) {
-            throw new Error(`Unknown terascope config "${key}" found in "${pkgInfo.name}" package`);
-        }
-    }
-}
-
 export function readPackageInfo(folderPath: string): i.PackageInfo {
     const dir = path.isAbsolute(folderPath)
         ? path.join(folderPath)
@@ -239,7 +232,6 @@ export function updatePkgInfo(pkgInfo: i.PackageInfo): void {
 
     pkgInfo.folderName = path.basename(pkgInfo.dir);
     pkgInfo.relativeDir = path.relative(rootInfo.dir, pkgInfo.dir);
-    addPackageConfig(pkgInfo);
 
     if (!pkgInfo.displayName) {
         pkgInfo.displayName = misc.getName(pkgInfo.folderName);

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -53,8 +53,8 @@ async function _runTests(
         await runE2ETest(options, tracker);
         return;
     }
-
     const filtered = utils.filterBySuite(pkgInfos, options);
+
     if (!filtered.length) {
         signale.warn('No tests found.');
         return;
@@ -128,7 +128,15 @@ async function runTestSuite(
         }
 
         const args = utils.getArgs(options);
-        args.projects = pkgs.map((pkgInfo) => pkgInfo.relativeDir);
+
+        args.projects = pkgs.map(
+            (pkgInfo) => {
+                if (pkgInfo.relativeDir.length) {
+                    return pkgInfo.relativeDir;
+                }
+                return '.';
+            }
+        );
 
         tracker.started += pkgs.length;
         try {


### PR DESCRIPTION
- Improve compatibility usage on how scripts test-suites can be used with our asset packages, will be first used with elasticsearch-assets 