### PR TITLE
Bigint interger bug fix

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.38.3",
+    "version": "0.38.4",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -29,9 +29,9 @@
         "test:watch": "TZ=utc ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.35.2",
+        "@terascope/data-types": "^0.35.3",
         "@terascope/types": "^0.10.3",
-        "@terascope/utils": "^0.44.3",
+        "@terascope/utils": "^0.44.4",
         "@types/validator": "^13.7.2",
         "awesome-phonenumber": "^2.70.0",
         "date-fns": "^2.29.1",
@@ -46,7 +46,7 @@
         "uuid": "^8.3.2",
         "valid-url": "^1.0.9",
         "validator": "^13.7.0",
-        "xlucene-parser": "^0.42.4"
+        "xlucene-parser": "^0.42.5"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.2",

--- a/packages/data-mate/test/vector/vector-spec.ts
+++ b/packages/data-mate/test/vector/vector-spec.ts
@@ -44,10 +44,10 @@ describe('Vector', () => {
         ],
         [
             FieldType.Integer,
-            [12.344, '2.01', BigInt(200), 1, 2, null, undefined],
+            [12.344, '2.01', BigInt(246071665871), 1, 2, null, undefined],
             undefined,
-            [12, 2, 200, 1, 2, null, null],
-            [-(2 ** 31) - 1, 2 ** 31 + 1, 'foo']
+            [12, 2, 246071665871, 1, 2, null, null],
+            ['foo']
         ],
         [
             FieldType.Byte,

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.35.2",
+    "version": "0.35.3",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.3",
-        "@terascope/utils": "^0.44.3",
+        "@terascope/utils": "^0.44.4",
         "graphql": "^14.7.0",
         "lodash": "^4.17.21",
         "yargs": "^17.4.0"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -22,7 +22,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.44.3",
+        "@terascope/utils": "^0.44.4",
         "bluebird": "^3.7.2",
         "setimmediate": "^1.0.5"
     },

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.62.2",
+    "version": "0.62.3",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -29,10 +29,10 @@
     },
     "dependencies": {
         "@opensearch-project/opensearch": "^1.0.2",
-        "@terascope/data-mate": "^0.38.3",
-        "@terascope/data-types": "^0.35.2",
+        "@terascope/data-mate": "^0.38.4",
+        "@terascope/data-types": "^0.35.3",
         "@terascope/types": "^0.10.3",
-        "@terascope/utils": "^0.44.3",
+        "@terascope/utils": "^0.44.4",
         "ajv": "^6.12.6",
         "elasticsearch": "^15.4.1",
         "elasticsearch6": "npm:@elastic/elasticsearch@^6.7.0",
@@ -40,7 +40,7 @@
         "elasticsearch8": "npm:@elastic/elasticsearch@^8.0.0",
         "setimmediate": "^1.0.5",
         "uuid": "^8.3.2",
-        "xlucene-translator": "^0.27.3"
+        "xlucene-translator": "^0.27.4"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.4"

--- a/packages/elasticsearch-store/src/elasticsearch-client/create-client.ts
+++ b/packages/elasticsearch-store/src/elasticsearch-client/create-client.ts
@@ -9,11 +9,6 @@ import { ClientMetadata, ElasticsearchDistribution } from '@terascope/types';
 import { logWrapper } from './log-wrapper';
 import { ClientConfig } from './interfaces';
 
-// polyfill because opensearch has references to an api that won't exist
-// on the client side, should be able to remove in the future
-// @ts-expect-error
-import('setimmediate');
-
 const clientList = [opensearch, elasticsearch8, elasticsearch7, elasticsearch6];
 
 interface ServerMetadata extends ClientMetadata {

--- a/packages/elasticsearch-store/src/index.ts
+++ b/packages/elasticsearch-store/src/index.ts
@@ -1,3 +1,8 @@
+// polyfill because opensearch has references to an api that won't exist
+// on the client side, should be able to remove in the future
+// @ts-expect-error
+import('setimmediate');
+
 export * from './utils';
 export * from './cluster';
 export * from './index-manager';

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.23.3",
+    "version": "0.23.4",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.44.3",
+        "@terascope/utils": "^0.44.4",
         "chalk": "^4.1.2",
         "lodash": "^4.17.21",
         "yeoman-generator": "^4.13.0",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.57.1",
+    "version": "0.57.2",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.44.3",
+        "@terascope/utils": "^0.44.4",
         "convict": "^4.4.1",
         "datemath-parser": "^1.0.6",
         "uuid": "^8.3.2"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.49.1",
+    "version": "0.49.2",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "typescript": "~4.6.3"
     },
     "dependencies": {
-        "@terascope/utils": "^0.44.3",
+        "@terascope/utils": "^0.44.4",
         "codecov": "^3.8.3",
         "execa": "^5.1.0",
         "fs-extra": "^10.0.1",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.39.2",
+    "version": "0.39.3",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -27,13 +27,13 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.44.3",
+        "@terascope/utils": "^0.44.4",
         "aws-sdk": "^2.1110.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.15",
         "convict": "^4.4.1",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^0.62.2",
+        "elasticsearch-store": "^0.62.3",
         "js-yaml": "^4.1.0",
         "mongoose": "~5.11.12",
         "nanoid": "^3.3.2",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.49.1",
+    "version": "0.49.2",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.8.7",
-        "@terascope/utils": "^0.44.3",
+        "@terascope/utils": "^0.44.4",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.1",
         "easy-table": "^1.2.0",
@@ -51,7 +51,7 @@
         "pretty-bytes": "^5.6.0",
         "prompts": "^2.4.2",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.45.1",
+        "teraslice-client-js": "^0.45.2",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.5",
         "yargs": "^17.4.0",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.45.1",
+    "version": "0.45.2",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.57.1",
+        "@terascope/job-components": "^0.57.2",
         "auto-bind": "^4.0.0",
         "got": "^11.8.3"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.27.3",
+    "version": "0.27.4",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/utils": "^0.44.3",
+        "@terascope/utils": "^0.44.4",
         "ms": "^2.1.3",
         "nanoid": "^3.3.2",
         "p-event": "^4.2.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.57.1"
+        "@terascope/job-components": "^0.57.2"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.57.1"
+        "@terascope/job-components": ">=0.57.2"
     },
     "engines": {
         "node": "^12.22.0 || >=14.17.0",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.35.1",
+    "version": "0.35.2",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^3.2.1",
-        "@terascope/utils": "^0.44.3"
+        "@terascope/elasticsearch-api": "^3.2.2",
+        "@terascope/utils": "^0.44.4"
     },
     "engines": {
         "node": "^12.22.0 || >=14.17.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^10.0.1"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.57.1"
+        "@terascope/job-components": "^0.57.2"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.57.1"
+        "@terascope/job-components": ">=0.57.2"
     },
     "engines": {
         "node": "^12.22.0 || >=14.17.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,10 +37,10 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^3.2.1",
-        "@terascope/job-components": "^0.57.1",
-        "@terascope/teraslice-messaging": "^0.27.3",
-        "@terascope/utils": "^0.44.3",
+        "@terascope/elasticsearch-api": "^3.2.2",
+        "@terascope/job-components": "^0.57.2",
+        "@terascope/teraslice-messaging": "^0.27.4",
+        "@terascope/utils": "^0.44.4",
         "async-mutex": "^0.3.2",
         "barbe": "^3.0.16",
         "body-parser": "^1.20.0",
@@ -61,7 +61,7 @@
         "semver": "^7.3.6",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.39.2",
+        "terafoundation": "^0.39.3",
         "uuid": "^8.3.2"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.67.3",
+    "version": "0.67.4",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.38.3",
+        "@terascope/data-mate": "^0.38.4",
         "@terascope/types": "^0.10.3",
-        "@terascope/utils": "^0.44.3",
+        "@terascope/utils": "^0.44.4",
         "awesome-phonenumber": "^2.70.0",
         "graphlib": "^2.1.8",
         "is-ip": "^3.1.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.44.3",
+    "version": "0.44.4",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/numbers.ts
+++ b/packages/utils/src/numbers.ts
@@ -48,6 +48,7 @@ export function toBigInt(input: unknown): bigint|false {
     if (!supportsBigInt) {
         throw new Error('BigInt isn\'t supported in this environment');
     }
+
     try {
         return toBigIntOrThrow(input);
     } catch {
@@ -66,6 +67,7 @@ export function toBigIntOrThrow(input: unknown): bigint {
     }
 
     if (isBigInt(input)) return input;
+
     if (!supportsBigInt) {
         throw new Error('BigInt isn\'t supported in this environment');
     }
@@ -81,6 +83,7 @@ export function toBigIntOrThrow(input: unknown): bigint {
     }
 
     let big: bigint;
+
     if (typeof input === 'string' && input.includes('.')) {
         big = BigInt(Number.parseInt(input, 10));
     } else {
@@ -144,6 +147,7 @@ export function toIntegerOrThrow(input: unknown): number {
 
     if (isBigInt(input)) {
         const val = bigIntToJSON(input);
+
         if (typeof val === 'string') {
             throw new TypeError(`Expected ${val} (${getTypeOf(input)}) to be parsable to a integer`);
         }
@@ -331,6 +335,7 @@ function setPrecisionFromString(
 export function toCelsius(input: unknown): number {
     const num = toFloatOrThrow(input);
     const cNum = (num - 32) * (5 / 9);
+
     return parseFloat(cNum.toFixed(2));
 }
 
@@ -341,13 +346,19 @@ export function toCelsius(input: unknown): number {
 export function toFahrenheit(input: unknown): number {
     const num = toFloatOrThrow(input);
     const fNum = ((9 / 5) * num) + 32;
+
     return parseFloat(fNum.toFixed(2));
 }
 
+/**
+ * A number in javascript is a double-precision 64-bit
+ * binary format IEEE 754 value, much bigger than a regular
+ * classical int value, any higher than that should be a bigint
+ */
 const INT_SIZES = {
     [FieldType.Byte]: { min: -128, max: 127 },
     [FieldType.Short]: { min: -32_768, max: 32_767 },
-    [FieldType.Integer]: { min: -(2 ** 31), max: (2 ** 31) - 1 },
+    [FieldType.Integer]: { min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
 } as const;
 
 function _validateNumberFieldType(input: unknown, type: FieldType): number {

--- a/packages/utils/test/type-coercion-spec.ts
+++ b/packages/utils/test/type-coercion-spec.ts
@@ -29,6 +29,7 @@ describe('type-coercion', () => {
             ]),
             [FieldType.Long, BigInt(12e12), BigInt(12e12)],
             [FieldType.Long, '120000', BigInt(120000)],
+            [FieldType.Integer, BigInt(246071665871), 246071665871],
         ];
         describe.each(validTestCases)('when given valid values for field type %s', (type, input, output) => {
             it(`should convert ${input} to ${output}`, () => {
@@ -46,8 +47,6 @@ describe('type-coercion', () => {
             [FieldType.Short, -32_768 - 1],
             [FieldType.Byte, -128 - 1],
             [FieldType.Byte, 127 + 1],
-            [FieldType.Integer, -(2 ** 31) - 1],
-            [FieldType.Integer, 2 ** 31],
         ];
         describe.each(invalidTestCases)('when given invalid values for field type %s', (type, input) => {
             it(`should fail to convert ${input}`, () => {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.42.4",
+    "version": "0.42.5",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.3",
-        "@terascope/utils": "^0.44.3",
+        "@terascope/utils": "^0.44.4",
         "netmask": "^2.0.2"
     },
     "devDependencies": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.27.3",
+    "version": "0.27.4",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,9 +29,9 @@
     },
     "dependencies": {
         "@terascope/types": "^0.10.3",
-        "@terascope/utils": "^0.44.3",
+        "@terascope/utils": "^0.44.4",
         "@types/elasticsearch": "^5.0.40",
-        "xlucene-parser": "^0.42.4"
+        "xlucene-parser": "^0.42.5"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "0.11.3",
+    "version": "0.11.4",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.44.3"
+        "@terascope/utils": "^0.44.4"
     },
     "devDependencies": {
         "@terascope/types": "^0.10.3"


### PR DESCRIPTION
- javascript numbers go up to ^51 while an integer in another system is ^31 which causes friction when a value is coerced into a number, this fix makes it more permissable