### PR TITLE
Ts-scripts publish fix

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.63.0",
+    "version": "0.63.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/sync/configs.ts
+++ b/packages/scripts/src/helpers/sync/configs.ts
@@ -9,10 +9,7 @@ export async function generateTSConfig(
 ): Promise<void> {
     const rootInfo = getRootInfo();
     const references = pkgInfos
-        .filter((pkgInfo) => {
-            if (pkgInfo.terascope?.main) return false;
-            return fs.existsSync(path.join(pkgInfo.dir, 'tsconfig.json'));
-        })
+        .filter((pkgInfo) => fs.existsSync(path.join(pkgInfo.dir, 'tsconfig.json')))
         .map((pkgInfo) => ({
             path: pkgInfo.relativeDir.replace(/^\.\//, '')
         }));

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -85,7 +85,7 @@
         "registry": "https://registry.npmjs.org/"
     },
     "terascope": {
-        "main": false,
+        "main": true,
         "enableTypedoc": false,
         "testSuite": "elasticsearch"
     }


### PR DESCRIPTION
This PR fixes an issue listed here #3490

- Changed `terascope.main` in the teraslice `package.json` back to true. 
  - This fixes an expectation in the code that relies on this to be true
- Removed check in the `generateTSConfig()` method that checks for `terascope.main` in every package.
  - This conflicts with the change above and is believed to be unnecessary. It's also problematic now that the teraslice package has been converted to typescript. 
- Bumped @terascope/scripts from v0.63.0 to v0.63.1