### PR TITLE
Update node versions

### DIFF
--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version:  18.16.0
+          node-version:  18.18.2
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version:  18.16.0
+          node-version:  18.18.2
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version:  18.16.0
+          node-version:  18.18.2
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.19.1, 18.16.0]
+        node-version: [16.20.2, 18.18.2]
     steps:
       # we login to docker to publish new teraslice image
       - name: Login to Docker Hub

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 18.16.0
+        node-version: 18.18.2
         cache: 'yarn'
 
     - name: Install and build packages
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.19.1, 18.16.0]
+        node-version: [16.20.2, 18.18.2]
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -57,7 +57,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [16.19.1, 18.16.0]
+        node-version: [16.20.2, 18.18.2]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -91,7 +91,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [16.19.1, 18.16.0]
+        node-version: [16.20.2, 18.18.2]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -129,7 +129,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.16.0
+          node-version: 18.18.2
           cache: 'yarn'
 
       # we login to docker to avoid docker pull limit rates
@@ -154,7 +154,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [16.19.1, 18.16.0]
+        node-version: [16.20.2, 18.18.2]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -193,7 +193,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.16.0
+          node-version: 18.18.2
           cache: 'yarn'
 
       # we login to docker to avoid docker pull limit rates
@@ -218,7 +218,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [16.19.1, 18.16.0]
+        node-version: [16.20.2, 18.18.2]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -252,7 +252,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [16.19.1, 18.16.0]
+        node-version: [16.20.2, 18.18.2]
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # NODE_VERSION is set by default in the config.ts, the following value will only
 # be used if you build images by default with docker build
-ARG NODE_VERSION=18.16.0
+ARG NODE_VERSION=18.18.2
 FROM terascope/node-base:${NODE_VERSION}
 
 ENV NODE_ENV production

--- a/packages/scripts/src/cmds/publish.ts
+++ b/packages/scripts/src/cmds/publish.ts
@@ -23,9 +23,9 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
             .example('$0 publish', '-t tag docker')
             .example('$0 publish', '-t dev docker')
             .example('$0 publish', '-t latest docker')
-            .example('$0 publish', '-n 18.16.0 -t latest docker')
+            .example('$0 publish', '-n 18.18.2 -t latest docker')
             .example('$0 publish', '--dry-run docker')
-            .example('$0 publish', '-n 18.16.0 --dry-run docker')
+            .example('$0 publish', '-n 18.18.2 --dry-run docker')
             .example('$0 publish', '-t tag npm')
             .example('$0 publish', '-t latest npm')
             .example('$0 publish', '--dry-run npm')
@@ -49,7 +49,7 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
             })
             .option('node-version', {
                 alias: 'n',
-                description: 'Node version, there must be a Docker base image with this version (e.g. 18.16.0)',
+                description: 'Node version, there must be a Docker base image with this version (e.g. 18.18.2)',
                 type: 'string',
                 default: NODE_VERSION
             })

--- a/packages/scripts/src/cmds/test.ts
+++ b/packages/scripts/src/cmds/test.ts
@@ -122,7 +122,7 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
                 default: config.OPENSEARCH_VERSION,
             })
             .option('node-version', {
-                description: 'Node version, there must be a Docker base image with this version (e.g. 18.16.0)',
+                description: 'Node version, there must be a Docker base image with this version (e.g. 18.18.2)',
                 type: 'string',
                 default: config.NODE_VERSION
             })

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -187,6 +187,6 @@ export const SEARCH_TEST_HOST = testHost;
 // This should match a node version from the base-docker-image repo:
 // https://github.com/terascope/base-docker-image
 // This overrides the value in the Dockerfile
-export const NODE_VERSION = process.env.NODE_VERSION || '18.16.0';
+export const NODE_VERSION = process.env.NODE_VERSION || '18.18.2';
 
 export const { TEST_PLATFORM = 'native' } = process.env;


### PR DESCRIPTION
I have replaced all node versions with the new base docker node versions

The new node versions are now:

- `node 16.20.2`
- `node 18.18.2`

This issue is referenced here #3459 