### PR TITLE
add bypass option to skip validation for _inactive jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -112,8 +112,19 @@ export class JobsService {
         return this.updateJob(jobId, job);
     }
 
+    /**
+     * Update a job
+     *
+     * @param {string} jobId
+     * @param {Partial<jobRecord>} jobSpec
+     * @returns {Promise<JobRecord>}
+     */
     async updateJob(jobId: string, jobSpec: Partial<JobRecord>) {
-        await this._validateJobSpec(jobSpec);
+        // If job is inactive job validation is skipped
+        // This allows for old jobs that are missing required resources to be marked inactive
+        if (jobSpec.active === true) {
+            await this._validateJobSpec(jobSpec);
+        }
 
         const originalJob = await this.jobsStorage.get(jobId);
 

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -120,13 +120,15 @@ export class JobsService {
      * @returns {Promise<JobRecord>}
      */
     async updateJob(jobId: string, jobSpec: Partial<JobRecord>) {
-        // If job is inactive job validation is skipped
+        const originalJob = await this.jobsStorage.get(jobId);
+
+        // If job is switching from active to inactive job validation is skipped
         // This allows for old jobs that are missing required resources to be marked inactive
-        if (jobSpec.active === true) {
+        if (originalJob.active !== false && jobSpec.active === false) {
+            this.logger.info(`Skipping job validation to set jobId ${jobId} as _inactive`);
+        } else {
             await this._validateJobSpec(jobSpec);
         }
-
-        const originalJob = await this.jobsStorage.get(jobId);
 
         return this.jobsStorage.update(jobId, Object.assign({}, jobSpec, {
             _created: originalJob._created


### PR DESCRIPTION
This PR makes the following changes:
- When marking a job as `_inactive` using the JSON API, job validation will be skipped. An old job may not have the needed connectors, assets, etc to pass validation, but we still want to be able to mark it as inactive.
- This will only skip validation when switching active from true or undefined to false.
- Bump teraslice from **1.2.0** to **1.2.1**

Ref: #3471