### PR TITLE
release: (patch) teraslice@1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
This PR updates the `terafoundation_kafka-connector` which includes a fix that will allow older kafka assets to work on this release of Teraslice.