### PR TITLE
Add labels to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@
 ARG NODE_VERSION=18.19.1
 FROM terascope/node-base:${NODE_VERSION}
 
+ARG TERASLICE_VERSION
+ARG BUILD_TIMESTAMP
+ARG GITHUB_SHA
+
 ENV NODE_ENV production
 
 ENV YARN_SETUP_ARGS "--prod=false --silent --frozen-lockfile"
@@ -41,5 +45,15 @@ EXPOSE 5678
 # set up the volumes
 VOLUME /app/config /app/logs /app/assets
 ENV TERAFOUNDATION_CONFIG /app/config/teraslice.yaml
+
+LABEL org.opencontainers.image.version="$TERASLICE_VERSION" \
+  org.opencontainers.image.created="$BUILD_TIMESTAMP" \
+  org.opencontainers.image.documentation="https://terascope.github.io/teraslice/docs/overview" \
+  org.opencontainers.image.licenses="Apache-2.0" \
+  org.opencontainers.image.revision="$GITHUB_SHA" \
+  org.opencontainers.image.source="https://github.com/terascope/teraslice" \
+  org.opencontainers.image.title="Teraslice" \
+  org.opencontainers.image.url="https://terascope.github.io/teraslice" \
+  org.opencontainers.image.vendor="Terascope"
 
 CMD ["node", "service.js"]

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,7 +1,7 @@
 {
     "name": "e2e",
     "displayName": "E2E Tests",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "private": true,
     "description": "Teraslice integration test suite",
     "keywords": [

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -43,9 +43,9 @@
         "ms": "^2.1.3"
     },
     "devDependencies": {
-        "@terascope/types": "^0.17.3",
+        "@terascope/types": "^0.18.0",
         "bunyan": "^1.8.15",
-        "elasticsearch-store": "^0.84.3",
+        "elasticsearch-store": "^0.85.0",
         "fs-extra": "^11.2.0",
         "ms": "^2.1.3",
         "nanoid": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "0.56.3",
+    "version": "0.57.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -29,9 +29,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^0.50.3",
-        "@terascope/types": "^0.17.3",
-        "@terascope/utils": "^0.59.3",
+        "@terascope/data-types": "^0.51.0",
+        "@terascope/types": "^0.18.0",
+        "@terascope/utils": "^0.60.0",
         "@types/validator": "^13.11.10",
         "awesome-phonenumber": "^2.70.0",
         "date-fns": "^2.30.0",
@@ -46,7 +46,7 @@
         "uuid": "^9.0.1",
         "valid-url": "^1.0.9",
         "validator": "^13.12.0",
-        "xlucene-parser": "^0.58.3"
+        "xlucene-parser": "^0.59.0"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.6",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "0.50.3",
+    "version": "0.51.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -26,8 +26,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.3",
-        "@terascope/utils": "^0.59.3",
+        "@terascope/types": "^0.18.0",
+        "@terascope/utils": "^0.60.0",
         "graphql": "^14.7.0",
         "lodash": "^4.17.21",
         "yargs": "^17.7.2"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "3.20.3",
+    "version": "3.21.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "TEST_RESTRAINED_ELASTICSEARCH='true' ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.3",
-        "@terascope/utils": "^0.59.3",
+        "@terascope/types": "^0.18.0",
+        "@terascope/utils": "^0.60.0",
         "bluebird": "^3.7.2",
         "setimmediate": "^1.0.5"
     },
@@ -32,7 +32,7 @@
         "@opensearch-project/opensearch": "^1.2.0",
         "@types/elasticsearch": "^5.0.43",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^0.84.3",
+        "elasticsearch-store": "^0.85.0",
         "elasticsearch6": "npm:@elastic/elasticsearch@^6.7.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@^7.0.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@^8.0.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "0.84.3",
+    "version": "0.85.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -29,10 +29,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.56.3",
-        "@terascope/data-types": "^0.50.3",
-        "@terascope/types": "^0.17.3",
-        "@terascope/utils": "^0.59.3",
+        "@terascope/data-mate": "^0.57.0",
+        "@terascope/data-types": "^0.51.0",
+        "@terascope/types": "^0.18.0",
+        "@terascope/utils": "^0.60.0",
         "ajv": "^6.12.6",
         "elasticsearch6": "npm:@elastic/elasticsearch@^6.7.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@^7.0.0",
@@ -41,7 +41,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@^2.2.1",
         "setimmediate": "^1.0.5",
         "uuid": "^9.0.1",
-        "xlucene-translator": "^0.44.3"
+        "xlucene-translator": "^0.45.0"
     },
     "devDependencies": {
         "@types/uuid": "^9.0.8"

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -32,8 +32,8 @@
         "test:watch": "NODE_OPTIONS='--experimental-vm-modules' ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.3",
-        "@terascope/utils": "^0.59.3",
+        "@terascope/types": "^0.18.0",
+        "@terascope/utils": "^0.60.0",
         "convict": "^6.2.4",
         "convict-format-with-moment": "^6.2.0",
         "convict-format-with-validator": "^6.2.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.79.0",
+    "version": "0.80.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -32,8 +32,7 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "^0.20.0",
-        "@terascope/types": "^0.17.3",
-        "@terascope/utils": "^0.59.3",
+        "@terascope/utils": "^0.60.0",
         "codecov": "^3.8.3",
         "execa": "^5.1.0",
         "fs-extra": "^11.2.0",

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -138,7 +138,14 @@ async function publishToDocker(options: PublishOptions) {
         }
         signale.debug(`building docker image ${imageToBuild}`);
 
-        await dockerBuild(imageToBuild, [devImage], undefined, `NODE_VERSION=${options.nodeVersion}`);
+        const buildTimestamp = new Date().toISOString();
+        const sha = process.env.GITHUB_SHA;
+        const { version } = getRootInfo();
+        await dockerBuild(imageToBuild,
+            [devImage],
+            undefined,
+            [`NODE_VERSION=${options.nodeVersion}`, `TERASLICE_VERSION=${version}`, `BUILD_TIMESTAMP=${buildTimestamp}`, `GITHUB_SHA=${sha}`]
+        );
 
         if (!imagesToPush.includes(imageToBuild)) {
             imagesToPush.push(imageToBuild);

--- a/packages/scripts/src/helpers/publish/utils.ts
+++ b/packages/scripts/src/helpers/publish/utils.ts
@@ -97,7 +97,7 @@ export async function buildDevDockerImage(
     signale.pending(`building docker image ${devImage}`);
 
     try {
-        await dockerBuild(devImage, cacheFromPrev ? [devImage] : [], undefined, `NODE_VERSION=${publishOptions.nodeVersion}`, publishOptions.useDevFile);
+        await dockerBuild(devImage, cacheFromPrev ? [devImage] : [], undefined, [`NODE_VERSION=${publishOptions.nodeVersion}`], publishOptions.useDevFile);
     } catch (err) {
         throw new TSError(err, {
             message: `Failed to build ${devImage} docker image`,

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -393,7 +393,7 @@ export async function dockerBuild(
     tag: string,
     cacheFrom?: string[],
     target?: string,
-    buildArg?: string,
+    buildArgs?: string[],
     useDevFile?: boolean
 ): Promise<void> {
     const cacheFromArgs: string[] = [];
@@ -403,7 +403,9 @@ export async function dockerBuild(
     });
 
     const targetArgs: string[] = target ? ['--target', target] : [];
-    const buildsArgs: string[] = buildArg ? ['--build-arg', buildArg] : [];
+    const buildsArgs: string[] = buildArgs
+        ? ['--build-arg', ...buildArgs.join(',--build-arg,').split(',')]
+        : [];
     const dockerFilePath = useDevFile ? ['-f', 'Dockerfile.dev', '.'] : ['.'];
 
     await fork({

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -29,15 +29,15 @@
     },
     "dependencies": {
         "@terascope/file-asset-apis": "^0.13.0",
-        "@terascope/types": "^0.17.3",
-        "@terascope/utils": "^0.59.3",
+        "@terascope/types": "^0.18.0",
+        "@terascope/utils": "^0.60.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.15",
         "convict": "^6.2.4",
         "convict-format-with-moment": "^6.2.0",
         "convict-format-with-validator": "^6.2.0",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^0.84.3",
+        "elasticsearch-store": "^0.85.0",
         "express": "^4.19.2",
         "js-yaml": "^4.1.0",
         "nanoid": "^3.3.4",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "2.0.3",
+    "version": "2.1.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -38,8 +38,8 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^0.8.10",
-        "@terascope/types": "^0.17.3",
-        "@terascope/utils": "^0.59.3",
+        "@terascope/types": "^0.18.0",
+        "@terascope/utils": "^0.60.0",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.4",
         "easy-table": "^1.2.0",
@@ -54,7 +54,7 @@
         "pretty-bytes": "^5.6.0",
         "prompts": "^2.4.2",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^0.60.3",
+        "teraslice-client-js": "^0.61.0",
         "tmp": "^0.2.0",
         "tty-table": "^4.2.3",
         "yargs": "^17.7.2",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "0.60.3",
+    "version": "0.61.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -32,8 +32,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.3",
-        "@terascope/utils": "^0.59.3",
+        "@terascope/types": "^0.18.0",
+        "@terascope/utils": "^0.60.0",
         "auto-bind": "^4.0.0",
         "got": "^11.8.3"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -35,8 +35,8 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.3",
-        "@terascope/utils": "^0.59.3",
+        "@terascope/types": "^0.18.0",
+        "@terascope/utils": "^0.60.0",
         "ms": "^2.1.3",
         "nanoid": "^3.3.4",
         "p-event": "^4.2.0",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "0.53.3",
+    "version": "0.54.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -23,8 +23,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^3.20.3",
-        "@terascope/utils": "^0.59.3"
+        "@terascope/elasticsearch-api": "^3.21.0",
+        "@terascope/utils": "^0.60.0"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {
@@ -36,10 +36,10 @@
         "fs-extra": "^11.2.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^1.0.1"
+        "@terascope/job-components": "^1.1.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=1.0.1"
+        "@terascope/job-components": ">=1.1.0"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -38,11 +38,11 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^3.20.3",
-        "@terascope/job-components": "^1.0.1",
-        "@terascope/teraslice-messaging": "^1.0.1",
-        "@terascope/types": "^0.17.3",
-        "@terascope/utils": "^0.59.3",
+        "@terascope/elasticsearch-api": "^3.21.0",
+        "@terascope/job-components": "^1.1.0",
+        "@terascope/teraslice-messaging": "^1.1.0",
+        "@terascope/types": "^0.18.0",
+        "@terascope/utils": "^0.60.0",
         "async-mutex": "^0.5.0",
         "barbe": "^3.0.16",
         "body-parser": "^1.20.2",
@@ -63,7 +63,7 @@
         "semver": "^7.6.2",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^1.0.1",
+        "terafoundation": "^1.1.0",
         "uuid": "^9.0.1"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "0.85.3",
+    "version": "0.86.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -35,9 +35,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^0.56.3",
-        "@terascope/types": "^0.17.3",
-        "@terascope/utils": "^0.59.3",
+        "@terascope/data-mate": "^0.57.0",
+        "@terascope/types": "^0.18.0",
+        "@terascope/utils": "^0.60.0",
         "awesome-phonenumber": "^2.70.0",
         "graphlib": "^2.1.8",
         "is-ip": "^3.1.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/types",
     "displayName": "Types",
-    "version": "0.17.3",
+    "version": "0.18.0",
     "description": "A collection of typescript interfaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/types#readme",
     "bugs": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "0.59.3",
+    "version": "0.60.0",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {
@@ -28,7 +28,7 @@
         "debug": "^4.3.4"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.3",
+        "@terascope/types": "^0.18.0",
         "@turf/bbox": "^6.4.0",
         "@turf/bbox-polygon": "^6.4.0",
         "@turf/boolean-contains": "^6.4.0",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "0.58.3",
+    "version": "0.59.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -30,8 +30,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.3",
-        "@terascope/utils": "^0.59.3"
+        "@terascope/types": "^0.18.0",
+        "@terascope/utils": "^0.60.0"
     },
     "devDependencies": {
         "@turf/invariant": "^6.2.0",

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "0.44.3",
+    "version": "0.45.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -28,10 +28,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^0.17.3",
-        "@terascope/utils": "^0.59.3",
+        "@terascope/types": "^0.18.0",
+        "@terascope/utils": "^0.60.0",
         "@types/elasticsearch": "^5.0.43",
-        "xlucene-parser": "^0.58.3"
+        "xlucene-parser": "^0.59.0"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "0.26.3",
+    "version": "0.27.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -23,10 +23,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^0.59.3"
+        "@terascope/utils": "^0.60.0"
     },
     "devDependencies": {
-        "@terascope/types": "^0.17.3"
+        "@terascope/types": "^0.18.0"
     },
     "engines": {
         "node": ">=14.17.0",


### PR DESCRIPTION
This PR makes the following changes:
- Adds these labels to the teraslice docker image:
  - org.opencontainers.image.version="$TERASLICE_VERSION"
  - org.opencontainers.image.created="$BUILD_TIMESTAMP"
  - org.opencontainers.image.documentation="https://terascope.github.io/teraslice/docs/overview"
  - org.opencontainers.image.licenses="Apache-2.0"
  - org.opencontainers.image.revision="$GITHUB_SHA"
  - org.opencontainers.image.source="https://github.com/terascope/teraslice"
  - org.opencontainers.image.title="Teraslice"
  - org.opencontainers.image.url="https://terascope.github.io/teraslice"
  - org.opencontainers.image.vendor="Terascope"
- Updates the `dockerBuild` function to allow a `buildArgs` array.
- Updates `publishToDocker` function to pass the following `buildArgs`:
  - `TERASLICE_VERSION`: equal to `version` in the teraslice root `package.json`.
  - `BUILD_TIMESTAMP`: equal to the result of `new Date().toISOString()` immediately before the `dockerBuild` function is called (ex: `2024-07-10T14:43:09.429Z`).
  - `GITHUB_SHA`: equal to the value of `process.env.GITHUB_SHA` immediately before the `dockerBuild` function is called. In the Github Actions CI pipeline where this script runs it will equal `the commit SHA that triggered the workflow` (ex: `ffac537e6cbbf934b08745a378932722df287a53`).

ref: #3257 