### PR TITLE
Update dependabot.yml to ignore /website dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,6 +74,8 @@ updates:
       interval: monthly
       time: '04:00'
       timezone: US/Arizona
+    ignore:
+      - dependency-name: "*"
     open-pull-requests-limit: 3
     assignees:
       - godber


### PR DESCRIPTION
Changes to dependabot.yml file:

- under `directory: '/website'` add:
     
       ignore:
          - dependency-name: "*"
