### PR TITLE
Bump asset feature dev fix

### DIFF
--- a/packages/scripts/src/helpers/interfaces.ts
+++ b/packages/scripts/src/helpers/interfaces.ts
@@ -52,6 +52,7 @@ export type PackageConfig = {
     allowBumpWhenPrivate?: boolean;
     linkToMain?: boolean;
     root?: boolean;
+    asset?: boolean;
     tests?: Record<string, Record<string, string[]>>
 };
 
@@ -117,7 +118,7 @@ export type RootPackageInfo = {
 
 export const AvailablePackageConfigKeys: readonly (keyof PackageConfig)[] = [
     'enableTypedoc', 'testSuite', 'main', 'allowBumpWhenPrivate',
-    'linkToMain', 'root', 'tests'
+    'linkToMain', 'root', 'tests', 'asset'
 ];
 
 export type TSCommands = 'docs';

--- a/packages/scripts/src/helpers/packages.ts
+++ b/packages/scripts/src/helpers/packages.ts
@@ -255,6 +255,7 @@ export function updatePkgJSON(
 
     const pkgJSON = getSortedPkgJSON(pkgInfo) as Partial<i.PackageInfo>;
     delete pkgJSON.folderName;
+    delete pkgJSON.terascope?.asset;
     delete pkgJSON.dir;
     delete pkgJSON.relativeDir;
     return misc.writeIfChanged(path.join(pkgInfo.dir, 'package.json'), pkgJSON, {


### PR DESCRIPTION
I made some updates based off of our final pr with the main branch here #3408

The main updates are: 

- Refactored code by removing ```console.logs``` and unnessesary comments
- Updating tests inside [bump-spec.ts](https://github.com/terascope/teraslice/blob/bump-asset-feature-dev-fix/packages/scripts/test/bump-spec.ts) to use temp files while testing "Bump Assets" instead of creating files in the root directory.
- Fixed a bug that added "asset:false" inside of the root ```package.json``` inside of teraslice causing "verify build" to fail on GitHub actions.