### PR TITLE
Test harness shutdown fix

### DIFF
--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/src/base-test-harness.ts
+++ b/packages/teraslice-test-harness/src/base-test-harness.ts
@@ -81,5 +81,8 @@ export default class BaseTestHarness<U extends ExecutionContext> {
     */
     async shutdown(): Promise<void> {
         this.events.removeAllListeners();
+        if (this.executionContext) {
+            await this.executionContext.shutdown();
+        }
     }
 }

--- a/packages/teraslice-test-harness/src/slicer-test-harness.ts
+++ b/packages/teraslice-test-harness/src/slicer-test-harness.ts
@@ -204,6 +204,5 @@ export default class SlicerTestHarness extends BaseTestHarness<SlicerExecutionCo
             clearInterval(this._emitInterval);
         }
         await super.shutdown();
-        await this.executionContext.shutdown();
     }
 }

--- a/packages/teraslice-test-harness/src/worker-test-harness.ts
+++ b/packages/teraslice-test-harness/src/worker-test-harness.ts
@@ -171,11 +171,6 @@ export default class WorkerTestHarness extends BaseTestHarness<WorkerExecutionCo
         // its undefined or null here
         return response;
     }
-
-    async shutdown(): Promise<void> {
-        await super.shutdown();
-        await this.executionContext.shutdown();
-    }
 }
 
 function isSlice(input: Slice | SliceRequest): input is Slice {

--- a/packages/teraslice-test-harness/test/slicer-test-harness-spec.ts
+++ b/packages/teraslice-test-harness/test/slicer-test-harness-spec.ts
@@ -94,6 +94,24 @@ describe('SlicerTestHarness', () => {
         });
 
         it('should be able to call shutdown', () => expect(slicerHarness.shutdown()).resolves.toBeNil());
+
+        it('should not throw if shutdown is called before initialized', async () => {
+            let test: SlicerTestHarness;
+
+            try {
+                test = new SlicerTestHarness(job, {
+                    assetDir: path.join(dirname, 'fixtures'),
+                    clients,
+                });
+
+                await expect(test.shutdown()).resolves.not.toThrow();
+            } finally {
+                // @ts-expect-error
+                if (test) {
+                    await test.shutdown();
+                }
+            }
+        });
     });
 
     describe('when given a slicer that is recoverable', () => {

--- a/packages/teraslice-test-harness/test/worker-test-harness-spec.ts
+++ b/packages/teraslice-test-harness/test/worker-test-harness-spec.ts
@@ -105,6 +105,24 @@ describe('WorkerTestHarness', () => {
         });
 
         it('should be able to call shutdown', () => expect(workerHarness.shutdown()).resolves.toBeNil());
+
+        it('should not throw if shutdown is called before initialized', async () => {
+            let test: WorkerTestHarness;
+
+            try {
+                test = new WorkerTestHarness(job, {
+                    assetDir: path.join(dirname, 'fixtures'),
+                    clients,
+                });
+
+                await expect(test.shutdown()).resolves.not.toThrow();
+            } finally {
+                // @ts-expect-error
+                if (test) {
+                    await test.shutdown();
+                }
+            }
+        });
     });
 
     describe('when using assets and multiple assetDirs', () => {


### PR DESCRIPTION
- the executionContext might not be set if shutdown is called before initialize, so we check for its existance