### PR TITLE
bump: (minor) @terascope/utils@0.51.0, @terascope/data-types@0.42.0

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -37,7 +37,7 @@
     },
     "devDependencies": {
         "bunyan": "^1.8.15",
-        "elasticsearch-store": "^0.71.2",
+        "elasticsearch-store": "^0.72.0",
         "fs-extra": "^10.1.0",
         "ms": "^2.1.3",
         "nanoid": "^3.3.4",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.46.2",
+    "version": "0.47.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -29,9 +29,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.41.2",
+        "@terascope/data-types": "^0.42.0",
         "@terascope/types": "^0.11.2",
-        "@terascope/utils": "^0.50.1",
+        "@terascope/utils": "^0.51.0",
         "@types/validator": "^13.7.17",
         "awesome-phonenumber": "^2.70.0",
         "date-fns": "^2.30.0",
@@ -46,7 +46,7 @@
         "uuid": "^9.0.0",
         "valid-url": "^1.0.9",
         "validator": "^13.9.0",
-        "xlucene-parser": "^0.49.1"
+        "xlucene-parser": "^0.50.0"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.2",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.41.2",
+    "version": "0.42.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.11.2",
-        "@terascope/utils": "^0.50.1",
+        "@terascope/utils": "^0.51.0",
         "graphql": "^14.7.0",
         "lodash": "^4.17.21",
         "yargs": "^17.7.2"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "3.10.2",
+    "version": "3.11.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -25,7 +25,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.11.2",
-        "@terascope/utils": "^0.50.1",
+        "@terascope/utils": "^0.51.0",
         "bluebird": "^3.7.2",
         "setimmediate": "^1.0.5"
     },
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "^1.2.0",
         "@types/elasticsearch": "^5.0.40",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^0.71.2",
+        "elasticsearch-store": "^0.72.0",
         "elasticsearch6": "npm:@elastic/elasticsearch@^6.7.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@^7.0.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@^8.0.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.71.2",
+    "version": "0.72.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,10 +30,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.46.2",
-        "@terascope/data-types": "^0.41.2",
+        "@terascope/data-mate": "^0.47.0",
+        "@terascope/data-types": "^0.42.0",
         "@terascope/types": "^0.11.2",
-        "@terascope/utils": "^0.50.1",
+        "@terascope/utils": "^0.51.0",
         "ajv": "^6.12.6",
         "elasticsearch": "^15.4.1",
         "elasticsearch6": "npm:@elastic/elasticsearch@^6.7.0",
@@ -43,7 +43,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@^2.2.1",
         "setimmediate": "^1.0.5",
         "uuid": "^9.0.0",
-        "xlucene-translator": "^0.34.2"
+        "xlucene-translator": "^0.35.0"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.4"

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.29.2",
+    "version": "0.30.0",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.50.1",
+        "@terascope/utils": "^0.51.0",
         "chalk": "^4.1.2",
         "lodash": "^4.17.21",
         "yeoman-generator": "^5.8.0",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.63.2",
+    "version": "0.64.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.50.1",
+        "@terascope/utils": "^0.51.0",
         "convict": "^6.2.4",
         "convict-format-with-moment": "^6.2.0",
         "convict-format-with-validator": "^6.2.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.58.2",
+    "version": "0.59.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "typescript": "~4.8.3"
     },
     "dependencies": {
-        "@terascope/utils": "^0.50.1",
+        "@terascope/utils": "^0.51.0",
         "codecov": "^3.8.3",
         "execa": "^5.1.0",
         "fs-extra": "^10.1.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.49.2",
+    "version": "0.50.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@terascope/file-asset-apis": "^0.9.0",
-        "@terascope/utils": "^0.50.1",
+        "@terascope/utils": "^0.51.0",
         "aws-sdk": "^2.1401.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.15",
@@ -36,7 +36,7 @@
         "convict-format-with-moment": "^6.2.0",
         "convict-format-with-validator": "^6.2.0",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^0.71.2",
+        "elasticsearch-store": "^0.72.0",
         "js-yaml": "^4.1.0",
         "mongoose": "~6.6.5",
         "nanoid": "^3.3.4",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.56.2",
+    "version": "0.57.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.8.7",
-        "@terascope/utils": "^0.50.1",
+        "@terascope/utils": "^0.51.0",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.3",
         "easy-table": "^1.2.0",
@@ -51,7 +51,7 @@
         "pretty-bytes": "^5.6.0",
         "prompts": "^2.4.2",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.51.2",
+        "teraslice-client-js": "^0.52.0",
         "tmp": "^0.2.0",
         "tty-table": "^4.1.6",
         "yargs": "^17.7.2",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.51.2",
+    "version": "0.52.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.63.2",
+        "@terascope/job-components": "^0.64.0",
         "auto-bind": "^4.0.0",
         "got": "^11.8.3"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.33.2",
+    "version": "0.34.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,7 +34,7 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/utils": "^0.50.1",
+        "@terascope/utils": "^0.51.0",
         "ms": "^2.1.3",
         "nanoid": "^3.3.4",
         "p-event": "^4.2.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.63.2"
+        "@terascope/job-components": "^0.64.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.63.2"
+        "@terascope/job-components": ">=0.64.0"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.43.2",
+    "version": "0.44.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^3.10.2",
-        "@terascope/utils": "^0.50.1"
+        "@terascope/elasticsearch-api": "^3.11.0",
+        "@terascope/utils": "^0.51.0"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^10.1.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.63.2"
+        "@terascope/job-components": "^0.64.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.63.2"
+        "@terascope/job-components": ">=0.64.0"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -41,10 +41,10 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^3.10.2",
-        "@terascope/job-components": "^0.63.2",
-        "@terascope/teraslice-messaging": "^0.33.2",
-        "@terascope/utils": "^0.50.1",
+        "@terascope/elasticsearch-api": "^3.11.0",
+        "@terascope/job-components": "^0.64.0",
+        "@terascope/teraslice-messaging": "^0.34.0",
+        "@terascope/utils": "^0.51.0",
         "async-mutex": "^0.4.0",
         "barbe": "^3.0.16",
         "body-parser": "^1.20.2",
@@ -65,7 +65,7 @@
         "semver": "^7.3.8",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.49.2",
+        "terafoundation": "^0.50.0",
         "uuid": "^9.0.0"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.75.2",
+    "version": "0.76.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.46.2",
+        "@terascope/data-mate": "^0.47.0",
         "@terascope/types": "^0.11.2",
-        "@terascope/utils": "^0.50.1",
+        "@terascope/utils": "^0.51.0",
         "awesome-phonenumber": "^2.70.0",
         "graphlib": "^2.1.8",
         "is-ip": "^3.1.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.50.1",
+    "version": "0.51.0",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.49.1",
+    "version": "0.50.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@terascope/types": "^0.11.2",
-        "@terascope/utils": "^0.50.1"
+        "@terascope/utils": "^0.51.0"
     },
     "devDependencies": {
         "@turf/invariant": "^6.2.0",

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.34.2",
+    "version": "0.35.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,9 +29,9 @@
     },
     "dependencies": {
         "@terascope/types": "^0.11.2",
-        "@terascope/utils": "^0.50.1",
+        "@terascope/utils": "^0.51.0",
         "@types/elasticsearch": "^5.0.40",
-        "xlucene-parser": "^0.49.1"
+        "xlucene-parser": "^0.50.0"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "0.17.2",
+    "version": "0.18.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -23,7 +23,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.50.1"
+        "@terascope/utils": "^0.51.0"
     },
     "devDependencies": {
         "@terascope/types": "^0.11.2"


### PR DESCRIPTION
bump: (minor) @terascope/data-mate@0.47.0, elasticsearch-store@0.72.0

bump: (minor) terafoundation@0.50.0, ts-transforms@0.76.0

bump: (minor) xlucene-parser@0.50.0, xlucene-translator@0.35.0

bump: (minor) @terascope/elasticsearch-api@3.11.0, @terascope/teraslice-state-storage@0.44.0

bump: (minor) generator-teraslice@0.30.0, @terascope/job-components@0.64.0