### PR TITLE
teraslice-cli - fix old asset build

### DIFF
--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"

--- a/packages/teraslice-cli/src/helpers/asset-src.ts
+++ b/packages/teraslice-cli/src/helpers/asset-src.ts
@@ -279,7 +279,6 @@ export class AssetSrc {
 
         const result = await build({
             bundle: true,
-            format: 'esm',
             entryPoints: [entryPoint],
             outdir: bundleDir.name,
             platform: 'node',


### PR DESCRIPTION
Removing the `format: esm` argument to esbuild lets old assets build correctly.