### PR TITLE
Add prom-client dependency to types

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -42,9 +42,9 @@
         "ms": "^2.1.3"
     },
     "devDependencies": {
-        "@terascope/types": "^0.17.0",
+        "@terascope/types": "^0.17.1",
         "bunyan": "^1.8.15",
-        "elasticsearch-store": "^0.84.0",
+        "elasticsearch-store": "^0.84.1",
         "fs-extra": "^11.2.0",
         "ms": "^2.1.3",
         "nanoid": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.56.0",
+    "version": "0.56.1",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -29,9 +29,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.50.0",
-        "@terascope/types": "^0.17.0",
-        "@terascope/utils": "^0.59.0",
+        "@terascope/data-types": "^0.50.1",
+        "@terascope/types": "^0.17.1",
+        "@terascope/utils": "^0.59.1",
         "@types/validator": "^13.11.9",
         "awesome-phonenumber": "^2.70.0",
         "date-fns": "^2.30.0",
@@ -46,7 +46,7 @@
         "uuid": "^9.0.1",
         "valid-url": "^1.0.9",
         "validator": "^13.11.0",
-        "xlucene-parser": "^0.58.0"
+        "xlucene-parser": "^0.58.1"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.6",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.50.0",
+    "version": "0.50.1",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -26,8 +26,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.0",
-        "@terascope/utils": "^0.59.0",
+        "@terascope/types": "^0.17.1",
+        "@terascope/utils": "^0.59.1",
         "graphql": "^14.7.0",
         "lodash": "^4.17.21",
         "yargs": "^17.7.2"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "3.20.0",
+    "version": "3.20.1",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "TEST_RESTRAINED_ELASTICSEARCH='true' ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.0",
-        "@terascope/utils": "^0.59.0",
+        "@terascope/types": "^0.17.1",
+        "@terascope/utils": "^0.59.1",
         "bluebird": "^3.7.2",
         "setimmediate": "^1.0.5"
     },
@@ -32,7 +32,7 @@
         "@opensearch-project/opensearch": "^1.2.0",
         "@types/elasticsearch": "^5.0.43",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^0.84.0",
+        "elasticsearch-store": "^0.84.1",
         "elasticsearch6": "npm:@elastic/elasticsearch@^6.7.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@^7.0.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@^8.0.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.84.0",
+    "version": "0.84.1",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -29,10 +29,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.56.0",
-        "@terascope/data-types": "^0.50.0",
-        "@terascope/types": "^0.17.0",
-        "@terascope/utils": "^0.59.0",
+        "@terascope/data-mate": "^0.56.1",
+        "@terascope/data-types": "^0.50.1",
+        "@terascope/types": "^0.17.1",
+        "@terascope/utils": "^0.59.1",
         "ajv": "^6.12.6",
         "elasticsearch6": "npm:@elastic/elasticsearch@^6.7.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@^7.0.0",
@@ -41,7 +41,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@^2.2.1",
         "setimmediate": "^1.0.5",
         "uuid": "^9.0.1",
-        "xlucene-translator": "^0.44.0"
+        "xlucene-translator": "^0.44.1"
     },
     "devDependencies": {
         "@types/uuid": "^9.0.8"

--- a/packages/generator-teraslice/package.json
+++ b/packages/generator-teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "generator-teraslice",
     "displayName": "Generator Teraslice",
-    "version": "0.38.0",
+    "version": "0.38.1",
     "description": "Generate teraslice related packages and code",
     "keywords": [
         "teraslice",
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.59.0",
+        "@terascope/utils": "^0.59.1",
         "chalk": "^4.1.2",
         "lodash": "^4.17.21",
         "yeoman-generator": "^5.8.0",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.74.0",
+    "version": "0.74.1",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -31,7 +31,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.59.0",
+        "@terascope/utils": "^0.59.1",
         "convict": "^6.2.4",
         "convict-format-with-moment": "^6.2.0",
         "convict-format-with-validator": "^6.2.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.77.0",
+    "version": "0.77.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "^0.20.0",
-        "@terascope/utils": "^0.59.0",
+        "@terascope/utils": "^0.59.1",
         "codecov": "^3.8.3",
         "execa": "^5.1.0",
         "fs-extra": "^11.2.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.63.0",
+    "version": "0.63.1",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -28,15 +28,15 @@
     },
     "dependencies": {
         "@terascope/file-asset-apis": "^0.13.0",
-        "@terascope/types": "^0.17.0",
-        "@terascope/utils": "^0.59.0",
+        "@terascope/types": "^0.17.1",
+        "@terascope/utils": "^0.59.1",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.15",
         "convict": "^6.2.4",
         "convict-format-with-moment": "^6.2.0",
         "convict-format-with-validator": "^6.2.0",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^0.84.0",
+        "elasticsearch-store": "^0.84.1",
         "express": "^4.19.2",
         "js-yaml": "^4.1.0",
         "nanoid": "^3.3.4",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -38,8 +38,8 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.8.7",
-        "@terascope/types": "^0.17.0",
-        "@terascope/utils": "^0.59.0",
+        "@terascope/types": "^0.17.1",
+        "@terascope/utils": "^0.59.1",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.4",
         "easy-table": "^1.2.0",
@@ -54,7 +54,7 @@
         "pretty-bytes": "^5.6.0",
         "prompts": "^2.4.2",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.60.0",
+        "teraslice-client-js": "^0.60.1",
         "tmp": "^0.2.0",
         "tty-table": "^4.2.3",
         "yargs": "^17.7.2",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.60.0",
+    "version": "0.60.1",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -31,8 +31,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.0",
-        "@terascope/utils": "^0.59.0",
+        "@terascope/types": "^0.17.1",
+        "@terascope/utils": "^0.59.1",
         "auto-bind": "^4.0.0",
         "got": "^11.8.3"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "0.42.0",
+    "version": "0.42.1",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -34,8 +34,8 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.0",
-        "@terascope/utils": "^0.59.0",
+        "@terascope/types": "^0.17.1",
+        "@terascope/utils": "^0.59.1",
         "ms": "^2.1.3",
         "nanoid": "^3.3.4",
         "p-event": "^4.2.0",

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.74.0"
+        "@terascope/job-components": "^0.74.1"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.74.0"
+        "@terascope/job-components": ">=0.74.1"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.53.0",
+    "version": "0.53.1",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^3.20.0",
-        "@terascope/utils": "^0.59.0"
+        "@terascope/elasticsearch-api": "^3.20.1",
+        "@terascope/utils": "^0.59.1"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^11.2.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.74.0"
+        "@terascope/job-components": "^0.74.1"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.74.0"
+        "@terascope/job-components": ">=0.74.1"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -38,11 +38,11 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^3.20.0",
-        "@terascope/job-components": "^0.74.0",
-        "@terascope/teraslice-messaging": "^0.42.0",
-        "@terascope/types": "^0.17.0",
-        "@terascope/utils": "^0.59.0",
+        "@terascope/elasticsearch-api": "^3.20.1",
+        "@terascope/job-components": "^0.74.1",
+        "@terascope/teraslice-messaging": "^0.42.1",
+        "@terascope/types": "^0.17.1",
+        "@terascope/utils": "^0.59.1",
         "async-mutex": "^0.5.0",
         "barbe": "^3.0.16",
         "body-parser": "^1.20.2",
@@ -64,7 +64,7 @@
         "semver": "^7.6.1",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.63.0",
+        "terafoundation": "^0.63.1",
         "uuid": "^9.0.1"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.85.0",
+    "version": "0.85.1",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.56.0",
-        "@terascope/types": "^0.17.0",
-        "@terascope/utils": "^0.59.0",
+        "@terascope/data-mate": "^0.56.1",
+        "@terascope/types": "^0.17.1",
+        "@terascope/utils": "^0.59.1",
         "awesome-phonenumber": "^2.70.0",
         "graphlib": "^2.1.8",
         "is-ip": "^3.1.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -35,5 +35,8 @@
     "terascope": {
         "testSuite": "disabled",
         "enableTypedoc": true
+    },
+    "dependencies": {
+        "prom-client": "^15.1.2"
     }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/types",
     "displayName": "Types",
-    "version": "0.17.0",
+    "version": "0.17.1",
     "description": "A collection of typescript interfaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/types#readme",
     "bugs": {
@@ -23,6 +23,9 @@
         "test:debug": "ts-scripts test --debug . --",
         "test:watch": "ts-scripts test --watch . --"
     },
+    "dependencies": {
+        "prom-client": "^15.1.2"
+    },
     "engines": {
         "node": ">=14.17.0",
         "yarn": ">=1.16.0"
@@ -35,8 +38,5 @@
     "terascope": {
         "testSuite": "disabled",
         "enableTypedoc": true
-    },
-    "dependencies": {
-        "prom-client": "^15.1.2"
     }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.59.0",
+    "version": "0.59.1",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {
@@ -28,7 +28,7 @@
         "debug": "^4.3.4"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.0",
+        "@terascope/types": "^0.17.1",
         "@turf/bbox": "^6.4.0",
         "@turf/bbox-polygon": "^6.4.0",
         "@turf/boolean-contains": "^6.4.0",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.58.0",
+    "version": "0.58.1",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -30,8 +30,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.0",
-        "@terascope/utils": "^0.59.0"
+        "@terascope/types": "^0.17.1",
+        "@terascope/utils": "^0.59.1"
     },
     "devDependencies": {
         "@turf/invariant": "^6.2.0",

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.44.0",
+    "version": "0.44.1",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -28,10 +28,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.0",
-        "@terascope/utils": "^0.59.0",
+        "@terascope/types": "^0.17.1",
+        "@terascope/utils": "^0.59.1",
         "@types/elasticsearch": "^5.0.43",
-        "xlucene-parser": "^0.58.0"
+        "xlucene-parser": "^0.58.1"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "0.26.0",
+    "version": "0.26.1",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -23,10 +23,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.59.0"
+        "@terascope/utils": "^0.59.1"
     },
     "devDependencies": {
-        "@terascope/types": "^0.17.0"
+        "@terascope/types": "^0.17.1"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11311,7 +11311,7 @@ progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-prom-client@15.1.2:
+prom-client@15.1.2, prom-client@^15.1.2:
   version "15.1.2"
   resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-15.1.2.tgz#78d79f12c35d395ca97edf7111c18210cf07f815"
   integrity sha512-on3h1iXb04QFLLThrmVYg1SChBQ9N1c+nKAjebBjokBqipddH3uxmOUcEkTnzmJ8Jh/5TSUnUqS40i2QB2dJHQ==


### PR DESCRIPTION
Add `prom-metrics` dependency to `types` package
Bump `types` from 0.17.0 to 0.17.1
Bump `teraslice` from 1.5.0 to 1.5.1