### PR TITLE
Add force option to POST /jobs/jobId/_stop and POST /ex/exId/_stop endpoints

### DIFF
--- a/docs/management-apis/endpoints-json.md
+++ b/docs/management-apis/endpoints-json.md
@@ -349,14 +349,15 @@ $ curl -XPOST 'localhost:5678/v1/jobs/5a50580c-4a50-48d9-80f8-ac70a00f3dbd/_star
 
 ## POST /v1/jobs/{jobId}/_stop
 
-Issues a stop command which will shutdown the execution controllers and workers, marks the job execution context state as stopped. You can optionally add a timeout query parameter to dynamically change how long it will wait as the time the slicer/fetcher exit will vary.
+Issues a stop command which will shutdown execution controller and workers for that job, marks the job execution context state as stopped. You can optionally add a timeout query parameter to dynamically change how long it will wait as the time the slicer/fetchers take to exit will vary. In a Kubernetes environment the force option will immediately kill all jobs, deployments, execution controllers and workers associated with the job.
 
-**Note:** the timeout your provide will be added to the `network_latency_buffer` for the final timeout used.
+**Note:** The timeout your provide will be added to the `network_latency_buffer` for the final timeout used.
 
 **Query Options:**
 
-- `timeout: number`
+- `timeout: number (native clustering only)`
 - `blocking: boolean = true`
+- `force: boolean = false (Kubernetes clustering only)`
 
 **Usage:**
 
@@ -730,14 +731,15 @@ $ curl 'localhost:5678/v1/ex/863678b3-daf3-4ea9-8cb0-88b846cd7e57/errors'
 
 ## POST /v1/ex/{exId}/_stop
 
-Issues a stop command which will shutdown execution controller and workers for that job, marks the job execution context state as stopped. You can optionally add a timeout query parameter to dynamically change how long it will wait as the time the slicer/fetchers will exit will vary.
+Issues a stop command which will shutdown execution controller and workers for that job, marks the job execution context state as stopped. You can optionally add a timeout query parameter to dynamically change how long it will wait as the time the slicer/fetchers take to exit will vary. In a Kubernetes environment the force option will immediately kill all jobs, deployments, execution controllers and workers associated with the job.
 
 **Note:** The timeout your provide will be added to the `network_latency_buffer` for the final timeout used.
 
 **Query Options:**
 
-- `timeout: number`
+- `timeout: number (native clustering only)`
 - `blocking: boolean = true`
+- `force: boolean = false (Kubernetes clustering only)`
 
 **Usage:**
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "0.88.0",
+    "version": "0.89.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/scripts/src/cmds/k8s-env.ts
+++ b/packages/scripts/src/cmds/k8s-env.ts
@@ -43,12 +43,12 @@ const cmd: CommandModule = {
                 default: config.NODE_VERSION
             })
             .option('skip-build', {
-                description: 'Skip building the teraslice docker iamge',
+                description: 'Skip building the teraslice docker image',
                 type: 'boolean',
                 default: config.SKIP_DOCKER_BUILD_IN_K8S
             })
             .option('rebuild', {
-                description: 'Stop, rebuild, then restart the teraslice docker iamge',
+                description: 'Stop, rebuild, then restart the teraslice docker image',
                 type: 'boolean',
                 default: false
             })

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "0.88.0",
+    "version": "0.89.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -340,13 +340,15 @@ export class ApiService {
         v1routes.post(['/jobs/:jobId/_stop', '/ex/:exId/_stop'], (req, res) => {
             const {
                 timeout,
-                blocking = true
-            } = req.query as unknown as { timeout: number, blocking: boolean };
+                blocking = true,
+                force = false
+            } = req.query as unknown as { timeout: number, blocking: boolean, force: boolean };
 
             const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not stop execution');
             requestHandler(async () => {
                 const exId = await this._getExIdFromRequest(req as TerasliceRequest);
-                await executionService.stopExecution(exId, timeout as number);
+                await executionService
+                    .stopExecution(exId, { timeout, force });
                 return this._waitForStop(exId, blocking);
             });
         });

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetes/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetes/index.ts
@@ -8,6 +8,7 @@ import { K8sResource } from './k8sResource';
 import { gen } from './k8sState';
 import { K8s } from './k8s';
 import { getRetryConfig } from './utils';
+import { StopExecutionOptions } from '../../../interfaces';
 
 /*
  Execution Life Cycle for _status
@@ -205,12 +206,14 @@ export class KubernetesClusterBackend {
 
     /**
      * Stops all workers for exId
-     * @param  {string} exId    The execution ID of the Execution to stop
+     * @param  {String}                 exId      The execution ID of the Execution to stop
+     * @param  {StopExecutionOptions} options     force, timeout, and excludeNode
+     *                                    force: stop all related pod, deployment, and job resources
+     *                                    timeout and excludeNode are not used in k8s clustering.
      * @return {Promise}
      */
-
-    async stopExecution(exId: string) {
-        return this.k8s.deleteExecution(exId);
+    async stopExecution(exId: string, options?: StopExecutionOptions) {
+        return this.k8s.deleteExecution(exId, options?.force);
     }
 
     async shutdown() {

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetes/k8s.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetes/k8s.ts
@@ -421,20 +421,23 @@ export class K8s {
             }
         }
 
-        if (isEmpty(objList.items) && isEmpty(forcePodsList)) {
+        if (isEmpty(objList.items) && isEmpty(forcePodsList?.items)) {
             this.logger.info(`k8s._deleteObjByExId: ${exId} ${nodeType} ${objType} has already been deleted`);
             return Promise.resolve();
         }
 
         const deletePodResponses = [];
-        for (const pod of forcePodsList.items) {
-            const podName = pod.metadata.name;
-            try {
-                deletePodResponses.push(await this.delete(podName, 'pods', force));
-            } catch (e) {
-                const err = new Error(`Request k8s.delete in _deleteObjByExId with name: ${podName} failed with: ${e}`);
-                this.logger.error(err);
-                return Promise.reject(err);
+        if (forcePodsList?.items) {
+            for (const pod of forcePodsList.items) {
+                const podName = pod.metadata.name;
+
+                try {
+                    deletePodResponses.push(await this.delete(podName, 'pods', force));
+                } catch (e) {
+                    const err = new Error(`Request k8s.delete in _deleteObjByExId with name: ${podName} failed with: ${e}`);
+                    this.logger.error(err);
+                    return Promise.reject(err);
+                }
             }
         }
 
@@ -449,7 +452,9 @@ export class K8s {
             return Promise.reject(err);
         }
 
-        deleteResponse.deletePodResponses = deletePodResponses;
+        if (deletePodResponses.length > 0) {
+            deleteResponse.deletePodResponses = deletePodResponses;
+        }
         return deleteResponse;
     }
 

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/native/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/native/index.ts
@@ -11,6 +11,7 @@ import { makeLogger } from '../../../../../workers/helpers/terafoundation';
 import { findWorkersByExecutionID } from '../state-utils';
 import { Messaging } from './messaging';
 import { ExecutionStorage } from '../../../../../storage';
+import { StopExecutionOptions } from '../../../interfaces';
 
 /*
  Execution Life Cycle for _status
@@ -604,16 +605,15 @@ export class NativeClustering {
 
     clusterAvailable() {}
 
-    async stopExecution(exId: string, timeout?: number | null | undefined, exclude?: string) {
+    async stopExecution(exId: string, options?:StopExecutionOptions) {
         // we are allowing stopExecution to be non blocking, we block at api level
-        const excludeNode = exclude ?? undefined;
         this.pendingWorkerRequests.remove(exId, 'ex_id');
         const sendingMessage = { message: 'cluster:execution:stop' } as Record<string, any>;
 
-        if (timeout) {
-            sendingMessage.timeout = timeout;
+        if (options?.timeout) {
+            sendingMessage.timeout = options.timeout;
         }
-        return this._notifyNodesWithExecution(exId, sendingMessage, excludeNode);
+        return this._notifyNodesWithExecution(exId, sendingMessage, options?.excludeNode);
     }
 
     async shutdown() {

--- a/packages/teraslice/src/lib/cluster/services/interfaces.ts
+++ b/packages/teraslice/src/lib/cluster/services/interfaces.ts
@@ -1,0 +1,5 @@
+export interface StopExecutionOptions {
+    timeout?: number | null;
+    excludeNode?: string;
+    force?: boolean;
+}

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8s-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8s-spec.ts
@@ -194,7 +194,38 @@ describe('k8s', () => {
             expect(response).toEqual({ statusCode: 200, body: {} });
         });
 
-        it('can force delete a job by name', async () => {
+        it('can delete a pod by name', async () => {
+            nock(_url)
+                .delete('/api/v1/namespaces/default/pods/test1')
+                .reply(200, {});
+
+            const response = await k8s.delete('test1', 'pods');
+            expect(response).toEqual({});
+        });
+    });
+
+    describe('-> _deletObjByExId', () => {
+        it('can force delete a job', async () => {
+            nock(_url)
+                .get('/apis/batch/v1/namespaces/default/jobs/')
+                .query({ labelSelector: /app\.kubernetes\.io\/component=execution_controller,teraslice\.terascope\.io\/exId=.*/ })
+                .reply(200, {
+                    kind: 'JobList',
+                    items: [
+                        { metadata: { name: 'testJob1' } }
+                    ]
+                });
+
+            nock(_url)
+                .get('/api/v1/namespaces/default/pods/')
+                .query({ labelSelector: /teraslice\.terascope\.io\/exId=.*/ })
+                .reply(200, {
+                    kind: 'PodList',
+                    items: [
+                        { metadata: { name: 'testEx1' } }, { metadata: { name: 'testWkr1' } }
+                    ]
+                });
+
             nock(_url)
                 .delete('/api/v1/namespaces/default/pods/testEx1')
                 .reply(200, {});
@@ -204,14 +235,12 @@ describe('k8s', () => {
                 .reply(200, {});
 
             nock(_url)
-                .delete('/apis/batch/v1/namespaces/default/jobs/test1')
+                .delete('/apis/batch/v1/namespaces/default/jobs/testJob1')
                 .reply(200, {});
 
-            const response = await k8s.delete('test1', 'jobs', { items: [{ metadata: { name: 'testEx1' } }, { metadata: { name: 'testWkr1' } }] });
+            const response = await k8s._deleteObjByExId('testJob1', 'execution_controller', 'jobs', true);
             expect(response).toEqual({
-                statusCode: 200,
-                body: {},
-                deletePodResponses: [{ statusCode: 200, body: {} }, { statusCode: 200, body: {} }]
+                deletePodResponses: [{}, {}]
             });
         });
     });

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8s-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8s-spec.ts
@@ -204,7 +204,7 @@ describe('k8s', () => {
         });
     });
 
-    describe('-> _deletObjByExId', () => {
+    describe('->_deletObjByExId', () => {
         it('can force delete a job', async () => {
             nock(_url)
                 .get('/apis/batch/v1/namespaces/default/jobs/')

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8s-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8s-spec.ts
@@ -173,7 +173,7 @@ describe('k8s', () => {
                 .reply(200, { });
 
             const response = await k8s.delete('test1', 'deployments');
-            expect(response).toEqual({});
+            expect(response).toEqual({ statusCode: 200, body: {} });
         });
 
         it('can delete a service by name', async () => {
@@ -182,7 +182,7 @@ describe('k8s', () => {
                 .reply(200, { });
 
             const response = await k8s.delete('test1', 'services');
-            expect(response).toEqual({});
+            expect(response).toEqual({ statusCode: 200, body: {} });
         });
 
         it('can delete a job by name', async () => {
@@ -191,7 +191,28 @@ describe('k8s', () => {
                 .reply(200, { });
 
             const response = await k8s.delete('test1', 'jobs');
-            expect(response).toEqual({});
+            expect(response).toEqual({ statusCode: 200, body: {} });
+        });
+
+        it('can force delete a job by name', async () => {
+            nock(_url)
+                .delete('/api/v1/namespaces/default/pods/testEx1')
+                .reply(200, {});
+
+            nock(_url)
+                .delete('/api/v1/namespaces/default/pods/testWkr1')
+                .reply(200, {});
+
+            nock(_url)
+                .delete('/apis/batch/v1/namespaces/default/jobs/test1')
+                .reply(200, {});
+
+            const response = await k8s.delete('test1', 'jobs', { items: [{ metadata: { name: 'testEx1' } }, { metadata: { name: 'testWkr1' } }] });
+            expect(response).toEqual({
+                statusCode: 200,
+                body: {},
+                deletePodResponses: [{ statusCode: 200, body: {} }, { statusCode: 200, body: {} }]
+            });
         });
     });
 

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8s-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8s-spec.ts
@@ -173,7 +173,7 @@ describe('k8s', () => {
                 .reply(200, { });
 
             const response = await k8s.delete('test1', 'deployments');
-            expect(response).toEqual({ statusCode: 200, body: {} });
+            expect(response).toEqual({});
         });
 
         it('can delete a service by name', async () => {
@@ -182,7 +182,7 @@ describe('k8s', () => {
                 .reply(200, { });
 
             const response = await k8s.delete('test1', 'services');
-            expect(response).toEqual({ statusCode: 200, body: {} });
+            expect(response).toEqual({});
         });
 
         it('can delete a job by name', async () => {
@@ -191,7 +191,7 @@ describe('k8s', () => {
                 .reply(200, { });
 
             const response = await k8s.delete('test1', 'jobs');
-            expect(response).toEqual({ statusCode: 200, body: {} });
+            expect(response).toEqual({});
         });
 
         it('can delete a pod by name', async () => {


### PR DESCRIPTION
This PR adds a `force` option to the `POST /jobs/{jobId}/_stop` and `POST /ex/{exId}/_stop` endpoints
- include `force='true'` as a request parameter to forcefully stop all jobs, deployments, replicaSets and pods labeled with the execution ID in the url or the execution ID associated with the jobID in the url.
- This overrides the default behavior of not allowing a job with a status of `'completed', 'stopped', 'rejected', 'failed', 'terminated', or 'stopping'` to be stopped.
- Endpoint documentation updated.
- Adds a test for deleting with force set to true.
- Modifies `delete` job, service, and deployment tests to expect the complete response, not the response.body.

Ref: #2670 