### PR TITLE
add mergeBy aggregation

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -37,7 +37,7 @@
     },
     "devDependencies": {
         "bunyan": "^1.8.15",
-        "elasticsearch-store": "^0.72.0",
+        "elasticsearch-store": "^0.73.0",
         "fs-extra": "^11.1.1",
         "ms": "^2.1.3",
         "nanoid": "^3.3.4",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.47.0",
+    "version": "0.48.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-mate/src/aggregation-frame/AggregationFrame.ts
+++ b/packages/data-mate/src/aggregation-frame/AggregationFrame.ts
@@ -119,6 +119,10 @@ export class AggregationFrame<
      * GroupBy fields
     */
     groupBy(...fieldArg: FieldArg<keyof T>[]): this {
+        if (this._merge) {
+            throw new Error('AggregationFrame.groupBy and AggregationFrame.mergeBy running at the same time is not currently supported');
+        }
+
         this._groupByFields = Object.freeze(this._groupByFields.concat(
             Array.from(getFieldsFromArg(this.fields, fieldArg))
         ));
@@ -129,6 +133,10 @@ export class AggregationFrame<
      * MergeBy fields
     */
     mergeBy(...fieldArg: FieldArg<keyof T>[]): this {
+        if (this._groupByFields.length) {
+            throw new Error('AggregationFrame.groupBy and AggregationFrame.mergeBy running at the same time is not currently supported');
+        }
+
         this._merge = true;
         this._groupByFields = Object.freeze(this._groupByFields.concat(
             Array.from(getFieldsFromArg(this.fields, fieldArg))

--- a/packages/data-mate/src/aggregation-frame/AggregationFrame.ts
+++ b/packages/data-mate/src/aggregation-frame/AggregationFrame.ts
@@ -133,7 +133,6 @@ export class AggregationFrame<
         this._groupByFields = Object.freeze(this._groupByFields.concat(
             Array.from(getFieldsFromArg(this.fields, fieldArg))
         ));
-
         return this;
     }
 
@@ -584,9 +583,9 @@ export class AggregationFrame<
 
         const merge = new Map<string, number[]>();
         for (let i = 0; i < this.size; i++) {
-            if (this._merge) {
-                const res = makeKeyForRow(keyAggs, i);
-                if (res) {
+            const res = makeKeyForRow(keyAggs, i);
+            if (res) {
+                if (this._merge) {
                     let indices = [i];
                     if (merge.has(res.key)) {
                         // if merging collect all indices, then it will
@@ -597,10 +596,7 @@ export class AggregationFrame<
                         merge.delete(res.key);
                     }
                     merge.set(res.key, indices);
-                }
-            } else {
-                const res = makeKeyForRow(keyAggs, i);
-                if (res) {
+                } else {
                     fieldAggMakers.forEach(
                         makeProcessFieldAgg(getFieldAggs(res.key, i), i)
                     );

--- a/packages/data-mate/src/builder/Builder.ts
+++ b/packages/data-mate/src/builder/Builder.ts
@@ -8,19 +8,19 @@ import {
 } from '../vector';
 
 /**
- * Since Vectors are immutable, a Builder can be to construct a
+ * Since Vectors are immutable, a Builder can be used to construct a
  * Vector. When values are inserted they are coerced and validated.
 */
 export abstract class Builder<T = unknown> {
     /**
-     * Make a instance of a Builder from a DataTypeField config
+     * Make an instance of a Builder from a DataTypeFieldConfig
     */
     static make<R = unknown>(
         data: WritableData<R>,
         options: BuilderOptions,
     ): Builder<R> {
         throw new Error(
-            `This will functionality replaced in the index file
+            `This functionality will be replaced in the index file
             ${options} ${length} ${data}`
         );
     }
@@ -47,7 +47,7 @@ export abstract class Builder<T = unknown> {
     }
 
     /**
-     * The type of Vector, this should only be set the specific Vector type classes.
+     * The type of Vector, this should only be set with the specific Vector type classes.
     */
     readonly type: VectorType;
 

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -697,6 +697,69 @@ export class DataFrame<
         return this.forkWithBuilders(builders, buckets.size);
     }
 
+    // merge(...fieldArg: FieldArg<keyof T>[]): DataFrame<T> {
+    //     return this._merge(getFieldsFromArg(this.fields, fieldArg));
+    // }
+
+    // private _merge(
+    //     fields: Iterable<keyof T>,
+    //     serializeOptions?: SerializeOptions
+    // ) {
+    //     const buckets = new Set<string>();
+    //     const keyAggs = new Map<keyof T, KeyAggFn>();
+
+    //     for (const name of fields) {
+    //         const column = this.getColumnOrThrow(name);
+    //         if (column) {
+    //             keyAggs.set(column.name, makeUniqueKeyAgg(
+    //                 column.vector, serializeOptions
+    //             ));
+    //         }
+    //     }
+
+    //     const builders = getBuildersForConfig<T>(this.config, this.size);
+
+    //     const rowBuilder = makeUniqueRowBuilder(
+    //         builders,
+    //         buckets,
+    //         (name, _indices) => {
+    //             const indices = castArray(_indices);
+    //             for (const i of indices) {
+    //                 const fetched = this.getColumnOrThrow(name).vector.get(i);
+    //                 if (fetched) return fetched;
+    //             }
+
+    //             return;
+    //         }
+    //     );
+
+    //     const reduced = new Map<string, [number[], any]>();
+    //     for (let i = 0; i < this.size; i++) {
+    //         const res = makeKeyForRow(keyAggs, i);
+    //         if (res) {
+    //             let indices = [i];
+    //             if (reduced.has(res.key)) {
+    //                 const _indices = reduced.get(res.key)?.[0];
+    //                 if (_indices?.length) indices = indices.concat(_indices);
+    //             }
+
+    //             reduced.delete(res.key);
+    //             reduced.set(res.key, [indices, res.row]);
+    //         }
+    //     }
+    //     if (reduced.size) {
+    //         [...reduced.entries()].forEach(([key, [indices, row]]) => {
+    //             if (!buckets.has(key)) {
+    //                 rowBuilder(row, key, indices);
+    //             } else {
+    //                 rowBuilder(row, key, indices);
+    //             }
+    //         });
+    //     }
+
+    //     return this.forkWithBuilders(builders, buckets.size);
+    // }
+
     /**
      * Create a new data frame from the builders
     */

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -697,69 +697,6 @@ export class DataFrame<
         return this.forkWithBuilders(builders, buckets.size);
     }
 
-    // merge(...fieldArg: FieldArg<keyof T>[]): DataFrame<T> {
-    //     return this._merge(getFieldsFromArg(this.fields, fieldArg));
-    // }
-
-    // private _merge(
-    //     fields: Iterable<keyof T>,
-    //     serializeOptions?: SerializeOptions
-    // ) {
-    //     const buckets = new Set<string>();
-    //     const keyAggs = new Map<keyof T, KeyAggFn>();
-
-    //     for (const name of fields) {
-    //         const column = this.getColumnOrThrow(name);
-    //         if (column) {
-    //             keyAggs.set(column.name, makeUniqueKeyAgg(
-    //                 column.vector, serializeOptions
-    //             ));
-    //         }
-    //     }
-
-    //     const builders = getBuildersForConfig<T>(this.config, this.size);
-
-    //     const rowBuilder = makeUniqueRowBuilder(
-    //         builders,
-    //         buckets,
-    //         (name, _indices) => {
-    //             const indices = castArray(_indices);
-    //             for (const i of indices) {
-    //                 const fetched = this.getColumnOrThrow(name).vector.get(i);
-    //                 if (fetched) return fetched;
-    //             }
-
-    //             return;
-    //         }
-    //     );
-
-    //     const reduced = new Map<string, [number[], any]>();
-    //     for (let i = 0; i < this.size; i++) {
-    //         const res = makeKeyForRow(keyAggs, i);
-    //         if (res) {
-    //             let indices = [i];
-    //             if (reduced.has(res.key)) {
-    //                 const _indices = reduced.get(res.key)?.[0];
-    //                 if (_indices?.length) indices = indices.concat(_indices);
-    //             }
-
-    //             reduced.delete(res.key);
-    //             reduced.set(res.key, [indices, res.row]);
-    //         }
-    //     }
-    //     if (reduced.size) {
-    //         [...reduced.entries()].forEach(([key, [indices, row]]) => {
-    //             if (!buckets.has(key)) {
-    //                 rowBuilder(row, key, indices);
-    //             } else {
-    //                 rowBuilder(row, key, indices);
-    //             }
-    //         });
-    //     }
-
-    //     return this.forkWithBuilders(builders, buckets.size);
-    // }
-
     /**
      * Create a new data frame from the builders
     */

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -679,10 +679,10 @@ export class DataFrame<
             buckets,
             (name, i) => {
                 if (!serializeOptions) {
-                    return this.getColumnOrThrow(name).vector.get(i);
+                    return this.getColumnOrThrow(name).vector.get(i as number);
                 }
                 return this.getColumnOrThrow(name).vector.get(
-                    i, true, serializeOptions
+                    i as number, true, serializeOptions
                 );
             }
         );

--- a/packages/data-mate/test/aggregation-frame-spec.ts
+++ b/packages/data-mate/test/aggregation-frame-spec.ts
@@ -1123,45 +1123,50 @@ describe('AggregationFrame', () => {
             ]);
         });
 
-        it('should create the correct results when mergeBy countBy', async () => {
+        it('should create the correct results when mergeBy + aggregations', async () => {
             const resultFrame = await dataFrame2
                 .aggregate()
-                .mergeBy('state')
                 .count('state', 'count')
+                .rename('name', 'mainAttraction')
+                .mergeBy('state')
+                .select('mainAttraction', 'count', 'state')
                 .run();
 
             expect(resultFrame.toJSON()).toEqual([
                 {
-                    name: 'some-trail-2',
+                    mainAttraction: 'some-trail-2',
                     state: 'AZ',
                     count: 2,
-                    fishing: false,
-                    boating: false,
-                    swimming: false,
-                    hiking: true,
-                    offRoad: false
                 },
                 {
-                    name: 'some-lake-3',
+                    mainAttraction: 'some-lake-3',
                     state: 'NY',
                     count: 1,
-                    fishing: false,
-                    boating: false,
-                    swimming: true,
-                    hiking: false,
-                    offRoad: false
                 },
                 {
-                    name: 'some-trail-3',
+                    mainAttraction: 'some-trail-3',
                     state: 'CA',
                     count: 3,
-                    fishing: false,
-                    boating: false,
-                    swimming: false,
-                    hiking: true,
-                    offRoad: true
                 }
             ]);
+        });
+
+        it('should throw when running mergeBy -> groupBy', () => {
+            expect(() => dataFrame2
+                .aggregate()
+                .mergeBy('state')
+                .count('state', 'count')
+                .groupBy('boating')
+            ).toThrowError('AggregationFrame.groupBy and AggregationFrame.mergeBy running at the same time is not currently supported');
+        });
+
+        it('should throw when running groupBy -> mergeBy', () => {
+            expect(() => dataFrame2
+                .aggregate()
+                .groupBy('boating')
+                .orderBy('state')
+                .mergeBy('state')
+            ).toThrowError('AggregationFrame.groupBy and AggregationFrame.mergeBy running at the same time is not currently supported');
         });
     });
 });

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "^1.2.0",
         "@types/elasticsearch": "^5.0.40",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^0.72.0",
+        "elasticsearch-store": "^0.73.0",
         "elasticsearch6": "npm:@elastic/elasticsearch@^6.7.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@^7.0.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@^8.0.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.72.0",
+    "version": "0.73.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,7 +30,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.47.0",
+        "@terascope/data-mate": "^0.48.0",
         "@terascope/data-types": "^0.42.0",
         "@terascope/types": "^0.11.2",
         "@terascope/utils": "^0.51.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.50.0",
+    "version": "0.51.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -36,7 +36,7 @@
         "convict-format-with-moment": "^6.2.0",
         "convict-format-with-validator": "^6.2.0",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^0.72.0",
+        "elasticsearch-store": "^0.73.0",
         "js-yaml": "^4.1.0",
         "mongoose": "~6.6.5",
         "nanoid": "^3.3.4",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -65,7 +65,7 @@
         "semver": "^7.3.8",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.50.0",
+        "terafoundation": "^0.51.0",
         "uuid": "^9.0.0"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.76.0",
+    "version": "0.77.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,7 +35,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.47.0",
+        "@terascope/data-mate": "^0.48.0",
         "@terascope/types": "^0.11.2",
         "@terascope/utils": "^0.51.0",
         "awesome-phonenumber": "^2.70.0",


### PR DESCRIPTION
- [x] add mergeBy aggregation to data-mate aggregation frame

MergeBy merges unique values from the specified fields together into a single record... if there are multiple values for the same field, the merged record will be the last value in the list of records.

Decided to not allow a frame to call groupBy and mergeBy in the same aggregation for now because would need to know whether to allow other aggregations (sum, count, select, etc) on both or just one and currently you can call those before or after groupBy so we would need to rework