### PR TITLE
Asset storage connection validation bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.58.1",
+    "version": "0.58.2",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/terafoundation/src/schema.ts
+++ b/packages/terafoundation/src/schema.ts
@@ -100,9 +100,9 @@ export function foundationSchema(sysconfig: SysConfig<any>): convict.Schema<any>
                 /// Check to make sure the asset_storage_connection exists inside the connector
                 /// Exclude elasticsearch as this connection type does not utilize this value
                 if (
-                    !connectionsPresent.includes(connectionName) &&
-                    !connectionType.includes('elasticsearch-next')
-                    ) {
+                    !connectionsPresent.includes(connectionName)
+                    && !connectionType.includes('elasticsearch-next')
+                ) {
                     throw new Error(`${connectionName} not found in terafoundation.connectors.${connectionType}`);
                 }
             }

--- a/packages/terafoundation/src/schema.ts
+++ b/packages/terafoundation/src/schema.ts
@@ -75,7 +75,7 @@ export function foundationSchema(sysconfig: SysConfig<any>): convict.Schema<any>
             doc: 'Name of the connection type used to store assets',
             default: DEFAULT_ASSET_STORAGE_CONNECTION_TYPE,
             format(connectionTypeName: any): void {
-                const validConnectionTypes = ['elasticsearch-next', 'elasticsearch', 's3'];
+                const validConnectionTypes = ['elasticsearch-next', 's3'];
                 const connectionTypesPresent = Object.keys(sysconfig.terafoundation.connectors);
                 if (!connectionTypesPresent.includes(connectionTypeName)) {
                     throw new Error('asset_storage_connection_type not found in terafoundation.connectors');

--- a/packages/terafoundation/src/schema.ts
+++ b/packages/terafoundation/src/schema.ts
@@ -89,7 +89,7 @@ export function foundationSchema(sysconfig: SysConfig<any>): convict.Schema<any>
             doc: 'Name of the connection used to store assets.',
             default: 'default',
             format(connectionName: any): void {
-                let connectionType;
+                let connectionType: string;
                 if (sysconfig.terafoundation.asset_storage_connection_type) {
                     connectionType = sysconfig.terafoundation.asset_storage_connection_type;
                 } else {
@@ -97,7 +97,12 @@ export function foundationSchema(sysconfig: SysConfig<any>): convict.Schema<any>
                 }
 
                 const connectionsPresent = Object.keys(sysconfig.terafoundation.connectors[`${connectionType}`]);
-                if (!connectionsPresent.includes(connectionName)) {
+                /// Check to make sure the asset_storage_connection exists inside the connector
+                /// Exclude elasticsearch as this connection type does not utilize this value
+                if (
+                    !connectionsPresent.includes(connectionName) &&
+                    !connectionType.includes('elasticsearch-next')
+                    ) {
                     throw new Error(`${connectionName} not found in terafoundation.connectors.${connectionType}`);
                 }
             }

--- a/packages/terafoundation/test/validate-configs-spec.ts
+++ b/packages/terafoundation/test/validate-configs-spec.ts
@@ -389,4 +389,51 @@ describe('Validate Configs', () => {
                 .toThrow('Error validating configuration, caused by Error: asset_storage_connection_type: Invalid asset_storage_connection_type. Valid types: elasticsearch-next,elasticsearch,s3: value was "kafka"');
         });
     });
+
+    describe('when given a config with an elasticsearch with no default connection', () => {
+        const configFile = {
+            terafoundation: {
+                connectors: {
+                    'elasticsearch-next': {
+                        'not-default': {}
+                    }
+                }
+            },
+            other: {}
+        };
+        const cluster = {
+            isMaster: true,
+        };
+        const config = {
+            config_schema() {
+                return {};
+            }
+        };
+
+        const validedConfig = validateConfigs(cluster as any, config as any, configFile as any);
+        it('should return valid config', () => {
+            expect(validedConfig).toMatchObject({
+                terafoundation: {
+                    environment: 'test',
+                    logging: [ 'console' ],
+                    log_level: 'info',
+                    workers: 10,
+                    asset_storage_bucket: undefined,
+                    connectors: {
+                        'elasticsearch-next': {
+                            'not-default': {
+                                node: [ 'http://127.0.0.1:9200' ],
+                                sniffOnStart: false,
+                                sniffOnConnectionFault: false,
+                                requestTimeout: 120000,
+                                maxRetries: 3
+                            }
+                        }
+                    },
+                },
+                other: {},
+                _nodeName: os.hostname()
+            });
+        });
+    });
 });

--- a/packages/terafoundation/test/validate-configs-spec.ts
+++ b/packages/terafoundation/test/validate-configs-spec.ts
@@ -386,7 +386,7 @@ describe('Validate Configs', () => {
 
         it('should throw an error', () => {
             expect(() => validateConfigs(cluster as any, config as any, configFile as any))
-                .toThrow('Error validating configuration, caused by Error: asset_storage_connection_type: Invalid asset_storage_connection_type. Valid types: elasticsearch-next,elasticsearch,s3: value was "kafka"');
+                .toThrow('Error validating configuration, caused by Error: asset_storage_connection_type: Invalid asset_storage_connection_type. Valid types: elasticsearch-next,s3: value was "kafka"');
         });
     });
 

--- a/packages/terafoundation/test/validate-configs-spec.ts
+++ b/packages/terafoundation/test/validate-configs-spec.ts
@@ -415,14 +415,14 @@ describe('Validate Configs', () => {
             expect(validedConfig).toMatchObject({
                 terafoundation: {
                     environment: 'test',
-                    logging: [ 'console' ],
+                    logging: ['console'],
                     log_level: 'info',
                     workers: 10,
                     asset_storage_bucket: undefined,
                     connectors: {
                         'elasticsearch-next': {
                             'not-default': {
-                                node: [ 'http://127.0.0.1:9200' ],
+                                node: ['http://127.0.0.1:9200'],
                                 sniffOnStart: false,
                                 sniffOnConnectionFault: false,
                                 requestTimeout: 120000,

--- a/packages/terafoundation/test/validate-configs-spec.ts
+++ b/packages/terafoundation/test/validate-configs-spec.ts
@@ -410,9 +410,9 @@ describe('Validate Configs', () => {
             }
         };
 
-        const validedConfig = validateConfigs(cluster as any, config as any, configFile as any);
+        const validatedConfig = validateConfigs(cluster as any, config as any, configFile as any);
         it('should return valid config', () => {
-            expect(validedConfig).toMatchObject({
+            expect(validatedConfig).toMatchObject({
                 terafoundation: {
                     environment: 'test',
                     logging: ['console'],

--- a/packages/terafoundation/test/validate-configs-spec.ts
+++ b/packages/terafoundation/test/validate-configs-spec.ts
@@ -417,7 +417,6 @@ describe('Validate Configs', () => {
                     environment: 'test',
                     logging: ['console'],
                     log_level: 'info',
-                    workers: 10,
                     asset_storage_bucket: undefined,
                     connectors: {
                         'elasticsearch-next': {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -64,7 +64,7 @@
         "semver": "^7.6.0",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.58.1",
+        "terafoundation": "^0.58.2",
         "uuid": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
This PR makes the following changes:

- Fixes issue where `terafoundation` validation fails if `elasticsearch-next` is the connection_type without a default connection
- Added test that checks said scenario 
- Removed `elasticsearch`  from the list of valid asset storage connection types


Ref to issue #3578