### PR TITLE
Change label used to get execution controller pod

### DIFF
--- a/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/index.js
+++ b/packages/teraslice/lib/cluster/services/cluster/backends/kubernetes/index.js
@@ -103,9 +103,9 @@ module.exports = function kubernetesClusterBackend(context, clusterMasterServer)
         const jobResult = await k8s.post(exJob, 'job');
         logger.debug(jobResult, 'k8s slicer job submitted');
 
-        const controllerUid = jobResult.spec.selector.matchLabels['controller-uid'];
+        const jobId = jobResult.metadata.labels['teraslice.terascope.io/jobId'];
         const pod = await k8s.waitForSelectedPod(
-            `controller-uid=${controllerUid}`,
+            `teraslice.terascope.io/jobId=${jobId}`,
             null,
             context.sysconfig.teraslice.slicer_timeout
         );


### PR DESCRIPTION
There was a breaking change between k8s v1.26 and v1.27.
Within a k8s job yaml file the `spec.selector.matchLabels.controller-uid` field was changed to `spec.selector.matchLabels.batch.kubernetes.io/controller-uid`.