### PR TITLE
add nodeSuffix flag to scripts publish

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.64.2",
+    "version": "0.65.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/cmds/publish.ts
+++ b/packages/scripts/src/cmds/publish.ts
@@ -27,6 +27,7 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
             .example('$0 publish', '-n 18.18.2 -t latest docker')
             .example('$0 publish', '--dry-run docker')
             .example('$0 publish', '-n 18.18.2 --dry-run docker')
+            .example('$0 publish', '-t tag --node-suffix=false docker')
             .example('$0 publish', '-t tag npm')
             .example('$0 publish', '-t latest npm')
             .example('$0 publish', '--dry-run npm')

--- a/packages/scripts/src/cmds/publish.ts
+++ b/packages/scripts/src/cmds/publish.ts
@@ -11,6 +11,7 @@ interface Options {
     type: PublishType;
     action?: PublishAction;
     'dry-run': boolean;
+    'node-suffix': boolean;
     'publish-outdated-packages': boolean;
     'node-version': string;
 }
@@ -34,6 +35,11 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
                 description: "For testing purposes, don't pushing or publishing",
                 type: 'boolean',
                 default: !isCI,
+            })
+            .option('node-suffix', {
+                description: 'Choose whether to include or exclude a node suffix with a docker image tag',
+                type: 'boolean',
+                default: true,
             })
             .option('publish-outdated-packages', {
                 description: 'Publish packages that may have newer versions',
@@ -68,6 +74,7 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
         return publish(argv.action!, {
             type: argv.type,
             dryRun: argv['dry-run'],
+            nodeSuffix: argv['node-suffix'],
             publishOutdatedPackages: argv['publish-outdated-packages'],
             nodeVersion: argv['node-version'],
         });

--- a/packages/scripts/src/helpers/k8s-env/index.ts
+++ b/packages/scripts/src/helpers/k8s-env/index.ts
@@ -128,6 +128,7 @@ async function buildAndTagTerasliceImage(options:k8sEnvOptions) {
         try {
             const publishOptions: PublishOptions = {
                 dryRun: true,
+                nodeSuffix: true,
                 nodeVersion: options.nodeVersion,
                 type: PublishType.Dev
             };

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -111,7 +111,12 @@ async function publishToDocker(options: PublishOptions) {
             }
 
             const image = `${registry}:v${mainPkgInfo.version}`;
-            const exists = await remoteDockerImageExists(`${image}-${nodeVersionSuffix}`);
+            let exists;
+            if (options.nodeSuffix) {
+                exists = await remoteDockerImageExists(`${image}-${nodeVersionSuffix}`);
+            } else {
+                exists = await remoteDockerImageExists(image);
+            }
             if (exists) {
                 err = new Error(`Docker Image ${image} already exists`);
                 continue;
@@ -129,7 +134,9 @@ async function publishToDocker(options: PublishOptions) {
         // TODO: perhaps this should be moved inside the block above and
         // repeated for each conditional branch to avoid the duplication on line
         // 113, I cant' decide which is worse.
-        imageToBuild = `${imageToBuild}-${nodeVersionSuffix}`;
+        if (options.nodeSuffix) {
+            imageToBuild = `${imageToBuild}-${nodeVersionSuffix}`;
+        }
         signale.debug(`building docker image ${imageToBuild}`);
 
         await dockerBuild(imageToBuild, [devImage], undefined, `NODE_VERSION=${options.nodeVersion}`);

--- a/packages/scripts/src/helpers/publish/interfaces.ts
+++ b/packages/scripts/src/helpers/publish/interfaces.ts
@@ -14,6 +14,7 @@ export enum PublishAction {
 export interface PublishOptions {
     type: PublishType;
     dryRun: boolean;
+    nodeSuffix: boolean;
     /**
      * Publish packages that may have newer versions
     */

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -251,6 +251,7 @@ async function runE2ETest(
         } else {
             const publishOptions: PublishOptions = {
                 dryRun: true,
+                nodeSuffix: true,
                 nodeVersion: options.nodeVersion,
                 type: PublishType.Dev
             };


### PR DESCRIPTION
- Added a `node-suffix` flag in `ts-scripts publish` to allow the ability to include or exclude a node version suffix in a docker image tag 
  - By default it's set to `true` to maintain original functionality 