### PR TITLE
Add force stop option to jobs stop and tjm stop cli commands

### DIFF
--- a/packages/teraslice-cli/src/cmds/jobs/stop.ts
+++ b/packages/teraslice-cli/src/cmds/jobs/stop.ts
@@ -28,6 +28,9 @@ export = {
         return yargs;
     },
     async handler(argv: any) {
+        if (argv.force === true && argv.jobId.includes('all')) {
+            reply.fatal('Force option cannot be used with the positional argument "all".');
+        }
         const cliConfig = new Config(argv);
         const jobs = new Jobs(cliConfig);
 

--- a/packages/teraslice-cli/src/cmds/jobs/stop.ts
+++ b/packages/teraslice-cli/src/cmds/jobs/stop.ts
@@ -18,9 +18,11 @@ export = {
         yargs.options('timeout', yargsOptions.buildOption('timeout'));
         yargs.options('interval', yargsOptions.buildOption('interval'));
         yargs.options('yes', yargsOptions.buildOption('yes'));
+        yargs.options('force', yargsOptions.buildOption('force'));
         yargs.strict()
             .example('$0 jobs stop CLUSTER_ALIAS JOB_ID1', 'stops job on the cluster')
             .example('$0 jobs stop CLUSTER_ALIAS JOB_ID1 JOB_ID2', 'stops two jobs on the cluster')
+            .example('$0 jobs stop CLUSTER_ALIAS JOB_ID1 --force', 'stops job on the cluster and forcefully kills any resources belonging to the job')
             .example('$0 jobs stop CLUSTER_ALIAS all --yes', 'stops all the jobs on the cluster bypasses the prompt to continue')
             .example('$0 jobs stop CLUSTER_ALIAS all', 'stops all jobs on the cluster and saves jobs locally to a json file in the .teraslice dir');
         return yargs;

--- a/packages/teraslice-cli/src/cmds/tjm/stop.ts
+++ b/packages/teraslice-cli/src/cmds/tjm/stop.ts
@@ -14,9 +14,11 @@ export = {
         yargs.option('src-dir', yargsOptions.buildOption('src-dir'));
         yargs.option('config-dir', yargsOptions.buildOption('config-dir'));
         yargs.options('status', yargsOptions.buildOption('jobs-status'));
+        yargs.options('force', yargsOptions.buildOption('force'));
         yargs
             .example('$0 tjm stop JOB_FILE.json', 'stops job')
-            .example('$0 tjm stop JOB_FILE.json JOB_FILE2.json', 'stops multiple jobs');
+            .example('$0 tjm stop JOB_FILE.json JOB_FILE2.json', 'stops multiple jobs')
+            .example('$0 tjm stop JOB_FILE.json --force', 'stops job on the cluster and forcefully kills any resources belonging to the job');
         return yargs;
     },
     async handler(argv) {

--- a/packages/teraslice-cli/src/helpers/yargs-options.ts
+++ b/packages/teraslice-cli/src/helpers/yargs-options.ts
@@ -227,6 +227,12 @@ export default class Options {
             describe: 'Silence non-error logging.',
             type: 'boolean'
         }),
+        force: () => ({
+            alias: 'f',
+            describe: 'Stops job on the cluster and forcefully kills any resources belonging to the job.',
+            default: false,
+            type: 'boolean'
+        }),
     };
 
     private positionals: Record<string, (...args: any[]) => yargs.PositionalOptions> = {

--- a/packages/teraslice-client-js/src/interfaces.ts
+++ b/packages/teraslice-client-js/src/interfaces.ts
@@ -302,6 +302,7 @@ export interface StoppedResponse {
 export interface StopQuery {
     timeout?: number;
     blocking?: boolean;
+    force?: boolean;
 }
 
 export interface AssetUploadQuery {

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -4,7 +4,7 @@ import { pipeline as streamPipeline } from 'node:stream/promises';
 import { RecoveryCleanupType, TerasliceConfig } from '@terascope/job-components';
 import {
     parseErrorInfo, parseList, logError,
-    TSError, startsWith, Logger
+    TSError, startsWith, Logger, toBoolean
 } from '@terascope/utils';
 import { ClusterMasterContext, TerasliceRequest, TerasliceResponse } from '../../../interfaces';
 import { makeLogger } from '../../workers/helpers/terafoundation';
@@ -338,11 +338,12 @@ export class ApiService {
         });
 
         v1routes.post(['/jobs/:jobId/_stop', '/ex/:exId/_stop'], (req, res) => {
-            const {
-                timeout,
-                blocking = true,
-                force = false
-            } = req.query as unknown as { timeout: number, blocking: boolean, force: boolean };
+            let timeout: number | undefined;
+            if (req.query.timeout) {
+                timeout = Number(req.query.timeout);
+            }
+            const blocking = toBoolean(req.query.blocking);
+            const force = toBoolean(req.query.force);
 
             const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not stop execution');
             requestHandler(async () => {

--- a/packages/teraslice/src/lib/cluster/services/execution.ts
+++ b/packages/teraslice/src/lib/cluster/services/execution.ts
@@ -256,6 +256,7 @@ export class ExecutionService {
     }
 
     async stopExecution(exId: string, options: StopExecutionOptions) {
+        let status = 'stopped';
         const execution = await this.getExecutionContext(exId);
 
         if (!execution) {
@@ -281,11 +282,12 @@ export class ExecutionService {
             await this.executionStorage.setStatus(exId, 'stopping');
         } else {
             this.logger.info(`force stopping execution ${exId}...`, withoutNil(options));
+            status = execution._status === 'running' ? 'terminated' : execution._status;
         }
 
         await this.clusterService.stopExecution(exId, options);
         // we are kicking this off in the background, not part of the promise chain
-        this.waitForExecutionStatus(exId);
+        this.waitForExecutionStatus(exId, status);
     }
 
     async pauseExecution(exId: string) {


### PR DESCRIPTION
This PR makes the following changes:
- Add the `force` option to `Teraslice-cli tjm stop`
- Add the `force` option to `Teraslice-cli jobs stop`
  - Add a check to `jobs stop` that disallows the use of `force` with the `all` positional
- Convert query parameters on the `_stop` endpoint to the proper types
- Allow end execution status to be in a terminal state besides stopped when force stopping an execution
  - Allows for force stopping a job in the failed state
  - Allows for a running job to be forced stopped, resulting in a terminated state
  - These changes lead me to believe that creating a new endpoint for force stopping might be preferable

Fixes: #3501 