### PR TITLE
Add proper label functionality to mockPromMetrics

### DIFF
--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.72.0",
+    "version": "0.73.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/job-components/src/test-helpers.ts
+++ b/packages/job-components/src/test-helpers.ts
@@ -113,18 +113,16 @@ export interface TestContextAPIs extends i.ContextAPIs {
 }
 
 export type MockPromMetrics = Record<string, {
-    readonly name?: string,
-    readonly help?: string,
-    readonly labelNames?: Array<string>,
+    readonly name: string,
+    readonly help: string,
+    readonly labelNames: Array<string>,
     readonly buckets?: Array<number>,
     readonly percentiles?: Array<number>,
     readonly ageBuckets?: number,
     readonly maxAgeSeconds?: number
-    readonly metric?: 'Gauge' | 'Counter' | 'Histogram' | 'Summary',
-    readonly functions?: Set<string>,
-    value?: number;
-    summary?: { count: number, sum: number};
-    histogram?: { count: number, sum: number};
+    readonly metric: 'Gauge' | 'Counter' | 'Histogram' | 'Summary',
+    readonly functions: Set<string>,
+    labels: Record<string, { sum: number, count: number, value: number}>
 }>;
 
 type GetKeyOpts = {
@@ -163,9 +161,18 @@ function isPromise(p: any): boolean {
     return false;
 }
 
+function getLabelKey(labels: Record<string, string>): string {
+    let key = '';
+    for (const entry of Object.entries(labels).sort()) {
+        key += `${entry[0]}:${entry[1]},`;
+    }
+    return key;
+}
+
 export interface TestContextOptions {
     assignment?: i.Assignment;
     clients?: TestClientConfig[];
+    cluster_manager_type?: i.ClusterManagerType;
 }
 
 const _cachedClients = new WeakMap<TestContext, CachedClients>();
@@ -216,7 +223,7 @@ export class TestContext implements i.Context {
                 action_timeout: 10000,
                 analytics_rate: 10000,
                 assets_directory: path.join(process.cwd(), 'assets'),
-                cluster_manager_type: 'native',
+                cluster_manager_type: options.cluster_manager_type || 'native',
                 hostname: 'localhost',
                 index_rollover_frequency: {
                     analytics: 'yearly',
@@ -342,27 +349,47 @@ export class TestContext implements i.Context {
                         logger.warn('Cannot create PromMetricsAPI because metrics are disabled.');
                         return false;
                     },
-                    set(name: string, labels: Record<string, string>, value: number): void {
+                    set(name: string, labelValues: Record<string, string>, value: number): void {
                         if (ctx.mockPromMetrics) {
                             const metric = ctx.mockPromMetrics[name];
-                            if (this.hasMetric(name) && metric.functions?.has('inc') && metric.value !== undefined) {
-                                ctx.mockPromMetrics[name].value = value;
+                            if (!metric || !metric.functions || !metric.metric) {
+                                throw new Error(`Metric ${name} is not setup`);
+                            }
+                            if (metric.functions.has('inc')) {
+                                const labelKey = getLabelKey(labelValues);
+                                metric.labels[labelKey] = { sum: 0, count: 0, value };
                             }
                         }
                     },
                     inc(name: string, labelValues: Record<string, string>, value: number): void {
                         if (ctx.mockPromMetrics) {
                             const metric = ctx.mockPromMetrics[name];
-                            if (this.hasMetric(name) && metric.functions?.has('inc') && metric.value !== undefined) {
-                                metric.value += value;
+                            if (!metric || !metric.functions || !metric.metric) {
+                                throw new Error(`Metric ${name} is not setup`);
+                            }
+                            if (metric.functions.has('inc')) {
+                                const labelKey = getLabelKey(labelValues);
+                                if (Object.keys(metric.labels).includes(labelKey)) {
+                                    metric.labels[labelKey].value += value;
+                                } else {
+                                    metric.labels[labelKey] = { sum: 0, count: 0, value };
+                                }
                             }
                         }
                     },
                     dec(name: string, labelValues: Record<string, string>, value: number): void {
                         if (ctx.mockPromMetrics) {
                             const metric = ctx.mockPromMetrics[name];
-                            if (this.hasMetric(name) && metric.functions?.has('dec') && metric.value !== undefined) {
-                                metric.value -= value;
+                            if (!metric || !metric.functions || !metric.metric) {
+                                throw new Error(`Metric ${name} is not setup`);
+                            }
+                            if (metric.functions.has('dec')) {
+                                const labelKey = getLabelKey(labelValues);
+                                if (Object.keys(metric.labels).includes(labelKey)) {
+                                    metric.labels[labelKey].value -= value;
+                                } else {
+                                    metric.labels[labelKey] = { sum: 0, count: 0, value: -value };
+                                }
                             }
                         }
                     },
@@ -373,18 +400,24 @@ export class TestContext implements i.Context {
                     ): void {
                         if (ctx.mockPromMetrics) {
                             const metric = ctx.mockPromMetrics[name];
-                            if (!metric.functions || !metric.metric) {
+                            if (!metric || !metric.functions || !metric.metric) {
                                 throw new Error(`Metric ${name} is not setup`);
                             }
 
                             if (metric.functions.has('observe')) {
-                                if (metric.summary) {
-                                    metric.summary.count += 1;
-                                    metric.summary.sum += value;
-                                }
-                                if (metric.histogram) {
-                                    metric.histogram.count += 1;
-                                    metric.histogram.sum += value;
+                                const labelKey = getLabelKey(labelValues);
+                                if (Object.keys(metric.labels).includes(labelKey)) {
+                                    metric.labels[labelKey] = {
+                                        sum: metric.labels[labelKey].sum += value,
+                                        count: metric.labels[labelKey].count + 1,
+                                        value: 0
+                                    };
+                                } else {
+                                    metric.labels[labelKey] = {
+                                        sum: value,
+                                        count: 1,
+                                        value: 0
+                                    };
                                 }
                             } else {
                                 throw new Error(`observe not available on ${name} metric`);
@@ -407,7 +440,7 @@ export class TestContext implements i.Context {
                                         labelNames,
                                         metric: 'Gauge',
                                         functions: new Set<string>(['inc', 'dec', 'set']),
-                                        value: 0
+                                        labels: {}
                                     };
                                 }
                                 if (type === 'counter') {
@@ -417,7 +450,7 @@ export class TestContext implements i.Context {
                                         labelNames,
                                         metric: 'Counter',
                                         functions: new Set<string>(['inc', 'dec']),
-                                        value: 0
+                                        labels: {}
                                     };
                                 }
                                 if (type === 'histogram') {
@@ -428,10 +461,7 @@ export class TestContext implements i.Context {
                                         buckets,
                                         metric: 'Histogram',
                                         functions: new Set<string>(['observe']),
-                                        histogram: {
-                                            sum: 0,
-                                            count: 0
-                                        }
+                                        labels: {}
                                     };
                                 }
                             } else {
@@ -457,10 +487,7 @@ export class TestContext implements i.Context {
                                 percentiles,
                                 metric: 'Summary',
                                 functions: new Set<string>(['observe']),
-                                summary: {
-                                    sum: 0,
-                                    count: 0
-                                }
+                                labels: {}
                             };
                         }
                     },

--- a/packages/job-components/src/test-helpers.ts
+++ b/packages/job-components/src/test-helpers.ts
@@ -161,12 +161,12 @@ function isPromise(p: any): boolean {
     return false;
 }
 
-function getLabelKey(labels: Record<string, string>): string {
-    let key = '';
-    for (const entry of Object.entries(labels).sort()) {
-        key += `${entry[0]}:${entry[1]},`;
+export function getLabelKey(labels: Record<string, string>): string {
+    let labelKey = '';
+    for (const [key, value] of Object.entries(labels).sort()) {
+        labelKey += `${key}:${value},`;
     }
-    return key;
+    return labelKey;
 }
 
 export interface TestContextOptions {

--- a/packages/job-components/test/test-helpers-spec.ts
+++ b/packages/job-components/test/test-helpers-spec.ts
@@ -211,15 +211,29 @@ describe('Test Helpers', () => {
             context.apis.foundation.promMetrics.set('test_gauge', { uuid: '437Ev89h' }, 10);
             context.apis.foundation.promMetrics.inc('test_gauge', { uuid: '437Ev89h' }, 1);
             context.apis.foundation.promMetrics.dec('test_gauge', { uuid: '437Ev89h' }, 2);
-            expect(context.mockPromMetrics?.test_gauge.value).toBe(9);
+            expect(context.mockPromMetrics?.test_gauge.labels['uuid:437Ev89h,'].value).toBe(9);
         });
 
+        it('should throw if inc called on metric that doesn\'t exist', async () => {
+            expect(() => context.apis.foundation.promMetrics.inc('missing_test_gauge', { uuid: 'fg7HUI5' }, 1))
+                .toThrow('Metric missing_test_gauge is not setup');
+        });
+
+        it('should throw if dec called on metric that doesn\'t exist', async () => {
+            expect(() => context.apis.foundation.promMetrics.dec('missing_test_gauge', { uuid: 'fg7HUI5' }, 1))
+                .toThrow('Metric missing_test_gauge is not setup');
+        });
+
+        it('should throw if set called on metric that doesn\'t exist', async () => {
+            expect(() => context.apis.foundation.promMetrics.set('missing_test_gauge', { uuid: 'fg7HUI5' }, 1))
+                .toThrow('Metric missing_test_gauge is not setup');
+        });
         it('should add and observe summary', async () => {
             await context.apis.foundation.promMetrics.addSummary('test_summary', 'test_summary help string', ['uuid']);
             context.apis.foundation.promMetrics.observe('test_summary', { uuid: '34rhEqrX' }, 12);
             context.apis.foundation.promMetrics.observe('test_summary', { uuid: '34rhEqrX' }, 5);
             context.apis.foundation.promMetrics.observe('test_summary', { uuid: '34rhEqrX' }, 18);
-            expect(context.mockPromMetrics?.test_summary?.summary).toEqual({ sum: 35, count: 3 });
+            expect(context.mockPromMetrics?.test_summary?.labels['uuid:34rhEqrX,']).toEqual({ sum: 35, count: 3, value: 0 });
         });
 
         it('should add and observe histogram', async () => {
@@ -227,8 +241,13 @@ describe('Test Helpers', () => {
             context.apis.foundation.promMetrics.observe('test_histogram', { uuid: 'dEF4Kby6' }, 10);
             context.apis.foundation.promMetrics.observe('test_histogram', { uuid: 'dEF4Kby6' }, 30);
             context.apis.foundation.promMetrics.observe('test_histogram', { uuid: 'dEF4Kby6' }, 2);
-            expect(context.mockPromMetrics?.test_histogram?.histogram)
-                .toEqual({ sum: 42, count: 3 });
+            expect(context.mockPromMetrics?.test_histogram?.labels['uuid:dEF4Kby6,'])
+                .toEqual({ sum: 42, count: 3, value: 0 });
+        });
+
+        it('should throw if observe called on metric that doesn\'t exist', async () => {
+            expect(() => context.apis.foundation.promMetrics.observe('missing_test_histogram', { uuid: 'Hz4XpL9' }, 1))
+                .toThrow('Metric missing_test_histogram is not setup');
         });
 
         it('should shutdown', async () => {

--- a/packages/job-components/test/test-helpers-spec.ts
+++ b/packages/job-components/test/test-helpers-spec.ts
@@ -7,6 +7,7 @@ import {
     newTestExecutionContext,
     newTestExecutionConfig,
     TestContext,
+    getLabelKey,
 } from '../src';
 
 describe('Test Helpers', () => {
@@ -253,6 +254,28 @@ describe('Test Helpers', () => {
         it('should shutdown', async () => {
             await context.apis.foundation.promMetrics.shutdown();
             expect(context.mockPromMetrics).toBeNull();
+        });
+    });
+
+    describe('getLabelKey', () => {
+        it('should produce the same key with any label order', async () => {
+            const key1 = getLabelKey({
+                arch: 'arm64',
+                clustering_type: 'kubernetes',
+                name: 'worker:test-job',
+                node_version: 'v18.19.1',
+                platform: 'darwin',
+                teraslice_version: '1.4.0',
+            });
+            const key2 = getLabelKey({
+                teraslice_version: '1.4.0',
+                clustering_type: 'kubernetes',
+                platform: 'darwin',
+                name: 'worker:test-job',
+                node_version: 'v18.19.1',
+                arch: 'arm64',
+            });
+            expect(key1).toEqual(key2);
         });
     });
 });

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.72.0"
+        "@terascope/job-components": "^0.73.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.72.0"
+        "@terascope/job-components": ">=0.73.0"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "0.29.0",
+    "version": "0.30.0",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {
@@ -36,10 +36,10 @@
         "fs-extra": "^11.2.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.72.0"
+        "@terascope/job-components": "^0.73.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.72.0"
+        "@terascope/job-components": ">=0.73.0"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice-test-harness/src/base-test-harness.ts
+++ b/packages/teraslice-test-harness/src/base-test-harness.ts
@@ -2,6 +2,7 @@ import {
     ExecutionConfig, JobValidator, TestContext,
     JobConfig, ExecutionContextConfig, Assignment,
     makeExecutionContext, TestClientConfig,
+    ClusterManagerType,
 } from '@terascope/job-components';
 import { EventEmitter } from 'events';
 import {
@@ -25,10 +26,14 @@ export default class BaseTestHarness<U extends ExecutionContext> {
         this.context = new TestContext(testName, {
             assignment,
             clients: options.clients,
+            cluster_manager_type: options.cluster_manager_type,
         });
 
         this.events = this.context.apis.foundation.getSystemEvents();
-        const config = this.makeContextConfig(job, this._getAssetDirs(options.assetDir));
+        const config = this.makeContextConfig(
+            job,
+            this._getAssetDirs(options.assetDir),
+            options.cluster_manager_type);
         this.executionContext = makeExecutionContext(config) as U;
     }
 
@@ -44,10 +49,12 @@ export default class BaseTestHarness<U extends ExecutionContext> {
 
     protected makeContextConfig(
         job: JobConfig,
-        assets: string[] = [process.cwd()]
+        assets: string[] = [process.cwd()],
+        cluster_manager_type: ClusterManagerType = 'native'
     ): ExecutionContextConfig {
         const assetIds = job.assets ? [...job.assets, '.'] : ['.'];
         this.context.sysconfig.teraslice.assets_directory = assets;
+        this.context.sysconfig.teraslice.cluster_manager_type = cluster_manager_type;
         job.assets = assetIds;
 
         const jobValidator = new JobValidator(this.context);

--- a/packages/teraslice-test-harness/src/interfaces.ts
+++ b/packages/teraslice-test-harness/src/interfaces.ts
@@ -6,7 +6,8 @@ import {
     ProcessorConstructor,
     SlicerConstructor,
     Slice,
-    DataEntity
+    DataEntity,
+    ClusterManagerType
 } from '@terascope/job-components';
 
 export type ExecutionContext = WorkerExecutionContext|SlicerExecutionContext;
@@ -15,6 +16,7 @@ export type Context = WorkerContext;
 export interface JobHarnessOptions {
     assetDir?: string | string[];
     clients?: TestClientConfig[];
+    cluster_manager_type?: ClusterManagerType
 }
 
 export interface OpTestHarnessOptions {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -39,7 +39,7 @@
     },
     "dependencies": {
         "@terascope/elasticsearch-api": "^3.19.0",
-        "@terascope/job-components": "^0.72.0",
+        "@terascope/job-components": "^0.73.0",
         "@terascope/teraslice-messaging": "^0.41.0",
         "@terascope/types": "^0.16.0",
         "@terascope/utils": "^0.58.0",


### PR DESCRIPTION
This PR makes the following changes:
- Adds the ability for `mockPromMetrics` in the `job-components` `TestContext` to properly gather metrics by labels. This was necessary to test `count_by_field` in `standard-assets`.
- Add `clusterManagerType` to `JobHarnessOptions` used by the `base-test-harness`. This will set `context.sysconfig.teraslice.cluster_manager_type`, which must be `kubernetes` for prom metrics to be enabled. 
