### PR TITLE
update docker-compose-js to use newer 'docker compose' command

### DIFF
--- a/packages/docker-compose-js/package.json
+++ b/packages/docker-compose-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/docker-compose-js",
     "displayName": "Docker Compose Js",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "Node.js driver for controlling docker-compose testing environments.",
     "keywords": [
         "docker",

--- a/packages/docker-compose-js/src/index.ts
+++ b/packages/docker-compose-js/src/index.ts
@@ -62,31 +62,48 @@ export class Compose {
             args.push(...extraParams.map((param) => `${param}`));
 
             debug('docker-compose', args);
-            const cmd = spawn('docker-compose', args, {
-                env: process.env
-            });
 
-            cmd.stdout.on('data', (data) => {
-                debug('stdout', data.toString());
-                stdout += data;
-            });
-
-            cmd.stderr.on('data', (data) => {
-                debug('stderr', data.toString());
-                stderr += data;
-            });
-
-            cmd.on('close', (code) => {
-                debug('close with code', code);
-                if (code !== 0) {
-                    const error = new Error(`Command exited: ${code}\n${stderr}`);
-                    // @ts-expect-error
-                    error.stdout = stdout;
-                    reject(error);
-                } else {
-                    resolve(stdout);
-                }
-            });
+            /// runs a spawn instance of either 'docker compose or 'docker-compose'
+            function runCommand(sCommand:string, a:Array<string>) {
+                const cmd = spawn(sCommand, a, {
+                    env: process.env
+                });
+                cmd.stdout.on('data', (data) => {
+                    debug('stdout', data.toString());
+                    stdout += data;
+                });
+                cmd.stderr.on('data', (data) => {
+                    debug('stderr', data.toString());
+                    stderr += data;
+                });
+                cmd.on('error', (err) => {
+                    /// check to see if the error is related to a missing 'docker compose' command
+                    if (err.message.includes('ENOENT') && !err.message.includes('compose')) {
+                        runCommand('docker-compose', args);
+                    } else {
+                        throw new Error('docker compose not found. Please install it and try again');
+                        // console.error(error.message);
+                        // process.exit();
+                    }
+                });
+                cmd.on('close', (code) => {
+                    debug('close with code', code);
+                    /// Do not throw an error if 'docker compose' fails
+                    if (code !== 0 && sCommand !== 'docker') {
+                        const error = new Error(`Command exited: ${code}\n${stderr}`);
+                        // @ts-expect-error
+                        error.stdout = stdout;
+                        reject(error);
+                    /// In the senario that the docker command exists but the compose arg is invalid
+                    } else if (code === 125 && a[0] === 'compose') {
+                        runCommand('docker-compose', args);
+                    } else {
+                        resolve(stdout);
+                    }
+                });
+            }
+            /// try running spawn with 'docker compose' first
+            runCommand('docker', ['compose', ...args]);
         });
     }
 

--- a/packages/docker-compose-js/src/index.ts
+++ b/packages/docker-compose-js/src/index.ts
@@ -63,7 +63,7 @@ export class Compose {
 
             debug('docker-compose', args);
 
-            /// runs a spawn instance of either 'docker compose or 'docker-compose'
+            /// runs a spawn instance of either 'docker compose' or 'docker-compose'
             function runCommand(sCommand:string, a:Array<string>) {
                 const cmd = spawn(sCommand, a, {
                     env: process.env
@@ -82,8 +82,6 @@ export class Compose {
                         runCommand('docker-compose', args);
                     } else {
                         throw new Error('docker compose not found. Please install it and try again');
-                        // console.error(error.message);
-                        // process.exit();
                     }
                 });
                 cmd.on('close', (code) => {


### PR DESCRIPTION
- Updated docker-compose-js package to use `docker compose` by default instead of `docker-compose`
  - This is because Compose V1 won’t be supported anymore and will be removed from all Docker Desktop versions.
  - NOTE: `docker-compose` is still backwards compatible if `docker compose` is not present.
- Bump **packages/docker-compose-js** from `v1.3.1` to `v1.3.2`
- Added user feedback in the event that `docker-compose` or `docker compose` is not installed.

ref to issue #3350