### PR TITLE
Prom client in mock prom metrics

### DIFF
--- a/docs/development/k8s.md
+++ b/docs/development/k8s.md
@@ -409,15 +409,15 @@ this.context.apis.foundation.promMetrics.inc(
 
 Example Gauge using collect() callback:
 ```typescript
-const self = this; // rename `this` to use inside collect()
+const { context, getSlicesDispatched } = this;
 await this.context.apis.foundation.promMetrics.addGauge(
     'slices_dispatched', // name
     'number of slices a slicer has dispatched', // help or description
     ['class'], // label names specific to this metric
     function collect() { // callback fn updates value only when '/metrics' endpoint is hit
-        const slicesFinished = self.getSlicesDispatched(); // get current value from local momory
+        const slicesFinished = getSlicesDispatched(); // get current value from local momory
         const labels = { // 'set()' needs both default labels and labels specific to metric to match the correct gauge
-            ...self.context.apis.foundation.promMetrics.getDefaultLabels(),
+            ...context.apis.foundation.promMetrics.getDefaultLabels(),
             class: 'SlicerExecutionContext'
         };
         this.set(labels, slicesFinished); // this refers to the Gauge

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -36,6 +36,7 @@
         "convict-format-with-moment": "^6.2.0",
         "convict-format-with-validator": "^6.2.0",
         "datemath-parser": "^1.0.6",
+        "prom-client": "^15.1.2",
         "uuid": "^9.0.1"
     },
     "devDependencies": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.74.1",
+    "version": "0.74.2",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/job-components/src/interfaces/context.ts
+++ b/packages/job-components/src/interfaces/context.ts
@@ -106,7 +106,7 @@ export interface FoundationApis {
     getSystemEvents(): EventEmitter;
     getConnection(config: ConnectionConfig): { client: any };
     createClient(config: ConnectionConfig): Promise<{ client: any }>;
-    promMetrics: tf.PromMetrics
+    promMetrics: tf.PromMetrics;
 }
 
 export interface LegacyFoundationApis {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.63.1",
+    "version": "0.63.2",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/terafoundation/test/apis/prom-metrics-spec.ts
+++ b/packages/terafoundation/test/apis/prom-metrics-spec.ts
@@ -306,7 +306,7 @@ describe('promMetrics foundation API', () => {
             tf_prom_metrics_port: terafoundation.prom_metrics_port,
             tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
             logger: debugLogger('prom-metrics-spec-logger'),
-            assignment: 'cluster-master',
+            assignment: 'master',
             labels: {},
             prefix: 'foundation_test_'
         };
@@ -372,7 +372,7 @@ describe('promMetrics foundation API', () => {
             tf_prom_metrics_port: terafoundation.prom_metrics_port,
             tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
             logger: debugLogger('prom-metrics-spec-logger'),
-            assignment: 'cluster-master',
+            assignment: 'master',
             labels: {},
             prefix: 'foundation_test_'
         };
@@ -466,7 +466,7 @@ describe('promMetrics foundation API', () => {
             tf_prom_metrics_port: terafoundation.prom_metrics_port,
             tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
             logger: debugLogger('prom-metrics-spec-logger'),
-            assignment: 'cluster-master',
+            assignment: 'master',
             prefix: 'foundation_test_'
         };
 
@@ -546,7 +546,7 @@ describe('promMetrics foundation API', () => {
             tf_prom_metrics_port: terafoundation.prom_metrics_port,
             tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
             logger: debugLogger('prom-metrics-spec-logger'),
-            assignment: 'cluster-master',
+            assignment: 'master',
             prefix: 'foundation_test_'
         };
         beforeAll(async () => {
@@ -625,7 +625,7 @@ describe('promMetrics foundation API', () => {
             tf_prom_metrics_port: terafoundation.prom_metrics_port,
             tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
             logger: debugLogger('prom-metrics-spec-logger'),
-            assignment: 'cluster-master',
+            assignment: 'master',
             prefix: 'foundation_test_',
             labels: { default1: 'value1' }
         };
@@ -642,7 +642,7 @@ describe('promMetrics foundation API', () => {
         it('should get all the default labels', () => {
             expect(context.apis.foundation.promMetrics.getDefaultLabels()).toEqual({
                 name: 'tera-test-labels',
-                assignment: 'cluster-master',
+                assignment: 'master',
                 default1: 'value1'
             });
         });

--- a/packages/terafoundation/test/test-context-spec.ts
+++ b/packages/terafoundation/test/test-context-spec.ts
@@ -130,7 +130,7 @@ describe('TestContext', () => {
             tf_prom_metrics_port: 3333,
             tf_prom_metrics_add_default: false,
             logger: context.logger,
-            assignment: 'cluster-master'
+            assignment: 'master'
         };
         expect(await context.apis.foundation.promMetrics.init(config)).toBe(true);
     });

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.74.1"
+        "@terascope/job-components": "^0.74.2"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.74.1"
+        "@terascope/job-components": ">=0.74.2"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^11.2.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.74.1"
+        "@terascope/job-components": "^0.74.2"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.74.1"
+        "@terascope/job-components": ">=0.74.2"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -39,7 +39,7 @@
     },
     "dependencies": {
         "@terascope/elasticsearch-api": "^3.20.1",
-        "@terascope/job-components": "^0.74.1",
+        "@terascope/job-components": "^0.74.2",
         "@terascope/teraslice-messaging": "^0.42.1",
         "@terascope/types": "^0.17.1",
         "@terascope/utils": "^0.59.1",
@@ -64,7 +64,7 @@
         "semver": "^7.6.1",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.63.1",
+        "terafoundation": "^0.63.2",
         "uuid": "^9.0.1"
     },
     "devDependencies": {

--- a/packages/teraslice/src/lib/cluster/cluster_master.ts
+++ b/packages/teraslice/src/lib/cluster/cluster_master.ts
@@ -150,7 +150,8 @@ export class ClusterMaster {
                     tf_prom_metrics_enabled: terafoundation.prom_metrics_enabled,
                     tf_prom_metrics_port: terafoundation.prom_metrics_port,
                     logger: this.logger,
-                    assignment: 'cluster_master'
+                    assignment: 'master',
+                    prefix: 'teraslice_'
                 });
 
                 await this.setupPromMetrics();
@@ -229,7 +230,7 @@ export class ClusterMaster {
         */
         await Promise.all([
             this.context.apis.foundation.promMetrics.addGauge(
-                'info',
+                'master_info',
                 'Information about Teraslice cluster master',
                 ['arch', 'clustering_type', 'name', 'node_version', 'platform', 'teraslice_version']
             ),
@@ -338,7 +339,7 @@ export class ClusterMaster {
         ]);
 
         this.context.apis.foundation.promMetrics.set(
-            'info',
+            'master_info',
             {
                 arch: this.context.arch,
                 clustering_type: this.context.sysconfig.teraslice.cluster_manager_type,

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -1113,9 +1113,7 @@ export class ExecutionController {
      * @link https://terascope.github.io/teraslice/docs/development/k8s#prometheus-metrics-api
      */
     async setupPromMetrics() {
-        this.logger.info(`adding ${this.context.assignment} prom metrics...`);
-        // eslint-disable-next-line @typescript-eslint/no-this-alias
-        const self = this;
+        const { context, executionAnalytics } = this;
         await Promise.all([
             this.context.apis.foundation.promMetrics.addGauge(
                 'info',
@@ -1127,9 +1125,9 @@ export class ExecutionController {
                 'Number of slices processed by all workers',
                 [],
                 function collect() {
-                    const slicesProcessed = self.executionAnalytics.get('processed');
+                    const slicesProcessed = executionAnalytics.get('processed');
                     const defaultLabels = {
-                        ...self.context.apis.foundation.promMetrics.getDefaultLabels()
+                        ...context.apis.foundation.promMetrics.getDefaultLabels()
                     };
                     this.set(defaultLabels, slicesProcessed);
                 }

--- a/packages/teraslice/src/lib/workers/worker/index.ts
+++ b/packages/teraslice/src/lib/workers/worker/index.ts
@@ -411,8 +411,7 @@ export class Worker {
      */
     async setupPromMetrics() {
         this.logger.info(`adding ${this.context.assignment} prom metrics...`);
-        // eslint-disable-next-line @typescript-eslint/no-this-alias
-        const self = this;
+        const { context, getSlicesProcessed } = this;
         await Promise.all([
             this.context.apis.foundation.promMetrics.addGauge(
                 'info',
@@ -424,9 +423,9 @@ export class Worker {
                 'Number of slices the worker has processed',
                 [],
                 function collect() {
-                    const slicesProcessed = self.getSlicesProcessed();
+                    const slicesProcessed = getSlicesProcessed();
                     const defaultLabels = {
-                        ...self.context.apis.foundation.promMetrics.getDefaultLabels()
+                        ...context.apis.foundation.promMetrics.getDefaultLabels()
                     };
                     this.set(defaultLabels, slicesProcessed);
                 }


### PR DESCRIPTION
This PR makes the following changes:
- add `teraslice_` prefix to `promMetrics.init()` for master so all metric names match what was in `teraslice-exporter` package.
- update `mockPrommetrics` to use `prom-client`. This allows `collect()` functions to be used in `TestContext`.