### PR TITLE
Resolution change ts cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "resolutions": {
         "@types/lodash": "^4.14.202",
         "debug": "^4.3.4",
-        "isbinaryfile": "<5.0.1",
         "ms": "^2.1.3",
-        "yeoman-environment/isbinaryfile": "^4.0.10"
+        "yeoman-environment/isbinaryfile": "4.0.10",
+        "**/isbinaryfile": "<5.0.1"
     },
     "devDependencies": {
         "@swc/core": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "resolutions": {
         "@types/lodash": "^4.14.202",
         "debug": "^4.3.4",
+        "isbinaryfile": "<5.0.1",
         "ms": "^2.1.3",
-        "yeoman-environment/isbinaryfile": "^4.0.10",
-        "isbinaryfile": "<5.0.1"
+        "yeoman-environment/isbinaryfile": "^4.0.10"
     },
     "devDependencies": {
         "@swc/core": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "debug": "^4.3.4",
         "ms": "^2.1.3",
         "yeoman-environment/isbinaryfile": "^4.0.10",
-        "yeoman-environment/mem-fs-editor/isbinaryfile": "5.0.0"
+        "isbinaryfile": "<5.0.1"
     },
     "devDependencies": {
         "@swc/core": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "resolutions": {
         "@types/lodash": "^4.14.202",
         "debug": "^4.3.4",
+        "isbinaryfile": "<5.0.1",
         "ms": "^2.1.3",
-        "yeoman-environment/isbinaryfile": "4.0.10",
-        "**/isbinaryfile": "<5.0.1"
+        "yeoman-environment/isbinaryfile": "4.0.10"
     },
     "devDependencies": {
         "@swc/core": "^1.4.0",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -37,7 +37,7 @@
     },
     "resolutions": {
         "yeoman-environment/isbinaryfile": "^4.0.10",
-        "yeoman-environment/mem-fs-editor/isbinaryfile": "5.0.0"
+        "isbinaryfile": "<5.0.1"
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.8.7",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "0.61.3",
+    "version": "0.61.5",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -36,8 +36,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "resolutions": {
-        "yeoman-environment/isbinaryfile": "^4.0.10",
-        "isbinaryfile": "<5.0.1"
+        "isbinaryfile": "<5.0.1",
+        "yeoman-environment/isbinaryfile": "^4.0.10"
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.8.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8382,7 +8382,7 @@ isbinaryfile@4.0.10:
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.10.tgz#0c5b5e30c2557a2f06febd37b7322946aaee42b3"
   integrity sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==
 
-isbinaryfile@<5.0.1, isbinaryfile@^4.0.10, isbinaryfile@^5.0.0:
+isbinaryfile@5.0.0, isbinaryfile@<5.0.1, isbinaryfile@^4.0.10, isbinaryfile@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-5.0.0.tgz#034b7e54989dab8986598cbcea41f66663c65234"
   integrity sha512-UDdnyGvMajJUWCkib7Cei/dvyJrrvo4FIrsvSFWdPpXSUorzXrDJ0S+X5Q4ZlasfPjca4yqCNNsjbCeiy8FFeg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8377,15 +8377,15 @@ isarray@^2.0.5:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
   integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
-isbinaryfile@5.0.0, isbinaryfile@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-5.0.0.tgz#034b7e54989dab8986598cbcea41f66663c65234"
-  integrity sha512-UDdnyGvMajJUWCkib7Cei/dvyJrrvo4FIrsvSFWdPpXSUorzXrDJ0S+X5Q4ZlasfPjca4yqCNNsjbCeiy8FFeg==
-
-isbinaryfile@^4.0.10:
+isbinaryfile@4.0.10:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.10.tgz#0c5b5e30c2557a2f06febd37b7322946aaee42b3"
   integrity sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==
+
+isbinaryfile@<5.0.1, isbinaryfile@^4.0.10, isbinaryfile@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-5.0.0.tgz#034b7e54989dab8986598cbcea41f66663c65234"
+  integrity sha512-UDdnyGvMajJUWCkib7Cei/dvyJrrvo4FIrsvSFWdPpXSUorzXrDJ0S+X5Q4ZlasfPjca4yqCNNsjbCeiy8FFeg==
 
 isexe@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This will limit `isbinaryfile` to a version less than `5.0.1` across All dependency trees. The second resolution (`"yeoman-environment/isbinaryfile": "4.0.10"`) will ensure that major versions 4 and 5 are both present to meet the requirements of all packages.