### PR TITLE
Add K8s version parameter to kind cluster creation

### DIFF
--- a/docs/development/k8s.md
+++ b/docs/development/k8s.md
@@ -263,7 +263,7 @@ When you're done and want to clean everything up, you can delete it all with a
 single Kind command and reset the modified job file as follows:
 
 ```bash
-kind delete cluster -n k8se2e
+kind delete cluster -n k8s-env
 git checkout examples/jobs/data_generator.json
 ```
 

--- a/e2e/k8s/kindConfigDefaultPorts.yaml
+++ b/e2e/k8s/kindConfigDefaultPorts.yaml
@@ -1,5 +1,5 @@
 kind: Cluster
-name: k8se2e
+name: k8s-env
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane

--- a/e2e/k8s/kindConfigTestPorts.yaml
+++ b/e2e/k8s/kindConfigTestPorts.yaml
@@ -1,5 +1,5 @@
 kind: Cluster
-name: k8se2e
+name: k8s-e2e
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane

--- a/e2e/k8s/masterDeployment.yaml
+++ b/e2e/k8s/masterDeployment.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         app.kubernetes.io/name: teraslice
         app.kubernetes.io/component: master
-        app.kubernetes.io/instance: k8se2e
+        app.kubernetes.io/instance: k8s-e2e
     spec:
       containers:
       - name: teraslice-master

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "tests": {
             "suites": {
                 "e2e": [],
-                "k8se2e": [],
+                "k8s-e2e": [],
                 "elasticsearch": [],
                 "search": [],
                 "restrained": [],
@@ -79,7 +79,7 @@
                 "_for_testing_": [
                     "elasticsearch"
                 ],
-                "k8s_env": []
+                "k8s-env": []
             }
         },
         "docker": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.63.2",
+    "version": "0.64.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/cmds/k8s-env.ts
+++ b/packages/scripts/src/cmds/k8s-env.ts
@@ -61,6 +61,11 @@ const cmd: CommandModule = {
                 description: 'Name of the kind kubernetes cluster.',
                 type: 'string',
                 default: 'k8s-env'
+            })
+            .option('k8s-version', {
+                description: 'Version of kubernetes to use in the kind cluster.',
+                type: 'string',
+                default: config.K8S_VERSION
             });
     },
     handler(argv) {
@@ -76,7 +81,8 @@ const cmd: CommandModule = {
             nodeVersion: argv['node-version'] as string,
             skipBuild: Boolean(argv['skip-build']),
             tsPort: argv['ts-port'] as number,
-            clusterName: argv['cluster-name'] as string
+            clusterName: argv['cluster-name'] as string,
+            k8sVersion: argv['k8s-version'] as string
         };
 
         if (Boolean(argv.rebuild) === true) {

--- a/packages/scripts/src/cmds/k8s-env.ts
+++ b/packages/scripts/src/cmds/k8s-env.ts
@@ -56,27 +56,16 @@ const cmd: CommandModule = {
                 description: 'Port where teraslice api will be exposed.',
                 type: 'number',
                 default: 5678
+            })
+            .option('cluster-name', {
+                description: 'Name of the kind kubernetes cluster.',
+                type: 'string',
+                default: 'k8s-env'
             });
     },
     handler(argv) {
         const kafkaCPVersion = kafkaVersionMapper(argv.kafkaVersion as string);
-
-        if (Boolean(argv.rebuild) === true) {
-            return rebuildTeraslice({
-                elasticsearchVersion: argv.elasticsearchVersion as string,
-                kafkaVersion: argv.kafkaVersion as string,
-                kafkaImageVersion: kafkaCPVersion,
-                zookeeperVersion: kafkaCPVersion,
-                minioVersion: argv.minioVersion as string,
-                rabbitmqVersion: argv.rabbitmqVersion as string,
-                opensearchVersion: argv.opensearchVersion as string,
-                nodeVersion: argv['node-version'] as string,
-                skipBuild: Boolean(argv['skip-build']),
-                tsPort: argv['ts-port'] as number
-            });
-        }
-
-        return launchK8sEnv({
+        const k8sEnvOptions = {
             elasticsearchVersion: argv.elasticsearchVersion as string,
             kafkaVersion: argv.kafkaVersion as string,
             kafkaImageVersion: kafkaCPVersion,
@@ -86,8 +75,15 @@ const cmd: CommandModule = {
             opensearchVersion: argv.opensearchVersion as string,
             nodeVersion: argv['node-version'] as string,
             skipBuild: Boolean(argv['skip-build']),
-            tsPort: argv['ts-port'] as number
-        });
+            tsPort: argv['ts-port'] as number,
+            clusterName: argv['cluster-name'] as string
+        };
+
+        if (Boolean(argv.rebuild) === true) {
+            return rebuildTeraslice(k8sEnvOptions);
+        }
+
+        return launchK8sEnv(k8sEnvOptions);
     },
 };
 

--- a/packages/scripts/src/cmds/test.ts
+++ b/packages/scripts/src/cmds/test.ts
@@ -28,6 +28,7 @@ type Options = {
     packages?: PackageInfo[];
     'ignore-mount': boolean;
     'test-platform': string;
+    'k8s-version': string | undefined;
 };
 
 const jestArgs = getExtraArgs();
@@ -136,6 +137,11 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
                 type: 'string',
                 default: config.TEST_PLATFORM,
             })
+            .option('k8s-version', {
+                description: 'Version of kubernetes to use in the kind cluster.',
+                type: 'string',
+                default: config.K8S_VERSION
+            })
             .positional('packages', {
                 description: 'Runs the tests for one or more package and/or an asset, if none specified it will run all of the tests',
                 coerce(arg) {
@@ -167,6 +173,7 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
         const ignoreMount = hoistJestArg(argv, 'ignore-mount', 'boolean');
         const testPlatform = hoistJestArg(argv, 'test-platform', 'string');
         const clusterName = testPlatform === 'kubernetes' ? 'k8s-e2e' : undefined;
+        const k8sVersion = hoistJestArg(argv, 'k8s-version', 'string');
 
         if (debug && watch) {
             throw new Error('--debug and --watch conflict, please set one or the other');
@@ -195,7 +202,8 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
             jestArgs,
             ignoreMount,
             testPlatform,
-            clusterName
+            clusterName,
+            k8sVersion,
         });
     },
 };

--- a/packages/scripts/src/cmds/test.ts
+++ b/packages/scripts/src/cmds/test.ts
@@ -166,6 +166,7 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
         const forceSuite = hoistJestArg(argv, 'force-suite', 'string');
         const ignoreMount = hoistJestArg(argv, 'ignore-mount', 'boolean');
         const testPlatform = hoistJestArg(argv, 'test-platform', 'string');
+        const clusterName = testPlatform === 'kubernetes' ? 'k8s-e2e' : undefined;
 
         if (debug && watch) {
             throw new Error('--debug and --watch conflict, please set one or the other');
@@ -193,7 +194,8 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
             reportCoverage,
             jestArgs,
             ignoreMount,
-            testPlatform
+            testPlatform,
+            clusterName
         });
     },
 };

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -177,4 +177,7 @@ export const SEARCH_TEST_HOST = testHost;
 // This overrides the value in the Dockerfile
 export const NODE_VERSION = process.env.NODE_VERSION || '18.18.2';
 
-export const { TEST_PLATFORM = 'native' } = process.env;
+export const {
+    TEST_PLATFORM = 'native',
+    K8S_VERSION = undefined
+} = process.env;

--- a/packages/scripts/src/helpers/interfaces.ts
+++ b/packages/scripts/src/helpers/interfaces.ts
@@ -133,6 +133,7 @@ export interface kindCluster {
     nodes: [
         {
             role: string;
+            image?: string;
             extraPortMappings: [
                 {
                     containerPort: number;

--- a/packages/scripts/src/helpers/k8s-env/interfaces.ts
+++ b/packages/scripts/src/helpers/k8s-env/interfaces.ts
@@ -10,6 +10,7 @@ export interface k8sEnvOptions {
     skipBuild: boolean;
     tsPort: number;
     clusterName: string;
+    k8sVersion: string;
 }
 
 // TODO: create a common parent for each resource type,

--- a/packages/scripts/src/helpers/k8s-env/interfaces.ts
+++ b/packages/scripts/src/helpers/k8s-env/interfaces.ts
@@ -8,7 +8,8 @@ export interface k8sEnvOptions {
     opensearchVersion: string;
     nodeVersion: string;
     skipBuild: boolean;
-    tsPort: number
+    tsPort: number;
+    clusterName: string;
 }
 
 // TODO: create a common parent for each resource type,

--- a/packages/scripts/src/helpers/k8s-env/k8s.ts
+++ b/packages/scripts/src/helpers/k8s-env/k8s.ts
@@ -21,8 +21,9 @@ export class K8s {
     terasliceNamespace: string;
     servicesNamespace: string;
     tsPort: number;
+    kindClusterName: string;
 
-    constructor(tsPort: number) {
+    constructor(tsPort: number, kindClusterName: string) {
         this.kc = new k8sClient.KubeConfig();
         this.kc.loadFromDefault();
 
@@ -33,6 +34,7 @@ export class K8s {
         this.terasliceNamespace = 'default';
         this.servicesNamespace = 'default';
         this.tsPort = tsPort;
+        this.kindClusterName = kindClusterName;
     }
 
     async createNamespace(yamlFile: string, namespaceCategory: string) {
@@ -98,6 +100,9 @@ export class K8s {
         try {
             /// Creates master deployment for teraslice
             const yamlTSMasterDeployment = this.loadYamlFile('masterDeployment.yaml') as k8sClient.V1Deployment;
+            if (yamlTSMasterDeployment.spec?.template.metadata?.labels) {
+                yamlTSMasterDeployment.spec.template.metadata.labels['app.kubernetes.io/instance'] = this.kindClusterName;
+            }
             const response = await this.k8sAppsV1Api.createNamespacedDeployment('ts-dev1', yamlTSMasterDeployment);
             logger.debug('deployK8sTeraslice yamlTSMasterDeployment: ', response.body);
         } catch (err) {

--- a/packages/scripts/src/helpers/kind.ts
+++ b/packages/scripts/src/helpers/kind.ts
@@ -1,0 +1,75 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import execa from 'execa';
+import yaml from 'js-yaml';
+import { Logger, debugLogger } from '@terascope/utils';
+import signale from './signale';
+import { getE2eK8sDir } from '../helpers/packages';
+import { kindCluster } from './interfaces';
+
+export class Kind {
+    clusterName: string;
+    logger: Logger;
+
+    constructor(clusterName = 'default') {
+        this.clusterName = clusterName;
+        this.logger = debugLogger('ts-scripts:Kind');
+    }
+
+    async createCluster(teraslicePort = 45678): Promise<void> {
+        const e2eK8sDir = getE2eK8sDir();
+        if (!e2eK8sDir) {
+            throw new Error('Missing k8s e2e test directory');
+        }
+
+        let configPath: string;
+        let tempDir;
+
+        // clusterName must match name in kind config yaml file
+        if (this.clusterName === 'k8s-env') {
+            configPath = path.join(e2eK8sDir, 'kindConfigDefaultPorts.yaml');
+
+            const configFile = yaml.load(fs.readFileSync(configPath, 'utf8')) as kindCluster;
+            configFile.nodes[0].extraPortMappings[1].hostPort = teraslicePort;
+            const updatedYaml = yaml.dump(configFile);
+
+            tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tempYaml'));
+            fs.writeFileSync(path.join(tempDir, 'kindConfigDefaultPorts.yaml'), updatedYaml);
+            configPath = `${path.join(tempDir, 'kindConfigDefaultPorts.yaml')}`;
+        } else if (this.clusterName === 'k8s-e2e') {
+            configPath = path.join(e2eK8sDir, 'kindConfigTestPorts.yaml');
+        } else {
+            signale.error(`No config file for cluster with name ${this.clusterName}`);
+            process.exit(1);
+        }
+        const subprocess = await execa.command(`kind create cluster --config ${configPath}`);
+        this.logger.debug(subprocess.stderr);
+        if (tempDir) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    }
+
+    async destroyCluster(): Promise<void> {
+        const subprocess = await execa.command(`kind delete cluster --name ${this.clusterName}`);
+        this.logger.debug(subprocess.stderr);
+    }
+
+    // TODO: check that image is loaded before we continue
+    async loadTerasliceImage(terasliceImage: string): Promise<void> {
+        const subprocess = await execa.command(`kind load docker-image ${terasliceImage} --name ${this.clusterName}`);
+        this.logger.debug(subprocess.stderr);
+    }
+
+    // TODO: check that image is loaded before we continue
+    async loadServiceImage(
+        serviceName: string, serviceImage: string, version: string
+    ): Promise<void> {
+        try {
+            const subprocess = await execa.command(`kind load docker-image ${serviceImage}:${version} --name ${this.clusterName}`);
+            this.logger.debug(subprocess.stderr);
+        } catch (err) {
+            this.logger.debug(`The ${serviceName} docker image ${serviceImage}:${version} could not be loaded. It may not be present locally.`);
+        }
+    }
+}

--- a/packages/scripts/src/helpers/kind.ts
+++ b/packages/scripts/src/helpers/kind.ts
@@ -11,39 +11,47 @@ import { kindCluster } from './interfaces';
 export class Kind {
     clusterName: string;
     logger: Logger;
+    kindVersion: string | undefined;
+    k8sVersion: string | undefined;
 
-    constructor(clusterName = 'default') {
+    constructor(k8sVersion: string | undefined, clusterName = 'default') {
         this.clusterName = clusterName;
         this.logger = debugLogger('ts-scripts:Kind');
+        this.kindVersion = undefined;
+        this.k8sVersion = k8sVersion;
     }
 
     async createCluster(teraslicePort = 45678): Promise<void> {
+        this.kindVersion = await this.getKindVersion();
+
         const e2eK8sDir = getE2eK8sDir();
         if (!e2eK8sDir) {
             throw new Error('Missing k8s e2e test directory');
         }
 
         let configPath: string;
-        let tempDir;
 
-        // clusterName must match name in kind config yaml file
+        // clusterName must match 'name' in kind config yaml file
         if (this.clusterName === 'k8s-env') {
             configPath = path.join(e2eK8sDir, 'kindConfigDefaultPorts.yaml');
-
-            const configFile = yaml.load(fs.readFileSync(configPath, 'utf8')) as kindCluster;
-            configFile.nodes[0].extraPortMappings[1].hostPort = teraslicePort;
-            const updatedYaml = yaml.dump(configFile);
-
-            tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tempYaml'));
-            fs.writeFileSync(path.join(tempDir, 'kindConfigDefaultPorts.yaml'), updatedYaml);
-            configPath = `${path.join(tempDir, 'kindConfigDefaultPorts.yaml')}`;
         } else if (this.clusterName === 'k8s-e2e') {
             configPath = path.join(e2eK8sDir, 'kindConfigTestPorts.yaml');
         } else {
             signale.error(`No config file for cluster with name ${this.clusterName}`);
             process.exit(1);
         }
-        const subprocess = await execa.command(`kind create cluster --config ${configPath}`);
+
+        const configFile = yaml.load(fs.readFileSync(configPath, 'utf8')) as kindCluster;
+        if (this.k8sVersion) {
+            configFile.nodes[0].image = kindToK8sImageMap(this.kindVersion, this.k8sVersion);
+        }
+        configFile.nodes[0].extraPortMappings[1].hostPort = teraslicePort;
+        const updatedYaml = yaml.dump(configFile);
+
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tempYaml'));
+        fs.writeFileSync(path.join(tempDir, 'kindConfig.yaml'), updatedYaml);
+        const updatedYamlConfigPath = `${path.join(tempDir, 'kindConfig.yaml')}`;
+        const subprocess = await execa.command(`kind create cluster --config ${updatedYamlConfigPath}`);
         this.logger.debug(subprocess.stderr);
         if (tempDir) {
             fs.rmSync(tempDir, { recursive: true, force: true });
@@ -72,4 +80,57 @@ export class Kind {
             this.logger.debug(`The ${serviceName} docker image ${serviceImage}:${version} could not be loaded. It may not be present locally.`);
         }
     }
+
+    async getKindVersion(): Promise<string> {
+        try {
+            const subprocess = await execa.command('kind version');
+            const version = subprocess.stdout.split(' ')[1].slice(1);
+            return version;
+        } catch (err) {
+            throw new Error('Kind version could not be determined.');
+        }
+    }
+}
+
+const map = {
+    '0.20.0': {
+        '1.28.0': 'kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31',
+        '1.27.3': 'kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72',
+        '1.26.6': 'kindest/node:v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb',
+        '1.25.11': 'kindest/node:v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8',
+        '1.24.15': 'kindest/node:v1.24.15@sha256:7db4f8bea3e14b82d12e044e25e34bd53754b7f2b0e9d56df21774e6f66a70ab',
+        '1.23.17': 'kindest/node:v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb',
+        '1.22.17': 'kindest/node:v1.22.17@sha256:f5b2e5698c6c9d6d0adc419c0deae21a425c07d81bbf3b6a6834042f25d4fba2',
+        '1.21.14': 'kindest/node:v1.21.14@sha256:8a4e9bb3f415d2bb81629ce33ef9c76ba514c14d707f9797a01e3216376ba093',
+    },
+    '0.19.0': {
+        '1.28.0': 'kindest/node:v1.28.0@sha256:dad5a6238c5e41d7cac405fae3b5eda2ad1de6f1190fa8bfc64ff5bb86173213',
+        '1.27.1': 'kindest/node:v1.27.1@sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b',
+        '1.26.4': 'kindest/node:v1.26.4@sha256:f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e',
+        '1.25.9': 'kindest/node:v1.25.9@sha256:c08d6c52820aa42e533b70bce0c2901183326d86dcdcbedecc9343681db45161',
+        '1.24.13': 'kindest/node:v1.24.13@sha256:cea86276e698af043af20143f4bf0509e730ec34ed3b7fa790cc0bea091bc5dd',
+        '1.23.17': 'kindest/node:v1.23.17@sha256:f77f8cf0b30430ca4128cc7cfafece0c274a118cd0cdb251049664ace0dee4ff',
+        '1.22.17': 'kindest/node:v1.22.17@sha256:9af784f45a584f6b28bce2af84c494d947a05bd709151466489008f80a9ce9d5',
+        '1.21.14': 'kindest/node:v1.21.14@sha256:220cfafdf6e3915fbce50e13d1655425558cb98872c53f802605aa2fb2d569cf',
+    },
+    '0.18.0': {
+        '1.27.1': 'kindest/node:v1.27.1@sha256:9915f5629ef4d29f35b478e819249e89cfaffcbfeebda4324e5c01d53d937b09',
+        '1.26.3': 'kindest/node:v1.26.3@sha256:61b92f38dff6ccc29969e7aa154d34e38b89443af1a2c14e6cfbd2df6419c66f',
+        '1.25.8': 'kindest/node:v1.25.8@sha256:00d3f5314cc35327706776e95b2f8e504198ce59ac545d0200a89e69fce10b7f',
+        '1.24.12': 'kindest/node:v1.24.12@sha256:1e12918b8bc3d4253bc08f640a231bb0d3b2c5a9b28aa3f2ca1aee93e1e8db16',
+        '1.23.17': 'kindest/node:v1.23.17@sha256:e5fd1d9cd7a9a50939f9c005684df5a6d145e8d695e78463637b79464292e66c',
+        '1.22.17': 'kindest/node:v1.22.17@sha256:c8a828709a53c25cbdc0790c8afe12f25538617c7be879083248981945c38693',
+        '1.21.14': 'kindest/node:v1.21.14@sha256:27ef72ea623ee879a25fe6f9982690a3e370c68286f4356bf643467c552a3888',
+    }
+};
+
+function kindToK8sImageMap(kindVersion: string, k8sVersion: string): string {
+    if (!map[kindVersion]) {
+        throw new Error(`Version ${kindVersion} of kind is not supported. Please use one of the following: ${Object.keys(map)}`);
+    }
+    if (!map[kindVersion][k8sVersion]) {
+        throw new Error(`Version ${k8sVersion} of k8s is not supported in kind version ${kindVersion}. Please use one of the following: ${Object.keys(map[kindVersion])}`);
+    }
+    const version = map[kindVersion][k8sVersion];
+    return version;
 }

--- a/packages/scripts/src/helpers/kind.ts
+++ b/packages/scripts/src/helpers/kind.ts
@@ -92,7 +92,7 @@ export class Kind {
     }
 }
 
-const map = {
+const kindToK8sVersionMap = {
     '0.20.0': {
         '1.28.0': 'kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31',
         '1.27.3': 'kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72',
@@ -125,12 +125,12 @@ const map = {
 };
 
 function kindToK8sImageMap(kindVersion: string, k8sVersion: string): string {
-    if (!map[kindVersion]) {
-        throw new Error(`Version ${kindVersion} of kind is not supported. Please use one of the following: ${Object.keys(map)}`);
+    if (!kindToK8sVersionMap[kindVersion]) {
+        throw new Error(`Version ${kindVersion} of kind is not supported. Please use one of the following: ${Object.keys(kindToK8sVersionMap)}`);
     }
-    if (!map[kindVersion][k8sVersion]) {
-        throw new Error(`Version ${k8sVersion} of k8s is not supported in kind version ${kindVersion}. Please use one of the following: ${Object.keys(map[kindVersion])}`);
+    if (!kindToK8sVersionMap[kindVersion][k8sVersion]) {
+        throw new Error(`Version ${k8sVersion} of k8s is not supported in kind version ${kindVersion}. Please use one of the following: ${Object.keys(kindToK8sVersionMap[kindVersion])}`);
     }
-    const version = map[kindVersion][k8sVersion];
+    const version = kindToK8sVersionMap[kindVersion][k8sVersion];
     return version;
 }

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -222,8 +222,14 @@ async function runE2ETest(
                 process.exit(1);
             }
 
-            kind = new Kind(options.clusterName);
-            await kind.createCluster();
+            kind = new Kind(options.k8sVersion, options.clusterName);
+            try {
+                await kind.createCluster();
+            } catch (err) {
+                signale.error(err);
+                await kind.destroyCluster();
+                process.exit(1);
+            }
             await createNamespace('services-ns.yaml');
         } catch (err) {
             tracker.addError(err);

--- a/packages/scripts/src/helpers/test-runner/interfaces.ts
+++ b/packages/scripts/src/helpers/test-runner/interfaces.ts
@@ -23,6 +23,7 @@ export type TestOptions = {
     jestArgs?: string[];
     ignoreMount: boolean;
     testPlatform: string;
+    clusterName?: string;
 };
 
 export type GroupedPackages = {

--- a/packages/scripts/src/helpers/test-runner/interfaces.ts
+++ b/packages/scripts/src/helpers/test-runner/interfaces.ts
@@ -24,6 +24,7 @@ export type TestOptions = {
     ignoreMount: boolean;
     testPlatform: string;
     clusterName?: string;
+    k8sVersion?: string;
 };
 
 export type GroupedPackages = {

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -11,10 +11,10 @@ import {
     getContainerInfo,
     dockerStop,
     dockerPull,
-    kindLoadServiceImage,
     k8sStartService,
     k8sStopService
 } from '../scripts';
+import { Kind } from '../kind';
 import { TestOptions } from './interfaces';
 import { Service } from '../interfaces';
 import * as config from '../config';
@@ -743,9 +743,10 @@ async function startService(options: TestOptions, service: Service): Promise<() 
     }
 
     if (options.testPlatform === 'kubernetes') {
+        const kind = new Kind(options.clusterName);
+        await kind.loadServiceImage(service, services[service].image, version);
         await k8sStopService(service);
-        await kindLoadServiceImage(service, services[service].image, version);
-        await k8sStartService(service, services[service].image, version);
+        await k8sStartService(service, services[service].image, version, kind);
         return () => { };
     }
 

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -743,7 +743,7 @@ async function startService(options: TestOptions, service: Service): Promise<() 
     }
 
     if (options.testPlatform === 'kubernetes') {
-        const kind = new Kind(options.clusterName);
+        const kind = new Kind(options.k8sVersion, options.clusterName);
         await kind.loadServiceImage(service, services[service].image, version);
         await k8sStopService(service);
         await k8sStartService(service, services[service].image, version, kind);


### PR DESCRIPTION
- This PR allows for the setting of a `K8S_VERSION` env variable when running `yarn test:k8s` or `yarn k8s` (#3482)
- The env variable is converted to a command option which is used by the `Kind` class to create a kind cluster using that k8s version. 
- A map of `kind` versions to available images lives in the `Kind` class and will need to be updated with new kind versions.
- K8s images are limited to one minor version per kind version, with the patch level equal to the latest version at release time. For example:
  - kind v0.20.0 --> kindest/node:v1.26.6
  - kind v0.19.0 --> kindest/node:v1.26.4
  - kind v0.19.0 --> kindest/node:v1.26.3
- Create Kind class
- add `clusterName` option to k8s