### PR TITLE
add restriction for regexp queries when prevent_prefix_wildcard

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -39,7 +39,7 @@
     },
     "devDependencies": {
         "bunyan": "^1.8.15",
-        "elasticsearch-store": "^0.73.0",
+        "elasticsearch-store": "^0.74.0",
         "fs-extra": "^11.1.1",
         "ms": "^2.1.3",
         "nanoid": "^3.3.4",

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "^1.2.0",
         "@types/elasticsearch": "^5.0.40",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^0.73.0",
+        "elasticsearch-store": "^0.74.0",
         "elasticsearch6": "npm:@elastic/elasticsearch@^6.7.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@^7.0.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@^8.0.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.73.0",
+    "version": "0.74.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -43,7 +43,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@^2.2.1",
         "setimmediate": "^1.0.5",
         "uuid": "^9.0.0",
-        "xlucene-translator": "^0.35.0"
+        "xlucene-translator": "^0.36.0"
     },
     "devDependencies": {
         "@types/uuid": "^8.3.4"

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.51.0",
+    "version": "0.52.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -36,7 +36,7 @@
         "convict-format-with-moment": "^6.2.0",
         "convict-format-with-validator": "^6.2.0",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^0.73.0",
+        "elasticsearch-store": "^0.74.0",
         "js-yaml": "^4.1.0",
         "mongoose": "~6.6.5",
         "nanoid": "^3.3.4",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -66,7 +66,7 @@
         "semver": "^7.3.8",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.51.0",
+        "terafoundation": "^0.52.0",
         "uuid": "^9.0.0"
     },
     "devDependencies": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.35.0",
+    "version": "0.36.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {

--- a/packages/xlucene-translator/src/query-access/query-access.ts
+++ b/packages/xlucene-translator/src/query-access/query-access.ts
@@ -146,7 +146,7 @@ export class QueryAccess<T extends ts.AnyObject = ts.AnyObject> {
                     if (startsWithWildcard(value, node.type)) {
                         const errMessage = node.type === p.NodeType.Wildcard
                             ? "Queries starting with wildcards in the form 'fieldname:*value' or 'fieldname:?value' are restricted"
-                            : "Queries starting with regular expressions in the form 'fieldname:/.*value/' or 'fieldname:/.?value/' are restricted";
+                            : "Regular expression queries starting with wildcards in the form 'fieldname:/.*value/' or 'fieldname:/.?value/' are restricted";
 
                         throw new ts.TSError(errMessage, {
                             statusCode: 403,

--- a/packages/xlucene-translator/src/query-access/query-access.ts
+++ b/packages/xlucene-translator/src/query-access/query-access.ts
@@ -145,8 +145,8 @@ export class QueryAccess<T extends ts.AnyObject = ts.AnyObject> {
 
                     if (startsWithWildcard(value, node.type)) {
                         const errMessage = node.type === p.NodeType.Wildcard
-                            ? "Wildcard queries of the form 'fieldname:*value' or 'fieldname:?value' in query are restricted"
-                            : "Regexp queries starting with wildcards in the form 'fieldname:/*value/' or 'fieldname:/.*?value/' in query are restricted";
+                            ? "Queries starting with wildcards in the form 'fieldname:*value' or 'fieldname:?value' are restricted"
+                            : "Queries starting with regular expressions in the form 'fieldname:/.*value/' or 'fieldname:/.?value/' are restricted";
 
                         throw new ts.TSError(errMessage, {
                             statusCode: 403,
@@ -158,7 +158,7 @@ export class QueryAccess<T extends ts.AnyObject = ts.AnyObject> {
                     }
 
                     if (isRegexpNode && hasNonGuaranteedMatch(value)) {
-                        throw new ts.TSError("Regexp queries with non-guaranteed wildcard matches in the form 'fieldname:/v*/' or 'fieldname:/v{0,1}/' in query are restricted", {
+                        throw new ts.TSError("Regular expression queries with non-guaranteed matches in the form 'fieldname:/v*/' or 'fieldname:/v{0,1}/' are restricted", {
                             statusCode: 403,
                             context: {
                                 q,

--- a/packages/xlucene-translator/test/query-access-spec.ts
+++ b/packages/xlucene-translator/test/query-access-spec.ts
@@ -506,7 +506,7 @@ describe('QueryAccess', () => {
             it('should throw an error', () => {
                 expect(() => queryAccess.restrict(query)).toThrowWithMessage(
                     TSError,
-                    "Queries starting with regular expressions in the form 'fieldname:/.*value/' or 'fieldname:/.?value/' are restricted"
+                    "Regular expression queries starting with wildcards in the form 'fieldname:/.*value/' or 'fieldname:/.?value/' are restricted"
                 );
             });
         });

--- a/packages/xlucene-translator/test/query-access-spec.ts
+++ b/packages/xlucene-translator/test/query-access-spec.ts
@@ -497,7 +497,7 @@ describe('QueryAccess', () => {
             it('should throw an error', () => {
                 expect(() => queryAccess.restrict(query)).toThrowWithMessage(
                     TSError,
-                    "Wildcard queries of the form 'fieldname:*value' or 'fieldname:?value' in query are restricted"
+                    "Queries starting with wildcards in the form 'fieldname:*value' or 'fieldname:?value' are restricted"
                 );
             });
         });
@@ -506,7 +506,7 @@ describe('QueryAccess', () => {
             it('should throw an error', () => {
                 expect(() => queryAccess.restrict(query)).toThrowWithMessage(
                     TSError,
-                    "Regexp queries starting with wildcards in the form 'fieldname:/*value/' or 'fieldname:/.*?value/' in query are restricted"
+                    "Queries starting with regular expressions in the form 'fieldname:/.*value/' or 'fieldname:/.?value/' are restricted"
                 );
             });
         });
@@ -515,7 +515,7 @@ describe('QueryAccess', () => {
             it('should throw an error', () => {
                 expect(() => queryAccess.restrict(query)).toThrowWithMessage(
                     TSError,
-                    "Regexp queries with non-guaranteed wildcard matches in the form 'fieldname:/v*/' or 'fieldname:/v{0,1}/' in query are restricted"
+                    "Regular expression queries with non-guaranteed matches in the form 'fieldname:/v*/' or 'fieldname:/v{0,1}/' are restricted"
                 );
             });
         });

--- a/packages/xlucene-translator/test/query-access-spec.ts
+++ b/packages/xlucene-translator/test/query-access-spec.ts
@@ -511,6 +511,15 @@ describe('QueryAccess', () => {
             });
         });
 
+        describe.each([['hello:/w*/'], ['hello:/w{0,1}/'], ['hello:/.+world/']])('when using a query of "%s"', (query) => {
+            it('should throw an error', () => {
+                expect(() => queryAccess.restrict(query)).toThrowWithMessage(
+                    TSError,
+                    "Regexp queries with non-guaranteed wildcard matches in the form 'fieldname:/v*/' or 'fieldname:/v{0,1}/' in query are restricted"
+                );
+            });
+        });
+
         it('should work range queries', () => {
             const query = 'hello:world AND bytes:{2000 TO *]';
 

--- a/packages/xlucene-translator/test/query-access-spec.ts
+++ b/packages/xlucene-translator/test/query-access-spec.ts
@@ -511,7 +511,7 @@ describe('QueryAccess', () => {
             });
         });
 
-        describe.each([['hello:/w*/'], ['hello:/w{0,1}/'], ['hello:/.+world/']])('when using a query of "%s"', (query) => {
+        describe.each([['hello:/w*/'], ['hello:/w{0,1}/']])('when using a query of "%s"', (query) => {
             it('should throw an error', () => {
                 expect(() => queryAccess.restrict(query)).toThrowWithMessage(
                     TSError,

--- a/packages/xlucene-translator/test/query-access-spec.ts
+++ b/packages/xlucene-translator/test/query-access-spec.ts
@@ -502,6 +502,15 @@ describe('QueryAccess', () => {
             });
         });
 
+        describe.each([['hello:/*world/'], ['hello:/.*world/'], ['hello:/.+world/']])('when using a query of "%s"', (query) => {
+            it('should throw an error', () => {
+                expect(() => queryAccess.restrict(query)).toThrowWithMessage(
+                    TSError,
+                    "Regexp queries starting with wildcards in the form 'fieldname:/*value/' or 'fieldname:/.*?value/' in query are restricted"
+                );
+            });
+        });
+
         it('should work range queries', () => {
             const query = 'hello:world AND bytes:{2000 TO *]';
 


### PR DESCRIPTION
- [x] Add restriction for prevent_prefix_wildcard on regexp queries ensuring they aren't prefixed with a regexp operator and also have a guaranteed match (i.e. ab* has to match a but a* doesn't so could search the whole index