### PR TITLE
fix broken promMetric collect callback

### DIFF
--- a/docs/development/k8s.md
+++ b/docs/development/k8s.md
@@ -409,18 +409,18 @@ this.context.apis.foundation.promMetrics.inc(
 
 Example Gauge using collect() callback:
 ```typescript
-const { context, getSlicesDispatched } = this;
+const self = this;
 await this.context.apis.foundation.promMetrics.addGauge(
     'slices_dispatched', // name
     'number of slices a slicer has dispatched', // help or description
     ['class'], // label names specific to this metric
     function collect() { // callback fn updates value only when '/metrics' endpoint is hit
-        const slicesFinished = getSlicesDispatched(); // get current value from local momory
+        const slicesFinished = self.getSlicesDispatched(); // get current value from local momory
         const labels = { // 'set()' needs both default labels and labels specific to metric to match the correct gauge
-            ...context.apis.foundation.promMetrics.getDefaultLabels(),
+            ...self.context.apis.foundation.promMetrics.getDefaultLabels(),
             class: 'SlicerExecutionContext'
         };
-        this.set(labels, slicesFinished); // this refers to the Gauge
+        this.set(labels, slicesFinished); // 'this' refers to the Gauge
     }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -1113,6 +1113,7 @@ export class ExecutionController {
      * @link https://terascope.github.io/teraslice/docs/development/k8s#prometheus-metrics-api
      */
     async setupPromMetrics() {
+        this.logger.info(`adding ${this.context.assignment} prom metrics...`);
         const { context, executionAnalytics } = this;
         await Promise.all([
             this.context.apis.foundation.promMetrics.addGauge(

--- a/packages/teraslice/src/lib/workers/worker/index.ts
+++ b/packages/teraslice/src/lib/workers/worker/index.ts
@@ -411,7 +411,8 @@ export class Worker {
      */
     async setupPromMetrics() {
         this.logger.info(`adding ${this.context.assignment} prom metrics...`);
-        const { context, getSlicesProcessed } = this;
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const self = this;
         await Promise.all([
             this.context.apis.foundation.promMetrics.addGauge(
                 'info',
@@ -423,9 +424,9 @@ export class Worker {
                 'Number of slices the worker has processed',
                 [],
                 function collect() {
-                    const slicesProcessed = getSlicesProcessed();
+                    const slicesProcessed = self.getSlicesProcessed();
                     const defaultLabels = {
-                        ...context.apis.foundation.promMetrics.getDefaultLabels()
+                        ...self.context.apis.foundation.promMetrics.getDefaultLabels()
                     };
                     this.set(defaultLabels, slicesProcessed);
                 }


### PR DESCRIPTION
This PR fixes a bug introduced in #3613, where the worker's `slicesProcessed` promMetric `collect()` function would throw an error when metrics were scraped, causing the pod to crash. 