### PR TITLE
Add node_master child process shutdown logic

### DIFF
--- a/packages/job-components/src/test-helpers.ts
+++ b/packages/job-components/src/test-helpers.ts
@@ -207,7 +207,10 @@ export class TestContext implements i.Context {
                 makeLogger(...params: any[]): Logger {
                     return logger.child(params[0]);
                 },
-                startWorkers: () => {},
+                startWorkers() {
+                    const workers: Terafoundation.FoundationWorker[] = [];
+                    return workers;
+                },
                 async createClient(opts: i.ConnectionConfig) {
                     const { cached } = opts;
 

--- a/packages/teraslice/src/lib/workers/helpers/worker-shutdown.ts
+++ b/packages/teraslice/src/lib/workers/helpers/worker-shutdown.ts
@@ -99,7 +99,12 @@ export function shutdownHandler(
 
     async function exit(event: string, err?: Error) {
         if (api.exiting) return;
-
+        /// Potential logic for cluster_master and asset_service
+        if (err) {
+            if (err.name.includes('Error')) {
+                setStatusCode(1);
+            }
+        }
         api.exiting = true;
         startTime = Date.now();
 

--- a/packages/types/src/terafoundation.ts
+++ b/packages/types/src/terafoundation.ts
@@ -94,7 +94,7 @@ export interface FoundationAPIs {
     makeLogger(name: string, filename: string): Logger;
     getSystemEvents(): EventEmitter;
     createClient(config: ConnectionConfig): Promise<ConnectorOutput>;
-    startWorkers(num: number, envOptions: Record<string, any>): void;
+    startWorkers(num: number, envOptions: Record<string, any>): FoundationWorker[];
     promMetrics: PromMetrics
 }
 


### PR DESCRIPTION
This PR makes the following changes:

- Fixes issue where the `node_master` process  doesn't shutdown in the event that the `cluster_master` or the `asset_service` child process exits with an error 
  - This will result in the master pod being left in the `running` state instead of `failed` with a `restartCrashLoop`
  - #3596