### PR TITLE
Change teraslice-cli tests to use temp dir

### DIFF
--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.59.1",
+    "version": "0.59.2",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"

--- a/packages/teraslice-cli/test/cmds/assets/init-spec.ts
+++ b/packages/teraslice-cli/test/cmds/assets/init-spec.ts
@@ -2,6 +2,7 @@ import 'jest-extended';
 import yargs from 'yargs';
 import path from 'path';
 import fs from 'fs-extra';
+import os from 'os';
 import assert from 'yeoman-assert';
 // @ts-expect-error
 import helpers from 'yeoman-test';
@@ -49,7 +50,7 @@ describe('assets deploy', () => {
     });
 
     describe('-> handler', () => {
-        const testAssetBasePath = path.join(__dirname, '..', '..', 'fixtures', 'generate-new-asset');
+        const testAssetBasePath = fs.mkdtempSync(path.join(os.tmpdir(), 'generate-new-asset'));
         const rootAssetPath = path.join(testAssetBasePath, 'generated-asset', 'new_asset');
 
         const deps = [
@@ -66,7 +67,7 @@ describe('assets deploy', () => {
             }));
 
         afterAll(() => {
-            fs.removeSync(rootAssetPath);
+            fs.rmSync(testAssetBasePath, { recursive: true, force: true });
         });
 
         it('should create new asset from cmd', async () => {

--- a/packages/teraslice-cli/test/generators/new-asset-spec.ts
+++ b/packages/teraslice-cli/test/generators/new-asset-spec.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
+import os from 'os';
 import assert from 'yeoman-assert';
 // @ts-expect-error
 import helpers from 'yeoman-test';
@@ -7,7 +8,7 @@ import helpers from 'yeoman-test';
 jest.setTimeout(10000);
 
 describe('new asset generator should', () => {
-    const testAssetBasePath = path.join(__dirname, '..', 'fixtures', 'generate-new-asset');
+    const testAssetBasePath = fs.mkdtempSync(path.join(os.tmpdir(), 'generate-new-asset'));
     const rootAssetPath = path.join(testAssetBasePath, 'generated-asset', 'new_asset');
     const assetAssetPath = path.join(testAssetBasePath, 'generated-asset', 'new_asset', 'asset');
 
@@ -25,7 +26,7 @@ describe('new asset generator should', () => {
         }));
 
     afterAll(() => {
-        fs.removeSync(rootAssetPath);
+        fs.rmSync(testAssetBasePath, { recursive: true, force: true });
     });
 
     it('should create the correct asset dir tree and put files in the correct dir', () => {

--- a/packages/teraslice-cli/test/generators/new-processor-spec.ts
+++ b/packages/teraslice-cli/test/generators/new-processor-spec.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import os from 'os';
 import fs from 'fs-extra';
 import assert from 'yeoman-assert';
 // @ts-expect-error
@@ -7,7 +8,7 @@ import helpers from 'yeoman-test';
 jest.setTimeout(10000);
 
 describe('processor generator with no new flag', () => {
-    const exampleAssetBasePath = path.join(__dirname, '..', 'fixtures', 'generate-new-processor');
+    const exampleAssetBasePath = fs.mkdtempSync(path.join(os.tmpdir(), 'generate-new-processor'));
     const processPath = path.join(exampleAssetBasePath, 'example-asset', 'asset');
     const testPath = path.join(exampleAssetBasePath, 'example-asset', 'test');
     const helpersPath = path.join(__dirname, '..', '..', 'src', 'generators', 'new-processor');
@@ -18,8 +19,7 @@ describe('processor generator with no new flag', () => {
         .withArguments(['example-asset']));
 
     afterAll(() => {
-        fs.removeSync(path.join(__dirname, '..', 'fixtures', 'generate-new-processor', 'example-asset', 'asset', 'example'));
-        fs.removeSync(path.join(__dirname, '..', 'fixtures', 'generate-new-processor', 'example-asset', 'spec', 'example-spec.js'));
+        fs.rmSync(exampleAssetBasePath, { recursive: true, force: true });
     });
 
     it('should generate index.js, processor.js, and schema.js in the asset dir', () => {
@@ -56,7 +56,7 @@ describe('processor generator with no new flag', () => {
 });
 
 describe('processor generator with new flag', () => {
-    const testAssetBasePath = path.join(__dirname, '..', 'fixtures', 'generate-new-processor');
+    const testAssetBasePath = fs.mkdtempSync(path.join(os.tmpdir(), 'generate-new-processor'));
     const processPath = path.join(testAssetBasePath, 'test-asset', 'asset');
     const testPath = path.join(testAssetBasePath, 'test-asset', 'test');
     const helpersPath = path.join(__dirname, '..', '..', 'src', 'generators', 'new-processor');
@@ -71,8 +71,7 @@ describe('processor generator with new flag', () => {
         }));
 
     afterAll(() => {
-        fs.removeSync(path.join(__dirname, '..', 'fixtures', 'generate-new-processor', 'test-asset', 'asset', 'good_processor'));
-        fs.removeSync(path.join(__dirname, '..', 'fixtures', 'generate-new-processor', 'test-asset', 'test', 'good_processor-spec.js'));
+        fs.rmSync(testAssetBasePath, { recursive: true, force: true });
     });
 
     it('should generate index.js, processor.js, and schema.js in the asset dir', () => {


### PR DESCRIPTION
- Changed tests inside `teraslice-cli` to use temp directories instead of sharing directories
  - This separates state between tests and guarantee directories even when tests are ran in parallel 

This fixes an issue posted here #3494