### PR TITLE
Dlq refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "0.83.0",
+    "version": "0.83.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "0.82.1",
+    "version": "0.82.2",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "0.82.2",
+    "version": "0.82.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "0.82.3",
+    "version": "0.82.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/elasticsearch-api/index.js
+++ b/packages/elasticsearch-api/index.js
@@ -311,7 +311,7 @@ module.exports = function elasticsearchApi(client, logger, _opConfig) {
                     reason = `${item.error.type}--${item.error.reason}`;
 
                     if (config._dead_letter_action === 'kafka_dead_letter') {
-                        actionRecords[i].data.setMetadata('_send_to_dlq', reason);
+                        actionRecords[i].data.setMetadata('_bulk_sender_rejection', reason);
                         continue;
                     }
 

--- a/packages/elasticsearch-api/index.js
+++ b/packages/elasticsearch-api/index.js
@@ -278,7 +278,6 @@ module.exports = function elasticsearchApi(client, logger, _opConfig) {
     */
     function _filterRetryRecords(actionRecords, result) {
         const retry = [];
-        const deadLetter = [];
         const { items } = result;
 
         let nonRetriableError = false;
@@ -312,7 +311,7 @@ module.exports = function elasticsearchApi(client, logger, _opConfig) {
                     reason = `${item.error.type}--${item.error.reason}`;
 
                     if (config._dead_letter_action === 'kafka_dead_letter') {
-                        deadLetter.push({ doc: actionRecords[i].data, reason });
+                        
                         continue;
                     }
                     break;
@@ -323,9 +322,7 @@ module.exports = function elasticsearchApi(client, logger, _opConfig) {
         }
 
         if (nonRetriableError) {
-            return {
-                retry: [], successful, error: true, reason, deadLetter
-            };
+            return { retry: [], successful, error: true, reason };
         }
 
         return { retry, successful, error: false };

--- a/packages/elasticsearch-api/index.js
+++ b/packages/elasticsearch-api/index.js
@@ -311,7 +311,7 @@ module.exports = function elasticsearchApi(client, logger, _opConfig) {
                     reason = `${item.error.type}--${item.error.reason}`;
 
                     if (config._dead_letter_action === 'kafka_dead_letter') {
-                        actionRecords[i].data.setMetadata('_dlq_reason', reason);
+                        actionRecords[i].data.setMetadata('_send_to_dlq', reason);
                         continue;
                     }
 

--- a/packages/elasticsearch-api/index.js
+++ b/packages/elasticsearch-api/index.js
@@ -311,9 +311,10 @@ module.exports = function elasticsearchApi(client, logger, _opConfig) {
                     reason = `${item.error.type}--${item.error.reason}`;
 
                     if (config._dead_letter_action === 'kafka_dead_letter') {
-                        
+                        actionRecords[i].data.setMetadata('_dlq_reason', reason);
                         continue;
                     }
+
                     break;
                 }
             } else if (item.status == null || item.status < 400) {
@@ -322,7 +323,9 @@ module.exports = function elasticsearchApi(client, logger, _opConfig) {
         }
 
         if (nonRetriableError) {
-            return { retry: [], successful, error: true, reason };
+            return {
+                retry: [], successful, error: true, reason
+            };
         }
 
         return { retry, successful, error: false };
@@ -334,7 +337,7 @@ module.exports = function elasticsearchApi(client, logger, _opConfig) {
 
     /**
      * @param data {Array<{ action: data }>}
-     * @returns {Promise<{ recordCount: number, deadLetter: record[] }>}
+     * @returns {Promise<number>}
     */
     async function _bulkSend(actionRecords, previousCount = 0, previousRetryDelay = 0) {
         const body = actionRecords.flatMap((record, index) => {
@@ -346,7 +349,18 @@ module.exports = function elasticsearchApi(client, logger, _opConfig) {
                 throw new Error(`Bulk send record is missing the action property${dbg}`);
             }
 
-            if (!isElasticsearch6()) return _nonEs6Prep(record);
+            if (!isElasticsearch6()) {
+                const actionKey = getFirstKey(record.action);
+                const { _type, ...withoutTypeAction } = record.action[actionKey];
+                // if data is specified return both
+                return record.data ? [{
+                    ...record.action,
+                    [actionKey]: withoutTypeAction
+                }, record.data] : [{
+                    ...record.action,
+                    [actionKey]: withoutTypeAction
+                }];
+            }
 
             // if data is specified return both
             return record.data ? [record.action, record.data] : [record.action];
@@ -355,51 +369,50 @@ module.exports = function elasticsearchApi(client, logger, _opConfig) {
         const response = await _clientRequest('bulk', { body });
         const results = response.body ? response.body : response;
 
-        if (!results.errors) return { recordCount: _affectedRowsCount(results) };
+        if (!results.errors) {
+            return results.items.reduce((c, item) => {
+                const [value] = Object.values(item);
+                // ignore non-successful status codes
+                if (value.status != null && value.status >= 400) return c;
+                return c + 1;
+            }, 0);
+        }
 
         const {
-            retry, successful, error, reason, deadLetter
+            retry, successful, error, reason
         } = _filterRetryRecords(actionRecords, results);
 
         if (error) {
             if (config._dead_letter_action === 'kafka_dead_letter') {
-                return {
-                    recordCount: previousCount + successful,
-                    deadLetter
-                };
+                // may still have retries even if kafka_dead_letter is active
+                if (retry.length > 0) {
+                    return _handleRetries(retry, previousCount + successful, previousRetryDelay);
+                }
+
+                return previousCount + successful;
             }
 
             throw new Error(`bulk send error: ${reason}`);
         }
 
         if (retry.length === 0) {
-            return { recordCount: previousCount + successful };
+            return previousCount + successful;
         }
 
+        return _handleRetries(retry, previousCount + successful, previousRetryDelay);
+    }
+
+    async function _handleRetries(retry, affectedCount, previousRetryDelay) {
         warning();
 
         const nextRetryDelay = await _awaitRetry(previousRetryDelay);
-        return _bulkSend(retry, previousCount + successful, nextRetryDelay);
-    }
-
-    function _nonEs6Prep(record) {
-        const actionKey = getFirstKey(record.action);
-
-        const { _type, ...withoutTypeAction } = record.action[actionKey];
-        // if data is specified return both
-
-        const body = [{ ...record.action, [actionKey]: withoutTypeAction }];
-
-        if (record.data != null) body.push(record.data);
-
-        return body;
+        return _bulkSend(retry, affectedCount, nextRetryDelay);
     }
 
     /**
      * The new and improved bulk send with proper retry support
      *
-     * @returns {Promise<{ recordCount: number, deadLetter: record[] }>}
-     * the number of affected rows and records for kafka dead letter queue
+     * @returns {Promise<number>} the number of affected rows
     */
     function bulkSend(data) {
         if (!Array.isArray(data)) {
@@ -407,15 +420,6 @@ module.exports = function elasticsearchApi(client, logger, _opConfig) {
         }
 
         return Promise.resolve(_bulkSend(data));
-    }
-
-    function _affectedRowsCount(results) {
-        return results.items.reduce((c, item) => {
-            const [value] = Object.values(item);
-            // ignore non-successful status codes
-            if (value.status != null && value.status >= 400) return c;
-            return c + 1;
-        }, 0);
     }
 
     function _warn(warnLogger, msg) {

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "3.4.0",
+    "version": "3.5.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-api/test/api-spec.js
+++ b/packages/elasticsearch-api/test/api-spec.js
@@ -768,7 +768,7 @@ describe('elasticsearch-api', () => {
                 { delete: { _index: 'some_index', _type: 'events', _id: 5 } }
             ]
         });
-        return expect(result).toEqual({ recordCount: 2 });
+        return expect(result).toBe(2);
     });
 
     it('can remove type from bulkSend', async () => {
@@ -877,7 +877,7 @@ describe('elasticsearch-api', () => {
         });
         const result = await api.bulkSend(myBulkData);
 
-        expect(result).toEqual({ recordCount: 2 });
+        expect(result).toBe(2);
 
         bulkError = ['some_thing_else', 'some_thing_else'];
 

--- a/packages/elasticsearch-api/test/bulk-send-dlq-spec.js
+++ b/packages/elasticsearch-api/test/bulk-send-dlq-spec.js
@@ -104,8 +104,8 @@ describe('bulkSend', () => {
             // 1 good doc  - so only 1 row affected
             expect(result).toBe(1);
 
-            expect(docs[0].getMetadata('_send_to_dlq')).toInclude('mapper_parsing_exception--failed to parse field [bytes]');
-            expect(docs[1].getMetadata('_send_to_dlq')).toBeUndefined();
+            expect(docs[0].getMetadata('_bulk_sender_rejection')).toInclude('mapper_parsing_exception--failed to parse field [bytes]');
+            expect(docs[1].getMetadata('_bulk_sender_rejection')).toBeUndefined();
         });
 
         it('should return a count if not un-retryable records if dlq is set', async () => {

--- a/packages/elasticsearch-api/test/bulk-send-dlq-spec.js
+++ b/packages/elasticsearch-api/test/bulk-send-dlq-spec.js
@@ -72,35 +72,48 @@ describe('bulkSend', () => {
             await cleanupIndex(client, index);
         });
 
-        it('returns records that cannot be tried again if dlq config is set', async () => {
+        it('should send records if no issues and dlq not set', async () => {
+            const diffApi = elasticsearchAPI(client, logger);
+
             const docs = cloneDeep(EvenDateData.data.slice(0, 2));
+
+            const result = await diffApi.bulkSend(formatUploadData(index, docs, isElasticsearch8));
+
+            expect(result).toBe(2);
+        });
+
+        it('should throw an error if dlq is not set', async () => {
+            const diffApi = elasticsearchAPI(client, logger);
+
+            const docs = cloneDeep(EvenDateData.data.slice(0, 2));
+
+            docs[0].bytes = 'this is a bad value';
+
+            await expect(diffApi.bulkSend(formatUploadData(index, docs, isElasticsearch8)))
+                .rejects.toThrow();
+        });
+
+        it('should update metadata for records that are not retryable and return results for successful updates if dlq is set', async () => {
+            const docs = cloneDeep(EvenDateData.data.slice(0, 2))
+                .map((doc, i) => DataEntity.make(doc, { _key: i + 1 }));
 
             docs[0].bytes = 'this is a bad value';
 
             const result = await api.bulkSend(formatUploadData(index, docs, isElasticsearch8));
 
-            expect(result.recordCount).toBe(1);
+            // 1 good doc  - so only 1 row affected
+            expect(result).toBe(1);
 
-            expect(result.deadLetter[0].doc).toEqual(DataEntity.make({
-                ip: '120.67.248.156',
-                userAgent: 'Mozilla/5.0 (Windows; U; Windows NT 6.1) AppleWebKit/533.1.2 (KHTML, like Gecko) Chrome/35.0.894.0 Safari/533.1.2',
-                url: 'http://lucious.biz',
-                uuid: 'b23a8550-0081-453f-9e80-93a90782a5bd',
-                created: '2019-04-26T15:00:23.225+00:00',
-                ipv6: '9e79:7798:585a:b847:f1c4:81eb:0c3d:7eb8',
-                location: '50.15003, -94.89355',
-                bytes: 'this is a bad value'
-            }));
-
-            expect(result.deadLetter[0].reason).toBeDefined();
+            expect(docs[0].getMetadata('_dlq_reason')).toInclude('mapper_parsing_exception--failed to parse field [bytes]');
+            expect(docs[1].getMetadata('_dlq_reason')).toBeUndefined();
         });
 
-        it('should return a count if not un-retryable records', async () => {
+        it('should return a count if not un-retryable records if dlq is set', async () => {
             const docs = cloneDeep(EvenDateData.data.slice(0, 2));
 
             const result = await api.bulkSend(formatUploadData(index, docs, isElasticsearch8));
 
-            expect(result).toEqual({ recordCount: 2 });
+            expect(result).toBe(2);
         });
     });
 });

--- a/packages/elasticsearch-api/test/bulk-send-dlq-spec.js
+++ b/packages/elasticsearch-api/test/bulk-send-dlq-spec.js
@@ -104,8 +104,8 @@ describe('bulkSend', () => {
             // 1 good doc  - so only 1 row affected
             expect(result).toBe(1);
 
-            expect(docs[0].getMetadata('_dlq_reason')).toInclude('mapper_parsing_exception--failed to parse field [bytes]');
-            expect(docs[1].getMetadata('_dlq_reason')).toBeUndefined();
+            expect(docs[0].getMetadata('_send_to_dlq')).toInclude('mapper_parsing_exception--failed to parse field [bytes]');
+            expect(docs[1].getMetadata('_send_to_dlq')).toBeUndefined();
         });
 
         it('should return a count if not un-retryable records if dlq is set', async () => {

--- a/packages/elasticsearch-api/types/index.d.ts
+++ b/packages/elasticsearch-api/types/index.d.ts
@@ -32,9 +32,9 @@ declare namespace elasticsearchAPI {
         /**
          * The new and improved bulk send with proper retry support
          *
-         * @returns the number of affected rows, and deadLetter records if config is set
+         * @returns the number of affected rows
         */
-        bulkSend: (data: BulkRecord[]) => Promise<{ recordCount: number; deadLetter?: any[]; }>;
+        bulkSend: (data: BulkRecord[]) => Promise<number>;
         nodeInfo: (query: any) => Promise<any>;
         nodeStats: (query: any) => Promise<any>;
         buildQuery: (opConfig: Config, msg: any) => ClientParams.SearchParams;

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.37.0",
+    "version": "0.38.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^3.4.0",
+        "@terascope/elasticsearch-api": "^3.5.0",
         "@terascope/utils": "^0.45.5"
     },
     "engines": {

--- a/packages/teraslice/lib/storage/backends/elasticsearch_store.js
+++ b/packages/teraslice/lib/storage/backends/elasticsearch_store.js
@@ -377,7 +377,7 @@ module.exports = async function elasticsearchStorage(backendConfig) {
         bulkQueue = [];
 
         try {
-            const { recordCount } = await bulkSend(bulkRequest);
+            const recordCount = await bulkSend(bulkRequest);
             const extraMsg = shuttingDown ? ', on shutdown' : '';
             logger.debug(`flushed ${recordCount}${extraMsg} records to index ${indexName}`);
         } finally {

--- a/packages/teraslice/lib/workers/execution-controller/scheduler.js
+++ b/packages/teraslice/lib/workers/execution-controller/scheduler.js
@@ -393,9 +393,9 @@ class Scheduler {
         this._creating += slices.length;
 
         try {
-            const { recordCount } = await this.stateStore.createSlices(this.exId, slices);
+            const count = await this.stateStore.createSlices(this.exId, slices);
             this.enqueueSlices(slices);
-            this._creating -= recordCount;
+            this._creating -= count;
         } catch (err) {
             const { lifecycle } = this.executionContext.config;
             if (lifecycle === 'once') {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "0.82.1",
+    "version": "0.83.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "0.83.0",
+    "version": "0.82.2",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "0.83.0",
+    "version": "0.83.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -37,7 +37,7 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^3.4.0",
+        "@terascope/elasticsearch-api": "^3.5.0",
         "@terascope/job-components": "^0.58.5",
         "@terascope/teraslice-messaging": "^0.28.5",
         "@terascope/utils": "^0.45.5",

--- a/packages/teraslice/test/workers/execution-controller/scheduler-spec.js
+++ b/packages/teraslice/test/workers/execution-controller/scheduler-spec.js
@@ -60,7 +60,7 @@ describe('Scheduler', () => {
                     throw new Error(`Got invalid ex_id ${exId}`);
                 }
                 await pDelay(0);
-                return { recordCount: slices.length };
+                return slices.length;
             }
         };
 


### PR DESCRIPTION
Reverted changes to apis and tests from the previous dead-letter-queue related pr and changed the dead letter queue action to update the docs metadata instead of returning the docs with non-retryable errors.  This allows the class apis and tests to remain the same while still supplying the dlq info for each doc sent to elasticsearch.