### PR TITLE
Remove PromMetrics proxy, check for promMetrics with isPromAvailable()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "0.75.0",
+    "version": "0.75.1",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/job-components/src/execution-context/base.ts
+++ b/packages/job-components/src/execution-context/base.ts
@@ -7,6 +7,7 @@ import { registerApis } from '../register-apis';
 import { ExecutionConfig, WorkerContext, OperationLifeCycle } from '../interfaces';
 import { EventHandlers, ExecutionContextConfig } from './interfaces';
 import { ExecutionContextAPI } from './api';
+import { isPromAvailable } from '../utils';
 
 /**
  * A base class for an Execution Context
@@ -119,7 +120,10 @@ export default class BaseExecutionContext<T extends OperationLifeCycle> {
                     this.events.removeListener(event, listener);
                 });
         });
-        await this.context.apis.foundation.promMetrics.shutdown();
+
+        if (isPromAvailable(this.context)) {
+            await this.context.apis.foundation.promMetrics.shutdown();
+        }
     }
 
     get api(): ExecutionContextAPI {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "0.64.0",
+    "version": "0.64.1",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/terafoundation/src/api/index.ts
+++ b/packages/terafoundation/src/api/index.ts
@@ -189,38 +189,4 @@ export default function registerApis(context: i.FoundationContext): void {
 
     _registerFoundationAPIs();
     _registerLegacyAPIs();
-
-    /*
-     * Setup proxy for 'foundation.promMetrics' here to have access to 'PromMetrics' functions.
-     * This proxy allows the interception of the 'promMetrics' function calls in the case that
-     * 'PromMetrics' has not been initialized.
-    */
-    const promMetricsProxy = new Proxy(context.apis.foundation.promMetrics, {
-        get(promMetrics, funcName) {
-            const apiExists = promMetrics.verifyAPI();
-            if (apiExists) {
-                if (funcName === 'init') {
-                    throw new Error('Prom metrics API cannot be initialized more than once.');
-                }
-                return promMetrics[funcName];
-            } if (funcName === 'init') {
-                return promMetrics[funcName];
-            } if (funcName === 'hasMetric' || funcName === 'deleteMetric') {
-                return () => false;
-            } if (
-                funcName === 'set' || funcName === 'addGauge'
-                || funcName === 'addCounter' || funcName === 'addHistogram'
-                || funcName === 'addSummary' || funcName === 'inc'
-                || funcName === 'dec' || funcName === 'observe'
-                || funcName === 'getDefaultLabels' || funcName === 'shutdown'
-            ) {
-                return () => {
-                    /// return empty function
-                };
-            }
-            return promMetrics[funcName];
-        }
-    });
-    /// Set the global promMetrics to the promMetricsProxy to override functions everywhere
-    context.apis.foundation.promMetrics = promMetricsProxy;
 }

--- a/packages/terafoundation/src/api/prom-metrics/prom-metrics-api.ts
+++ b/packages/terafoundation/src/api/prom-metrics/prom-metrics-api.ts
@@ -40,6 +40,9 @@ export class PromMetrics {
      * @returns {Promise<boolean>} Was the API initialized
      */
     async init(config: tf.PromMetricsInitConfig) {
+        if (this.apiRunning) {
+            throw new Error('Prom metrics API cannot be initialized more than once.');
+        }
         const {
             assignment, job_prom_metrics_add_default, job_prom_metrics_enabled,
             job_prom_metrics_port, tf_prom_metrics_add_default, tf_prom_metrics_enabled,

--- a/packages/terafoundation/test/apis/prom-metrics-spec.ts
+++ b/packages/terafoundation/test/apis/prom-metrics-spec.ts
@@ -56,8 +56,8 @@ describe('promMetrics foundation API', () => {
                 });
 
                 it('should throw an error if promMetricsAPI is already initialized', async () => {
-                    expect(() => context.apis.foundation.promMetrics.init(config))
-                        .toThrow('Prom metrics API cannot be initialized more than once.');
+                    await expect(() => context.apis.foundation.promMetrics.init(config))
+                        .rejects.toThrow('Prom metrics API cannot be initialized more than once.');
                 });
             });
 
@@ -145,8 +145,8 @@ describe('promMetrics foundation API', () => {
                 });
 
                 it('should throw an error if promMetricsAPI is already initialized', async () => {
-                    expect(() => context.apis.foundation.promMetrics.init(config))
-                        .toThrow('Prom metrics API cannot be initialized more than once.');
+                    await expect(() => context.apis.foundation.promMetrics.init(config))
+                        .rejects.toThrow('Prom metrics API cannot be initialized more than once.');
                 });
             });
         });
@@ -277,8 +277,8 @@ describe('promMetrics foundation API', () => {
                 });
 
                 it('should throw an error if promMetricsAPI is already initialized', async () => {
-                    expect(() => context.apis.foundation.promMetrics.init(config))
-                        .toThrow('Prom metrics API cannot be initialized more than once.');
+                    await expect(() => context.apis.foundation.promMetrics.init(config))
+                        .rejects.toThrow('Prom metrics API cannot be initialized more than once.');
                 });
             });
         });

--- a/packages/teraslice-op-test-harness/package.json
+++ b/packages/teraslice-op-test-harness/package.json
@@ -21,10 +21,10 @@
         "bluebird": "^3.7.2"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.75.0"
+        "@terascope/job-components": "^0.75.1"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.75.0"
+        "@terascope/job-components": ">=0.75.1"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^11.2.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^0.75.0"
+        "@terascope/job-components": "^0.75.1"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=0.75.0"
+        "@terascope/job-components": ">=0.75.1"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -39,7 +39,7 @@
     },
     "dependencies": {
         "@terascope/elasticsearch-api": "^3.20.2",
-        "@terascope/job-components": "^0.75.0",
+        "@terascope/job-components": "^0.75.1",
         "@terascope/teraslice-messaging": "^0.42.2",
         "@terascope/types": "^0.17.2",
         "@terascope/utils": "^0.59.2",
@@ -64,7 +64,7 @@
         "semver": "^7.6.1",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^0.64.0",
+        "terafoundation": "^0.64.1",
         "uuid": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
This is a follow-up PR to #3629 which created a utility function to test if promMetrics are available, allowing assets to be backward compatible with teraslice before promMetrics were introduced (< 1.4.0). At the same time we decided to just make `isPromAvailable()` checks everywhere promMetrics was used, instead of using a proxy to catch calls to undefined functions. See #3625 for more details.

This PR makes the following changes:
- Removes the `promMetricsAPI` Proxy from `terafoundation`
- Add checks using `isPromAvailable` before all calls to `promMetricsAPI` functions.
- Update `promMetrics docs`.
- Bump teraslice from 1.7.1 to 1.7.2
- Bump job-components from 0.75.0 to 0.75.1
- Bump terafoundation from 0.64.0 to 0.64.1