### PR TITLE
Add node version to spaces e2e image

### DIFF
--- a/e2e/test/config.js
+++ b/e2e/test/config.js
@@ -35,7 +35,8 @@ const {
     HOST_IP = '127.0.0.1',
     GENERATE_ONLY,
     TEST_OPENSEARCH = false,
-    TEST_PLATFORM = 'native'
+    TEST_PLATFORM = 'native',
+    NODE_VERSION = '18.18.2' // keep in sync with NODE_VERSION in packages/scripts/src/helpers/config.ts
 } = process.env;
 
 const TEST_HOST = TEST_OPENSEARCH ? OPENSEARCH_HOST : ELASTICSEARCH_HOST;
@@ -82,5 +83,6 @@ module.exports = {
     newId,
     TEST_HOST,
     TEST_PLATFORM,
-    TERASLICE_PORT
+    TERASLICE_PORT,
+    NODE_VERSION
 };

--- a/e2e/test/config.js
+++ b/e2e/test/config.js
@@ -3,6 +3,7 @@
 const { ElasticsearchTestHelpers } = require('elasticsearch-store');
 const { customAlphabet } = require('nanoid');
 const path = require('path');
+const defaultNodeVersion = require('../../packages/scripts/src/helpers/config.ts');
 
 const {
     TEST_INDEX_PREFIX,
@@ -36,7 +37,7 @@ const {
     GENERATE_ONLY,
     TEST_OPENSEARCH = false,
     TEST_PLATFORM = 'native',
-    NODE_VERSION = '18.18.2' // keep in sync with NODE_VERSION in packages/scripts/src/helpers/config.ts
+    NODE_VERSION = defaultNodeVersion
 } = process.env;
 
 const TEST_HOST = TEST_OPENSEARCH ? OPENSEARCH_HOST : ELASTICSEARCH_HOST;

--- a/e2e/test/docker-helpers.js
+++ b/e2e/test/docker-helpers.js
@@ -36,6 +36,8 @@ async function dockerUp() {
         'force-recreate': ''
     });
     signale.success('Docker environment is good to go', getElapsed(startTime));
+    const e2eNodeVersion = await compose.runCmd('exec', undefined, 'teraslice-master', 'node', '--version');
+    signale.info('teraslice node version: ', e2eNodeVersion);
 }
 
 function getElapsed(time) {

--- a/e2e/test/docker-helpers.js
+++ b/e2e/test/docker-helpers.js
@@ -2,7 +2,8 @@
 
 const { Compose } = require('@terascope/docker-compose-js');
 const ms = require('ms');
-const { DEFAULT_WORKERS } = require('./config');
+const semver = require('semver');
+const { DEFAULT_WORKERS, NODE_VERSION } = require('./config');
 const signale = require('./signale');
 
 const compose = new Compose('docker-compose.yml');
@@ -36,8 +37,17 @@ async function dockerUp() {
         'force-recreate': ''
     });
     signale.success('Docker environment is good to go', getElapsed(startTime));
-    const e2eNodeVersion = await compose.runCmd('exec', undefined, 'teraslice-master', 'node', '--version');
-    signale.info('teraslice node version: ', e2eNodeVersion);
+
+    let e2eNodeVersion = await compose.runCmd('exec', undefined, 'teraslice-master', 'node', '--version');
+    signale.info('Teraslice node version: ', e2eNodeVersion);
+    const parsedVersion = semver.parse(e2eNodeVersion);
+    if (parsedVersion?.version) {
+        e2eNodeVersion = parsedVersion.version;
+    }
+    if (e2eNodeVersion !== NODE_VERSION) {
+        signale.error(`Expected node version(${NODE_VERSION}) does not match teraslice node version(${e2eNodeVersion})`);
+        process.exit(1);
+    }
 }
 
 function getElapsed(time) {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.69.0",
+    "version": "0.69.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -172,9 +172,9 @@ if (testElasticsearch) {
 
 export const SEARCH_TEST_HOST = testHost;
 
+export const defaultNodeVersion = '18.18.2';
 // This overrides the value in the Dockerfile
-// keep default in sync with NODE_VERSION in Dockerfile and e2e/test/config.js
-export const NODE_VERSION = process.env.NODE_VERSION || '18.18.2';
+export const NODE_VERSION = process.env.NODE_VERSION || defaultNodeVersion;
 
 export const {
     TEST_PLATFORM = 'native',

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -173,6 +173,7 @@ if (testElasticsearch) {
 export const SEARCH_TEST_HOST = testHost;
 
 // This overrides the value in the Dockerfile
+// keep default in sync with NODE_VERSION in Dockerfile and e2e/test/config.js
 export const NODE_VERSION = process.env.NODE_VERSION || '18.18.2';
 
 export const {

--- a/packages/scripts/src/helpers/k8s-env/index.ts
+++ b/packages/scripts/src/helpers/k8s-env/index.ts
@@ -153,9 +153,7 @@ async function buildAndTagTerasliceImage(options:k8sEnvOptions) {
     }
 
     try {
-        signale.pending(`Tagging image ${runImage} as ${e2eImage}`);
         await dockerTag(runImage, e2eImage);
-        signale.success(`Image ${runImage} re-tagged as ${e2eImage}`);
     } catch (err) {
         throw new Error(`Failed to tag docker image ${runImage} as ${e2eImage}: ${err}`);
     }

--- a/packages/scripts/src/helpers/misc.ts
+++ b/packages/scripts/src/helpers/misc.ts
@@ -129,7 +129,7 @@ export function getServicesForSuite(suite: string): Service[] {
 }
 
 export function getDevDockerImage(nodeVersion?: string): string {
-    if (DEV_DOCKER_IMAGE) return DEV_DOCKER_IMAGE; // an override so shouldn't change
+    if (DEV_DOCKER_IMAGE) return `${DEV_DOCKER_IMAGE}-nodev${nodeVersion}`;
 
     const rootInfo = getRootInfo();
     const [registry] = rootInfo.terascope.docker.registries;

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -200,11 +200,12 @@ export async function dockerStop(name: string): Promise<void> {
 }
 
 export async function dockerTag(from: string, to: string): Promise<void> {
-    logger.debug(`dockerTag: ${from} -> ${to}`);
+    signale.pending(`Tagging image ${from} as ${to}`);
     await exec({
         cmd: 'docker',
         args: ['tag', from, to],
     });
+    signale.success(`Image ${from} re-tagged as ${to}`);
 }
 
 export async function getContainerInfo(name: string): Promise<any> {

--- a/packages/scripts/src/helpers/test-runner/utils.ts
+++ b/packages/scripts/src/helpers/test-runner/utils.ts
@@ -67,7 +67,8 @@ export function getEnv(options: TestOptions, suite?: string): ExecEnv {
         NODE_ENV: 'test',
         FORCE_COLOR: config.FORCE_COLOR,
         TEST_NAMESPACE: config.TEST_NAMESPACE,
-        TZ: 'utc'
+        TZ: 'utc',
+        NODE_VERSION: options.nodeVersion
     };
 
     if (config.DOCKER_NETWORK_NAME) {


### PR DESCRIPTION
This PR makes the following changes:
- Updates `getDevDockerImage()` to add node suffix to the image tag passed in by spaces. This allows the right image to be used in e2e tests. The suffix will be removed in the publish stage of spaces, where it is not needed.
- Add a check in e2e tests to ensure the teraslice node version matches the desired version.