### PR TITLE
Fix ts scripts opensearch timeout

### DIFF
--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -91,7 +91,7 @@ export const OPENSEARCH_HOSTNAME = process.env.OPENSEARCH_HOSTNAME || HOST_IP;
 export const OPENSEARCH_PORT = process.env.OPENSEARCH_PORT || '49210';
 export const OPENSEARCH_USER = process.env.OPENSEARCH_USER || 'admin';
 export const OPENSEARCH_PASSWORD = process.env.OPENSEARCH_PASSWORD || 'admin';
-export const OPENSEARCH_VERSION = process.env.OPENSEARCH_VERSION || '1.3.6';
+export const OPENSEARCH_VERSION = process.env.OPENSEARCH_VERSION || '1.3.10';
 export const OPENSEARCH_HOST = `http://${OPENSEARCH_USER}:${OPENSEARCH_PASSWORD}@${OPENSEARCH_HOSTNAME}:${OPENSEARCH_PORT}`;
 export const OPENSEARCH_DOCKER_IMAGE = process.env.OPENSEARCH_DOCKER_IMAGE || 'opensearchproject/opensearch';
 

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -88,7 +88,8 @@ const services: Readonly<Record<Service, Readonly<DockerRunOptions>>> = {
             'http.port': config.OPENSEARCH_PORT,
             'discovery.type': 'single-node',
             DISABLE_INSTALL_DEMO_CONFIG: 'true',
-            DISABLE_SECURITY_PLUGIN: 'true'
+            DISABLE_SECURITY_PLUGIN: 'true',
+            DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI: 'true'
         },
         network: config.DOCKER_NETWORK_NAME
     },


### PR DESCRIPTION
I have followed the instructions and guidance of issue #3363 to hopefully fix the opensearch timeout problem. 

- Updated the default opensearch version to be  `v1.3.10`
> > This is to have access to an environment variable that can turn off the performance analyzer.

- Set DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI to 'true' for opensearch container
> > This will ideally stop opensearch from failing to startup randomly 

References to this solution [here](https://github.com/terascope/teraslice/issues/3363#issuecomment-1646317566)