### PR TITLE
Add daily docker cache workflow to master

### DIFF
--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -65,7 +65,7 @@ jobs:
         echo "Deleting caches..."
         for cacheKey in $cacheKeysForPR
         do
-            gh actions-cache delete $cacheKey -R $REPO --confirm
+            gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
         done
         echo "Done"
       env:

--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -3,9 +3,7 @@ name: Daily Docker Cache
 on:
   schedule:
     - cron: '0 12 * * 1-5' # Monday - Friday at 5am Arizona Time
-  push:
-    branches:
-      - master
+  workflow_dispatch:
 
 jobs:
   cache-docker-images:
@@ -51,12 +49,30 @@ jobs:
         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
         lookup-only: true
 
+    - name: Clear old docker cache
+      if: ${{steps.docker-cache.outputs.cache-hit == 'true'}}
+      run: |
+        gh extension install actions/gh-actions-cache
+
+        echo "Fetching list of cache key"
+        cacheKeysForPR=$(gh actions-cache list -R $REPO -L 100 | cut -f 1 )
+
+        ## Setting this to not fail the workflow while deleting cache keys.
+        set +e
+        echo "Deleting caches..."
+        for cacheKey in $cacheKeysForPR
+        do
+            gh actions-cache delete docker-images-* -R $REPO --confirm
+        done
+        echo "Done"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+
     - name: Pull and save Docker images
-      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
       run: yarn docker:saveImages
 
     - name: Update Docker image cache
-      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
       uses: actions/cache@v4
       with:
         path: /tmp/docker_cache

--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -3,11 +3,14 @@ name: Daily Docker Cache
 on:
   schedule:
     - cron: '0 12 * * 1-5' # Monday - Friday at 5am Arizona Time
-  workflow_dispatch:
 
 jobs:
   cache-docker-images:
     runs-on: ubuntu-latest
+
+    # # final check to make sure it runs only on master branch
+    if: github.ref == 'refs/heads/master'
+
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -55,25 +58,26 @@ jobs:
         gh extension install actions/gh-actions-cache
 
         echo "Fetching list of cache key"
-        cacheKeysForPR=$(gh actions-cache list -R $REPO -L 100 | cut -f 1 )
+        cacheKeysForPR=$(gh actions-cache list --key "docker-images-" -R $REPO -B $BRANCH -L 100 | cut -f 1 )
 
         ## Setting this to not fail the workflow while deleting cache keys.
         set +e
         echo "Deleting caches..."
         for cacheKey in $cacheKeysForPR
         do
-            gh actions-cache delete docker-images-* -R $REPO --confirm
+            gh actions-cache delete $cacheKey -R $REPO --confirm
         done
         echo "Done"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
+        BRANCH: refs/heads/master
 
     - name: Pull and save Docker images
       run: yarn docker:saveImages
 
     - name: Update Docker image cache
-      uses: actions/cache@v4
+      uses: actions/cache/save@v4
       with:
         path: /tmp/docker_cache
         key: docker-images-${{ hashFiles('./images/image-list.txt') }}

--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -54,6 +54,10 @@ jobs:
 
     - name: Clear old docker cache
       if: ${{steps.docker-cache.outputs.cache-hit == 'true'}}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        BRANCH: refs/heads/master
       run: |
         gh extension install actions/gh-actions-cache
 
@@ -68,10 +72,6 @@ jobs:
             gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
         done
         echo "Done"
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        REPO: ${{ github.repository }}
-        BRANCH: refs/heads/master
 
     - name: Pull and save Docker images
       run: yarn docker:saveImages

--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -1,0 +1,69 @@
+name: Daily Docker Cache
+
+on:
+  schedule:
+    - cron: '0 12 * * 1-5' # Monday - Friday at 5am Arizona Time
+  push:
+    branches:
+      - master
+
+jobs:
+  cache-docker-images:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18.19.1
+        cache: 'yarn'
+
+    # we login to docker to avoid docker pull limit rates
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Check docker.hub limit start of job
+      env:
+        USER: ${{ secrets.DOCKER_USERNAME }}
+        PASS: ${{ secrets.DOCKER_PASSWORD }}
+      run: yarn docker:limit
+
+    - name: Install and build packages
+      run: yarn setup
+      env:
+        YARN_SETUP_ARGS: "--prod=false --silent"
+
+    - name: Create Docker Image List
+      run: |
+        yarn docker:listImages
+        cat ./images/image-list.txt
+
+    - name: Restore Docker image cache
+      id: docker-cache
+      uses: actions/cache@v4
+      with:
+        path: /tmp/docker_cache
+        key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+        lookup-only: true
+
+    - name: Pull and save Docker images
+      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
+      run: yarn docker:saveImages
+
+    - name: Update Docker image cache
+      if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
+      uses: actions/cache@v4
+      with:
+        path: /tmp/docker_cache
+        key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+
+    - name: Check docker.hub limit end of job
+      env:
+        USER: ${{ secrets.DOCKER_USERNAME }}
+        PASS: ${{ secrets.DOCKER_PASSWORD }}
+      run: npm run docker:limit


### PR DESCRIPTION
This PR makes the following changes:

- Adds a new workflow action that runs once a day `Monday - Friday` at 5am to build a fresh docker cache
  - This will allow all child branches to have access to this cache