### PR TITLE
Add node22 to teraslice-cli

### DIFF
--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"

--- a/packages/teraslice-cli/src/helpers/yargs-options.ts
+++ b/packages/teraslice-cli/src/helpers/yargs-options.ts
@@ -70,7 +70,8 @@ export default class Options {
             choices: [
                 'node16',
                 'node18',
-                'node20'
+                'node20',
+                'node22'
             ],
             // I have disabled this because for some reason this requirement was
             // being enforced even when `bundle-target` wasn't specified.


### PR DESCRIPTION
This PR makes the following changes:

- Adds `node22` to the bundle-target list in `teraslice-cli`
- Bumps **teraslice-cli** from `v1.6.0` to `v1.6.1`