### PR TITLE
Check for orphaned processes by job_id when starting a job

### DIFF
--- a/docs/management-apis/endpoints-json.md
+++ b/docs/management-apis/endpoints-json.md
@@ -372,7 +372,8 @@ Remove orphaned pods from a failed job:
 ```sh
 $ curl -XPOST 'localhost:5678/v1/jobs/5a50580c-4a50-48d9-80f8-ac70a00f3dbd/_stop?force=true'
 {
-    Force stop complete for exId 041a00a9-a474-4355-96aa-03e5ecf9b246, job status: failed
+    "message": "Force stop complete for exId: 041a00a9-a474-4355-96aa-03e5ecf9b246",
+    "status": "failed"
 }
 ```
 
@@ -762,7 +763,8 @@ Remove orphaned pods from a failed job:
 ```sh
 $ curl -XPOST 'localhost:5678/v1/ex/863678b3-daf3-4ea9-8cb0-88b846cd7e57/_stop?force=true'
 {
-    Force stop complete for exId 863678b3-daf3-4ea9-8cb0-88b846cd7e57, job status: failed
+    "message": "Force stop complete for exId: 863678b3-daf3-4ea9-8cb0-88b846cd7e57",
+    "status": "failed"
 }
 ```
 

--- a/docs/management-apis/endpoints-json.md
+++ b/docs/management-apis/endpoints-json.md
@@ -368,6 +368,14 @@ $ curl -XPOST 'localhost:5678/v1/jobs/5a50580c-4a50-48d9-80f8-ac70a00f3dbd/_stop
 }
 ```
 
+Remove orphaned pods from a failed job:
+```sh
+$ curl -XPOST 'localhost:5678/v1/jobs/5a50580c-4a50-48d9-80f8-ac70a00f3dbd/_stop?force=true'
+{
+    Force stop complete for exId 041a00a9-a474-4355-96aa-03e5ecf9b246, job status: failed
+}
+```
+
 ## POST /v1/jobs/{jobId}/_pause
 
 Issues a pause command, this will prevent the execution controller from invoking slicers and also prevent the allocation of slices to workers, marks the job execution context state as paused.
@@ -747,6 +755,14 @@ Issues a stop command which will shutdown execution controller and workers for t
 $ curl -XPOST 'localhost:5678/v1/ex/863678b3-daf3-4ea9-8cb0-88b846cd7e57/_stop'
 {
     "status": "stopped"
+}
+```
+
+Remove orphaned pods from a failed job:
+```sh
+$ curl -XPOST 'localhost:5678/v1/ex/863678b3-daf3-4ea9-8cb0-88b846cd7e57/_stop?force=true'
+{
+    Force stop complete for exId 863678b3-daf3-4ea9-8cb0-88b846cd7e57, job status: failed
 }
 ```
 

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -349,7 +349,12 @@ export class ApiService {
                 const exId = await this._getExIdFromRequest(req as TerasliceRequest);
                 await executionService
                     .stopExecution(exId, { timeout, force });
-                return this._waitForStop(exId, blocking);
+                const statusPromise = this._waitForStop(exId, blocking);
+                if (force) {
+                    const status = await statusPromise;
+                    return `Force stop complete for exId ${exId}, job status: ${status.status}`;
+                }
+                return statusPromise;
             });
         });
 

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -352,7 +352,10 @@ export class ApiService {
                 const statusPromise = this._waitForStop(exId, blocking);
                 if (force) {
                     const status = await statusPromise;
-                    return `Force stop complete for exId ${exId}, job status: ${status.status}`;
+                    return {
+                        message: `Force stop complete for exId ${exId}`,
+                        status: status.status
+                    };
                 }
                 return statusPromise;
             });

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetes/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetes/index.ts
@@ -220,6 +220,24 @@ export class KubernetesClusterBackend {
         clearInterval(this.clusterStateInterval);
     }
 
+    /**
+     * Returns a list of all k8s resources associated with a job ID
+     * @param {string}         jobId   The job ID of the job to list associated resources
+     * @returns {Array<any>}
+     */
+    async listResourcesForJobId(jobId: string) {
+        const resources = [];
+        const resourceTypes = ['pods', 'deployments', 'services', 'jobs'];
+        for (const type of resourceTypes) {
+            const list = await this.k8s.list(`teraslice.terascope.io/jobId=${jobId}`, type);
+            if (list.items.length > 0) {
+                resources.push(list.items);
+            }
+        }
+
+        return resources;
+    }
+
     async initialize() {
         this.logger.info('kubernetes clustering initializing');
 

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/native/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/native/index.ts
@@ -6,9 +6,7 @@ import {
 } from '@terascope/utils';
 import type { EventEmitter } from 'node:events';
 import { ExecutionRecord } from '@terascope/types';
-import type {
-    ClusterMasterContext, NodeState, ExecutionNode, WorkerNode
-} from '../../../../../../interfaces';
+import type { ClusterMasterContext, NodeState } from '../../../../../../interfaces';
 import { makeLogger } from '../../../../../workers/helpers/terafoundation';
 import { findWorkersByExecutionID } from '../state-utils';
 import { Messaging } from './messaging';
@@ -32,7 +30,7 @@ interface StateMessage {
     __source: string;
 }
 
-type Message = StateMessage
+ type Message = StateMessage
 
 export class NativeClustering {
     context: ClusterMasterContext;
@@ -605,9 +603,9 @@ export class NativeClustering {
         return this._availableWorkers() >= 2;
     }
 
-    clusterAvailable() { }
+    clusterAvailable() {}
 
-    async stopExecution(exId: string, options?: StopExecutionOptions) {
+    async stopExecution(exId: string, options?:StopExecutionOptions) {
         // we are allowing stopExecution to be non blocking, we block at api level
         this.pendingWorkerRequests.remove(exId, 'ex_id');
         const sendingMessage = { message: 'cluster:execution:stop' } as Record<string, any>;
@@ -629,17 +627,7 @@ export class NativeClustering {
         }
     }
 
-    async listResourcesForJobId(jobId: string) {
-        const resources = [];
-        const nodeStates = Object.values(this.clusterState);
-        for (const nodeState of nodeStates) {
-            const processNodes = nodeState.active;
-            for (const processNode of processNodes) {
-                if ((processNode as ExecutionNode | WorkerNode).job_id === jobId) {
-                    resources.push(processNode);
-                }
-            }
-        }
-        return resources;
+    async listResourcesForJobId() {
+        return [];
     }
 }

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/native/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/native/index.ts
@@ -640,6 +640,6 @@ export class NativeClustering {
                 }
             }
         }
-        return [];
+        return resources;
     }
 }

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/native/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/native/index.ts
@@ -6,7 +6,9 @@ import {
 } from '@terascope/utils';
 import type { EventEmitter } from 'node:events';
 import { ExecutionRecord } from '@terascope/types';
-import type { ClusterMasterContext, NodeState } from '../../../../../../interfaces';
+import type {
+    ClusterMasterContext, NodeState, ExecutionNode, WorkerNode
+} from '../../../../../../interfaces';
 import { makeLogger } from '../../../../../workers/helpers/terafoundation';
 import { findWorkersByExecutionID } from '../state-utils';
 import { Messaging } from './messaging';
@@ -30,7 +32,7 @@ interface StateMessage {
     __source: string;
 }
 
- type Message = StateMessage
+type Message = StateMessage
 
 export class NativeClustering {
     context: ClusterMasterContext;
@@ -603,9 +605,9 @@ export class NativeClustering {
         return this._availableWorkers() >= 2;
     }
 
-    clusterAvailable() {}
+    clusterAvailable() { }
 
-    async stopExecution(exId: string, options?:StopExecutionOptions) {
+    async stopExecution(exId: string, options?: StopExecutionOptions) {
         // we are allowing stopExecution to be non blocking, we block at api level
         this.pendingWorkerRequests.remove(exId, 'ex_id');
         const sendingMessage = { message: 'cluster:execution:stop' } as Record<string, any>;
@@ -625,5 +627,19 @@ export class NativeClustering {
         } else {
             await pDelay(100);
         }
+    }
+
+    async listResourcesForJobId(jobId: string) {
+        const resources = [];
+        const nodeStates = Object.values(this.clusterState);
+        for (const nodeState of nodeStates) {
+            const processNodes = nodeState.active;
+            for (const processNode of processNodes) {
+                if ((processNode as ExecutionNode | WorkerNode).job_id === jobId) {
+                    resources.push(processNode);
+                }
+            }
+        }
+        return [];
     }
 }

--- a/packages/teraslice/src/lib/cluster/services/execution.ts
+++ b/packages/teraslice/src/lib/cluster/services/execution.ts
@@ -264,7 +264,7 @@ export class ExecutionService {
 
         const isTerminal = this.isExecutionTerminal(execution);
 
-        if (this.isNative || !options.force) {
+        if (!options.force) {
             if (isTerminal) {
                 this.logger.info(`execution ${exId} is in terminal status "${execution._status}", it cannot be stopped`);
                 return;
@@ -280,7 +280,7 @@ export class ExecutionService {
             this.logger.debug(`stopping execution ${exId}...`, withoutNil(options));
             await this.executionStorage.setStatus(exId, 'stopping');
         } else {
-            this.logger.debug(`force stopping execution ${exId}...`, withoutNil(options));
+            this.logger.info(`force stopping execution ${exId}...`, withoutNil(options));
         }
 
         await this.clusterService.stopExecution(exId, options);
@@ -510,5 +510,9 @@ export class ExecutionService {
         } catch (err) {
             this.logger.error(err, 'failure reaping executions');
         }
+    }
+
+    async listResourcesForJobId(jobId: string) {
+        return this.clusterService.listResourcesForJobId(jobId);
     }
 }

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -138,9 +138,8 @@ export class JobsService {
             });
         }
 
-        const clusterType = this.context.sysconfig.teraslice.cluster_manager_type;
         const currentResources = await this.executionService.listResourcesForJobId(jobId);
-        if (currentResources.length > 0 && clusterType === 'kubernetes') {
+        if (currentResources.length > 0) {
             throw new TSError(`There are orphaned resources for job ${jobId}. Use curl -XPOST <teraslice host>/v1/jobs/${jobId}/_stop?force=true to remove orphaned resources.`);
         }
 

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -138,6 +138,12 @@ export class JobsService {
             });
         }
 
+        const clusterType = this.context.sysconfig.teraslice.cluster_manager_type;
+        const currentResources = await this.executionService.listResourcesForJobId(jobId);
+        if (currentResources.length > 0 && clusterType === 'kubernetes') {
+            throw new TSError(`There are orphaned resources for job ${jobId}. Use curl -XPOST <teraslice host>/v1/jobs/${jobId}/_stop?force=true to remove orphaned resources.`);
+        }
+
         const jobSpec = await this.jobsStorage.get(jobId);
         const validJob = await this._validateJobSpec(jobSpec) as JobRecord;
 

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -150,7 +150,7 @@ export class JobsService {
             const exIdsString = exIdsArr.join(', ');
             throw new TSError(`There are orphaned resources for job: ${jobId}, exId: ${exIdsString}.
             To remove orphaned resources:
-                curl -XPOST <teraslice host>/v1/jobs/${jobId}/_stop?force=true
+                curl -XPOST <teraslice host>/v1/jobs/${jobId}/_stop?force=true`);
         }
 
         const jobSpec = await this.jobsStorage.get(jobId);

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -151,8 +151,6 @@ export class JobsService {
             throw new TSError(`There are orphaned resources for job: ${jobId}, exId: ${exIdsString}.
             To remove orphaned resources:
                 curl -XPOST <teraslice host>/v1/jobs/${jobId}/_stop?force=true
-                Or:
-                curl -XPOST <teraslice host>/v1/ex/${exIdsArr[0]}/_stop?force=true`);
         }
 
         const jobSpec = await this.jobsStorage.get(jobId);


### PR DESCRIPTION
This PR makes the following changes:
- Add check for orphaned resources by job_id before starting job.
- Add listResourcesForJobId function to execution service.
- Add listResourcesForJobId function to k8s and native cluster backends.

- Improve messaging to user when using force option on the POST /jobs/{job_id}/_stop endpoint
- Remove check for native clustering when using force stop.
- Update docs for _stop endpoint to show an example using force