### PR TITLE
Fix publish-master workflow

### DIFF
--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -22,7 +22,7 @@ jobs:
 
       # we login to docker to publish new teraslice image
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -85,4 +85,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR makes the following changes:

- Updates `actions/deploy-pages` from `v2` to `v4`
- Updates `docker/login-action` to `v3`

This should resolve a broken pipeline where publishing docs fail. 
https://github.com/terascope/teraslice/actions/runs/9814144681/job/27101692541

This is most likely because we updated `upload-pages-artifact` to `v3` which requires `actions/deploy-pages@v4` or newer. Stated here: https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0