### PR TITLE
Set default label 'name' at init, not when PromMetrics class is created.

### DIFF
--- a/docs/development/k8s.md
+++ b/docs/development/k8s.md
@@ -374,6 +374,7 @@ The `PromMetrics` class lives within `packages/terafoundation/src/api/prom-metri
 Example init:
 ```typescript
 await config.context.apis.foundation.promMetrics.init({
+    terasliceName: context.sysconfig.teraslice.name,
     assignment: 'execution_controller',
     logger: this.logger,
     tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,

--- a/packages/job-components/test/test-helpers-spec.ts
+++ b/packages/job-components/test/test-helpers-spec.ts
@@ -136,6 +136,7 @@ describe('Test Helpers', () => {
         const context = new TestContext('test-prom-metrics');
         context.sysconfig.teraslice.cluster_manager_type = 'kubernetes';
         const config = {
+            terasliceName: context.sysconfig.teraslice.name,
             assignment: 'master',
             logger: debugLogger('test-helpers-spec-logger'),
             tf_prom_metrics_enabled: true,

--- a/packages/terafoundation/src/api/index.ts
+++ b/packages/terafoundation/src/api/index.ts
@@ -114,7 +114,7 @@ export default function registerApis(context: Terafoundation.Context): void {
 
             return workers;
         },
-        promMetrics: new PromMetrics(context.name, context.logger)
+        promMetrics: new PromMetrics(context.logger)
     };
     function _registerFoundationAPIs() {
         registerAPI('foundation', foundationApis);

--- a/packages/terafoundation/src/api/prom-metrics/prom-metrics-api.ts
+++ b/packages/terafoundation/src/api/prom-metrics/prom-metrics-api.ts
@@ -13,16 +13,13 @@ export class PromMetrics {
     default_labels!: Record<string, string>;
     prefix: string;
     private metricExporter!: Exporter;
-    name: string;
     apiConfig: tf.PromMetricsAPIConfig;
     apiRunning: boolean;
     logger: Logger;
 
     constructor(
-        name: string,
         logger: Logger,
     ) {
-        this.name = name;
         this.apiRunning = false;
         this.apiConfig = {} as tf.PromMetricsAPIConfig;
         this.prefix = '';
@@ -44,7 +41,7 @@ export class PromMetrics {
         const {
             assignment, job_prom_metrics_add_default, job_prom_metrics_enabled,
             job_prom_metrics_port, tf_prom_metrics_add_default, tf_prom_metrics_enabled,
-            tf_prom_metrics_port, labels, prefix
+            tf_prom_metrics_port, labels, prefix, terasliceName
         } = config;
 
         const portToUse = job_prom_metrics_port || tf_prom_metrics_port;
@@ -68,7 +65,7 @@ export class PromMetrics {
             this.prefix = apiConfig.prefix || `teraslice_${apiConfig.assignment}_`;
 
             this.default_labels = {
-                name: this.name,
+                name: terasliceName,
                 assignment: apiConfig.assignment,
                 ...apiConfig.labels
             };

--- a/packages/terafoundation/src/test-context.ts
+++ b/packages/terafoundation/src/test-context.ts
@@ -138,7 +138,7 @@ export class TestContext<
             return client;
         };
 
-        this.apis.foundation.promMetrics = new PromMetrics(ctx.name, ctx.logger);
+        this.apis.foundation.promMetrics = new PromMetrics(ctx.logger);
 
         this.apis.setTestClients = (clients: TestClientConfig[] = []) => {
             clients.forEach((clientConfig) => {

--- a/packages/terafoundation/test/apis/prom-metrics-spec.ts
+++ b/packages/terafoundation/test/apis/prom-metrics-spec.ts
@@ -21,13 +21,14 @@ describe('promMetrics foundation API', () => {
                         },
                         teraslice: {
                             cluster_manager_type: 'kubernetes',
+                            name: 'tera-test'
                         }
                     },
-                    name: 'tera-test'
                 } as any;
 
-                const { terafoundation } = context.sysconfig;
+                const { terafoundation, teraslice } = context.sysconfig;
                 const config = {
+                    terasliceName: teraslice.name,
                     tf_prom_metrics_enabled: terafoundation.prom_metrics_enabled,
                     tf_prom_metrics_port: terafoundation.prom_metrics_port,
                     tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
@@ -72,13 +73,14 @@ describe('promMetrics foundation API', () => {
                         },
                         teraslice: {
                             cluster_manager_type: 'kubernetes',
+                            name: 'tera-test'
                         }
                     },
-                    name: 'tera-test'
                 } as any;
 
-                const { terafoundation } = context.sysconfig;
+                const { terafoundation, teraslice } = context.sysconfig;
                 const config = {
+                    terasliceName: teraslice.name,
                     tf_prom_metrics_enabled: terafoundation.prom_metrics_enabled,
                     tf_prom_metrics_port: terafoundation.prom_metrics_port,
                     tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
@@ -114,13 +116,14 @@ describe('promMetrics foundation API', () => {
                         },
                         teraslice: {
                             cluster_manager_type: 'kubernetes',
+                            name: 'tera-test'
                         }
                     },
-                    name: 'tera-test'
                 } as any;
 
-                const { terafoundation } = context.sysconfig;
+                const { terafoundation, teraslice } = context.sysconfig;
                 const config = {
+                    terasliceName: teraslice.name,
                     tf_prom_metrics_enabled: terafoundation.prom_metrics_enabled,
                     tf_prom_metrics_port: terafoundation.prom_metrics_port,
                     tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
@@ -163,13 +166,14 @@ describe('promMetrics foundation API', () => {
                         },
                         teraslice: {
                             cluster_manager_type: 'kubernetes',
+                            name: 'tera-test'
                         }
                     },
-                    name: 'tera-test'
                 } as any;
 
-                const { terafoundation } = context.sysconfig;
+                const { terafoundation, teraslice } = context.sysconfig;
                 const config = {
+                    terasliceName: teraslice.name,
                     tf_prom_metrics_enabled: terafoundation.prom_metrics_enabled,
                     tf_prom_metrics_port: terafoundation.prom_metrics_port,
                     tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
@@ -204,13 +208,14 @@ describe('promMetrics foundation API', () => {
                         },
                         teraslice: {
                             cluster_manager_type: 'kubernetes',
+                            name: 'tera-test'
                         }
                     },
-                    name: 'tera-test'
                 } as any;
 
-                const { terafoundation } = context.sysconfig;
+                const { terafoundation, teraslice } = context.sysconfig;
                 const config = {
+                    terasliceName: teraslice.name,
                     tf_prom_metrics_enabled: terafoundation.prom_metrics_enabled,
                     tf_prom_metrics_port: terafoundation.prom_metrics_port,
                     tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
@@ -246,13 +251,14 @@ describe('promMetrics foundation API', () => {
                         },
                         teraslice: {
                             cluster_manager_type: 'kubernetes',
+                            name: 'tera-test'
                         }
                     },
-                    name: 'tera-test'
                 } as any;
 
-                const { terafoundation } = context.sysconfig;
+                const { terafoundation, teraslice } = context.sysconfig;
                 const config = {
+                    terasliceName: teraslice.name,
                     tf_prom_metrics_enabled: terafoundation.prom_metrics_enabled,
                     tf_prom_metrics_port: terafoundation.prom_metrics_port,
                     tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
@@ -295,13 +301,14 @@ describe('promMetrics foundation API', () => {
                 },
                 teraslice: {
                     cluster_manager_type: 'kubernetes',
+                    name: 'tera-test'
                 }
             },
-            name: 'tera-test'
         } as any;
 
-        const { terafoundation } = context.sysconfig;
+        const { terafoundation, teraslice } = context.sysconfig;
         const config = {
+            terasliceName: teraslice.name,
             tf_prom_metrics_enabled: terafoundation.prom_metrics_enabled,
             tf_prom_metrics_port: terafoundation.prom_metrics_port,
             tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
@@ -361,13 +368,14 @@ describe('promMetrics foundation API', () => {
                 },
                 teraslice: {
                     cluster_manager_type: 'kubernetes',
+                    name: 'tera-test'
                 }
             },
-            name: 'tera-test'
         } as any;
 
-        const { terafoundation } = context.sysconfig;
+        const { terafoundation, teraslice } = context.sysconfig;
         const config = {
+            terasliceName: teraslice.name,
             tf_prom_metrics_enabled: terafoundation.prom_metrics_enabled,
             tf_prom_metrics_port: terafoundation.prom_metrics_port,
             tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
@@ -455,13 +463,14 @@ describe('promMetrics foundation API', () => {
                 },
                 teraslice: {
                     cluster_manager_type: 'kubernetes',
+                    name: 'tera-test'
                 }
             },
-            name: 'tera-test'
         } as any;
 
-        const { terafoundation } = context.sysconfig;
+        const { terafoundation, teraslice } = context.sysconfig;
         const config = {
+            terasliceName: teraslice.name,
             tf_prom_metrics_enabled: terafoundation.prom_metrics_enabled,
             tf_prom_metrics_port: terafoundation.prom_metrics_port,
             tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
@@ -535,13 +544,14 @@ describe('promMetrics foundation API', () => {
                 },
                 teraslice: {
                     cluster_manager_type: 'kubernetes',
+                    name: 'tera-test'
                 }
             },
-            name: 'tera-test'
         } as any;
 
-        const { terafoundation } = context.sysconfig;
+        const { terafoundation, teraslice } = context.sysconfig;
         const config = {
+            terasliceName: teraslice.name,
             tf_prom_metrics_enabled: terafoundation.prom_metrics_enabled,
             tf_prom_metrics_port: terafoundation.prom_metrics_port,
             tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
@@ -614,13 +624,14 @@ describe('promMetrics foundation API', () => {
                 },
                 teraslice: {
                     cluster_manager_type: 'kubernetes',
+                    name: 'tera-test-labels'
                 }
             },
-            name: 'tera-test-labels'
         } as any;
 
-        const { terafoundation } = context.sysconfig;
+        const { terafoundation, teraslice } = context.sysconfig;
         const config = {
+            terasliceName: teraslice.name,
             tf_prom_metrics_enabled: terafoundation.prom_metrics_enabled,
             tf_prom_metrics_port: terafoundation.prom_metrics_port,
             tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,

--- a/packages/terafoundation/test/apis/prom-metrics-spec.ts
+++ b/packages/terafoundation/test/apis/prom-metrics-spec.ts
@@ -56,6 +56,11 @@ describe('promMetrics foundation API', () => {
                     expect(apiExists).toBe(true);
                 });
 
+                it('should have correct default labels', async () => {
+                    const labels = await context.apis.foundation.promMetrics.getDefaultLabels();
+                    expect(labels).toEqual({ assignment: 'worker', name: 'tera-test' });
+                });
+
                 it('should throw an error if promMetricsAPI is already initialized', async () => {
                     await expect(() => context.apis.foundation.promMetrics.init(config))
                         .rejects.toThrow('Prom metrics API cannot be initialized more than once.');

--- a/packages/terafoundation/test/test-context-spec.ts
+++ b/packages/terafoundation/test/test-context-spec.ts
@@ -71,6 +71,7 @@ describe('TestContext', () => {
         context.sysconfig.teraslice = { cluster_manager_type: 'kubernetes' };
         context.sysconfig.terafoundation.prom_metrics_enabled = true;
         const config = {
+            terasliceName: context.sysconfig.teraslice.name,
             tf_prom_metrics_enabled: true,
             tf_prom_metrics_port: 3333,
             tf_prom_metrics_add_default: false,

--- a/packages/terafoundation/test/test-context-spec.ts
+++ b/packages/terafoundation/test/test-context-spec.ts
@@ -68,7 +68,7 @@ describe('TestContext', () => {
 
     it('should be able to init prom_metrics_api', async () => {
         const context = await TestContext.createContext();
-        context.sysconfig.teraslice = { cluster_manager_type: 'kubernetes' };
+        context.sysconfig.teraslice = { cluster_manager_type: 'kubernetes', name: 'ts-test' };
         context.sysconfig.terafoundation.prom_metrics_enabled = true;
         const config = {
             terasliceName: context.sysconfig.teraslice.name,

--- a/packages/teraslice/src/lib/cluster/cluster_master.ts
+++ b/packages/teraslice/src/lib/cluster/cluster_master.ts
@@ -147,6 +147,7 @@ export class ClusterMaster {
             } else {
                 const { terafoundation } = this.context.sysconfig;
                 await this.context.apis.foundation.promMetrics.init({
+                    terasliceName: this.context.sysconfig.teraslice.name,
                     tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
                     tf_prom_metrics_enabled: terafoundation.prom_metrics_enabled,
                     tf_prom_metrics_port: terafoundation.prom_metrics_port,

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -646,7 +646,8 @@ export class ApiService {
             return match ? match[0] : 'Version number not available';
         }
 
-        if (this.context.sysconfig.terafoundation.prom_metrics_enabled) {
+        const { terafoundation, teraslice } = this.context.sysconfig;
+        if (terafoundation.prom_metrics_enabled && teraslice.cluster_manager_type !== 'native') {
             try {
                 const apiTimeout = 15000;
                 const apiTimeoutError = `Unable to verify that prom metrics API is running after ${apiTimeout / 1000} seconds`;

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -145,6 +145,7 @@ export class ExecutionController {
             const { terafoundation } = this.context.sysconfig;
             const { config, exId, jobId } = this.executionContext;
             await this.context.apis.foundation.promMetrics.init({
+                terasliceName: this.context.sysconfig.teraslice.name,
                 assignment: 'execution_controller',
                 logger: this.logger,
                 tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,

--- a/packages/teraslice/src/lib/workers/worker/index.ts
+++ b/packages/teraslice/src/lib/workers/worker/index.ts
@@ -92,6 +92,7 @@ export class Worker {
             const { terafoundation } = this.context.sysconfig;
             const { config, exId, jobId } = this.executionContext;
             await this.context.apis.foundation.promMetrics.init({
+                terasliceName: this.context.sysconfig.teraslice.name,
                 assignment: 'worker',
                 logger: this.logger,
                 tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,

--- a/packages/types/src/terafoundation.ts
+++ b/packages/types/src/terafoundation.ts
@@ -166,24 +166,25 @@ export interface Connector<S = Record<string, any>> {
 }
 
 export interface PromMetricsInitConfig {
-    assignment: string
-    logger: Logger,
+    terasliceName: string;
+    assignment: string;
+    logger: Logger;
     tf_prom_metrics_enabled: boolean;
     tf_prom_metrics_port: number;
     tf_prom_metrics_add_default: boolean;
-    job_prom_metrics_enabled?: boolean,
-    job_prom_metrics_port?: number
-    job_prom_metrics_add_default?: boolean
-    labels?: Record<string, string>,
-    prefix?: string
+    job_prom_metrics_enabled?: boolean;
+    job_prom_metrics_port?: number;
+    job_prom_metrics_add_default?: boolean;
+    labels?: Record<string, string>;
+    prefix?: string;
 }
 
 export interface PromMetricsAPIConfig {
-    assignment: string
-    port: number
-    default_metrics: boolean,
-    labels?: Record<string, string>,
-    prefix?: string
+    assignment: string;
+    port: number;
+    default_metrics: boolean;
+    labels?: Record<string, string>;
+    prefix?: string;
 }
 
 export interface PromMetrics {


### PR DESCRIPTION
The default label `name` was being set at `PromMetrics` class creation within `terafoundation` instead of being set at initialization. It previously was getting the value for `name` from `context.name`, but this doesn't always match with `teraslice.name` and would never be correct if used with `spaces`.

There is now a test in `prom-metrics-spec.ts` that checks the default labels for the correct values.