### PR TITLE
WIP: updated es-api types

### DIFF
--- a/packages/elasticsearch-api/types/index.d.ts
+++ b/packages/elasticsearch-api/types/index.d.ts
@@ -32,9 +32,9 @@ declare namespace elasticsearchAPI {
         /**
          * The new and improved bulk send with proper retry support
          *
-         * @returns the number of affected rows
+         * @returns the number of affected rows, and deadLetter records if config is set
         */
-        bulkSend: (data: BulkRecord[]) => Promise<number>;
+        bulkSend: (data: BulkRecord[]) => Promise<{ count: number; deadLetter?: any[]; }>;
         nodeInfo: (query: any) => Promise<any>;
         nodeStats: (query: any) => Promise<any>;
         buildQuery: (opConfig: Config, msg: any) => ClientParams.SearchParams;


### PR DESCRIPTION
Idea is to return the non-retryable records back to the bulk_sender if the dead letter action is `kakfka_dead_letter`, for example records where a value is different than it's es index mapping.

Currently the bulkSender returns a count, this would change the returned value an object with the count and an array of deadLetter records if there are any.  So I need to track down what functions this would affect where they are expecting just a number to be returned.

The other part of this would be to change the es_bulk processor so that if deadLetter records are returned it could use  the `rejectRecord` function to send the records to the kafka dead letter topic.

If `_dead_letter_action` is not set to `kafka_dead_letter` in the opConfig it should behave like normal.

