### PR TITLE
Dataframe missing variable field fix

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.38.1",
+    "version": "0.38.2",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -46,7 +46,7 @@
         "uuid": "^8.3.2",
         "valid-url": "^1.0.9",
         "validator": "^13.7.0",
-        "xlucene-parser": "^0.42.2"
+        "xlucene-parser": "^0.42.3"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.2",

--- a/packages/data-mate/src/data-frame/search/buildMatcherForNode.ts
+++ b/packages/data-mate/src/data-frame/search/buildMatcherForNode.ts
@@ -85,9 +85,11 @@ function getComparisonValue(
     node: p.TermLikeNode, variables: xLuceneVariables
 ): unknown {
     if (!node) return undefined;
+
     if ('value' in node) {
         return p.getFieldValue((node as p.Term).value, variables);
     }
+
     throw new Error(`Unsupported value in node: ${inspect(node)}`);
 }
 

--- a/packages/data-mate/src/data-frame/search/buildSearchMatcherForQuery.ts
+++ b/packages/data-mate/src/data-frame/search/buildSearchMatcherForQuery.ts
@@ -19,6 +19,7 @@ export function buildSearchMatcherForQuery(
     if (variables) {
         parser = parser.resolveVariables(variables);
     }
+
     return buildMatcherForNode(dataFrame, parser.typeConfig, variables ?? {})(
         parser.ast
     );

--- a/packages/data-mate/src/document-matcher/logic-builder/string.ts
+++ b/packages/data-mate/src/document-matcher/logic-builder/string.ts
@@ -6,13 +6,17 @@ import {
 } from '@terascope/utils';
 import { BooleanCB } from '../interfaces';
 
-export function regexp(regexStr: string) {
+export function regexp(regexStr: string|undefined) {
+    if (regexStr === undefined) return () => false;
+
     return function regexpTerm(str: string): boolean {
         return match(`^${regexStr}$`, str) != null;
     };
 }
 
-export function wildcard(wildcardStr: string) {
+export function wildcard(wildcardStr: string|undefined) {
+    if (wildcardStr === undefined) return () => false;
+
     return function wildcardTerm(str: string): boolean {
         return matchWildcard(wildcardStr, str);
     };

--- a/packages/data-mate/test/data-frame-search-partial-variables-spec.ts
+++ b/packages/data-mate/test/data-frame-search-partial-variables-spec.ts
@@ -1,0 +1,139 @@
+import 'jest-extended';
+import { LATEST_VERSION } from '@terascope/data-types';
+import {
+    DataTypeConfig, FieldType, Maybe
+} from '@terascope/types';
+import { DataFrame } from '../src';
+
+describe('DataFrame->search', () => {
+    type PartialPerson = {
+        name?: Maybe<string>;
+        age?: Maybe<number>;
+        alive?: Maybe<boolean>;
+        friends?: Maybe<Maybe<string>[]>
+    }
+
+    let partialPeopleDataFrame: DataFrame<PartialPerson>;
+
+    const peopleDTConfig: DataTypeConfig = {
+        version: LATEST_VERSION,
+        fields: {
+            name: {
+                type: FieldType.Keyword,
+            },
+            age: {
+                type: FieldType.Short,
+            },
+            alive: {
+                type: FieldType.Boolean,
+            },
+            friends: {
+                type: FieldType.Keyword,
+                array: true,
+            }
+        }
+    };
+
+    function createPartialPeopleDataFrame(data: PartialPerson[]): DataFrame<PartialPerson> {
+        return DataFrame.fromJSON<PartialPerson>(peopleDTConfig, data);
+    }
+
+    beforeAll(() => {
+        partialPeopleDataFrame = createPartialPeopleDataFrame([
+            {
+                alive: true,
+                friends: ['Frank', 'Jane'] // sucks for Billy
+            },
+            {
+                name: 'Billy',
+                friends: ['Jill']
+            },
+            {
+                age: 20,
+                friends: ['Jill']
+            },
+            {
+                name: 'Jane',
+                alive: false,
+                friends: ['Jill']
+            },
+            {
+                name: 'Nancy',
+                age: 10,
+                friends: null
+            },
+        ]);
+    });
+
+    it('should be able to search on partial data', () => {
+        const resultFrame = partialPeopleDataFrame
+            .search('name:Jill OR age:>=12')
+            .select('age', 'alive', 'name', 'friends');
+
+        expect(resultFrame.toJSON()).toEqual([
+            {
+                age: 20,
+                friends: ['Jill']
+            },
+
+        ]);
+    });
+
+    it('should be able to search with partial variables in OR statements (term type)', () => {
+        const resultFrame = partialPeopleDataFrame
+            .search('name:@name OR age:@age', { '@name': undefined, '@age': 20 })
+            .select('age', 'alive', 'name', 'friends');
+
+        expect(resultFrame.toJSON()).toEqual([
+            {
+                age: 20,
+                friends: ['Jill']
+            },
+
+        ]);
+    });
+
+    it('should be able to search with partial variables in OR statements (int type)', () => {
+        const resultFrame = partialPeopleDataFrame
+            .search('name:@name OR age:@age', { '@name': 'Billy', '@age': undefined })
+            .select('age', 'alive', 'name', 'friends');
+
+        expect(resultFrame.toJSON()).toEqual([
+            {
+                name: 'Billy',
+                friends: ['Jill']
+            },
+        ]);
+    });
+
+    it('should be able to search with partial variables in AND statements', () => {
+        const resultFrame = partialPeopleDataFrame
+            .search('name:@name AND age:@age', { '@name': 'Billy', '@age': undefined })
+            .select('age', 'alive', 'name', 'friends');
+
+        expect(resultFrame.toJSON()).toBeArrayOfSize(0);
+    });
+
+    it('should be able to search with partial variables in Complex statements', () => {
+        const variables = {
+            '@name': 'Billy',
+            '@age': undefined,
+            '@alive': false
+        };
+        const resultFrame = partialPeopleDataFrame
+            .search('name:@name OR (age:@age OR alive:@alive)', variables)
+            .select('age', 'alive', 'name', 'friends');
+
+        expect(resultFrame.toJSON()).toEqual([
+            {
+                name: 'Billy',
+                friends: ['Jill']
+            },
+            {
+                name: 'Jane',
+                alive: false,
+                friends: ['Jill']
+            },
+        ]);
+    });
+});

--- a/packages/data-mate/test/data-frame-search-partial-variables-spec.ts
+++ b/packages/data-mate/test/data-frame-search-partial-variables-spec.ts
@@ -54,6 +54,7 @@ describe('DataFrame->search', () => {
             },
             {
                 name: 'Jane',
+                age: 10,
                 alive: false,
                 friends: ['Jill']
             },
@@ -79,6 +80,14 @@ describe('DataFrame->search', () => {
         ]);
     });
 
+    it('should be able to search with partial variables in simple queries)', () => {
+        const resultFrame = partialPeopleDataFrame
+            .search('name:@name', { '@name': undefined })
+            .select('age', 'alive', 'name', 'friends');
+
+        expect(resultFrame.toJSON()).toBeArrayOfSize(0);
+    });
+
     it('should be able to search with partial variables in OR statements (term type)', () => {
         const resultFrame = partialPeopleDataFrame
             .search('name:@name OR age:@age', { '@name': undefined, '@age': 20 })
@@ -88,8 +97,7 @@ describe('DataFrame->search', () => {
             {
                 age: 20,
                 friends: ['Jill']
-            },
-
+            }
         ]);
     });
 
@@ -131,6 +139,27 @@ describe('DataFrame->search', () => {
             },
             {
                 name: 'Jane',
+                age: 10,
+                alive: false,
+                friends: ['Jill']
+            },
+        ]);
+    });
+
+    it('should be able to search with partial variables in Complex AND statements', () => {
+        const variables = {
+            '@name': undefined,
+            '@age': 10,
+            '@alive': false
+        };
+        const resultFrame = partialPeopleDataFrame
+            .search('name:@name OR (age:@age AND alive:@alive)', variables)
+            .select('age', 'alive', 'name', 'friends');
+
+        expect(resultFrame.toJSON()).toEqual([
+            {
+                name: 'Jane',
+                age: 10,
                 alive: false,
                 friends: ['Jill']
             },

--- a/packages/data-mate/test/matcher/cases/document-matcher/index.ts
+++ b/packages/data-mate/test/matcher/cases/document-matcher/index.ts
@@ -6,6 +6,7 @@ import ip from './ip';
 import dates from './dates';
 import wildcard from './wildcard';
 import complexQueries from './complex-queries';
+import partialVariables from './partial-variables';
 
 export default {
     basic_queries_and_logic: basicQueries,
@@ -15,5 +16,6 @@ export default {
     regexp,
     wildcard,
     geo,
-    complex_queries: complexQueries
+    complex_queries: complexQueries,
+    partial_variables: partialVariables
 };

--- a/packages/data-mate/test/matcher/cases/document-matcher/partial-variables.ts
+++ b/packages/data-mate/test/matcher/cases/document-matcher/partial-variables.ts
@@ -1,0 +1,130 @@
+import { xLuceneFieldType } from '@terascope/types';
+import { cloneDeep } from '@terascope/utils';
+import { TestCase } from './interfaces';
+
+const data = [
+    {
+        alive: true,
+        friends: ['Frank', 'Jane']
+    },
+    {
+        name: 'Billy',
+        friends: ['Jill']
+    },
+    {
+        age: 20,
+        friends: ['Jill']
+    },
+    {
+        name: 'Jane',
+        age: 10,
+        alive: false,
+        friends: ['Jill']
+    },
+    {
+        name: 'Nancy',
+        age: 10,
+        friends: null
+    },
+];
+
+export default [
+    [
+        'should be able to search on partial data',
+        'name:Jill OR age:>=12',
+        cloneDeep(data),
+        [false, false, true, false, false],
+        {
+            name: xLuceneFieldType.String,
+            age: xLuceneFieldType.Number,
+            alive: xLuceneFieldType.Boolean,
+            friends: xLuceneFieldType.String
+        },
+    ],
+    [
+        'should be able to search with partial variables in simple queries',
+        'name:@name',
+        cloneDeep(data),
+        [false, false, false, false, false],
+        {
+            name: xLuceneFieldType.String,
+            age: xLuceneFieldType.Number,
+            alive: xLuceneFieldType.Boolean,
+            friends: xLuceneFieldType.String
+        },
+        { '@name': undefined }
+    ],
+    [
+        'should be able to search with partial variables in OR statements (term type)',
+        'name:@name OR age:@age',
+        cloneDeep(data),
+        [false, false, true, false, false],
+        {
+            name: xLuceneFieldType.String,
+            age: xLuceneFieldType.Number,
+            alive: xLuceneFieldType.Boolean,
+            friends: xLuceneFieldType.String
+        },
+        { '@name': undefined, '@age': 20 }
+    ],
+    [
+        'should be able to search with partial variables in OR statements (int type)',
+        'name:@name OR age:@age',
+        cloneDeep(data),
+        [false, true, false, false, false],
+        {
+            name: xLuceneFieldType.String,
+            age: xLuceneFieldType.Number,
+            alive: xLuceneFieldType.Boolean,
+            friends: xLuceneFieldType.String
+        },
+        { '@name': 'Billy', '@age': undefined }
+    ],
+    [
+        'should be able to search with partial variables in AND statements',
+        'name:@name AND age:@age',
+        cloneDeep(data),
+        [false, false, false, false, false],
+        {
+            name: xLuceneFieldType.String,
+            age: xLuceneFieldType.Number,
+            alive: xLuceneFieldType.Boolean,
+            friends: xLuceneFieldType.String
+        },
+        { '@name': 'Billy', '@age': undefined }
+    ],
+    [
+        'should be able to search with partial variables in Complex statements',
+        'name:@name OR (age:@age OR alive:@alive)',
+        cloneDeep(data),
+        [false, true, false, true, false],
+        {
+            name: xLuceneFieldType.String,
+            age: xLuceneFieldType.Number,
+            alive: xLuceneFieldType.Boolean,
+            friends: xLuceneFieldType.String
+        },
+        {
+            '@name': 'Billy',
+            '@age': undefined,
+            '@alive': false
+        }
+    ],
+    [
+        'should be able to search with partial variables in Complex AND statements',
+        'name:@name OR (age:@age AND alive:@alive)',
+        cloneDeep(data),
+        [false, false, false, true, false],
+        {
+            name: xLuceneFieldType.String,
+            age: xLuceneFieldType.Number,
+            alive: xLuceneFieldType.Boolean,
+            friends: xLuceneFieldType.String
+        },
+        {
+            '@name': undefined,
+            '@age': 10,
+            '@alive': false
+        }
+    ],
+] as TestCase[];

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.62.0",
+    "version": "0.62.1",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@opensearch-project/opensearch": "^1.0.2",
-        "@terascope/data-mate": "^0.38.1",
+        "@terascope/data-mate": "^0.38.2",
         "@terascope/data-types": "^0.35.1",
         "@terascope/types": "^0.10.3",
         "@terascope/utils": "^0.44.2",
@@ -40,7 +40,7 @@
         "elasticsearch8": "npm:@elastic/elasticsearch@^8.0.0",
         "setimmediate": "^1.0.5",
         "uuid": "^8.3.2",
-        "xlucene-translator": "^0.27.1"
+        "xlucene-translator": "^0.27.2"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.4"

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.39.0",
+    "version": "0.39.1",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -33,7 +33,7 @@
         "bunyan": "^1.8.15",
         "convict": "^4.4.1",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^0.62.0",
+        "elasticsearch-store": "^0.62.1",
         "js-yaml": "^4.1.0",
         "mongoose": "~5.11.12",
         "nanoid": "^3.3.2",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -61,7 +61,7 @@
         "semver": "^7.3.6",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.39.0",
+        "terafoundation": "^0.39.1",
         "uuid": "^8.3.2"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.67.1",
+    "version": "0.67.2",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.38.1",
+        "@terascope/data-mate": "^0.38.2",
         "@terascope/types": "^0.10.3",
         "@terascope/utils": "^0.44.2",
         "awesome-phonenumber": "^2.70.0",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.42.2",
+    "version": "0.42.3",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.27.1",
+    "version": "0.27.2",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -31,7 +31,7 @@
         "@terascope/types": "^0.10.3",
         "@terascope/utils": "^0.44.2",
         "@types/elasticsearch": "^5.0.40",
-        "xlucene-parser": "^0.42.2"
+        "xlucene-parser": "^0.42.3"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"


### PR DESCRIPTION
- undefined variables will turn the logic node to return false as it is inoperable
- this allows dataframes and document matcher to behave more like elasticsearch, so it wont blow up or return wrong data