### PR TITLE
Ts scripts bump asset only

### DIFF
--- a/docs/packages/test-pkg/overview.md
+++ b/docs/packages/test-pkg/overview.md
@@ -1,6 +1,0 @@
----
-title: Test Pkg
-sidebar_label: overview
----
-
-> undefined

--- a/packages/scripts/src/cmds/bump-asset.ts
+++ b/packages/scripts/src/cmds/bump-asset.ts
@@ -1,0 +1,86 @@
+import { ReleaseType } from 'semver';
+import { CommandModule } from 'yargs';
+import { castArray } from '@terascope/utils';
+import { coercePkgArg } from '../helpers/args';
+import { bumpAssetOnly } from '../helpers/bump';
+import { PackageInfo } from '../helpers/interfaces';
+import { syncAll } from '../helpers/sync';
+import { getRootInfo } from '../helpers/misc';
+import signale from '../helpers/signale';
+
+const releaseChoices: readonly ReleaseType[] = [
+    'patch', 'minor', 'major', 'prerelease', 'prepatch', 'preminor', 'premajor'
+];
+
+const cmd: CommandModule = {
+    command: 'bump-asset',
+    describe: 'Update an asset to specific version. This should be run in the root of the workspace.',
+    builder(yargs) {
+        let y = yargs
+            .example('$0 bump-asset', 'asset // 0.20.0 => 0.20.1') // FixMe: change asset to ???
+            .example('$0 bump-asset', '--patch asset // 0.20.0 => 0.20.1')
+            .example('$0 bump-asset', '--minor asset // 0.5.0 => 0.6.0')
+            .example('$0 bump-asset', '--prepatch asset // 0.20.0 => 0.20.1-rc.0')
+            .example('$0 bump-asset', '--premajor asset // 0.15.0 => 1.0.0-rc.0')
+            .example('$0 bump-asset', '--prerelease asset // 0.20.1-rc.0 => 0.20.1-rc.1')
+            .option('prerelease-id', {
+                default: 'rc',
+                description: 'Specify the prerelease identifier, defaults to RC',
+            })
+            .option('skip-reset', { // FixMe: remove this????
+                description: 'Skip resetting the packages to latest from NPM',
+                type: 'boolean',
+                default: false,
+            });
+
+        releaseChoices.forEach((choice, i, arr) => {
+            const otherChoices = arr.filter((_item, index) => index !== i);
+
+            y = y.option(choice, {
+                description: `Bump release by ${choice}`,
+                type: 'boolean',
+                default: false,
+                conficts: ['release', ...otherChoices],
+                demandOption: true,
+            });
+        });
+
+        return y;
+    },
+    async handler(argv) {
+        const release = getRelease(argv);
+        const rootInfo = getRootInfo();
+
+        // FixMe: necessary?
+        await syncAll({ verify: true, tsconfigOnly: rootInfo.terascope.version === 2 });
+
+        if (!rootInfo.terascope.asset) {
+            signale.error('Bump-asset must be run in the root directory of an Asset.');
+            return;
+        }
+        return bumpAssetOnly({
+            preId: argv['prerelease-id'] as string | undefined,
+            release,
+            skipReset: Boolean(argv['skip-reset']) // FixMe: necessary?
+        });
+    },
+};
+
+function getRelease(argv: any): ReleaseType {
+    const found = releaseChoices.filter((choice) => argv[choice]);
+    const release = argv.release as ReleaseType | undefined;
+
+    if (!found.length) {
+        const choices = releaseChoices.map((choice) => `--${choice}`).join(', ');
+        throw new Error(`Bump requires at least one of ${choices} to be specified`);
+    } else if (release && found[0] && release !== found[0]) {
+        throw new Error(`Cannot specify --release (DEPRECATED), use --${release} instead`);
+    } else if (found.length > 1) {
+        const choices = found.map((choice) => `--${choice}`).join(' and ');
+        throw new Error(`Cannot specify ${choices}, pick one`);
+    }
+
+    return found[0];
+}
+
+export = cmd;

--- a/packages/scripts/src/cmds/bump-asset.ts
+++ b/packages/scripts/src/cmds/bump-asset.ts
@@ -42,7 +42,6 @@ const cmd: CommandModule = {
         const release = getRelease(argv);
         const rootInfo = getRootInfo();
 
-        // FixMe: necessary?
         await syncAll({ verify: true, tsconfigOnly: rootInfo.terascope.version === 2 });
 
         if (!rootInfo.terascope.asset) {

--- a/packages/scripts/src/cmds/bump-asset.ts
+++ b/packages/scripts/src/cmds/bump-asset.ts
@@ -1,9 +1,6 @@
 import { ReleaseType } from 'semver';
 import { CommandModule } from 'yargs';
-import { castArray } from '@terascope/utils';
-import { coercePkgArg } from '../helpers/args';
 import { bumpAssetOnly } from '../helpers/bump';
-import { PackageInfo } from '../helpers/interfaces';
 import { syncAll } from '../helpers/sync';
 import { getRootInfo } from '../helpers/misc';
 import signale from '../helpers/signale';
@@ -17,20 +14,14 @@ const cmd: CommandModule = {
     describe: 'Update an asset to specific version. This should be run in the root of the workspace.',
     builder(yargs) {
         let y = yargs
-            .example('$0 bump-asset', 'asset // 0.20.0 => 0.20.1') // FixMe: change asset to ???
-            .example('$0 bump-asset', '--patch asset // 0.20.0 => 0.20.1')
-            .example('$0 bump-asset', '--minor asset // 0.5.0 => 0.6.0')
-            .example('$0 bump-asset', '--prepatch asset // 0.20.0 => 0.20.1-rc.0')
-            .example('$0 bump-asset', '--premajor asset // 0.15.0 => 1.0.0-rc.0')
-            .example('$0 bump-asset', '--prerelease asset // 0.20.1-rc.0 => 0.20.1-rc.1')
+            .example('$0 bump-asset', '--patch // 0.20.0 => 0.20.1')
+            .example('$0 bump-asset', '--minor // 0.5.0 => 0.6.0')
+            .example('$0 bump-asset', '--prepatch // 0.20.0 => 0.20.1-rc.0')
+            .example('$0 bump-asset', '--premajor // 0.15.0 => 1.0.0-rc.0')
+            .example('$0 bump-asset', '--prerelease // 0.20.1-rc.0 => 0.20.1-rc.1')
             .option('prerelease-id', {
                 default: 'rc',
                 description: 'Specify the prerelease identifier, defaults to RC',
-            })
-            .option('skip-reset', { // FixMe: remove this????
-                description: 'Skip resetting the packages to latest from NPM',
-                type: 'boolean',
-                default: false,
             });
 
         releaseChoices.forEach((choice, i, arr) => {
@@ -60,9 +51,8 @@ const cmd: CommandModule = {
         }
         return bumpAssetOnly({
             preId: argv['prerelease-id'] as string | undefined,
-            release,
-            skipReset: Boolean(argv['skip-reset']) // FixMe: necessary?
-        });
+            release
+        }, rootInfo.terascope.asset);
     },
 };
 

--- a/packages/scripts/src/cmds/bump.ts
+++ b/packages/scripts/src/cmds/bump.ts
@@ -93,6 +93,7 @@ const cmd: CommandModule = {
             release,
             deps: Boolean(argv.deps),
             skipReset: Boolean(argv['skip-reset']),
+            skipAsset: Boolean(argv['skip-asset'])
         }, rootInfo.terascope.asset);
     },
 };

--- a/packages/scripts/src/cmds/bump.ts
+++ b/packages/scripts/src/cmds/bump.ts
@@ -2,7 +2,7 @@ import { ReleaseType } from 'semver';
 import { CommandModule } from 'yargs';
 import { castArray } from '@terascope/utils';
 import { coercePkgArg } from '../helpers/args';
-import { bumpPackages, bumpPackagesForAsset } from '../helpers/bump';
+import { bumpPackages } from '../helpers/bump';
 import { PackageInfo } from '../helpers/interfaces';
 import { syncAll } from '../helpers/sync';
 import { getRootInfo } from '../helpers/misc';
@@ -86,15 +86,6 @@ const cmd: CommandModule = {
         if (rootInfo.terascope.asset) {
             signale.warn('bump has detected the root directory is an Asset.');
             signale.note('bump is in Asset mode.');
-
-            return bumpPackagesForAsset({
-                packages: argv.packages as PackageInfo[],
-                preId: argv['prerelease-id'] as string | undefined,
-                release,
-                deps: Boolean(argv.deps),
-                skipReset: Boolean(argv['skip-reset']), // Skip resetting the packages to latest from NPM
-                skipAsset: Boolean(argv['skip-asset'])
-            });
         }
         return bumpPackages({
             packages: argv.packages as PackageInfo[],
@@ -102,7 +93,7 @@ const cmd: CommandModule = {
             release,
             deps: Boolean(argv.deps),
             skipReset: Boolean(argv['skip-reset']),
-        });
+        }, rootInfo.terascope.asset);
     },
 };
 

--- a/packages/scripts/src/helpers/bump/index.ts
+++ b/packages/scripts/src/helpers/bump/index.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { BumpPackageOptions } from './interfaces';
+import { BumpAssetOnlyOptions, BumpPackageOptions } from './interfaces';
 import { listPackages, isMainPackage, updatePkgJSON } from '../packages';
 import { Hook, PackageInfo } from '../interfaces';
 
@@ -113,4 +113,8 @@ export async function bumpAssetVersion(
 
         if (assetUpdated) signale.info(`=> Updated asset.json from version ${oldVersion} to ${newVersion}`);
     }
+}
+
+export async function bumpAssetOnly(options:BumpAssetOnlyOptions): Promise<void> {
+    signale.info(`@@@@ options: ${JSON.stringify(options)}`);
 }

--- a/packages/scripts/src/helpers/bump/index.ts
+++ b/packages/scripts/src/helpers/bump/index.ts
@@ -105,7 +105,7 @@ export async function bumpAssetVersion(
     }
 
     const pathToAssetJson = path.join(rootPkgInfo.dir, '/asset/asset.json');
-    updateAndSaveAssetJson(pathToAssetJson, newVersion);
+    await updateAndSaveAssetJson(pathToAssetJson, newVersion);
 
     return bumpAssetInfo;
 }
@@ -126,5 +126,6 @@ async function updateAndSaveAssetJson(
         log: true,
     });
 
+    console.log('Did find asset json', assetUpdated);
     if (assetUpdated) signale.info(`=> Updated asset.json from version ${oldVersion} to ${newVersion}`);
 }

--- a/packages/scripts/src/helpers/bump/index.ts
+++ b/packages/scripts/src/helpers/bump/index.ts
@@ -1,6 +1,11 @@
 import fs from 'fs';
 import path from 'path';
-import { BumpAssetOnlyOptions, BumpPackageOptions } from './interfaces';
+import {
+    AssetJsonInfo,
+    BumpAssetOnlyOptions,
+    BumpPkgInfo,
+    BumpPackageOptions
+} from './interfaces';
 import { listPackages, isMainPackage, updatePkgJSON } from '../packages';
 import { Hook, PackageInfo } from '../interfaces';
 
@@ -13,12 +18,14 @@ import { executeHook } from '../hooks';
 export async function bumpPackages(options: BumpPackageOptions, isAsset: boolean): Promise<void> {
     const rootInfo = getRootInfo();
     const _packages = listPackages();
-    const packages: PackageInfo[] = [..._packages, rootInfo as any];
 
+    // The bumpAssetVersion function requires rootInfo to be the last object in the packages array
+    const packages: PackageInfo[] = [..._packages, rootInfo as any];
     const packagesToBump = await utils.getPackagesToBump(packages, options);
     utils.bumpPackagesList(packagesToBump, packages);
-    bumpAssetVersion(packages, options, isAsset);
-    const commitMsgs = utils.getBumpCommitMessages(packagesToBump, options.release);
+    const bumpAssetInfo = await bumpAssetVersion(packages, options, isAsset);
+    const allBumps = { ...packagesToBump, ...bumpAssetInfo };
+    const commitMsgs = utils.getBumpCommitMessages(allBumps, options.release);
 
     const mainInfo = packages.find(isMainPackage);
     const bumpedMain = mainInfo ? packagesToBump[mainInfo.name] : false;
@@ -46,14 +53,39 @@ Please commit these changes:
 `);
 }
 
-export async function bumpAssetVersion(
-    packages: PackageInfo[],
-    options: BumpPackageOptions,
+export async function bumpAssetOnly(
+    options: BumpAssetOnlyOptions,
     isAsset: boolean
 ): Promise<void> {
-    if (options.skipAsset || !isAsset) {
-        return;
+    const rootInfo = getRootInfo();
+    const _packages = listPackages();
+
+    // The bumpAssetVersion function requires rootInfo to be the last object in the packages array
+    const packages: PackageInfo[] = [..._packages, rootInfo as any];
+    const bumpAssetInfo = await bumpAssetVersion(packages, options, isAsset);
+    const commitMsgs = utils.getBumpCommitMessages(bumpAssetInfo, options.release);
+
+    for (const pkgInfo of packages) {
+        await updatePkgJSON(pkgInfo);
     }
+    signale.success(`
+
+Please commit these changes:
+
+    git commit -a -m "${commitMsgs.join('" -m "')}" && git push
+`);
+}
+
+export async function bumpAssetVersion(
+    packages: PackageInfo[],
+    options: BumpPackageOptions | BumpAssetOnlyOptions,
+    isAsset: boolean
+): Promise<Record<string, BumpPkgInfo>> {
+    if (('skipAsset' in options && options.skipAsset) || !isAsset) {
+        return {};
+    }
+
+    const bumpAssetInfo: Record<string, BumpPkgInfo> = {};
     const rootPkgInfo = packages[packages.length - 1];
     const oldVersion = rootPkgInfo.version;
     const newVersion = utils.bumpVersion(rootPkgInfo, options.release, options?.preId);
@@ -63,22 +95,36 @@ export async function bumpAssetVersion(
 
     for (const pkg of pkgsToUpdate) {
         pkg.version = newVersion;
+        bumpAssetInfo[pkg.name] = {
+            from: oldVersion,
+            to: newVersion,
+            main: false,
+            deps: []
+        };
         signale.info(`=> Updated ${pkg.displayName} from version ${oldVersion} to ${newVersion}`);
     }
 
     const pathToAssetJson = path.join(rootPkgInfo.dir, '/asset/asset.json');
+    updateAndSaveAssetJson(pathToAssetJson, newVersion);
 
-    if (fs.existsSync(pathToAssetJson)) {
-        const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
-        assetJsonInfo.version = newVersion;
-        const assetUpdated = await writeIfChanged(pathToAssetJson, assetJsonInfo, {
-            log: true,
-        });
-
-        if (assetUpdated) signale.info(`=> Updated asset.json from version ${oldVersion} to ${newVersion}`);
-    }
+    return bumpAssetInfo;
 }
 
-export async function bumpAssetOnly(options:BumpAssetOnlyOptions): Promise<void> {
-    signale.info(`@@@@ options: ${JSON.stringify(options)}`);
+async function updateAndSaveAssetJson(
+    pathToAssetJson: string,
+    newVersion: string
+): Promise<void> {
+    if (!fs.existsSync(pathToAssetJson)) {
+        signale.fatal('Bump and bump-asset require an asset/asset.json file');
+        process.exit(1);
+    }
+
+    const assetJsonInfo: AssetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
+    const oldVersion = assetJsonInfo.version;
+    assetJsonInfo.version = newVersion;
+    const assetUpdated = await writeIfChanged(pathToAssetJson, assetJsonInfo, {
+        log: true,
+    });
+
+    if (assetUpdated) signale.info(`=> Updated asset.json from version ${oldVersion} to ${newVersion}`);
 }

--- a/packages/scripts/src/helpers/bump/index.ts
+++ b/packages/scripts/src/helpers/bump/index.ts
@@ -126,6 +126,5 @@ async function updateAndSaveAssetJson(
         log: true,
     });
 
-    console.log('Did find asset json', assetUpdated);
     if (assetUpdated) signale.info(`=> Updated asset.json from version ${oldVersion} to ${newVersion}`);
 }

--- a/packages/scripts/src/helpers/bump/interfaces.ts
+++ b/packages/scripts/src/helpers/bump/interfaces.ts
@@ -4,7 +4,6 @@ import { PackageInfo } from '../interfaces';
 export interface BumpAssetOnlyOptions {
     preId?: string;
     release: ReleaseType;
-    skipReset?: boolean;
 }
 
 export interface BumpPackageOptions {
@@ -24,6 +23,12 @@ export interface BumpPkgInfo {
         name: string;
         type: BumpType;
     }[];
+}
+
+export interface AssetJsonInfo {
+    name: string;
+    version: string;
+    description: string;
 }
 
 export enum BumpType {

--- a/packages/scripts/src/helpers/bump/interfaces.ts
+++ b/packages/scripts/src/helpers/bump/interfaces.ts
@@ -1,6 +1,12 @@
 import { ReleaseType } from 'semver';
 import { PackageInfo } from '../interfaces';
 
+export interface BumpAssetOnlyOptions {
+    preId?: string;
+    release: ReleaseType;
+    skipReset?: boolean;
+}
+
 export interface BumpPackageOptions {
     release: ReleaseType;
     packages: PackageInfo[];

--- a/packages/scripts/src/helpers/bump/utils.ts
+++ b/packages/scripts/src/helpers/bump/utils.ts
@@ -143,7 +143,6 @@ export function bumpPackagesList(
 
         for (const depBumpInfo of bumpInfo.deps) {
             const depPkgInfo = findPackageByName(packages, depBumpInfo.name);
-
             const key = getDepKeyFromType(depBumpInfo.type);
 
             if (!depPkgInfo[key]) continue;

--- a/packages/scripts/src/helpers/interfaces.ts
+++ b/packages/scripts/src/helpers/interfaces.ts
@@ -52,7 +52,6 @@ export type PackageConfig = {
     allowBumpWhenPrivate?: boolean;
     linkToMain?: boolean;
     root?: boolean;
-    asset?: boolean;
     tests?: Record<string, Record<string, string[]>>
 };
 
@@ -118,7 +117,7 @@ export type RootPackageInfo = {
 
 export const AvailablePackageConfigKeys: readonly (keyof PackageConfig)[] = [
     'enableTypedoc', 'testSuite', 'main', 'allowBumpWhenPrivate',
-    'linkToMain', 'root', 'tests', 'asset'
+    'linkToMain', 'root', 'tests'
 ];
 
 export type TSCommands = 'docs';

--- a/packages/scripts/src/helpers/packages.ts
+++ b/packages/scripts/src/helpers/packages.ts
@@ -66,6 +66,7 @@ export function listPackages(
 
     if (!workspaces) return [];
 
+    // TODO: determine why '.' needs to be in our workspaces.
     workspaces = workspaces.filter((space) => space !== '.');
 
     const hasE2E = workspaces.find((workspacePath) => workspacePath.includes('e2e'));

--- a/packages/scripts/src/helpers/packages.ts
+++ b/packages/scripts/src/helpers/packages.ts
@@ -58,7 +58,6 @@ export function listPackages(
     const rootPkg = misc.getRootInfo();
     if (!rootPkg.workspaces) return [];
 
-    ///   changing constant to let
     let workspaces = (
         Array.isArray(rootPkg.workspaces)
             ? rootPkg.workspaces
@@ -67,7 +66,6 @@ export function listPackages(
 
     if (!workspaces) return [];
 
-    ///    Testing in the case where one of the workspaces is the root directory
     workspaces = workspaces.filter((space) => space !== '.');
 
     const hasE2E = workspaces.find((workspacePath) => workspacePath.includes('e2e'));

--- a/packages/scripts/src/helpers/sync/utils.ts
+++ b/packages/scripts/src/helpers/sync/utils.ts
@@ -64,9 +64,7 @@ export async function verify(files: string[], options: SyncOptions): Promise<voi
 
     const diff = changed.filter((file) => !prevChanged.includes(file));
     prevChanged = [];
-    if (!diff.length) {
-        return;
-    }
+    if (!diff.length) return;
 
     console.error(`
 This command made changes to the following files:

--- a/packages/scripts/test/bump-asset-spec.ts
+++ b/packages/scripts/test/bump-asset-spec.ts
@@ -1,0 +1,211 @@
+// import 'jest-extended';
+// import fs from 'fs';
+// import os from 'os';
+// import path from 'path';
+// import { cloneDeep } from '@terascope/utils';
+// import { BumpPackageOptions, BumpType, BumpPkgInfo, BumpAssetOnlyOptions } from '../src/helpers/bump/interfaces';
+// import { PackageInfo } from '../src/helpers/interfaces';
+// import { bumpAssetVersion, bumpAssetOnly } from '../src/helpers/bump/index';
+// import {
+//     getPackagesToBump,
+//     bumpPackagesList,
+//     getBumpCommitMessages
+// } from '../src/helpers/bump/utils';
+
+// describe('Bump-asset', () => {
+//     const tempRootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'asset'));
+//     const testPackages: PackageInfo[] = [
+//         {
+//             name: 'package-asset',
+//             version: '1.0.0',
+//             relativeDir: 'asset',
+//             dependencies: {
+//             },
+//             devDependencies: {
+//             },
+//         } as any,
+//         {
+//             name: 'package-2',
+//             version: '1.0.0',
+//             dependencies: {
+//                 'package-1': '^2.1.0'
+//             },
+//             devDependencies: {
+//             },
+//         } as any,
+//         {
+//             name: 'package-1',
+//             version: '2.1.0',
+//             dependencies: {
+//             },
+//             devDependencies: {
+//             },
+//         } as any,
+//         {
+//             name: 'package-main-asset',
+//             version: '1.0.0',
+//             relativeDir: '.',
+//             dir: `${tempRootDir}`,
+//             dependencies: {
+//             },
+//             terascope: {
+//                 main: true,
+//                 root: true
+//             }
+//         } as any,
+//     ];
+
+//     const assetJSONData = `{
+//         "name": "asset-json",
+//         "version": "1.0.0",
+//         "description": "A set of processors for working with files"
+//     }`;
+//     afterAll(async () => {
+//         /// Remove the temp root file after all tests have been done
+//         fs.rmSync(tempRootDir, { recursive: true, force: true });
+//     });
+//     describe('when bumping an Asset', () => {
+//         describe('when release=patch', () => {
+//             const packages = cloneDeep(testPackages);
+//             const options: BumpAssetOnlyOptions = {
+//                 release: 'patch',
+//             };
+//             let result: Record<string, BumpPkgInfo>;
+
+//             beforeAll(async () => {
+//                 // result = await getPackagesToBump(testPackages, options);
+//                 /// Create an asset folder with asset.json
+//                 const assetPath = `${tempRootDir}/asset`;
+//                 fs.mkdirSync(assetPath);
+//                 fs.writeFileSync(`${assetPath}/asset.json`, assetJSONData);
+//             });
+
+//             afterAll(async () => {
+//                 /// Remove the asset folder within the temp root file
+//                 fs.rmSync(`${tempRootDir}/asset`, { recursive: true, force: true });
+//             });
+
+//             // it('should return a list of correctly bump packages', () => {
+//             //     expect(result).toEqual({
+//             //         'package-1': {
+//             //             from: '2.1.0',
+//             //             to: '2.1.1',
+//             //             main: false,
+//             //             deps: [
+//             //                 {
+//             //                     type: BumpType.Prod,
+//             //                     name: 'package-2'
+//             //                 },
+//             //             ]
+//             //         },
+//             //         'package-2': {
+//             //             from: '1.0.0',
+//             //             to: '1.0.1',
+//             //             main: false,
+//             //             deps: []
+//             //         }
+//             //     });
+//             // });
+
+//             // it('should correctly bump the packages list', () => {
+//             //     bumpPackagesList(result, packages);
+//             //     expect(packages).toEqual([
+//             //         {
+//             //             name: 'package-asset',
+//             //             version: '1.0.0',
+//             //             relativeDir: 'asset',
+//             //             dependencies: {
+//             //             },
+//             //             devDependencies: {
+//             //             }
+//             //         },
+//             //         {
+//             //             name: 'package-2',
+//             //             version: '1.0.1',
+//             //             dependencies: {
+//             //                 'package-1': '^2.1.1'
+//             //             },
+//             //             devDependencies: {
+//             //             },
+//             //         },
+//             //         {
+//             //             name: 'package-1',
+//             //             version: '2.1.1',
+//             //             dependencies: {
+//             //             },
+//             //             devDependencies: {
+//             //             },
+//             //         },
+//             //         {
+//             //             name: 'package-main-asset',
+//             //             version: '1.0.0',
+//             //             relativeDir: '.',
+//             //             dir: `${tempRootDir}`,
+//             //             dependencies: {
+//             //             },
+//             //             terascope: {
+//             //                 main: true,
+//             //                 root: true
+//             //             }
+//             //         },
+//             //     ]);
+//             // });
+
+//             it('should correctly bump all 3 asset versions', async () => {
+//                 await bumpAssetVersion(packages, options, true);
+//                 const pathToAssetJson = `${tempRootDir}/asset/asset.json`;
+//                 const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
+//                 expect(packages).toEqual([
+//                     {
+//                         name: 'package-asset',
+//                         version: '1.0.1',
+//                         relativeDir: 'asset',
+//                         dependencies: {
+//                         },
+//                         devDependencies: {
+//                         }
+//                     },
+//                     {
+//                         name: 'package-2',
+//                         version: '1.0.0',
+//                         dependencies: {
+//                             'package-1': '^2.1.0'
+//                         },
+//                         devDependencies: {
+//                         },
+//                     },
+//                     {
+//                         name: 'package-1',
+//                         version: '2.1.0',
+//                         dependencies: {
+//                         },
+//                         devDependencies: {
+//                         },
+//                     },
+//                     {
+//                         name: 'package-main-asset',
+//                         version: '1.0.1',
+//                         relativeDir: '.',
+//                         dir: `${tempRootDir}`,
+//                         dependencies: {
+//                         },
+//                         terascope: {
+//                             main: true,
+//                             root: true
+//                         }
+//                     }
+//                 ]);
+//                 expect(assetJsonInfo.version).toEqual('1.0.1');
+//             });
+
+//             it('should be able to get a readable commit message', () => {
+//                 const messages = getBumpCommitMessages(result, options.release);
+//                 expect(messages).toEqual([
+//                     'bump: (patch) package-asset@1.0.1, package-main-asset@1.0.1'
+//                 ]);
+//             });
+//         });
+//     });
+// });
+
+export {}

--- a/packages/scripts/test/bump-asset-spec.ts
+++ b/packages/scripts/test/bump-asset-spec.ts
@@ -1,211 +1,223 @@
-// import 'jest-extended';
-// import fs from 'fs';
-// import os from 'os';
-// import path from 'path';
-// import { cloneDeep } from '@terascope/utils';
-// import { BumpPackageOptions, BumpType, BumpPkgInfo, BumpAssetOnlyOptions } from '../src/helpers/bump/interfaces';
-// import { PackageInfo } from '../src/helpers/interfaces';
-// import { bumpAssetVersion, bumpAssetOnly } from '../src/helpers/bump/index';
-// import {
-//     getPackagesToBump,
-//     bumpPackagesList,
-//     getBumpCommitMessages
-// } from '../src/helpers/bump/utils';
+import 'jest-extended';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { cloneDeep } from '@terascope/utils';
+import { BumpPkgInfo, BumpAssetOnlyOptions } from '../src/helpers/bump/interfaces';
+import { PackageInfo } from '../src/helpers/interfaces';
+import { bumpAssetVersion } from '../src/helpers/bump/index';
+import { getBumpCommitMessages } from '../src/helpers/bump/utils';
 
-// describe('Bump-asset', () => {
-//     const tempRootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'asset'));
-//     const testPackages: PackageInfo[] = [
-//         {
-//             name: 'package-asset',
-//             version: '1.0.0',
-//             relativeDir: 'asset',
-//             dependencies: {
-//             },
-//             devDependencies: {
-//             },
-//         } as any,
-//         {
-//             name: 'package-2',
-//             version: '1.0.0',
-//             dependencies: {
-//                 'package-1': '^2.1.0'
-//             },
-//             devDependencies: {
-//             },
-//         } as any,
-//         {
-//             name: 'package-1',
-//             version: '2.1.0',
-//             dependencies: {
-//             },
-//             devDependencies: {
-//             },
-//         } as any,
-//         {
-//             name: 'package-main-asset',
-//             version: '1.0.0',
-//             relativeDir: '.',
-//             dir: `${tempRootDir}`,
-//             dependencies: {
-//             },
-//             terascope: {
-//                 main: true,
-//                 root: true
-//             }
-//         } as any,
-//     ];
+describe('Bump-asset-only', () => {
+    const tempRootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'asset'));
+    const testPackages: PackageInfo[] = [
+        {
+            name: 'package-asset',
+            version: '1.0.0',
+            relativeDir: 'asset',
+            dependencies: {
+            },
+            devDependencies: {
+            },
+        } as any,
+        {
+            name: 'package-2',
+            version: '1.0.0',
+            dependencies: {
+                'package-1': '^2.1.0'
+            },
+            devDependencies: {
+            },
+        } as any,
+        {
+            name: 'package-1',
+            version: '2.1.0',
+            dependencies: {
+            },
+            devDependencies: {
+            },
+        } as any,
+        {
+            name: 'package-main-asset',
+            version: '1.0.0',
+            relativeDir: '.',
+            dir: `${tempRootDir}`,
+            dependencies: {
+            },
+            terascope: {
+                main: true,
+                root: true
+            }
+        } as any,
+    ];
 
-//     const assetJSONData = `{
-//         "name": "asset-json",
-//         "version": "1.0.0",
-//         "description": "A set of processors for working with files"
-//     }`;
-//     afterAll(async () => {
-//         /// Remove the temp root file after all tests have been done
-//         fs.rmSync(tempRootDir, { recursive: true, force: true });
-//     });
-//     describe('when bumping an Asset', () => {
-//         describe('when release=patch', () => {
-//             const packages = cloneDeep(testPackages);
-//             const options: BumpAssetOnlyOptions = {
-//                 release: 'patch',
-//             };
-//             let result: Record<string, BumpPkgInfo>;
+    const assetJSONData = `{
+        "name": "asset-json",
+        "version": "1.0.0",
+        "description": "A set of processors for working with files"
+    }`;
+    afterAll(async () => {
+        /// Remove the temp root file after all tests have been done
+        fs.rmSync(tempRootDir, { recursive: true, force: true });
+    });
+    describe('when bumping an Asset', () => {
+        describe('when release=patch', () => {
+            const packages = cloneDeep(testPackages);
+            const options: BumpAssetOnlyOptions = {
+                release: 'patch',
+            };
+            // let result: Record<string, BumpPkgInfo>;
+            let bumpAssetInfo: Record<string, BumpPkgInfo>;
 
-//             beforeAll(async () => {
-//                 // result = await getPackagesToBump(testPackages, options);
-//                 /// Create an asset folder with asset.json
-//                 const assetPath = `${tempRootDir}/asset`;
-//                 fs.mkdirSync(assetPath);
-//                 fs.writeFileSync(`${assetPath}/asset.json`, assetJSONData);
-//             });
+            beforeAll(async () => {
+                // result = await getPackagesToBump(testPackages, options);
+                /// Create an asset folder with asset.json
+                const assetPath = `${tempRootDir}/asset`;
+                fs.mkdirSync(assetPath);
+                fs.writeFileSync(`${assetPath}/asset.json`, assetJSONData);
+            });
 
-//             afterAll(async () => {
-//                 /// Remove the asset folder within the temp root file
-//                 fs.rmSync(`${tempRootDir}/asset`, { recursive: true, force: true });
-//             });
+            afterAll(async () => {
+                /// Remove the asset folder within the temp root file
+                fs.rmSync(`${tempRootDir}/asset`, { recursive: true, force: true });
+            });
 
-//             // it('should return a list of correctly bump packages', () => {
-//             //     expect(result).toEqual({
-//             //         'package-1': {
-//             //             from: '2.1.0',
-//             //             to: '2.1.1',
-//             //             main: false,
-//             //             deps: [
-//             //                 {
-//             //                     type: BumpType.Prod,
-//             //                     name: 'package-2'
-//             //                 },
-//             //             ]
-//             //         },
-//             //         'package-2': {
-//             //             from: '1.0.0',
-//             //             to: '1.0.1',
-//             //             main: false,
-//             //             deps: []
-//             //         }
-//             //     });
-//             // });
+            it('should return a list of package.json files to bump', async () => {
+                bumpAssetInfo = await bumpAssetVersion(packages, options, true);
+                expect(bumpAssetInfo).toEqual({
+                    'package-main-asset': {
+                        from: '1.0.0',
+                        to: '1.0.1',
+                        main: false,
+                        deps: []
+                    },
+                    'package-asset': {
+                        from: '1.0.0',
+                        to: '1.0.1',
+                        main: false,
+                        deps: []
+                    }
+                });
+            });
 
-//             // it('should correctly bump the packages list', () => {
-//             //     bumpPackagesList(result, packages);
-//             //     expect(packages).toEqual([
-//             //         {
-//             //             name: 'package-asset',
-//             //             version: '1.0.0',
-//             //             relativeDir: 'asset',
-//             //             dependencies: {
-//             //             },
-//             //             devDependencies: {
-//             //             }
-//             //         },
-//             //         {
-//             //             name: 'package-2',
-//             //             version: '1.0.1',
-//             //             dependencies: {
-//             //                 'package-1': '^2.1.1'
-//             //             },
-//             //             devDependencies: {
-//             //             },
-//             //         },
-//             //         {
-//             //             name: 'package-1',
-//             //             version: '2.1.1',
-//             //             dependencies: {
-//             //             },
-//             //             devDependencies: {
-//             //             },
-//             //         },
-//             //         {
-//             //             name: 'package-main-asset',
-//             //             version: '1.0.0',
-//             //             relativeDir: '.',
-//             //             dir: `${tempRootDir}`,
-//             //             dependencies: {
-//             //             },
-//             //             terascope: {
-//             //                 main: true,
-//             //                 root: true
-//             //             }
-//             //         },
-//             //     ]);
-//             // });
+            it('should bump asset.json in temp folder', () => {
+                const pathToAssetJson = `${tempRootDir}/asset/asset.json`;
+                const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
+                expect(assetJsonInfo.version).toEqual('1.0.1');
+            });
 
-//             it('should correctly bump all 3 asset versions', async () => {
-//                 await bumpAssetVersion(packages, options, true);
-//                 const pathToAssetJson = `${tempRootDir}/asset/asset.json`;
-//                 const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
-//                 expect(packages).toEqual([
-//                     {
-//                         name: 'package-asset',
-//                         version: '1.0.1',
-//                         relativeDir: 'asset',
-//                         dependencies: {
-//                         },
-//                         devDependencies: {
-//                         }
-//                     },
-//                     {
-//                         name: 'package-2',
-//                         version: '1.0.0',
-//                         dependencies: {
-//                             'package-1': '^2.1.0'
-//                         },
-//                         devDependencies: {
-//                         },
-//                     },
-//                     {
-//                         name: 'package-1',
-//                         version: '2.1.0',
-//                         dependencies: {
-//                         },
-//                         devDependencies: {
-//                         },
-//                     },
-//                     {
-//                         name: 'package-main-asset',
-//                         version: '1.0.1',
-//                         relativeDir: '.',
-//                         dir: `${tempRootDir}`,
-//                         dependencies: {
-//                         },
-//                         terascope: {
-//                             main: true,
-//                             root: true
-//                         }
-//                     }
-//                 ]);
-//                 expect(assetJsonInfo.version).toEqual('1.0.1');
-//             });
+            it('should be able to get a readable commit message', () => {
+                const messages = getBumpCommitMessages(bumpAssetInfo, options.release);
+                expect(messages).toEqual([
+                    'bump: (patch) package-asset@1.0.1, package-main-asset@1.0.1'
+                ]);
+            });
+        });
 
-//             it('should be able to get a readable commit message', () => {
-//                 const messages = getBumpCommitMessages(result, options.release);
-//                 expect(messages).toEqual([
-//                     'bump: (patch) package-asset@1.0.1, package-main-asset@1.0.1'
-//                 ]);
-//             });
-//         });
-//     });
-// });
+        describe('when release=minor', () => {
+            const packages = cloneDeep(testPackages);
+            const options: BumpAssetOnlyOptions = {
+                release: 'minor',
+            };
+            // let result: Record<string, BumpPkgInfo>;
+            let bumpAssetInfo: Record<string, BumpPkgInfo>;
 
-export {}
+            beforeAll(async () => {
+                // result = await getPackagesToBump(testPackages, options);
+                /// Create an asset folder with asset.json
+                const assetPath = `${tempRootDir}/asset`;
+                fs.mkdirSync(assetPath);
+                fs.writeFileSync(`${assetPath}/asset.json`, assetJSONData);
+            });
+
+            afterAll(async () => {
+                /// Remove the asset folder within the temp root file
+                fs.rmSync(`${tempRootDir}/asset`, { recursive: true, force: true });
+            });
+
+            it('should return a list of package.json files to bump', async () => {
+                bumpAssetInfo = await bumpAssetVersion(packages, options, true);
+                expect(bumpAssetInfo).toEqual({
+                    'package-main-asset': {
+                        from: '1.0.0',
+                        to: '1.1.0',
+                        main: false,
+                        deps: []
+                    },
+                    'package-asset': {
+                        from: '1.0.0',
+                        to: '1.1.0',
+                        main: false,
+                        deps: []
+                    }
+                });
+            });
+
+            it('should bump asset.json in temp folder', () => {
+                const pathToAssetJson = `${tempRootDir}/asset/asset.json`;
+                const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
+                expect(assetJsonInfo.version).toEqual('1.1.0');
+            });
+
+            it('should be able to get a readable commit message', () => {
+                const messages = getBumpCommitMessages(bumpAssetInfo, options.release);
+                expect(messages).toEqual([
+                    'bump: (minor) package-asset@1.1.0, package-main-asset@1.1.0'
+                ]);
+            });
+        });
+
+        describe('when release=major', () => {
+            const packages = cloneDeep(testPackages);
+            const options: BumpAssetOnlyOptions = {
+                release: 'major',
+            };
+            // let result: Record<string, BumpPkgInfo>;
+            let bumpAssetInfo: Record<string, BumpPkgInfo>;
+
+            beforeAll(async () => {
+                // result = await getPackagesToBump(testPackages, options);
+                /// Create an asset folder with asset.json
+                const assetPath = `${tempRootDir}/asset`;
+                fs.mkdirSync(assetPath);
+                fs.writeFileSync(`${assetPath}/asset.json`, assetJSONData);
+            });
+
+            afterAll(async () => {
+                /// Remove the asset folder within the temp root file
+                fs.rmSync(`${tempRootDir}/asset`, { recursive: true, force: true });
+            });
+
+            it('should return a list of package.json files to bump', async () => {
+                bumpAssetInfo = await bumpAssetVersion(packages, options, true);
+                expect(bumpAssetInfo).toEqual({
+                    'package-main-asset': {
+                        from: '1.0.0',
+                        to: '2.0.0',
+                        main: false,
+                        deps: []
+                    },
+                    'package-asset': {
+                        from: '1.0.0',
+                        to: '2.0.0',
+                        main: false,
+                        deps: []
+                    }
+                });
+            });
+
+            it('should bump asset.json in temp folder', () => {
+                const pathToAssetJson = `${tempRootDir}/asset/asset.json`;
+                const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
+                expect(assetJsonInfo.version).toEqual('2.0.0');
+            });
+
+            it('should be able to get a readable commit message', () => {
+                const messages = getBumpCommitMessages(bumpAssetInfo, options.release);
+                expect(messages).toEqual([
+                    'bump: (major) package-asset@2.0.0, package-main-asset@2.0.0'
+                ]);
+            });
+        });
+    });
+});

--- a/packages/scripts/test/bump-spec.ts
+++ b/packages/scripts/test/bump-spec.ts
@@ -1,5 +1,7 @@
 import 'jest-extended';
 import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { cloneDeep } from '@terascope/utils';
 import { BumpPackageOptions, BumpType, BumpPkgInfo } from '../src/helpers/bump/interfaces';
 import { PackageInfo } from '../src/helpers/interfaces';
@@ -376,6 +378,7 @@ describe('Bump Utils', () => {
 /// Testing bump when running in Asset Mode
 
 describe('Bump Assets', () => {
+    const tempRootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'asset'));
     const testPackages: PackageInfo[] = [
         {
             name: 'package-asset',
@@ -407,7 +410,7 @@ describe('Bump Assets', () => {
             name: 'package-main-asset',
             version: '1.0.0',
             relativeDir: '.',
-            dir: `${process.cwd()}`,
+            dir: `${tempRootDir}`,
             dependencies: {
             },
             terascope: {
@@ -422,7 +425,10 @@ describe('Bump Assets', () => {
         "version": "1.0.0",
         "description": "A set of processors for working with files"
     }`;
-
+    afterAll(async () => {
+        /// Remove the temp root file after all tests have been done
+        fs.rmSync(tempRootDir, { recursive: true, force: true });
+    });
     describe('when bumping package-1', () => {
         const pkg1 = testPackages.find(({ name }) => name === 'package-1');
 
@@ -439,15 +445,14 @@ describe('Bump Assets', () => {
             beforeAll(async () => {
                 result = await getPackagesToBump(testPackages, options);
                 /// Create an asset folder with asset.json
-                const path = `${process.cwd()}/asset`;
-                if (!fs.existsSync(path)) {
-                    fs.mkdirSync(path);
-                    fs.writeFileSync(`${path}/asset.json`, assetJSONData);
-                }
+                const assetPath = `${tempRootDir}/asset`;
+                fs.mkdirSync(assetPath);
+                fs.writeFileSync(`${assetPath}/asset.json`, assetJSONData);
             });
 
             afterAll(async () => {
-                fs.rmSync(`${process.cwd()}/asset`, { recursive: true, force: true });
+                /// Remove the asset folder within the temp root file
+                fs.rmSync(`${tempRootDir}/asset`, { recursive: true, force: true });
             });
 
             it('should return a list of correctly bump packages', () => {
@@ -505,7 +510,7 @@ describe('Bump Assets', () => {
                         name: 'package-main-asset',
                         version: '1.0.0',
                         relativeDir: '.',
-                        dir: `${process.cwd()}`,
+                        dir: `${tempRootDir}`,
                         dependencies: {
                         },
                         terascope: {
@@ -518,7 +523,7 @@ describe('Bump Assets', () => {
 
             it('should correctly bump all 3 asset versions', async () => {
                 await bumpAssetVersion(packages, options);
-                const pathToAssetJson = `${process.cwd()}/asset/asset.json`;
+                const pathToAssetJson = `${tempRootDir}/asset/asset.json`;
                 const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
                 expect(packages).toEqual([
                     {
@@ -551,7 +556,7 @@ describe('Bump Assets', () => {
                         name: 'package-main-asset',
                         version: '1.0.1',
                         relativeDir: '.',
-                        dir: `${process.cwd()}`,
+                        dir: `${tempRootDir}`,
                         dependencies: {
                         },
                         terascope: {
@@ -587,16 +592,14 @@ describe('Bump Assets', () => {
             beforeAll(async () => {
                 result = await getPackagesToBump(testPackages, options);
                 /// Create an asset folder with asset.json
-                const path = `${process.cwd()}/asset`;
-                if (!fs.existsSync(path)) {
-                    fs.mkdirSync(path);
-                    fs.writeFileSync(`${path}/asset.json`, assetJSONData);
-                }
+                const assetPath = `${tempRootDir}/asset`;
+                fs.mkdirSync(assetPath);
+                fs.writeFileSync(`${assetPath}/asset.json`, assetJSONData);
             });
 
             afterAll(async () => {
-                /// Delete asset folder with asset.json
-                fs.rmSync(`${process.cwd()}/asset`, { recursive: true, force: true });
+                /// Remove the asset folder within the temp root file
+                fs.rmSync(`${tempRootDir}/asset`, { recursive: true, force: true });
             });
 
             it('should return a list of correctly bump packages', () => {
@@ -648,7 +651,7 @@ describe('Bump Assets', () => {
                         name: 'package-main-asset',
                         version: '1.0.0',
                         relativeDir: '.',
-                        dir: `${process.cwd()}`,
+                        dir: `${tempRootDir}`,
                         dependencies: {
                         },
                         terascope: {
@@ -661,7 +664,7 @@ describe('Bump Assets', () => {
 
             it('should correctly NOT bump all 3 asset versions', async () => {
                 await bumpAssetVersion(packages, options);
-                const pathToAssetJson = `${process.cwd()}/asset/asset.json`;
+                const pathToAssetJson = `${tempRootDir}/asset/asset.json`;
                 const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
                 expect(packages).toEqual([
                     {
@@ -694,7 +697,7 @@ describe('Bump Assets', () => {
                         name: 'package-main-asset',
                         version: '1.0.0',
                         relativeDir: '.',
-                        dir: `${process.cwd()}`,
+                        dir: `${tempRootDir}`,
                         dependencies: {
                         },
                         terascope: {

--- a/packages/scripts/test/bump-spec.ts
+++ b/packages/scripts/test/bump-spec.ts
@@ -574,143 +574,122 @@ describe('Bump Assets', () => {
                 ]);
             });
         });
-        // describe('when release=minor and deps=false and skip-asset=true', () => {
-        //     const packages = cloneDeep(testPackages);
-        //     const options: BumpPackageOptions = {
-        //         release: 'minor',
-        //         deps: false,
-        //         skipReset: true,
-        //         skipAsset: true,
-        //         packages: [cloneDeep(pkg1!)]
-        //     };
-        //     let result: Record<string, BumpPkgInfo>;
+        describe('when release=minor and deps=false and skip-asset=true', () => {
+            const packages = cloneDeep(testPackages);
+            const options: BumpPackageOptions = {
+                release: 'minor',
+                deps: false,
+                skipReset: true,
+                skipAsset: true,
+                packages: [cloneDeep(pkg1!)]
+            };
+            let result: Record<string, BumpPkgInfo>;
+            let assetPackages: Record<string, BumpPkgInfo>;
 
-        //     beforeAll(async () => {
-        //         result = await getPackagesToBump(testPackages, options);
-        //         /// Create an asset folder with asset.json
-        //         const assetPath = `${tempRootDir}/asset`;
-        //         await fs.promises.mkdir(assetPath);
-        //         await fs.promises.writeFile(`${assetPath}/asset.json`, assetJSONData);
-        //     });
+            beforeAll(async () => {
+                result = await getPackagesToBump(testPackages, options);
+                /// Create an asset folder with asset.json
+                const assetPath = `${tempRootDir}/asset`;
+                await fs.promises.mkdir(assetPath);
+                await fs.promises.writeFile(`${assetPath}/asset.json`, assetJSONData);
+            });
 
-        //     afterAll(async () => {
-        //         /// Remove the asset folder within the temp root file
-        //         await fs.promises.rm(`${tempRootDir}/asset`, { recursive: true, force: true });
-        //     });
+            afterAll(async () => {
+                /// Remove the asset folder within the temp root file
+                await fs.promises.rm(`${tempRootDir}/asset`, { recursive: true, force: true });
+            });
 
-        //     it('should return a list of correctly bump packages', () => {
-        //         expect(result).toEqual({
-        //             'package-1': {
-        //                 from: '2.1.0',
-        //                 to: '2.2.0',
-        //                 main: false,
-        //                 deps: [
-        //                     {
-        //                         type: BumpType.Prod,
-        //                         name: 'package-2'
-        //                     },
-        //                 ]
-        //             }
-        //         });
-        //     });
+            it('should return a list of correctly bump packages', () => {
+                expect(result).toEqual({
+                    'package-1': {
+                        from: '2.1.0',
+                        to: '2.2.0',
+                        main: false,
+                        deps: [
+                            {
+                                type: BumpType.Prod,
+                                name: 'package-2'
+                            },
+                        ]
+                    }
+                });
+            });
 
-        //     it('should correctly bump the packages list', () => {
-        //         bumpPackagesList(result, packages);
-        //         expect(packages).toEqual([
-        //             {
-        //                 name: 'package-asset',
-        //                 version: '1.0.0',
-        //                 relativeDir: 'asset',
-        //                 dependencies: {
-        //                 },
-        //                 devDependencies: {
-        //                 }
-        //             },
-        //             {
-        //                 name: 'package-2',
-        //                 version: '1.0.0',
-        //                 dependencies: {
-        //                     'package-1': '^2.2.0'
-        //                 },
-        //                 devDependencies: {
-        //                 },
-        //             },
-        //             {
-        //                 name: 'package-1',
-        //                 version: '2.2.0',
-        //                 dependencies: {
-        //                 },
-        //                 devDependencies: {
-        //                 },
-        //             },
-        //             {
-        //                 name: 'package-main-asset',
-        //                 version: '1.0.0',
-        //                 relativeDir: '.',
-        //                 dir: `${tempRootDir}`,
-        //                 dependencies: {
-        //                 },
-        //                 terascope: {
-        //                     main: true,
-        //                     root: true
-        //                 }
-        //             },
-        //         ]);
-        //     });
+            it('should correctly bump the packages list', () => {
+                bumpPackagesList(result, packages);
+                expect(packages).toEqual([
+                    {
+                        name: 'package-asset',
+                        version: '1.0.0',
+                        relativeDir: 'asset',
+                        dependencies: {
+                        },
+                        devDependencies: {
+                        }
+                    },
+                    {
+                        name: 'package-2',
+                        version: '1.0.0',
+                        dependencies: {
+                            'package-1': '^2.2.0'
+                        },
+                        devDependencies: {
+                        },
+                    },
+                    {
+                        name: 'package-1',
+                        version: '2.2.0',
+                        dependencies: {
+                        },
+                        devDependencies: {
+                        },
+                    },
+                    {
+                        name: 'package-main-asset',
+                        version: '1.0.0',
+                        relativeDir: '.',
+                        dir: `${tempRootDir}`,
+                        dependencies: {
+                        },
+                        terascope: {
+                            main: true,
+                            root: true
+                        }
+                    },
+                ]);
+            });
 
-        //     it('should correctly NOT bump all 3 asset versions', async () => {
-        //         await bumpAssetVersion(packages, options, true);
-        //         const pathToAssetJson = `${tempRootDir}/asset/asset.json`;
-        //         const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
-        //         expect(packages).toEqual([
-        //             {
-        //                 name: 'package-asset',
-        //                 version: '1.0.0',
-        //                 relativeDir: 'asset',
-        //                 dependencies: {
-        //                 },
-        //                 devDependencies: {
-        //                 }
-        //             },
-        //             {
-        //                 name: 'package-2',
-        //                 version: '1.0.0',
-        //                 dependencies: {
-        //                     'package-1': '^2.2.0'
-        //                 },
-        //                 devDependencies: {
-        //                 },
-        //             },
-        //             {
-        //                 name: 'package-1',
-        //                 version: '2.2.0',
-        //                 dependencies: {
-        //                 },
-        //                 devDependencies: {
-        //                 },
-        //             },
-        //             {
-        //                 name: 'package-main-asset',
-        //                 version: '1.0.0',
-        //                 relativeDir: '.',
-        //                 dir: `${tempRootDir}`,
-        //                 dependencies: {
-        //                 },
-        //                 terascope: {
-        //                     main: true,
-        //                     root: true
-        //                 }
-        //             }
-        //         ]);
-        //         expect(assetJsonInfo.version).toEqual('1.0.0');
-        //     });
+            it('should return a list with all packages excluding asset', async () => {
+                assetPackages = await bumpAssetVersion(packages, options, true);
+                const allBumps = { ...result, ...assetPackages };
+                expect(allBumps).toEqual({
+                    'package-1': {
+                        from: '2.1.0',
+                        to: '2.2.0',
+                        main: false,
+                        deps: [
+                            {
+                                type: BumpType.Prod,
+                                name: 'package-2'
+                            },
+                        ]
+                    }
+                });
+            });
 
-        //     it('should be able to get a readable commit message', () => {
-        //         const messages = getBumpCommitMessages(result, options.release);
-        //         expect(messages).toEqual([
-        //             'bump: (minor) package-1@2.2.0'
-        //         ]);
-        //     });
-        // });
+            it('should NOT bump asset.json in temp folder', () => {
+                const pathToAssetJson = `${tempRootDir}/asset/asset.json`;
+                const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
+                expect(assetJsonInfo.version).toEqual('1.0.0');
+            });
+
+            it('should be able to get a readable commit message', () => {
+                const allBumps = { ...result, ...assetPackages };
+                const messages = getBumpCommitMessages(allBumps, options.release);
+                expect(messages).toEqual([
+                    'bump: (minor) package-1@2.2.0'
+                ]);
+            });
+        });
     });
 });

--- a/packages/scripts/test/bump-spec.ts
+++ b/packages/scripts/test/bump-spec.ts
@@ -438,21 +438,23 @@ describe('Bump Assets', () => {
                 release: 'patch',
                 deps: true,
                 skipReset: true,
+                skipAsset: false,
                 packages: [cloneDeep(pkg1!)]
             };
             let result: Record<string, BumpPkgInfo>;
+            let assetPackages: Record<string, BumpPkgInfo>;
 
             beforeAll(async () => {
                 result = await getPackagesToBump(testPackages, options);
                 /// Create an asset folder with asset.json
                 const assetPath = `${tempRootDir}/asset`;
-                fs.mkdirSync(assetPath);
-                fs.writeFileSync(`${assetPath}/asset.json`, assetJSONData);
+                await fs.promises.mkdir(assetPath);
+                await fs.promises.writeFile(`${assetPath}/asset.json`, assetJSONData);
             });
 
             afterAll(async () => {
                 /// Remove the asset folder within the temp root file
-                fs.rmSync(`${tempRootDir}/asset`, { recursive: true, force: true });
+                await fs.promises.rm(`${tempRootDir}/asset`, { recursive: true, force: true });
             });
 
             it('should return a list of correctly bump packages', () => {
@@ -521,92 +523,13 @@ describe('Bump Assets', () => {
                 ]);
             });
 
-            it('should correctly bump all 3 asset versions', async () => {
-                await bumpAssetVersion(packages, options, true);
-                const pathToAssetJson = `${tempRootDir}/asset/asset.json`;
-                const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
-                expect(packages).toEqual([
-                    {
-                        name: 'package-asset',
-                        version: '1.0.1',
-                        relativeDir: 'asset',
-                        dependencies: {
-                        },
-                        devDependencies: {
-                        }
-                    },
-                    {
-                        name: 'package-2',
-                        version: '1.0.1',
-                        dependencies: {
-                            'package-1': '^2.1.1'
-                        },
-                        devDependencies: {
-                        },
-                    },
-                    {
-                        name: 'package-1',
-                        version: '2.1.1',
-                        dependencies: {
-                        },
-                        devDependencies: {
-                        },
-                    },
-                    {
-                        name: 'package-main-asset',
-                        version: '1.0.1',
-                        relativeDir: '.',
-                        dir: `${tempRootDir}`,
-                        dependencies: {
-                        },
-                        terascope: {
-                            main: true,
-                            root: true
-                        }
-                    }
-                ]);
-                expect(assetJsonInfo.version).toEqual('1.0.1');
-            });
-
-            it('should be able to get a readable commit message', () => {
-                const messages = getBumpCommitMessages(result, options.release);
-                expect(messages).toEqual([
-                    'bump: (patch) package-1@2.1.1, package-2@1.0.1'
-                ]);
-                expect(messages).toEqual([
-                    'bump: (patch) package-1@2.1.1, package-2@1.0.1'
-                ]);
-            });
-        });
-        describe('when release=minor and deps=false and skip-asset=true', () => {
-            const packages = cloneDeep(testPackages);
-            const options: BumpPackageOptions = {
-                release: 'minor',
-                deps: false,
-                skipReset: true,
-                skipAsset: true,
-                packages: [cloneDeep(pkg1!)]
-            };
-            let result: Record<string, BumpPkgInfo>;
-
-            beforeAll(async () => {
-                result = await getPackagesToBump(testPackages, options);
-                /// Create an asset folder with asset.json
-                const assetPath = `${tempRootDir}/asset`;
-                fs.mkdirSync(assetPath);
-                fs.writeFileSync(`${assetPath}/asset.json`, assetJSONData);
-            });
-
-            afterAll(async () => {
-                /// Remove the asset folder within the temp root file
-                fs.rmSync(`${tempRootDir}/asset`, { recursive: true, force: true });
-            });
-
-            it('should return a list of correctly bump packages', () => {
-                expect(result).toEqual({
+            it('should return a list with all packages including assets bump', async () => {
+                assetPackages = await bumpAssetVersion(packages, options, true);
+                const allBumps = { ...result, ...assetPackages };
+                expect(allBumps).toEqual({
                     'package-1': {
                         from: '2.1.0',
-                        to: '2.2.0',
+                        to: '2.1.1',
                         main: false,
                         deps: [
                             {
@@ -614,110 +537,180 @@ describe('Bump Assets', () => {
                                 name: 'package-2'
                             },
                         ]
+                    },
+                    'package-2': {
+                        from: '1.0.0',
+                        to: '1.0.1',
+                        main: false,
+                        deps: []
+                    },
+                    'package-main-asset': {
+                        from: '1.0.0',
+                        to: '1.0.1',
+                        main: false,
+                        deps: []
+                    },
+                    'package-asset': {
+                        from: '1.0.0',
+                        to: '1.0.1',
+                        main: false,
+                        deps: []
                     }
                 });
             });
 
-            it('should correctly bump the packages list', () => {
-                bumpPackagesList(result, packages);
-                expect(packages).toEqual([
-                    {
-                        name: 'package-asset',
-                        version: '1.0.0',
-                        relativeDir: 'asset',
-                        dependencies: {
-                        },
-                        devDependencies: {
-                        }
-                    },
-                    {
-                        name: 'package-2',
-                        version: '1.0.0',
-                        dependencies: {
-                            'package-1': '^2.2.0'
-                        },
-                        devDependencies: {
-                        },
-                    },
-                    {
-                        name: 'package-1',
-                        version: '2.2.0',
-                        dependencies: {
-                        },
-                        devDependencies: {
-                        },
-                    },
-                    {
-                        name: 'package-main-asset',
-                        version: '1.0.0',
-                        relativeDir: '.',
-                        dir: `${tempRootDir}`,
-                        dependencies: {
-                        },
-                        terascope: {
-                            main: true,
-                            root: true
-                        }
-                    },
-                ]);
-            });
-
-            it('should correctly NOT bump all 3 asset versions', async () => {
-                await bumpAssetVersion(packages, options, true);
+            it('should bump asset.json in temp folder', () => {
                 const pathToAssetJson = `${tempRootDir}/asset/asset.json`;
                 const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
-                expect(packages).toEqual([
-                    {
-                        name: 'package-asset',
-                        version: '1.0.0',
-                        relativeDir: 'asset',
-                        dependencies: {
-                        },
-                        devDependencies: {
-                        }
-                    },
-                    {
-                        name: 'package-2',
-                        version: '1.0.0',
-                        dependencies: {
-                            'package-1': '^2.2.0'
-                        },
-                        devDependencies: {
-                        },
-                    },
-                    {
-                        name: 'package-1',
-                        version: '2.2.0',
-                        dependencies: {
-                        },
-                        devDependencies: {
-                        },
-                    },
-                    {
-                        name: 'package-main-asset',
-                        version: '1.0.0',
-                        relativeDir: '.',
-                        dir: `${tempRootDir}`,
-                        dependencies: {
-                        },
-                        terascope: {
-                            main: true,
-                            root: true
-                        }
-                    }
-                ]);
-                expect(assetJsonInfo.version).toEqual('1.0.0');
+                expect(assetJsonInfo.version).toEqual('1.0.1');
             });
 
             it('should be able to get a readable commit message', () => {
-                const messages = getBumpCommitMessages(result, options.release);
+                const allBumps = { ...result, ...assetPackages };
+                const messages = getBumpCommitMessages(allBumps, options.release);
                 expect(messages).toEqual([
-                    'bump: (minor) package-1@2.2.0'
-                ]);
-                expect(messages).toEqual([
-                    'bump: (minor) package-1@2.2.0'
+                    'bump: (patch) package-1@2.1.1, package-2@1.0.1',
+                    'bump: (patch) package-asset@1.0.1, package-main-asset@1.0.1'
                 ]);
             });
         });
+        // describe('when release=minor and deps=false and skip-asset=true', () => {
+        //     const packages = cloneDeep(testPackages);
+        //     const options: BumpPackageOptions = {
+        //         release: 'minor',
+        //         deps: false,
+        //         skipReset: true,
+        //         skipAsset: true,
+        //         packages: [cloneDeep(pkg1!)]
+        //     };
+        //     let result: Record<string, BumpPkgInfo>;
+
+        //     beforeAll(async () => {
+        //         result = await getPackagesToBump(testPackages, options);
+        //         /// Create an asset folder with asset.json
+        //         const assetPath = `${tempRootDir}/asset`;
+        //         await fs.promises.mkdir(assetPath);
+        //         await fs.promises.writeFile(`${assetPath}/asset.json`, assetJSONData);
+        //     });
+
+        //     afterAll(async () => {
+        //         /// Remove the asset folder within the temp root file
+        //         await fs.promises.rm(`${tempRootDir}/asset`, { recursive: true, force: true });
+        //     });
+
+        //     it('should return a list of correctly bump packages', () => {
+        //         expect(result).toEqual({
+        //             'package-1': {
+        //                 from: '2.1.0',
+        //                 to: '2.2.0',
+        //                 main: false,
+        //                 deps: [
+        //                     {
+        //                         type: BumpType.Prod,
+        //                         name: 'package-2'
+        //                     },
+        //                 ]
+        //             }
+        //         });
+        //     });
+
+        //     it('should correctly bump the packages list', () => {
+        //         bumpPackagesList(result, packages);
+        //         expect(packages).toEqual([
+        //             {
+        //                 name: 'package-asset',
+        //                 version: '1.0.0',
+        //                 relativeDir: 'asset',
+        //                 dependencies: {
+        //                 },
+        //                 devDependencies: {
+        //                 }
+        //             },
+        //             {
+        //                 name: 'package-2',
+        //                 version: '1.0.0',
+        //                 dependencies: {
+        //                     'package-1': '^2.2.0'
+        //                 },
+        //                 devDependencies: {
+        //                 },
+        //             },
+        //             {
+        //                 name: 'package-1',
+        //                 version: '2.2.0',
+        //                 dependencies: {
+        //                 },
+        //                 devDependencies: {
+        //                 },
+        //             },
+        //             {
+        //                 name: 'package-main-asset',
+        //                 version: '1.0.0',
+        //                 relativeDir: '.',
+        //                 dir: `${tempRootDir}`,
+        //                 dependencies: {
+        //                 },
+        //                 terascope: {
+        //                     main: true,
+        //                     root: true
+        //                 }
+        //             },
+        //         ]);
+        //     });
+
+        //     it('should correctly NOT bump all 3 asset versions', async () => {
+        //         await bumpAssetVersion(packages, options, true);
+        //         const pathToAssetJson = `${tempRootDir}/asset/asset.json`;
+        //         const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
+        //         expect(packages).toEqual([
+        //             {
+        //                 name: 'package-asset',
+        //                 version: '1.0.0',
+        //                 relativeDir: 'asset',
+        //                 dependencies: {
+        //                 },
+        //                 devDependencies: {
+        //                 }
+        //             },
+        //             {
+        //                 name: 'package-2',
+        //                 version: '1.0.0',
+        //                 dependencies: {
+        //                     'package-1': '^2.2.0'
+        //                 },
+        //                 devDependencies: {
+        //                 },
+        //             },
+        //             {
+        //                 name: 'package-1',
+        //                 version: '2.2.0',
+        //                 dependencies: {
+        //                 },
+        //                 devDependencies: {
+        //                 },
+        //             },
+        //             {
+        //                 name: 'package-main-asset',
+        //                 version: '1.0.0',
+        //                 relativeDir: '.',
+        //                 dir: `${tempRootDir}`,
+        //                 dependencies: {
+        //                 },
+        //                 terascope: {
+        //                     main: true,
+        //                     root: true
+        //                 }
+        //             }
+        //         ]);
+        //         expect(assetJsonInfo.version).toEqual('1.0.0');
+        //     });
+
+        //     it('should be able to get a readable commit message', () => {
+        //         const messages = getBumpCommitMessages(result, options.release);
+        //         expect(messages).toEqual([
+        //             'bump: (minor) package-1@2.2.0'
+        //         ]);
+        //     });
+        // });
     });
 });

--- a/packages/scripts/test/bump-spec.ts
+++ b/packages/scripts/test/bump-spec.ts
@@ -522,7 +522,7 @@ describe('Bump Assets', () => {
             });
 
             it('should correctly bump all 3 asset versions', async () => {
-                await bumpAssetVersion(packages, options);
+                await bumpAssetVersion(packages, options, true);
                 const pathToAssetJson = `${tempRootDir}/asset/asset.json`;
                 const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
                 expect(packages).toEqual([
@@ -663,7 +663,7 @@ describe('Bump Assets', () => {
             });
 
             it('should correctly NOT bump all 3 asset versions', async () => {
-                await bumpAssetVersion(packages, options);
+                await bumpAssetVersion(packages, options, true);
                 const pathToAssetJson = `${tempRootDir}/asset/asset.json`;
                 const assetJsonInfo = JSON.parse(fs.readFileSync(pathToAssetJson, 'utf8'));
                 expect(packages).toEqual([


### PR DESCRIPTION
Create a new command called `bump-asset` that will bump an assets version without bumping any package versions.