### PR TITLE
Add the --rebuild option to the k8s-env command

### DIFF
--- a/e2e/test/config.js
+++ b/e2e/test/config.js
@@ -41,6 +41,9 @@ const {
 
 const TEST_HOST = TEST_OPENSEARCH ? OPENSEARCH_HOST : ELASTICSEARCH_HOST;
 
+// TERASLICE_PORT must match e2e/docker-compose.yml
+const TERASLICE_PORT = 45678;
+
 function newId(prefix, lowerCase = false, length = 15) {
     let characters = '0123456789abcdefghijklmnopqrstuvwxyz';
 
@@ -80,5 +83,6 @@ module.exports = {
     newId,
     TEST_HOST,
     TEST_PLATFORM,
-    KEEP_OPEN
+    KEEP_OPEN,
+    TERASLICE_PORT
 };

--- a/e2e/test/global.setup.js
+++ b/e2e/test/global.setup.js
@@ -13,10 +13,8 @@ const signale = require('./signale');
 const setupTerasliceConfig = require('./setup-config');
 const downloadAssets = require('./download-assets');
 const {
-    CONFIG_PATH, ASSETS_PATH, TEST_PLATFORM
+    CONFIG_PATH, ASSETS_PATH, TEST_PLATFORM, TERASLICE_PORT
 } = require('./config');
-
-const TERASLICE_PORT = 45678;
 
 module.exports = async () => {
     const teraslice = new TerasliceHarness();

--- a/e2e/test/global.setup.js
+++ b/e2e/test/global.setup.js
@@ -16,6 +16,8 @@ const {
     CONFIG_PATH, ASSETS_PATH, TEST_PLATFORM
 } = require('./config');
 
+const TERASLICE_PORT = 45678;
+
 module.exports = async () => {
     const teraslice = new TerasliceHarness();
     await teraslice.init();
@@ -39,9 +41,9 @@ module.exports = async () => {
     ]);
 
     if (TEST_PLATFORM === 'kubernetes') {
-        await deployK8sTeraslice();
+        await deployK8sTeraslice(TERASLICE_PORT);
         await teraslice.waitForTeraslice();
-        await setAliasAndBaseAssets();
+        await setAliasAndBaseAssets(TERASLICE_PORT);
     } else {
         await Promise.all([setupTerasliceConfig(), downloadAssets()]);
         await dockerUp();

--- a/e2e/test/setup-config.js
+++ b/e2e/test/setup-config.js
@@ -8,6 +8,7 @@ const {
     KAFKA_BROKER,
     ELASTICSEARCH_HOST,
     TEST_HOST,
+    TERASLICE_PORT,
     ELASTICSEARCH_API_VERSION,
     CLUSTER_NAME,
     HOST_IP,
@@ -66,7 +67,7 @@ module.exports = async function setupTerasliceConfig() {
             assets_directory: '/app/assets',
             autoload_directory: '/app/autoload',
             workers: WORKERS_PER_NODE,
-            port: 45678,
+            port: TERASLICE_PORT,
             name: CLUSTER_NAME,
             master_hostname: HOST_IP,
             index_settings: {

--- a/e2e/test/teraslice-harness.js
+++ b/e2e/test/teraslice-harness.js
@@ -13,7 +13,7 @@ const fse = require('fs-extra');
 const {
     TEST_HOST, HOST_IP, SPEC_INDEX_PREFIX,
     DEFAULT_NODES, newId, DEFAULT_WORKERS, GENERATE_ONLY,
-    EXAMPLE_INDEX_SIZES, EXAMPLE_INDEX_PREFIX, TEST_PLATFORM
+    EXAMPLE_INDEX_SIZES, EXAMPLE_INDEX_PREFIX, TEST_PLATFORM, TERASLICE_PORT
 } = require('./config');
 const { scaleWorkers, getElapsed } = require('./docker-helpers');
 const signale = require('./signale');
@@ -22,7 +22,6 @@ const { cleanupIndex } = ElasticsearchTestHelpers;
 
 const generateOnly = GENERATE_ONLY ? parseInt(GENERATE_ONLY, 10) : null;
 
-const TERASLICE_PORT = 45678;
 const ELASTICSEARCH_PORT = 49200;
 
 module.exports = class TerasliceHarness {

--- a/e2e/test/teraslice-harness.js
+++ b/e2e/test/teraslice-harness.js
@@ -22,12 +22,15 @@ const { cleanupIndex } = ElasticsearchTestHelpers;
 
 const generateOnly = GENERATE_ONLY ? parseInt(GENERATE_ONLY, 10) : null;
 
+const TERASLICE_PORT = 45678;
+const ELASTICSEARCH_PORT = 49200;
+
 module.exports = class TerasliceHarness {
     async init() {
         const { client } = await createClient({ node: TEST_HOST });
         this.client = client;
         this.teraslice = new TerasliceClient({
-            host: `http://${HOST_IP}:45678`,
+            host: `http://${HOST_IP}:${TERASLICE_PORT}`,
             timeout: 2 * 60 * 1000
         });
     }
@@ -90,7 +93,7 @@ module.exports = class TerasliceHarness {
         if (TEST_PLATFORM === 'kubernetes') {
             try {
                 cleanupIndex(this.client, `${SPEC_INDEX_PREFIX}*`);
-                await showState();
+                await showState(ELASTICSEARCH_PORT);
             } catch (err) {
                 signale.error('Failure to clean indices and assets', err);
                 throw err;

--- a/e2e/test/teraslice-harness.js
+++ b/e2e/test/teraslice-harness.js
@@ -22,8 +22,6 @@ const { cleanupIndex } = ElasticsearchTestHelpers;
 
 const generateOnly = GENERATE_ONLY ? parseInt(GENERATE_ONLY, 10) : null;
 
-const ELASTICSEARCH_PORT = 49200;
-
 module.exports = class TerasliceHarness {
     async init() {
         const { client } = await createClient({ node: TEST_HOST });
@@ -92,7 +90,7 @@ module.exports = class TerasliceHarness {
         if (TEST_PLATFORM === 'kubernetes') {
             try {
                 cleanupIndex(this.client, `${SPEC_INDEX_PREFIX}*`);
-                await showState(ELASTICSEARCH_PORT);
+                await showState(TERASLICE_PORT);
             } catch (err) {
                 signale.error('Failure to clean indices and assets', err);
                 throw err;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "k8s": "TEST_ELASTICSEARCH='true' ELASTICSEARCH_PORT='9200' ts-scripts k8s-env",
         "k8s:kafka": "TEST_ELASTICSEARCH='true' ELASTICSEARCH_PORT='9200' TEST_KAFKA='true' KAFKA_PORT='9092' ts-scripts k8s-env",
         "k8s:noBuild": "TEST_ELASTICSEARCH='true' ELASTICSEARCH_PORT='9200' SKIP_DOCKER_BUILD_IN_K8S='true' ts-scripts k8s-env",
+        "k8s:rebuild": "ts-scripts k8s-env --rebuild='true'",
         "lint": "eslint --cache --ext .js,.jsx,.ts,.tsx .",
         "lint:fix": "yarn lint --fix && yarn sync",
         "setup": "yarn $YARN_SETUP_ARGS && yarn run build --force",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.61.0",
+    "version": "0.62.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/cmds/k8s-env.ts
+++ b/packages/scripts/src/cmds/k8s-env.ts
@@ -11,6 +11,7 @@ const cmd: CommandModule = {
             .example('TEST_ELASTICSEARCH=\'true\' ELASTICSEARCH_PORT=\'9200\' $0 k8s-env', 'Start a kind kubernetes cluster running teraslice and elasticsearch.')
             .example('TEST_ELASTICSEARCH=\'true\' ELASTICSEARCH_PORT=\'9200\' TEST_KAFKA=\'true\' KAFKA_PORT=\'9092\' $0 k8s-env', 'Start a kind kubernetes cluster running teraslice, elasticsearch, kafka, and zookeeper.')
             .example('TEST_ELASTICSEARCH=\'true\' ELASTICSEARCH_PORT=\'9200\' SKIP_DOCKER_BUILD_IN_K8S=\'true\' $0 k8s-env', 'Start a kind kubernetes cluster, but skip building a new teraslice docker image.')
+            .example('$0 k8s-env --rebuild=\'true\'', 'Rebuild teraslice and redeploy to k8s cluster. ES store data is retained.')
             .option('elasticsearch-version', {
                 description: 'The elasticsearch version to use',
                 type: 'string',

--- a/packages/scripts/src/helpers/interfaces.ts
+++ b/packages/scripts/src/helpers/interfaces.ts
@@ -125,3 +125,28 @@ export const AvailablePackageConfigKeys: readonly (keyof PackageConfig)[] = [
 export type TSCommands = 'docs';
 
 export type GlobalCMDOptions = EmptyObject;
+
+export interface kindCluster {
+    kind: string;
+    apiVersion: string;
+    name: string;
+    nodes: [
+        {
+            role: string;
+            extraPortMappings: [
+                {
+                    containerPort: number;
+                    hostPort: number;
+                },
+                {
+                    containerPort: number;
+                    hostPort: number;
+                },
+                {
+                    containerPort: number;
+                    hostPort: number;
+                }
+            ]
+        }
+    ]
+}

--- a/packages/scripts/src/helpers/k8s-env/index.ts
+++ b/packages/scripts/src/helpers/k8s-env/index.ts
@@ -52,6 +52,7 @@ export async function launchK8sEnv(options: k8sEnvOptions) {
         await buildAndTagTerasliceImage(options);
     } catch (err) {
         signale.error(err);
+        await destroyKindCluster();
         process.exit(1);
     }
 

--- a/packages/scripts/src/helpers/k8s-env/index.ts
+++ b/packages/scripts/src/helpers/k8s-env/index.ts
@@ -36,7 +36,7 @@ export async function launchK8sEnv(options: k8sEnvOptions) {
     }
 
     signale.pending('Creating kind cluster');
-    await createKindCluster('k8s-env');
+    await createKindCluster('k8s-env', options.tsPort);
     signale.success('Kind cluster created');
 
     const k8s = new K8s(options.tsPort);

--- a/packages/scripts/src/helpers/k8s-env/index.ts
+++ b/packages/scripts/src/helpers/k8s-env/index.ts
@@ -14,8 +14,12 @@ import * as config from '../config';
 import { ensureServices } from '../test-runner/services';
 import { K8s } from './k8s';
 
+const rootInfo = getRootInfo();
+const e2eImage = `${rootInfo.name}:e2e`;
+
 export async function launchK8sEnv(options: k8sEnvOptions) {
     signale.pending('Starting k8s environment with the following options: ', options);
+    const k8s = new K8s(options.tsPort);
 
     // TODO: create a kind class
     const kindInstalled = await isKindInstalled();
@@ -34,13 +38,46 @@ export async function launchK8sEnv(options: k8sEnvOptions) {
     signale.pending('Creating kind cluster');
     await createKindCluster('k8s-env');
     signale.success('Kind cluster created');
-    const k8s = new K8s();
 
     await k8s.createNamespace('services-ns.yaml', 'services');
 
-    const rootInfo = getRootInfo();
-    const e2eImage = `${rootInfo.name}:e2e`;
+    await buildAndTagTerasliceImage(options);
+    await kindLoadTerasliceImage(e2eImage);
 
+    await ensureServices('k8s_env', {
+        ...options,
+        debug: false,
+        trace: false,
+        bail: false,
+        watch: false,
+        all: false,
+        keepOpen: false,
+        reportCoverage: false,
+        useExistingServices: false,
+        elasticsearchAPIVersion: config.ELASTICSEARCH_API_VERSION,
+        ignoreMount: false,
+        testPlatform: 'kubernetes'
+    });
+
+    await k8s.deployK8sTeraslice(true);
+    signale.success('k8s environment ready.\nNext steps:\n\tAdd alias: teraslice-cli aliases add <cluster-alias> http://localhost:5678\n\t\tExample: teraslice-cli aliases add cluster1 http://localhost:5678\n\tLoad assets: teraslice-cli assets deploy <cluster-alias> <user/repo-name>\n\t\tExample: teraslice-cli assets deploy cluster1 terascope/elasticsearch-assets\n\tRegister a job: teraslice-cli tjm register <cluster-alias> <path/to/job/file.json>\n\t\tExample: teraslice-cli tjm reg cluster1 JOB.JSON\n\tStart a job: teraslice-cli tjm start <path/to/job/file.json>\n\t\tExample: teraslice-cli tjm start JOB.JSON\nDelete the kind k8s cluster: kind delete cluster --name k8se2e\n\tSee the docs for more options: https://terascope.github.io/teraslice/docs/packages/teraslice-cli/overview');
+}
+
+export async function rebuildTeraslice(options: k8sEnvOptions) {
+    const k8s = new K8s(options.tsPort);
+
+    signale.time('Rebuild teraslice');
+    await buildAndTagTerasliceImage(options);
+
+    signale.pending('Loading Teraslice Docker image');
+    await kindLoadTerasliceImage(e2eImage);
+    signale.success('Teraslice Docker image loaded');
+
+    await k8s.deployK8sTeraslice(true);
+    signale.timeEnd('Rebuild teraslice');
+}
+
+async function buildAndTagTerasliceImage(options:k8sEnvOptions) {
     let devImage;
     if (options.skipBuild) {
         devImage = `${getDevDockerImage()}-nodev${options.nodeVersion}`;
@@ -63,26 +100,4 @@ export async function launchK8sEnv(options: k8sEnvOptions) {
     } catch (err) {
         signale.error(`Failed to tag docker image ${devImage} as ${e2eImage}.`, err);
     }
-
-    signale.pending('Loading teraslice docker image');
-    await kindLoadTerasliceImage(e2eImage);
-    signale.success('Teraslice docker image loaded');
-
-    await ensureServices('k8s_env', {
-        ...options,
-        debug: false,
-        trace: false,
-        bail: false,
-        watch: false,
-        all: false,
-        keepOpen: false,
-        reportCoverage: false,
-        useExistingServices: false,
-        elasticsearchAPIVersion: config.ELASTICSEARCH_API_VERSION,
-        ignoreMount: false,
-        testPlatform: 'kubernetes'
-    });
-
-    await k8s.deployK8sTeraslice(true);
-    signale.success('k8s environment ready.\nNext steps:\n\tAdd alias: teraslice-cli aliases add <cluster-alias> http://localhost:5678\n\t\tExample: teraslice-cli aliases add cluster1 http://localhost:5678\n\tLoad assets: teraslice-cli assets deploy <cluster-alias> <user/repo-name>\n\t\tExample: teraslice-cli assets deploy cluster1 terascope/elasticsearch-assets\n\tRegister a job: teraslice-cli tjm register <cluster-alias> <path/to/job/file.json>\n\t\tExample: teraslice-cli tjm reg cluster1 JOB.JSON\n\tStart a job: teraslice-cli tjm start <path/to/job/file.json>\n\t\tExample: teraslice-cli tjm start JOB.JSON\nDelete the kind k8s cluster: kind delete cluster --name k8se2e\n\tSee the docs for more options: https://terascope.github.io/teraslice/docs/packages/teraslice-cli/overview');
 }

--- a/packages/scripts/src/helpers/k8s-env/interfaces.ts
+++ b/packages/scripts/src/helpers/k8s-env/interfaces.ts
@@ -8,6 +8,7 @@ export interface k8sEnvOptions {
     opensearchVersion: string;
     nodeVersion: string;
     skipBuild: boolean;
+    tsPort: number
 }
 
 // TODO: create a common parent for each resource type,

--- a/packages/scripts/src/helpers/k8s-env/k8s.ts
+++ b/packages/scripts/src/helpers/k8s-env/k8s.ts
@@ -211,10 +211,10 @@ export class K8s {
             logger.debug('Teraslice namespace cannot be deleted. It might not yet exist: ', err.response.body);
         }
 
-        await this.confirmDeletion(terasliceNamespace, this.k8sCoreV1Api);
+        await this.confirmNamespaceDeletion(terasliceNamespace, this.k8sCoreV1Api);
     }
 
-    async confirmDeletion(terasliceNamespace: string, coreV1Api: k8sClient.CoreV1Api) {
+    async confirmNamespaceDeletion(terasliceNamespace: string, coreV1Api: k8sClient.CoreV1Api) {
         let existingNamespace: k8sClient.V1Namespace[];
         const timeoutMs = 120000;
         try {

--- a/packages/scripts/src/helpers/k8s-env/k8s.ts
+++ b/packages/scripts/src/helpers/k8s-env/k8s.ts
@@ -211,6 +211,10 @@ export class K8s {
             logger.debug('Teraslice namespace cannot be deleted. It might not yet exist: ', err.response.body);
         }
 
+        await this.confirmDeletion(terasliceNamespace, this.k8sCoreV1Api);
+    }
+
+    async confirmDeletion(terasliceNamespace: string, coreV1Api: k8sClient.CoreV1Api) {
         let existingNamespace: k8sClient.V1Namespace[];
         const timeoutMs = 120000;
         try {
@@ -222,7 +226,7 @@ export class K8s {
                 }
 
                 await pDelay(1000);
-                const response = await this.k8sCoreV1Api
+                const response = await coreV1Api
                     .listNamespace();
                 const namespaceList = response.body.items;
                 existingNamespace = namespaceList

--- a/packages/scripts/src/helpers/k8s-env/k8s.ts
+++ b/packages/scripts/src/helpers/k8s-env/k8s.ts
@@ -189,7 +189,7 @@ export class K8s {
             const response = await this.k8sSchedulingV1Api.createPriorityClass(yamlPriorityClass);
             logger.debug('deployK8sTeraslice yamlPriorityClass: ', response.body);
         } catch (err) {
-            if (err.status !== 409) { // don't throw if priorityClass already exists
+            if (err.body.code !== 409) { // don't throw if priorityClass already exists
                 throw new Error(`Error creating priorityClass: ${err}`);
             }
         }

--- a/packages/scripts/src/helpers/k8s-env/k8s.ts
+++ b/packages/scripts/src/helpers/k8s-env/k8s.ts
@@ -13,9 +13,6 @@ import * as config from '../config';
 import { destroyKindCluster } from '../scripts';
 
 const logger = debugLogger('ts-scripts:k8s-env');
-// TODO: consider setting TS_PORT with an env variable or cmd option
-const TS_PORT = '5678';
-
 export class K8s {
     kc: k8sClient.KubeConfig;
     k8sAppsV1Api: k8sClient.AppsV1Api;
@@ -24,8 +21,9 @@ export class K8s {
     k8sSchedulingV1Api: k8sClient.SchedulingV1Api;
     terasliceNamespace: string;
     servicesNamespace: string;
+    tsPort: number;
 
-    constructor() {
+    constructor(tsPort: number) {
         this.kc = new k8sClient.KubeConfig();
         this.kc.loadFromDefault();
 
@@ -35,6 +33,7 @@ export class K8s {
         this.k8sSchedulingV1Api = this.kc.makeApiClient(k8sClient.SchedulingV1Api);
         this.terasliceNamespace = 'default';
         this.servicesNamespace = 'default';
+        this.tsPort = tsPort;
     }
 
     async createNamespace(yamlFile: string, namespaceCategory: string) {
@@ -161,7 +160,7 @@ export class K8s {
             let terasliceRunning = false;
             try {
                 // TODO: switch to a teraslice client
-                const kubectlResponse = await execa.command(`curl http://${config.HOST_IP}:${TS_PORT}`);
+                const kubectlResponse = await execa.command(`curl http://${config.HOST_IP}:${this.tsPort}`);
                 response = JSON.parse(kubectlResponse.stdout);
                 if (response.clustering_type === 'kubernetes') {
                     terasliceRunning = true;


### PR DESCRIPTION
This PR includes the following changes:
- Add the `--rebuild` option to `ts-scripts k8s-env`
- Use `yarn k8s:rebuild` script from root of teraslice
- This allows you to build a new Teraslice docker image and restart Teraslice in your k8s cluster. Previously you had to delete the cluster and re-run `yarn k8s`. Now services and the cluster do not need to be rebuilt.
- Changes to how teraslice and elasticsearch ports are determined. 
- Elasticserach store data is preserved between rebuilds. We may need to add the option to reset the ES store.
