### PR TITLE
Cli version fix

### DIFF
--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -45,7 +45,7 @@
         "execa": "^5.1.0",
         "fs-extra": "^10.1.0",
         "glob": "^8.0.3",
-        "glob-promise": "^5.0.0",
+        "glob-promise": "5.0.0",
         "got": "^11.8.3",
         "js-yaml": "^4.1.0",
         "pretty-bytes": "^5.6.0",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.50.2",
+    "version": "0.50.3",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5160,7 +5160,7 @@ glob-parent@^6.0.1:
   dependencies:
     is-glob "^4.0.3"
 
-glob-promise@^5.0.0:
+glob-promise@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/glob-promise/-/glob-promise-5.0.0.tgz#aee3317ee1c211866d0425e1ac2e9089ded09c28"
   integrity sha512-YQ7+beqmmQ3yUzybHoxnj7XMImztIdusIFate36/aB1gEWugR1qZI9a2u1A5mt6gYRqYldipZ7NB9s1UEq3vzw==


### PR DESCRIPTION
- lock package  "glob-promise" to version "5.0.0", as "5.0.1" introduces an node engine breaking change to require v16, it would break our v14 servers and tests