### PR TITLE
K8s env reset es store option

### DIFF
--- a/docs/development/k8s.md
+++ b/docs/development/k8s.md
@@ -315,6 +315,16 @@ yarn k8s:rebuild
 yarn run ts-scripts k8s-env --rebuild
 ```
 
+If you would like to reset the elasticsearch store at the same time:
+
+```bash
+# from the teraslice root directory:
+yarn k8s:rebuild --reset-store
+
+# from any other directory:
+yarn run ts-scripts k8s-env --rebuild --reset-store
+```
+
 If you need to restart Teraslice without rebuilding you can use the following command:
 
 NOTE: this does not reset state in the elasticsearch store
@@ -325,6 +335,16 @@ yarn k8s:restart
 
 # from any other directory:
 yarn run ts-scripts k8s-env --rebuild --skip-build
+```
+
+If you would like to reset the elasticsearch store at the same time:
+
+```bash
+# from the teraslice root directory:
+yarn k8s:restart --reset-store
+
+# from any other directory:
+yarn run ts-scripts k8s-env --rebuild --skip-build --reset-store
 ```
 
 ## Extras

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.68.1",
+    "version": "0.69.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/cmds/k8s-env.ts
+++ b/packages/scripts/src/cmds/k8s-env.ts
@@ -2,6 +2,7 @@ import { CommandModule } from 'yargs';
 import * as config from '../helpers/config';
 import { launchK8sEnv, rebuildTeraslice } from '../helpers/k8s-env';
 import { kafkaVersionMapper } from '../helpers/mapper';
+import { k8sEnvOptions } from '../helpers/k8s-env/interfaces';
 
 const cmd: CommandModule = {
     command: 'k8s-env',
@@ -12,6 +13,9 @@ const cmd: CommandModule = {
             .example('TEST_ELASTICSEARCH=\'true\' ELASTICSEARCH_PORT=\'9200\' $0 k8s-env --teraslice-image=terascope/teraslice:v0.91.0-nodev18.18.2', 'Start a kind kubernetes cluster running teraslice from a specific docker image and elasticsearch.')
             .example('TEST_ELASTICSEARCH=\'true\' ELASTICSEARCH_PORT=\'9200\' TEST_KAFKA=\'true\' KAFKA_PORT=\'9092\' $0 k8s-env', 'Start a kind kubernetes cluster running teraslice, elasticsearch, kafka, and zookeeper.')
             .example('TEST_ELASTICSEARCH=\'true\' ELASTICSEARCH_PORT=\'9200\' $0 k8s-env --skip-build', 'Start a kind kubernetes cluster, but skip building a new teraslice docker image.')
+            .example('TEST_ELASTICSEARCH=\'true\' ELASTICSEARCH_PORT=\'9200\' $0 k8s-env --rebuild', 'Stop teraslice, rebuild docker image, and restart teraslice.')
+            .example('TEST_ELASTICSEARCH=\'true\' ELASTICSEARCH_PORT=\'9200\' $0 k8s-env --rebuild -reset-store', 'Rebuild and also clear the elasticsearch store.')
+            .example('TEST_ELASTICSEARCH=\'true\' ELASTICSEARCH_PORT=\'9200\' $0 k8s-env --rebuild -skip-build', 'Restart teraslice without rebuilding docker image.')
             .example('$0 k8s-env --rebuild', 'Rebuild teraslice and redeploy to k8s cluster. ES store data is retained.')
             .option('elasticsearch-version', {
                 description: 'The elasticsearch version to use',
@@ -53,6 +57,11 @@ const cmd: CommandModule = {
                 type: 'boolean',
                 default: false
             })
+            .option('reset-store', {
+                description: 'Restart the elasticsearch service when rebuilding teraslice. This flag is ignored if not accompanied by --rebuild',
+                type: 'boolean',
+                default: false
+            })
             .option('ts-port', {
                 description: 'Port where teraslice api will be exposed.',
                 type: 'number',
@@ -76,7 +85,7 @@ const cmd: CommandModule = {
     },
     handler(argv) {
         const kafkaCPVersion = kafkaVersionMapper(argv.kafkaVersion as string);
-        const k8sEnvOptions = {
+        const k8sOptions: k8sEnvOptions = {
             elasticsearchVersion: argv.elasticsearchVersion as string,
             kafkaVersion: argv.kafkaVersion as string,
             kafkaImageVersion: kafkaCPVersion,
@@ -93,10 +102,13 @@ const cmd: CommandModule = {
         };
 
         if (Boolean(argv.rebuild) === true) {
-            return rebuildTeraslice(k8sEnvOptions);
+            if (argv['reset-store']) {
+                k8sOptions.resetStore = true;
+            }
+            return rebuildTeraslice(k8sOptions);
         }
 
-        return launchK8sEnv(k8sEnvOptions);
+        return launchK8sEnv(k8sOptions);
     },
 };
 

--- a/packages/scripts/src/helpers/k8s-env/interfaces.ts
+++ b/packages/scripts/src/helpers/k8s-env/interfaces.ts
@@ -12,6 +12,7 @@ export interface k8sEnvOptions {
     clusterName: string;
     k8sVersion: string;
     terasliceImage?: string;
+    resetStore?: boolean;
 }
 
 // TODO: create a common parent for each resource type,


### PR DESCRIPTION
Add `--reset-store` option to `k8s-env` command.
- Issues the command `kubectl delete -n services-dev1 -f elasticsearchDeployment.yaml` to delete service, then `kubectl create -n services-dev1 -f elasticsearchDeployment.yaml` to restart it.
- Only works with `--rebuild` flag, otherwise ignored
- Use `k8s-env --rebuild -reset-store` to rebuild teraslice and reset elasticsearch. 
- Use `k8s-env --rebuild --skip-build -reset-store` to reset teraslice and elasticsearch without a rebuild.

ref: #3483 