### PR TITLE
fix error if job finishes before status check

### DIFF
--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -125,7 +125,7 @@ export default class Jobs {
             const { status } = this.getJobIdentifiers(job);
 
             if (this.terminalStatuses.includes(status)) {
-                this.logUpdate({ action: 'adjustWorkersTerminal', job });
+                this.logUpdate({ action: 'adjust_workers_terminal', job });
                 return;
             }
 
@@ -147,7 +147,7 @@ export default class Jobs {
             const { status } = this.getJobIdentifiers(job);
 
             if (status !== Teraslice.ExecutionStatusEnum.failed) {
-                this.logUpdate({ action: 'recoverNotFailed', job });
+                this.logUpdate({ action: 'recover_not_failed', job });
                 continue;
             }
 
@@ -184,7 +184,7 @@ export default class Jobs {
                 if (rows.length > 0) {
                     await display.display(header, rows, format, active, parse);
                 } else {
-                    this.logUpdate({ action: 'checkForErrors', job });
+                    this.logUpdate({ action: 'check_for_errors', job });
                 }
             } catch (e) {
                 this.commandFailed(e.message, job);
@@ -298,7 +298,7 @@ export default class Jobs {
                 this.commandFailed(e.message, job);
             }
 
-            await this.verifyJobRunning(job);
+            await this.verifyJobRunningOrCompleted(job);
             return;
         }
 
@@ -351,10 +351,10 @@ export default class Jobs {
         return batches;
     }
 
-    private async verifyJobRunning(job: JobMetadata) {
+    private async verifyJobRunningOrCompleted(job: JobMetadata) {
         const statusUpdate = await this.waitStatusChange(
             job,
-            statusEnum.running
+            [statusEnum.running, statusEnum.completed]
         );
 
         const newStatus = statusUpdate.newStatus! as Teraslice.ExecutionStatus;
@@ -370,12 +370,17 @@ export default class Jobs {
             this.logUpdate({ action: 'running', job });
             return;
         }
+
+        if (newStatus === statusEnum.completed) {
+            this.logUpdate({ action: 'quick_completed', job });
+            return;
+        }
     }
 
     private async watchJob(job: JobMetadata) {
         const { timeout, interval, watch: slices } = this.config.args;
 
-        this.logUpdate({ action: 'startWatching', job });
+        this.logUpdate({ action: 'start_watching', job });
 
         const startCheck = new Date().getTime();
         let slicesCompleted = 0;
@@ -714,16 +719,20 @@ export default class Jobs {
                 message: `status: ${status}`,
                 final: true
             },
-            adjustWorkersTerminal: {
+            adjust_workers_terminal: {
                 message: `Cannot adjust workers. Job in terminal status ${status}`,
                 final: true
             },
-            recoverNotFailed: {
+            recover_not_failed: {
                 message: `Status is not failed, but ${status}. No need to recover`,
                 final: true
             },
-            checkForErrors: {
+            check_for_errors: {
                 message: 'No Errors',
+                final: true
+            },
+            quick_completed: {
+                message: 'Job has already completed',
                 final: true
             },
             resuming: {
@@ -734,7 +743,7 @@ export default class Jobs {
                 message: `${display.setAction('start', 'present')} ${name}, ${id}`,
                 final: false
             },
-            startWatching: {
+            start_watching: {
                 message: `Watching for ${name}, ${id}, for ${this.config.args.watch} slices`,
                 final: false
             },
@@ -755,11 +764,11 @@ export default class Jobs {
                 final: this.finalAction(action)
             },
             cannot_pause: {
-                message: `Job status is ${status}, cannot pause`,
+                message: `Job is in terminal status ${status}, cannot pause`,
                 final: true,
             },
             cannot_stop: {
-                message: `Job status is ${status}, cannot stop`,
+                message: `No need to stop, job is already in terminal status ${status}`,
                 final: this.finalAction(action)
             }
         };

--- a/packages/teraslice-cli/test/helpers/jobs-spec.ts
+++ b/packages/teraslice-cli/test/helpers/jobs-spec.ts
@@ -439,7 +439,7 @@ describe('Job helper class', () => {
 
             expect(job.jobs[0].status).toBe('stopped');
 
-            await expect(job.start()).rejects.toThrow('Job cannot reach the target status, "running", because it is in the terminal state, "failed"');
+            await expect(job.start()).rejects.toThrow('Job cannot reach the target status, "running,completed", because it is in the terminal state, "failed"');
         });
 
         it('should check workers and slice failures if watch flag is provided', async () => {


### PR DESCRIPTION
* no longer errors if job finishes before status check
* updated language for job that doesn't have a stopped status on restarting
* minor consistency fixes in message properties