### PR TITLE
update minikube dev for new ES connector

### DIFF
--- a/examples/k8s/elasticsearchDeployment.yaml
+++ b/examples/k8s/elasticsearchDeployment.yaml
@@ -19,12 +19,14 @@ spec:
     spec:
       containers:
       - name: elasticsearch
-        image: elasticsearch:5.6.10
+        image: elasticsearch:7.9.3
         ports:
         - containerPort: 9200
         env:
         - name: ES_JAVA_OPTS
           value: "-Xms512m -Xmx512m"
+        - name: discovery.type
+          value: single-node
 ---
 kind: Service
 apiVersion: v1

--- a/examples/k8s/teraslice-master.yaml.tpl
+++ b/examples/k8s/teraslice-master.yaml.tpl
@@ -7,6 +7,10 @@ terafoundation:
                 apiVersion: "5.6"
                 host:
                     - "elasticsearch:9200"
+        elasticsearch-next:
+            default:
+                node:
+                    - "http://elasticsearch:9200"
 teraslice:
     worker_disconnect_timeout: 60000
     node_disconnect_timeout: 60000

--- a/examples/k8s/teraslice-worker.yaml.tpl
+++ b/examples/k8s/teraslice-worker.yaml.tpl
@@ -7,6 +7,10 @@ terafoundation:
                 apiVersion: "5.6"
                 host:
                     - "elasticsearch:9200"
+        elasticsearch-next:
+            default:
+                node:
+                    - "http://elasticsearch:9200"
 teraslice:
     worker_disconnect_timeout: 60000
     node_disconnect_timeout: 60000


### PR DESCRIPTION
I've updated the minikube development setup to use a newer elasticsearch
image (v7.9.3) as well as to use the new elasticsearch-next connector