### PR TITLE
Release Teraslice v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:

- Updates base image that updates `terafoundation_kafka_connector` from `0.11.1` to `0.12.0` and `node-rdkafka` to `3.0.1`
- Bump **teraslice** from `v1.2.1` to `v1.3.0`