### PR TITLE
Add external ports to job automatically when promMetrics are enabled

### DIFF
--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetes/k8sResource.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetes/k8sResource.ts
@@ -246,7 +246,6 @@ export class K8sResource {
                         .push(
                             {
                                 name: portValue.name,
-                                // @ts-expect-error TODO: don't know types here
                                 containerPort: portValue.port
                             }
                         );

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -346,9 +346,9 @@ export class JobsService {
      * This ensures that the Prometheus exporter server can be scraped.
      * Check if prom_metrics_enabled is true on jobSpec or teraslice config.
      * If so, add or update external_ports property with correct port.
-     * @param {Partial<JobRecord>} jobSpec
+     * @param {Partial<JobConfig>} jobSpec
     */
-    addExternalPortsToJobSpec(jobSpec: Partial<JobRecord>) {
+    addExternalPortsToJobSpec(jobSpec: Partial<JobConfig>) {
         const {
             prom_metrics_enabled: enabledInTF,
             prom_metrics_port: tfPort

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -79,6 +79,7 @@ export class JobsService {
             });
         }
 
+        this.addExternalPortsToJobSpec(jobSpec);
         const validJob = await this._validateJobSpec(jobSpec);
 
         // We don't create with the fully parsed validJob as it changes the asset names
@@ -122,6 +123,7 @@ export class JobsService {
         if (originalJob.active !== false && jobSpec.active === false) {
             this.logger.info(`Skipping job validation to set jobId ${jobId} as _inactive`);
         } else {
+            this.addExternalPortsToJobSpec(jobSpec);
             await this._validateJobSpec(jobSpec);
         }
 
@@ -337,5 +339,35 @@ export class JobsService {
         parsedAssetJob.assets = assetIds;
 
         return parsedAssetJob;
+    }
+
+    /**
+     * Automatically add external_ports to jobSpec if needed.
+     * This ensures that the Prometheus exporter server can be scraped.
+     * Check if prom_metrics_enabled is true on jobSpec or teraslice config.
+     * If so, add or update external_ports property with correct port.
+     * @param {Partial<JobRecord>} jobSpec
+    */
+    addExternalPortsToJobSpec(jobSpec: Partial<JobRecord>) {
+        const {
+            prom_metrics_enabled: enabledInTF,
+            prom_metrics_port: tfPort
+        } = this.context.sysconfig.terafoundation;
+        const { prom_metrics_enabled: enabledInJob, prom_metrics_port: jobPort } = jobSpec;
+        const portToUse: number = jobPort || tfPort;
+
+        if (enabledInJob === true || (enabledInJob === undefined && enabledInTF)) {
+            let portPresent = false;
+            if (!jobSpec.external_ports) {
+                jobSpec.external_ports = [];
+            }
+            for (const item of jobSpec.external_ports) {
+                const currentPort = typeof item === 'number' ? item : item.port;
+                if (currentPort === portToUse) portPresent = true;
+            }
+            if (!portPresent) {
+                jobSpec.external_ports.push({ name: 'metrics', port: portToUse });
+            }
+        }
     }
 }

--- a/packages/types/src/teraslice.ts
+++ b/packages/types/src/teraslice.ts
@@ -308,7 +308,7 @@ export interface Targets {
 
 export interface ExternalPort {
     name: string;
-    containerPort: number
+    port: number
 }
 
 export interface Volume {


### PR DESCRIPTION
This PR makees the following changes:
- Creates an `addExternalPortsToJobSpec()` function that will add the `external_ports` field to a job if `promMetrics` are enabled and configure it to use the correct port.
- Adds a call to `addExternalPortsToJobSpec()` with the `submit()` and `update()` function within the `JobService` class.

ref: #3604