### PR TITLE
Fix recovery-spec test to use only the autoloaded assets in the jobSpec

### DIFF
--- a/e2e/test/cases/data/recovery-spec.ts
+++ b/e2e/test/cases/data/recovery-spec.ts
@@ -47,9 +47,7 @@ describe('recovery', () => {
         }
         jobSpec.name = 'test recovery job';
 
-        const files = await fse.readdir(ASSETS_PATH);
-        jobSpec.assets = files.filter((asset) => asset.length === 40);
-
+        jobSpec.assets = await terasliceHarness.getBaseAssetIds();
         specIndex = terasliceHarness.newSpecIndex('test-recovery-job');
 
         if (!jobSpec.operations) {

--- a/e2e/test/download-assets.ts
+++ b/e2e/test/download-assets.ts
@@ -24,7 +24,7 @@ const nodeVersion = getNodeVersion();
 const leaveZipped = true;
 const disableLogging = true;
 
-const bundles = [
+export const defaultAssetBundles = [
     {
         repo: 'elasticsearch-assets',
         name: 'elasticsearch'
@@ -134,7 +134,7 @@ function logAssets() {
  * @todo change this to not download both the bundled and non-bundled versions
 */
 export async function downloadAssets() {
-    await Promise.all(bundles.map(({ repo }) => downloadRelease(
+    await Promise.all(defaultAssetBundles.map(({ repo }) => downloadRelease(
         'terascope',
         repo,
         AUTOLOAD_PATH,


### PR DESCRIPTION
This PR makes the following changes:
- export the array of e2e autoloaded assets
- Use the array of autoloaded assets in `TerasliceHarness.getBaseAssetIds()` to get the IDs of autoloaded assets
- Use `TerasliceHarness.getBaseAssetIds()` in `recovery-spec` to set the `jobSpec.assets` array to only the autoloaded assets.

These changes prevent the `recovery-spec` from trying to use assets placed in the `teraslice.assets_directory` by other tests running in parallel, that have not finished uploading to ES.
Ref: #3567 