### PR TITLE
 Update typedoc to be compatible with current typescript version.

### DIFF
--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -44,39 +44,39 @@ jobs:
       - name: Publish to docker
         run: yarn ts-scripts publish -t dev docker
 
-  # build-docs:
-  #   runs-on: ubuntu-latest
-  #   needs: build-release
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v3
+  build-docs:
+    runs-on: ubuntu-latest
+    needs: build-release
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
 
-  #     - name: Setup Node
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version:  18.18.2
-  #         registry-url: 'https://registry.npmjs.org'
-  #         cache: 'yarn'
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version:  18.18.2
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
 
-  #     - name: Build documentation
-  #       run: ./scripts/build-documentation.sh  # output in website/build
-  #     - name: Check Output
-  #       run: find ./website/build
-  #     - name: Upload artifact
-  #       uses: actions/upload-pages-artifact@v1
-  #       with:
-  #         path: ./website/build/teraslice
+      - name: Build documentation
+        run: ./scripts/build-documentation.sh  # output in website/build
+      - name: Check Output
+        run: find ./website/build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./website/build/teraslice
 
-  # publish-docs:
-  #   runs-on: ubuntu-latest
-  #   needs: build-docs
-  #   permissions:
-  #     pages: write      # to deploy to Pages
-  #     id-token: write
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
-  #   steps:
-  #     - name: Deploy to GitHub Pages
-  #       id: deployment
-  #       uses: actions/deploy-pages@v2
+  publish-docs:
+    runs-on: ubuntu-latest
+    needs: build-docs
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -50,8 +50,8 @@
         "signale": "^1.4.0",
         "sort-package-json": "~1.57.0",
         "toposort": "^2.0.2",
-        "typedoc": "~0.23.26",
-        "typedoc-plugin-markdown": "~3.14.0",
+        "typedoc": "~0.25.4",
+        "typedoc-plugin-markdown": "~3.17.1",
         "yargs": "^17.7.2"
     },
     "devDependencies": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.63.1",
+    "version": "0.63.2",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/doc-builder/typedoc.ts
+++ b/packages/scripts/src/helpers/doc-builder/typedoc.ts
@@ -89,27 +89,27 @@ export async function generateTSDocs(pkgInfo: PackageInfo, outputDir: string): P
     const cwd = process.cwd();
     try {
         process.chdir(pkgInfo.dir);
-        const app = new Application();
-        app.options.addReader(new TSConfigReader());
-        app.bootstrap({
-            name: pkgInfo.name,
-            tsconfig: path.join(pkgInfo.dir, 'tsconfig.json'),
-            theme: 'markdown',
-            exclude: ['test', 'node_modules'],
-            excludePrivate: true,
-            excludeExternals: true,
-            hideGenerator: true,
-            readme: 'none',
-        });
-
-        app.options.setValue('entryPoints', './src');
-        app.options.setValue('entryPointStrategy', 'expand');
+        const app = await Application.bootstrapWithPlugins(
+            {
+                name: pkgInfo.name,
+                tsconfig: path.join(pkgInfo.dir, 'tsconfig.json'),
+                plugin: ['typedoc-plugin-markdown'],
+                entryPoints: ['./src'],
+                entryPointStrategy: 'expand',
+                exclude: ['test', 'node_modules'],
+                excludePrivate: true,
+                excludeExternals: true,
+                hideGenerator: true,
+                readme: 'none',
+            },
+            [new TSConfigReader()]
+        );
 
         if (app.logger.hasErrors()) {
             signale.error(`found errors typedocs for package ${pkgInfo.name}`);
             return;
         }
-        const project = app.convert();
+        const project = await app.convert();
         if (!project) {
             signale.error(`invalid typedocs for package ${pkgInfo.name}`);
             return;

--- a/packages/terafoundation/src/master.ts
+++ b/packages/terafoundation/src/master.ts
@@ -36,7 +36,7 @@ export default function masterModule<
 
         let workersAlive = 0;
         let funcRun = 0;
-        let shutdownInterval: NodeJS.Timer;
+        let shutdownInterval: NodeJS.Timeout;
 
         const emitShutdown = once(() => {
             // optional hook for shutdown sequences

--- a/yarn.lock
+++ b/yarn.lock
@@ -9031,7 +9031,7 @@ map-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
   integrity sha512-TzQSV2DiMYgoF5RycneKVUzIa9bQsj/B3tTgsE3dOGqlzHnGIDaC7XBE7grnA+8kZPnfqSGFe95VHc2oc0VFUQ==
 
-marked@^4.2.12:
+marked@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
   integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
@@ -9194,7 +9194,7 @@ minimatch@^5.0.1, minimatch@^5.1.0:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^7.1.3, minimatch@^7.2.0:
+minimatch@^7.2.0:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-7.4.6.tgz#845d6f254d8f4a5e4fd6baf44d5f10c8448365fb"
   integrity sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==
@@ -9205,6 +9205,13 @@ minimatch@^9.0.0, minimatch@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.1.tgz#8a555f541cf976c622daf078bb28f29fb927c253"
   integrity sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -12618,21 +12625,21 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typedoc-plugin-markdown@~3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.14.0.tgz#17b99ee3ab0d21046d253f185f7669e80d0d7891"
-  integrity sha512-UyQLkLRkfTFhLdhSf3RRpA3nNInGn+k6sll2vRXjflaMNwQAAiB61SYbisNZTg16t4K1dt1bPQMMGLrxS0GZ0Q==
+typedoc-plugin-markdown@~3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.17.1.tgz#c33f42363c185adf842f4699166015f7fe0ed02b"
+  integrity sha512-QzdU3fj0Kzw2XSdoL15ExLASt2WPqD7FbLeaqwT70+XjKyTshBnUlQA5nNREO1C2P8Uen0CDjsBLMsCQ+zd0lw==
   dependencies:
     handlebars "^4.7.7"
 
-typedoc@~0.23.26:
-  version "0.23.28"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.23.28.tgz#3ce9c36ef1c273fa849d2dea18651855100d3ccd"
-  integrity sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==
+typedoc@~0.25.4:
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.25.4.tgz#5c2c0677881f504e41985f29d9aef0dbdb6f1e6f"
+  integrity sha512-Du9ImmpBCw54bX275yJrxPVnjdIyJO/84co0/L9mwe0R3G4FSR6rQ09AlXVRvZEGMUg09+z/usc8mgygQ1aidA==
   dependencies:
     lunr "^2.3.9"
-    marked "^4.2.12"
-    minimatch "^7.1.3"
+    marked "^4.3.0"
+    minimatch "^9.0.3"
     shiki "^0.14.1"
 
 typescript@~5.2.2:


### PR DESCRIPTION
Typedoc v0.23.28 was not compatible with typescript v5.2.2.
The following packages were upgraded:
- typedoc from v0.23.28 to v0.25.4
- typedoc-plugin-markdown from 3.14.0 to 3.17.1

The `typedoc.Application` class now requires a call to `bootstrapWithPlugins()` to initialize.

Ref: #3489 