### PR TITLE
remove old elasticsearch from more places

### DIFF
--- a/config/docker-teraslice-master.yml
+++ b/config/docker-teraslice-master.yml
@@ -2,10 +2,6 @@ terafoundation:
     environment: 'development'
     log_level: info
     connectors:
-        elasticsearch:
-            default:
-                host:
-                    - "elasticsearch:9200"
         elasticsearch-next:
             default:
                 node:

--- a/config/docker-teraslice-worker.yml
+++ b/config/docker-teraslice-worker.yml
@@ -2,10 +2,6 @@ terafoundation:
     environment: 'development'
     log_level: info
     connectors:
-        elasticsearch:
-            default:
-                host:
-                    - "elasticsearch:9200"
         elasticsearch-next:
             default:
                 node:

--- a/docs/configuration/clustering-k8s.md
+++ b/docs/configuration/clustering-k8s.md
@@ -28,7 +28,7 @@ Teraslice master and worker nodes.  In the case of minikube based deployments
 IP address of that interface is what you need to set as:
 
 ```yaml
-terafoundation.connectors.elasticsearch.default.host
+terafoundation.connectors.elasticsearch_next.default.node
 ```
 
 in both the `teraslice-master` and `teraslice-worker` ConfigMaps.

--- a/docs/configuration/clustering-native.md
+++ b/docs/configuration/clustering-native.md
@@ -24,10 +24,6 @@ terafoundation:
     log_path: '/path/to/logs'
 
     connectors:
-        elasticsearch:
-            default:
-                host:
-                    - YOUR_ELASTICSEARCH_IP:9200
         elasticsearch-next:
             default:
                 node:
@@ -49,10 +45,6 @@ terafoundation:
     log_path: '/path/to/logs'
 
     connectors:
-        elasticsearch:
-            default:
-                host:
-                    - YOUR_ELASTICSEARCH_IP:9200
         elasticsearch-next:
             default:
                 node:

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -16,10 +16,6 @@ The configuration file is provided to the Teraslice process at startup using the
 terafoundation:
     log_level: info
     connectors:
-        elasticsearch:
-            default:
-                host:
-                    - localhost:9200
         elasticsearch-next:
             default:
                 node:
@@ -40,7 +36,7 @@ teraslice:
 | :-------------: | :--------: | :-------------: | :-----------------------------------------------------------------------------------: |
 | **asset_storage_bucket** |  `String` | `ts-assets-<teraslice.name>` |       Name of S3 bucket if using S3 external asset storage.        |
 | **asset_storage_connection** |  `String`  | `"default"` |       Name of the connection of `asset_storage_connection_type` where asset bundles will be stored.        |
-| **asset_storage_connection_type** |  `String`  | `"elasticsearch-next"` |       Name of the connection type that will store asset bundles. options: `elasticsearch-next`, `elasticsearch`, `s3`.        |
+| **asset_storage_connection_type** |  `String`  | `"elasticsearch-next"` |       Name of the connection type that will store asset bundles. options: `elasticsearch-next`, `s3`.        |
 | **connectors** |  `Object`  | none |       Required. An object whose keys are connection types and values are objects describing each connection of that type. See [Terafoundation Connectors](#terafoundation-connectors).        |
 | **environment** |  `String`  | `"development"` |       If set to `development` console logging will automatically be turned on.        |
 |  **log_level**  |  `String`  |    `"info"`     |                                Default logging levels                                 |
@@ -108,18 +104,6 @@ For Example
 terafoundation:
     # ...
     connectors:
-        elasticsearch:
-            default:
-                host:
-                    - '127.0.0.1:9200'
-                keepAlive: false
-                maxRetries: 5
-                maxSockets: 20
-            secondary:
-                host:
-                    - 'some-other-ip:9200'
-                apiVersion: '6.5'
-                maxRetries: 0
         elasticsearch-next:
             default:
                 node:
@@ -130,11 +114,11 @@ terafoundation:
 # ...
 ```
 
-In this example we specify three different connector types: `elasticsearch`, `elasticsearch-next` and `kafka`. Under each connector type you may then create custom endpoint configurations that will be validated against the defaults specified in node_modules/terafoundation/lib/connectors. In the elasticsearch example there is the `default` endpoint and the `secondary` endpoint which connects to a different elasticsearch cluster. Each endpoint has independent configuration options.
+In this example we specify two different connector types: `elasticsearch-next` and `kafka`. Under each connector type you may then create custom endpoint configurations that will be validated against the defaults specified in node_modules/terafoundation/lib/connectors. Each endpoint has independent configuration options.
 
 These different endpoints can be retrieved through terafoundations's connector API. As it's name implies, the `default` connector is what will be provided if a connection is requested without providing a specific name. In general we don't recommend doing that if you have multiple clusters, but it's convenient if you only have one.
 
-The difference between `elasticsearch` and `elasticsearch-next` is that the former relies on a legacy client that works on version 6 and 7.9 or lower, while the later dynamically queries the cluster to verify the version and distribution and returns the appropriate client. It can work with versions 6, 7, 8 and with opensearch.
+The `elasticsearch-next` connector dynamically queries the cluster to verify the version and distribution and returns the appropriate client. It can work with versions 6, 7, 8 and with opensearch.
 
 ## Configuration Single Node / Native Clustering - Cluster Master
 
@@ -153,10 +137,6 @@ terafoundation:
     log_path: '/path/to/logs'
 
     connectors:
-        elasticsearch:
-            default:
-                host:
-                    - YOUR_ELASTICSEARCH_IP:9200
         elasticsearch-next:
             default:
                 node:
@@ -178,10 +158,6 @@ terafoundation:
     log_path: '/path/to/logs'
 
     connectors:
-        elasticsearch:
-            default:
-                host:
-                    - YOUR_ELASTICSEARCH_IP:9200
         elasticsearch-next:
             default:
                 node:
@@ -204,10 +180,6 @@ terafoundation:
     asset_storage_bucket: ts-assets
     log_level: info
     connectors:
-        elasticsearch:
-            default:
-                host:
-                    - localhost:9200
         elasticsearch-next:
             default:
                 node:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,10 +34,6 @@ Create a configuration file called `config.yaml`:
 ```yaml
 terafoundation:
     connectors:
-        elasticsearch:
-            default:
-                host:
-                    - localhost:9200
         elasticsearch-next:
             default:
                 node:

--- a/docs/packages/terafoundation/overview.md
+++ b/docs/packages/terafoundation/overview.md
@@ -202,23 +202,19 @@ terafoundation:
   - console: info
   - elasticsearch: info
   connectors:
-    elasticsearch:
+    elasticsearch-next:
       default:
-        host:
-        - 127.0.0.1:9200
+        node:
+        - YOUR_ELASTICSEARCH_IP:9200
         keepAlive: true
         maxRetries: 5
         maxSockets: 20
       endpoint2:
-         host:
+         node:
          - 127.0.0.1:9215
          keepAlive: true
          maxRetries: 5
          maxSockets: 20
-    elasticsearch-next:
-      default:
-        node:
-          - YOUR_ELASTICSEARCH_IP:9200"
     mongo:
       default:
         host: 127.0.0.1
@@ -233,7 +229,7 @@ The values are once again objects with keys set to different endpoints within ea
 
 Each endpoint will have its own configuration which will then be used by the actual client of the library
 
-The difference between `elasticsearch` and `elasticsearch-next` is that the former relies on a legacy client that works on version 6 and 7.9.0 or lower, while the later dynamically queries the cluster to verify the version and distribution and returns the appropriate client. It can work with versions 6, 7, 8 and with opensearch.
+The `elasticsearch-next` connector dynamically queries the cluster to verify the version and distribution and returns the appropriate client. It can work with versions 6, 7, 8 and with opensearch.
 
 ### Configuration Settings
 

--- a/e2e/k8s/masterConfig/teraslice.yaml
+++ b/e2e/k8s/masterConfig/teraslice.yaml
@@ -2,10 +2,6 @@ terafoundation:
   environment: "development"
   log_level: debug
   connectors:
-    elasticsearch:
-      default:
-        host:
-          - "elasticsearch.services-dev1:9200"
     elasticsearch-next:
       default:
         node:

--- a/e2e/k8s/workerConfig/teraslice.yaml
+++ b/e2e/k8s/workerConfig/teraslice.yaml
@@ -2,10 +2,6 @@ terafoundation:
   environment: "development"
   log_level: debug
   connectors:
-    elasticsearch:
-      default:
-        host:
-          - "elasticsearch.services-dev1:9200"
     elasticsearch-next:
       default:
         node:

--- a/examples/config/teraslice-master-k8s.yaml
+++ b/examples/config/teraslice-master-k8s.yaml
@@ -5,10 +5,6 @@ terafoundation:
         # ***********************
         # Elastic Search Configuration
         # ***********************
-        elasticsearch:
-            default:
-                host:
-                    - "127.0.0.1:9200"
         elasticsearch-next:
             default:
                 node:

--- a/examples/config/teraslice-master.yaml
+++ b/examples/config/teraslice-master.yaml
@@ -5,10 +5,6 @@ terafoundation:
         # ***********************
         # Elastic Search Configuration
         # ***********************
-        elasticsearch:
-            default:
-                host:
-                    - "127.0.0.1:9200"
         elasticsearch-next:
             default:
                 node:

--- a/examples/config/teraslice-worker.yaml
+++ b/examples/config/teraslice-worker.yaml
@@ -5,10 +5,6 @@ terafoundation:
         # ***********************
         # Elastic Search Configuration
         # ***********************
-        elasticsearch:
-            default:
-                host:
-                    - "127.0.0.1:9200"
         elasticsearch-next:
             default:
                 node:

--- a/examples/es-to-s3/config/docker-teraslice-master.yml
+++ b/examples/es-to-s3/config/docker-teraslice-master.yml
@@ -2,10 +2,6 @@ terafoundation:
     environment: 'development'
     log_level: info
     connectors:
-        elasticsearch:
-            default:
-                host:
-                    - "elasticsearch:9200"
         elasticsearch-next:
             default:
                 node:

--- a/examples/es-to-s3/config/docker-teraslice-worker.yml
+++ b/examples/es-to-s3/config/docker-teraslice-worker.yml
@@ -2,10 +2,6 @@ terafoundation:
     environment: 'development'
     log_level: info
     connectors:
-        elasticsearch:
-            default:
-                host:
-                    - "elasticsearch:9200"
         elasticsearch-next:
             default:
                 node:

--- a/examples/k8s/Makefile
+++ b/examples/k8s/Makefile
@@ -160,7 +160,7 @@ else
 	# FIXME: Figure out where to clean this up
 	# Note that the ES Port Here is 30200 because that is the port the service
 	# NodePort gets exposed on
-	yq eval ".terafoundation.connectors.elasticsearch.default.host[0] = \"$(shell minikube ip):30200\"" teraslice-master.yaml.tpl | yq eval ".teraslice.kubernetes_image = \"$(TERASLICE_K8S_IMAGE)\"" - | yq eval ".teraslice.assets_directory = \"/tmp/assets\"" - > teraslice-master-local.yaml
+	yq eval ".terafoundation.connectors.elasticsearch_next.default.node[0] = \"$(shell minikube ip):30200\"" teraslice-master.yaml.tpl | yq eval ".teraslice.kubernetes_image = \"$(TERASLICE_K8S_IMAGE)\"" - | yq eval ".teraslice.assets_directory = \"/tmp/assets\"" - > teraslice-master-local.yaml
 endif
 
 build: ## builds docker images

--- a/examples/k8s/teraslice-master.yaml
+++ b/examples/k8s/teraslice-master.yaml
@@ -1,10 +1,6 @@
 terafoundation:
     environment: 'development'
     connectors:
-        elasticsearch:
-            default:
-                host:
-                    - "<ELASTICSEARCH_HOST>:<ELASTICSEARCH_PORT>"
         elasticsearch-next:
             default:
                 node:

--- a/examples/k8s/teraslice-master.yaml.tpl
+++ b/examples/k8s/teraslice-master.yaml.tpl
@@ -2,11 +2,6 @@ terafoundation:
     environment: 'development'
     log_level: debug
     connectors:
-        elasticsearch:
-            default:
-                apiVersion: "5.6"
-                host:
-                    - "elasticsearch:9200"
         elasticsearch-next:
             default:
                 node:

--- a/examples/k8s/teraslice-worker.yaml
+++ b/examples/k8s/teraslice-worker.yaml
@@ -1,10 +1,6 @@
 terafoundation:
     environment: 'development'
     connectors:
-        elasticsearch:
-            default:
-                host:
-                    - "<ELASTICSEARCH_HOST>:<ELASTICSEARCH_PORT>"
         elasticsearch-next:
             default:
                 node:

--- a/examples/k8s/teraslice-worker.yaml.tpl
+++ b/examples/k8s/teraslice-worker.yaml.tpl
@@ -2,11 +2,6 @@ terafoundation:
     environment: 'development'
     log_level: debug
     connectors:
-        elasticsearch:
-            default:
-                apiVersion: "5.6"
-                host:
-                    - "elasticsearch:9200"
         elasticsearch-next:
             default:
                 node:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.70.0",
+    "version": "0.71.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/job-components/src/test-helpers.ts
+++ b/packages/job-components/src/test-helpers.ts
@@ -186,9 +186,6 @@ export class TestContext implements i.Context {
         const sysconfig: i.SysConfig = {
             terafoundation: {
                 connectors: {
-                    elasticsearch: {
-                        default: {},
-                    },
                     'elasticsearch-next': {
                         default: {}
                     },

--- a/packages/job-components/test/register-apis-spec.ts
+++ b/packages/job-components/test/register-apis-spec.ts
@@ -75,16 +75,6 @@ describe('registerApis', () => {
 
         const clients: TestClientConfig[] = [
             {
-                type: 'elasticsearch',
-                create() {
-                    return {
-                        client: {
-                            elasticsearch: true,
-                        },
-                    };
-                },
-            },
-            {
                 type: 'elasticsearch-next',
                 create() {
                     return {
@@ -95,24 +85,24 @@ describe('registerApis', () => {
                 },
             },
             {
-                type: 'elasticsearch',
+                type: 'elasticsearch-next',
                 endpoint: 'otherConnection',
                 create() {
                     return {
                         client: {
-                            elasticsearch: true,
+                            'elasticsearch-next': true,
                             endpoint: 'otherConnection',
                         },
                     };
                 },
             },
             {
-                type: 'elasticsearch',
+                type: 'elasticsearch-next',
                 endpoint: 'thirdConnection',
                 create() {
                     return {
                         client: {
-                            elasticsearch: true,
+                            'elasticsearch-next': true,
                             endpoint: 'thirdConnection',
                         },
                     };
@@ -144,8 +134,8 @@ describe('registerApis', () => {
         context.apis.setTestClients(clients);
 
         it('getClient should return a client', () => {
-            expect(getClient({}, 'elasticsearch')).toEqual({
-                elasticsearch: true,
+            expect(getClient({}, 'elasticsearch-next')).toEqual({
+                'elasticsearch-next': true,
             });
 
             const firstResult = getClient(
@@ -153,11 +143,11 @@ describe('registerApis', () => {
                     connection: 'otherConnection',
                     connection_cache: true,
                 },
-                'elasticsearch'
+                'elasticsearch-next'
             );
 
             expect(firstResult).toEqual({
-                elasticsearch: true,
+                'elasticsearch-next': true,
                 endpoint: 'otherConnection',
             });
 
@@ -167,7 +157,7 @@ describe('registerApis', () => {
                         connection: 'otherConnection',
                         connection_cache: true,
                     },
-                    'elasticsearch'
+                    'elasticsearch-next'
                 )
             ).toBe(firstResult);
 
@@ -177,10 +167,10 @@ describe('registerApis', () => {
                         connection: 'thirdConnection',
                         connection_cache: false,
                     },
-                    'elasticsearch'
+                    'elasticsearch-next'
                 )
             ).toEqual({
-                elasticsearch: true,
+                'elasticsearch-next': true,
                 endpoint: 'thirdConnection',
             });
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.75.0",
+    "version": "0.75.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/cmds/k8s-env.ts
+++ b/packages/scripts/src/cmds/k8s-env.ts
@@ -86,7 +86,7 @@ const cmd: CommandModule = {
                 description: 'Choose what backend service assets are stored in.',
                 type: 'string',
                 default: 'elasticsearch-next',
-                choices: ['elasticsearch-next', 'elasticsearch', 's3'],
+                choices: ['elasticsearch-next', 's3'],
             })
             .check((args) => {
                 if (args['asset-storage'] === 's3' && process.env.TEST_MINIO !== 'true') {

--- a/packages/scripts/src/helpers/k8s-env/k8s.ts
+++ b/packages/scripts/src/helpers/k8s-env/k8s.ts
@@ -3,11 +3,7 @@ import fs from 'fs';
 import ms from 'ms';
 import path from 'path';
 import execa from 'execa';
-import {
-    AnyObject,
-    debugLogger, pDelay,
-    // pDelay,
-} from '@terascope/utils';
+import { AnyObject, debugLogger, pDelay } from '@terascope/utils';
 import { getE2eK8sDir } from '../../helpers/packages';
 import { K8sEnvOptions } from './interfaces';
 import signale from '../signale';

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.70.0"
+        "@terascope/job-components": "^0.71.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.70.0"
+        "@terascope/job-components": ">=0.71.0"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^11.2.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.70.0"
+        "@terascope/job-components": "^0.71.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.70.0"
+        "@terascope/job-components": ">=0.71.0"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -39,7 +39,7 @@
     },
     "dependencies": {
         "@terascope/elasticsearch-api": "^3.18.0",
-        "@terascope/job-components": "^0.70.0",
+        "@terascope/job-components": "^0.71.0",
         "@terascope/teraslice-messaging": "^0.40.0",
         "@terascope/types": "^0.15.0",
         "@terascope/utils": "^0.57.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/config/default-sysconfig.ts
+++ b/packages/teraslice/src/lib/config/default-sysconfig.ts
@@ -1,10 +1,5 @@
 function getConnectors() {
     const connectors: Record<string, Record<string, any>> = {
-        elasticsearch: {
-            default: {
-                host: ['localhost:9200']
-            }
-        },
         'elasticsearch-next': {
             default: {
                 node: ['localhost:9200']


### PR DESCRIPTION
Had a weird issue updating another PR w/master before merging where e2e tests failed that hadn't on the PR that changed  it so wanted to fix it here but CI failed so decided to just fix it in the range coercion PR instead.  Ci was retried the next morning and worked for these changes.