### PR TITLE
Change s3 store to use terafoundation createClient

### DIFF
--- a/packages/teraslice/src/lib/storage/backends/s3_store.ts
+++ b/packages/teraslice/src/lib/storage/backends/s3_store.ts
@@ -5,14 +5,12 @@ import { Context, TerafoundationConfig } from '@terascope/job-components';
 import {
     S3ClientResponse,
     createS3Bucket,
-    createS3Client,
     deleteS3Object,
     doesBucketExist,
     getS3Object,
     listS3Objects,
     putS3Object,
     S3Client,
-    S3ClientConfig,
     s3RequestWithRetry
 } from '@terascope/file-asset-apis';
 import { makeLogger } from '../../workers/helpers/terafoundation.js';
@@ -53,7 +51,6 @@ export class S3Store {
     }
 
     async initialize() {
-
         const { client } = await this.context.apis.foundation
             .createClient({ type: 's3', cached: true, endpoint: this.connection });
 
@@ -61,7 +58,6 @@ export class S3Store {
 
         await pWhile(async () => {
             try {
-                const client = this.api;
                 const exists = await doesBucketExist(client, { Bucket: this.bucket });
                 if (!exists) {
                     await createS3Bucket(client, { Bucket: this.bucket });

--- a/packages/teraslice/src/lib/storage/backends/s3_store.ts
+++ b/packages/teraslice/src/lib/storage/backends/s3_store.ts
@@ -53,9 +53,11 @@ export class S3Store {
     }
 
     async initialize() {
-        this.api = await createS3Client(
-            this.terafoundation.connectors.s3[this.connection] as S3ClientConfig
-        );
+
+        const { client } = await this.context.apis.foundation
+            .createClient({ type: 's3', cached: true, endpoint: this.connection });
+
+        this.api = client;
 
         await pWhile(async () => {
             try {

--- a/packages/teraslice/test/services/assets-spec.ts
+++ b/packages/teraslice/test/services/assets-spec.ts
@@ -1,7 +1,9 @@
 import { TestContext, TestContextOptions } from '@terascope/job-components';
 import fs from 'fs';
 import got from 'got';
+import { Logger } from '@terascope/utils';
 import { createClient } from 'elasticsearch-store';
+import { createS3Client } from '@terascope/file-asset-apis';
 import { AssetsService } from '../../src/lib/cluster/services/assets';
 import { TEST_INDEX_PREFIX } from '../test.config';
 
@@ -12,6 +14,14 @@ describe('Assets Service', () => {
             {
                 type: 'elasticsearch-next',
                 createClient,
+                endpoint: 'default'
+            },
+            {
+                type: 's3',
+                createClient: async (customConfig: Record<string, any>, logger: Logger) => {
+                    const client = await createS3Client(customConfig, logger);
+                    return { client, logger };
+                },
                 endpoint: 'default'
             }
         ]

--- a/packages/teraslice/test/storage/assets_storage-spec.ts
+++ b/packages/teraslice/test/storage/assets_storage-spec.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import { TestContext, TestContextOptions } from '@terascope/job-components';
+import { Logger } from '@terascope/utils';
 import { createClient } from 'elasticsearch-store';
+import { createS3Client } from '@terascope/file-asset-apis';
 import { AssetsStorage } from '../../src/lib/storage';
 import { TEST_INDEX_PREFIX } from '../test.config';
 
@@ -12,6 +14,14 @@ describe('AssetsStorage using S3 backend', () => {
             {
                 type: 'elasticsearch-next',
                 createClient,
+                endpoint: 'default'
+            },
+            {
+                type: 's3',
+                createClient: async (customConfig: Record<string, any>, logger: Logger) => {
+                    const client = await createS3Client(customConfig, logger);
+                    return { client, logger };
+                },
                 endpoint: 'default'
             }
         ]


### PR DESCRIPTION
This PR refactors the s3 store backend in teraslice to use the proper terafoundation `createClient` function instead of using the `createClient` directly from `file-assets-apis`.