### PR TITLE
Update default node versions to 18.19.1 and release Teraslice 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # NODE_VERSION is set by default in the config.ts, the following value will only
 # be used if you build images by default with docker build
-ARG NODE_VERSION=18.18.2
+ARG NODE_VERSION=18.19.1
 FROM terascope/node-base:${NODE_VERSION}
 
 ENV NODE_ENV production

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "0.93.0",
+    "version": "1.0.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.72.0",
+    "version": "0.72.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -173,7 +173,7 @@ if (testElasticsearch) {
 
 export const SEARCH_TEST_HOST = testHost;
 
-const defaultNodeVersion = '18.18.2';
+const defaultNodeVersion = '18.19.1';
 // This overrides the value in the Dockerfile
 export const NODE_VERSION = process.env.NODE_VERSION || defaultNodeVersion;
 

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "0.93.0",
+    "version": "1.0.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
Update default node version in `Dockerfile`and `config.ts` from `18.18.2` to `18.19.1`
Bump teraslice to `1.0.0`