### PR TITLE
Add Node 22.1.0 

### DIFF
--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.19.1, 20.11.1]
+        node-version: [18.19.1, 20.11.1, 22.1.0]
     steps:
       # we login to docker to publish new teraslice image
       - name: Login to Docker Hub

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.19.1, 20.11.1]
+        node-version: [18.19.1, 20.11.1, 22.1.0]
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.19.1, 20.11.1]
+        node-version: [18.19.1, 20.11.1, 22.1.0]
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -83,7 +83,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 20.11.1]
+        node-version: [18.19.1, 20.11.1, 22.1.0]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -117,7 +117,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 20.11.1]
+        node-version: [18.19.1, 20.11.1, 22.1.0]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -151,7 +151,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 20.11.1]
+        node-version: [18.19.1, 20.11.1, 22.1.0]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -185,7 +185,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 20.11.1]
+        node-version: [18.19.1, 20.11.1, 22.1.0]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -223,7 +223,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 20.11.1]
+        node-version: [18.19.1, 20.11.1, 22.1.0]
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/docs/development/node.md
+++ b/docs/development/node.md
@@ -1,0 +1,23 @@
+---
+title: Updating Node Versions
+sidebar_label: Node
+---
+
+## Adding a new node verison
+
+Updating node is a multi-step process that starts with updating the CI yaml files within the `base-docker-image` repo.
+
+https://github.com/terascope/base-docker-image
+
+There are two files that must be modified in order to create new base images that have the new appropriate node versions for teraslice to use. They can be located here:
+
+https://github.com/terascope/base-docker-image/tree/master/.github/workflows
+
+- build.yml
+- release.yml
+
+Add the node version in the array list of each file and push up a new branch. Once merged and a new release is made, CI should create new base docker images with the new node version that was added. They will show up on docker-hub here:
+
+https://hub.docker.com/r/terascope/node-base/tags
+
+Once finished, add the new node version to all the spots needed inside each file in `.github/workflows`.


### PR DESCRIPTION
This PR makes the following changes:

- Adds node `22.1.0` in CI testing environment 
- Updates documentation to include instructions on how to add node versions to teraslice