### PR TITLE
Further improvements to CI test pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,6 @@ jobs:
 
   linux-unit-tests:
     runs-on: ubuntu-latest
-    needs: verify-build
     strategy:
       matrix:
         node-version: [18.19.1, 20.11.1, 22.2.0]
@@ -114,7 +113,6 @@ jobs:
 
   linux-unit-esm-tests:
     runs-on: ubuntu-latest
-    needs: verify-build
     strategy:
       matrix:
         node-version: [18.19.1, 20.11.1, 22.2.0]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
 
   linux-unit-tests:
     runs-on: ubuntu-latest
+    needs: verify-build
     strategy:
       matrix:
         node-version: [18.19.1, 20.11.1, 22.2.0]
@@ -113,6 +114,7 @@ jobs:
 
   linux-unit-esm-tests:
     runs-on: ubuntu-latest
+    needs: verify-build
     strategy:
       matrix:
         node-version: [18.19.1, 20.11.1, 22.2.0]
@@ -197,7 +199,7 @@ jobs:
 
   elasticsearch-store-tests:
     runs-on: ubuntu-latest
-    needs: cache-docker-images
+    needs: [verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
@@ -256,7 +258,7 @@ jobs:
 
   elasticsearch-api-tests:
     runs-on: ubuntu-latest
-    needs: cache-docker-images
+    needs: [verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
@@ -445,7 +447,7 @@ jobs:
 
   e2e-k8s-v2-tests:
     runs-on: ubuntu-latest
-    needs: cache-docker-images
+    needs: [verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
@@ -512,7 +514,7 @@ jobs:
 
   e2e-external-storage-tests:
     runs-on: ubuntu-latest
-    needs: cache-docker-images
+    needs: [verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
@@ -574,7 +576,7 @@ jobs:
 
   e2e-external-storage-tests-encrypted:
     runs-on: ubuntu-latest
-    needs: cache-docker-images
+    needs: [verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       id: docker-cache
       uses: actions/cache@v4
       with:
-        path: /tmp/docker_cache
+        path: /images/docker_cache
         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
         lookup-only: true
 
@@ -79,7 +79,7 @@ jobs:
       if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
       uses: actions/cache@v4
       with:
-        path: /tmp/docker_cache
+        path: /images/docker_cache
         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
     - name: Check docker.hub limit end of job
@@ -88,53 +88,53 @@ jobs:
         PASS: ${{ secrets.DOCKER_PASSWORD }}
       run: npm run docker:limit
 
-  # linux-unit-tests:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       node-version: [18.19.1, 20.11.1, 22.2.0]
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  linux-unit-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.19.1, 20.11.1, 22.2.0]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
-  #     - name: Install and build packages
-  #       run: yarn setup
-  #       env:
-  #         YARN_SETUP_ARGS: "--prod=false --silent"
+      - name: Install and build packages
+        run: yarn setup
+        env:
+          YARN_SETUP_ARGS: "--prod=false --silent"
 
-  #     - name: Test
-  #       run: yarn --silent test -- --suite unit --
+      - name: Test
+        run: yarn --silent test -- --suite unit --
 
-  # linux-unit-esm-tests:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       node-version: [18.19.1, 20.11.1, 22.2.0]
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  linux-unit-esm-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.19.1, 20.11.1, 22.2.0]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
-  #     - name: Install and build packages
-  #       run: yarn setup
-  #       env:
-  #         YARN_SETUP_ARGS: "--prod=false --silent"
+      - name: Install and build packages
+        run: yarn setup
+        env:
+          YARN_SETUP_ARGS: "--prod=false --silent"
 
-  #     - name: Test
-  #       run: yarn --silent test -- --suite unit-esm --
-  #       env:
-  #         NODE_OPTIONS: '--experimental-vm-modules'
+      - name: Test
+        run: yarn --silent test -- --suite unit-esm --
+        env:
+          NODE_OPTIONS: '--experimental-vm-modules'
 
   teraslice-elasticsearch-tests:
     runs-on: ubuntu-latest
@@ -143,8 +143,8 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1] #, 20.11.1, 22.2.0]
-        search-version: [elasticsearch6] #, elasticsearch7, opensearch1, opensearch2]
+        node-version: [18.19.1, 20.11.1, 22.2.0]
+        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -182,7 +182,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: /tmp/docker_cache
+          path: /images/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Test ${{ matrix.search-version }}
@@ -195,133 +195,15 @@ jobs:
           PASS: ${{ secrets.DOCKER_PASSWORD }}
         run: npm run docker:limit
 
-  # elasticsearch-store-tests:
-  #   runs-on: ubuntu-latest
-  #   needs: cache-docker-images
-  #   strategy:
-  #     # opensearch is finiky, keep testing others if it fails
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: [18.19.1, 20.11.1, 22.2.0]
-  #       search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
-
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
-
-  #     # we login to docker to avoid docker pull limit rates
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
-
-  #     - name: Check docker.hub limit start
-  #       env:
-  #         USER: ${{ secrets.DOCKER_USERNAME }}
-  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
-  #       run: npm run docker:limit
-
-  #     - name: Install and build packages
-  #       run: yarn setup
-  #       env:
-  #         YARN_SETUP_ARGS: "--prod=false --silent"
-
-  #     - name: Create Docker Image List
-  #       run: |
-  #         yarn docker:listImages
-  #         cat ./images/image-list.txt
-
-  #     - name: Restore Docker image cache
-  #       id: docker-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/docker_cache
-  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
-
-  #     - name: Test ${{ matrix.search-version }}
-  #       run: yarn --silent test:${{ matrix.search-version }}
-  #       working-directory: ./packages/elasticsearch-store
-
-  #     - name: Check docker.hub limit end of job
-  #       env:
-  #         USER: ${{ secrets.DOCKER_USERNAME }}
-  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
-  #       run: npm run docker:limit
-
-  # elasticsearch-api-tests:
-  #   runs-on: ubuntu-latest
-  #   needs: cache-docker-images
-  #   strategy:
-  #     # opensearch is finiky, keep testing others if it fails
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: [18.19.1, 20.11.1, 22.2.0]
-  #       search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
-
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
-
-  #     # we login to docker to avoid docker pull limit rates
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
-
-  #     - name: Check docker.hub limit start
-  #       env:
-  #         USER: ${{ secrets.DOCKER_USERNAME }}
-  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
-  #       run: npm run docker:limit
-
-  #     - name: Install and build packages
-  #       run: yarn setup
-  #       env:
-  #         YARN_SETUP_ARGS: "--prod=false --silent"
-
-  #     - name: Create Docker Image List
-  #       run: |
-  #         yarn docker:listImages
-  #         cat ./images/image-list.txt
-
-  #     - name: Restore Docker image cache
-  #       id: docker-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/docker_cache
-  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
-
-  #     - name: Test ${{ matrix.search-version }}
-  #       run: yarn --silent test:${{ matrix.search-version }}
-  #       working-directory: ./packages/elasticsearch-api
-
-  #     - name: Check docker.hub limit end of job
-  #       env:
-  #         USER: ${{ secrets.DOCKER_USERNAME }}
-  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
-  #       run: npm run docker:limit
-
-  e2e-tests:
+  elasticsearch-store-tests:
     runs-on: ubuntu-latest
-    needs: [verify-build, cache-docker-images]
+    needs: cache-docker-images
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1] #, 20.11.1, 22.2.0]
-        search-version: [elasticsearch6] #, elasticsearch7, opensearch1, opensearch2]
+        node-version: [18.19.1, 20.11.1, 22.2.0]
+        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -359,7 +241,125 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: /tmp/docker_cache
+          path: /images/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+
+      - name: Test ${{ matrix.search-version }}
+        run: yarn --silent test:${{ matrix.search-version }}
+        working-directory: ./packages/elasticsearch-store
+
+      - name: Check docker.hub limit end of job
+        env:
+          USER: ${{ secrets.DOCKER_USERNAME }}
+          PASS: ${{ secrets.DOCKER_PASSWORD }}
+        run: npm run docker:limit
+
+  elasticsearch-api-tests:
+    runs-on: ubuntu-latest
+    needs: cache-docker-images
+    strategy:
+      # opensearch is finiky, keep testing others if it fails
+      fail-fast: false
+      matrix:
+        node-version: [18.19.1, 20.11.1, 22.2.0]
+        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+
+      # we login to docker to avoid docker pull limit rates
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Check docker.hub limit start
+        env:
+          USER: ${{ secrets.DOCKER_USERNAME }}
+          PASS: ${{ secrets.DOCKER_PASSWORD }}
+        run: npm run docker:limit
+
+      - name: Install and build packages
+        run: yarn setup
+        env:
+          YARN_SETUP_ARGS: "--prod=false --silent"
+
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
+
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /images/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+
+      - name: Test ${{ matrix.search-version }}
+        run: yarn --silent test:${{ matrix.search-version }}
+        working-directory: ./packages/elasticsearch-api
+
+      - name: Check docker.hub limit end of job
+        env:
+          USER: ${{ secrets.DOCKER_USERNAME }}
+          PASS: ${{ secrets.DOCKER_PASSWORD }}
+        run: npm run docker:limit
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    needs: [verify-build, cache-docker-images]
+    strategy:
+      # opensearch is finiky, keep testing others if it fails
+      fail-fast: false
+      matrix:
+        node-version: [18.19.1, 20.11.1, 22.2.0]
+        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+
+      # we login to docker to avoid docker pull limit rates
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Check docker.hub limit start
+        env:
+          USER: ${{ secrets.DOCKER_USERNAME }}
+          PASS: ${{ secrets.DOCKER_PASSWORD }}
+        run: npm run docker:limit
+
+      - name: Install and build packages
+        run: yarn setup
+        env:
+          YARN_SETUP_ARGS: "--prod=false --silent"
+
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
+
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /images/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Compile e2e code
@@ -383,7 +383,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1] #, 20.11.1, 22.2.0]
+        node-version: [18.19.1, 20.11.1, 22.2.0]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -421,7 +421,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: /tmp/docker_cache
+          path: /images/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Compile e2e code
@@ -443,205 +443,205 @@ jobs:
           PASS: ${{ secrets.DOCKER_PASSWORD }}
         run: npm run docker:limit
 
-  # e2e-k8s-v2-tests:
-  #   runs-on: ubuntu-latest
-  #   needs: cache-docker-images
-  #   strategy:
-  #     # opensearch is finiky, keep testing others if it fails
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: [18.19.1, 20.11.1]
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  e2e-k8s-v2-tests:
+    runs-on: ubuntu-latest
+    needs: cache-docker-images
+    strategy:
+      # opensearch is finiky, keep testing others if it fails
+      fail-fast: false
+      matrix:
+        node-version: [18.19.1, 20.11.1]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
-  #     # we login to docker to avoid docker pull limit rates
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
+      # we login to docker to avoid docker pull limit rates
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-  #     - name: Check docker.hub limit start
-  #       env:
-  #         USER: ${{ secrets.DOCKER_USERNAME }}
-  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
-  #       run: npm run docker:limit
+      - name: Check docker.hub limit start
+        env:
+          USER: ${{ secrets.DOCKER_USERNAME }}
+          PASS: ${{ secrets.DOCKER_PASSWORD }}
+        run: npm run docker:limit
 
-  #     - name: Install and build packages
-  #       run: yarn setup
-  #       env:
-  #         YARN_SETUP_ARGS: "--prod=false --silent"
+      - name: Install and build packages
+        run: yarn setup
+        env:
+          YARN_SETUP_ARGS: "--prod=false --silent"
 
-  #     - name: Create Docker Image List
-  #       run: |
-  #         yarn docker:listImages
-  #         cat ./images/image-list.txt
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
 
-  #     - name: Restore Docker image cache
-  #       id: docker-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/docker_cache
-  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /images/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-  #     - name: Compile e2e code
-  #       run: yarn build
-  #       working-directory: ./e2e
+      - name: Compile e2e code
+        run: yarn build
+        working-directory: ./e2e
 
-  #     - name: Install Kind and Kubectl
-  #       uses: helm/kind-action@v1.10.0
-  #       with:
-  #         install_only: "true"
+      - name: Install Kind and Kubectl
+        uses: helm/kind-action@v1.10.0
+        with:
+          install_only: "true"
 
-  #     - name: Test k8s V2 elasticsearch7
-  #       run: yarn --silent test:k8sV2 --node-version ${{ matrix.node-version }}
-  #       working-directory: ./e2e
+      - name: Test k8s V2 elasticsearch7
+        run: yarn --silent test:k8sV2 --node-version ${{ matrix.node-version }}
+        working-directory: ./e2e
 
-  #     - name: Check docker.hub limit end of job
-  #       env:
-  #         USER: ${{ secrets.DOCKER_USERNAME }}
-  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
-  #       run: npm run docker:limit
+      - name: Check docker.hub limit end of job
+        env:
+          USER: ${{ secrets.DOCKER_USERNAME }}
+          PASS: ${{ secrets.DOCKER_PASSWORD }}
+        run: npm run docker:limit
 
-  # e2e-external-storage-tests:
-  #   runs-on: ubuntu-latest
-  #   needs: cache-docker-images
-  #   strategy:
-  #     # opensearch is finiky, keep testing others if it fails
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: [18.19.1]
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  e2e-external-storage-tests:
+    runs-on: ubuntu-latest
+    needs: cache-docker-images
+    strategy:
+      # opensearch is finiky, keep testing others if it fails
+      fail-fast: false
+      matrix:
+        node-version: [18.19.1]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
-  #     # we login to docker to avoid docker pull limit rates
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
+      # we login to docker to avoid docker pull limit rates
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-  #     - name: Check docker.hub limit start
-  #       env:
-  #         USER: ${{ secrets.DOCKER_USERNAME }}
-  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
-  #       run: npm run docker:limit
+      - name: Check docker.hub limit start
+        env:
+          USER: ${{ secrets.DOCKER_USERNAME }}
+          PASS: ${{ secrets.DOCKER_PASSWORD }}
+        run: npm run docker:limit
 
-  #     - name: Install and build packages
-  #       run: yarn setup
-  #       env:
-  #         YARN_SETUP_ARGS: "--prod=false --silent"
+      - name: Install and build packages
+        run: yarn setup
+        env:
+          YARN_SETUP_ARGS: "--prod=false --silent"
 
-  #     - name: Create Docker Image List
-  #       run: |
-  #         yarn docker:listImages
-  #         cat ./images/image-list.txt
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
 
-  #     - name: Restore Docker image cache
-  #       id: docker-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/docker_cache
-  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /images/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-  #     - name: Compile e2e code
-  #       run: yarn build
-  #       working-directory: ./e2e
+      - name: Compile e2e code
+        run: yarn build
+        working-directory: ./e2e
 
-  #     - name: Test external Asset Storage opensearch1
-  #       run: yarn --silent test:s3AssetStorage --node-version ${{ matrix.node-version }}
-  #       working-directory: ./e2e
+      - name: Test external Asset Storage opensearch1
+        run: yarn --silent test:s3AssetStorage --node-version ${{ matrix.node-version }}
+        working-directory: ./e2e
 
-  #     - name: Check docker.hub limit end of job
-  #       env:
-  #         USER: ${{ secrets.DOCKER_USERNAME }}
-  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
-  #       run: npm run docker:limit
+      - name: Check docker.hub limit end of job
+        env:
+          USER: ${{ secrets.DOCKER_USERNAME }}
+          PASS: ${{ secrets.DOCKER_PASSWORD }}
+        run: npm run docker:limit
 
-  # e2e-external-storage-tests-encrypted:
-  #   runs-on: ubuntu-latest
-  #   needs: cache-docker-images
-  #   strategy:
-  #     # opensearch is finiky, keep testing others if it fails
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: [18.19.1]
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  e2e-external-storage-tests-encrypted:
+    runs-on: ubuntu-latest
+    needs: cache-docker-images
+    strategy:
+      # opensearch is finiky, keep testing others if it fails
+      fail-fast: false
+      matrix:
+        node-version: [18.19.1]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
-  #     # we login to docker to avoid docker pull limit rates
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
+      # we login to docker to avoid docker pull limit rates
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-  #     - name: Check docker.hub limit start
-  #       env:
-  #         USER: ${{ secrets.DOCKER_USERNAME }}
-  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
-  #       run: npm run docker:limit
+      - name: Check docker.hub limit start
+        env:
+          USER: ${{ secrets.DOCKER_USERNAME }}
+          PASS: ${{ secrets.DOCKER_PASSWORD }}
+        run: npm run docker:limit
 
-  #     - name: Install and build packages
-  #       run: yarn setup
-  #       env:
-  #         YARN_SETUP_ARGS: "--prod=false --silent"
+      - name: Install and build packages
+        run: yarn setup
+        env:
+          YARN_SETUP_ARGS: "--prod=false --silent"
 
-  #     - name: Create Docker Image List
-  #       run: |
-  #         yarn docker:listImages
-  #         cat ./images/image-list.txt
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
 
-  #     - name: Restore Docker image cache
-  #       id: docker-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/docker_cache
-  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /images/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-  #     - name: Install mkcert
-  #       run: curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" && sudo chmod 777 mkcert-v*-linux-amd64 && sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
+      - name: Install mkcert
+        run: curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" && sudo chmod 777 mkcert-v*-linux-amd64 && sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
 
-  #     - name: Install grep
-  #       run: sudo apt update && sudo apt install grep
+      - name: Install grep
+        run: sudo apt update && sudo apt install grep
 
-  #     - name: Check mkcert
-  #       run: command -v mkcert
+      - name: Check mkcert
+        run: command -v mkcert
 
-  #     - name: Check grep
-  #       run: command -v grep
+      - name: Check grep
+        run: command -v grep
 
-  #     - name: Compile e2e code
-  #       run: yarn build
-  #       working-directory: ./e2e
+      - name: Compile e2e code
+        run: yarn build
+        working-directory: ./e2e
 
-  #     - name: Test external Asset Storage opensearch1
-  #       run: ENCRYPT_MINIO=true yarn --silent test:s3AssetStorage --node-version ${{ matrix.node-version }}
-  #       working-directory: ./e2e
+      - name: Test external Asset Storage opensearch1
+        run: ENCRYPT_MINIO=true yarn --silent test:s3AssetStorage --node-version ${{ matrix.node-version }}
+        working-directory: ./e2e
 
-  #     - name: Check docker.hub limit end of job
-  #       env:
-  #         USER: ${{ secrets.DOCKER_USERNAME }}
-  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
-  #       run: npm run docker:limit
+      - name: Check docker.hub limit end of job
+        env:
+          USER: ${{ secrets.DOCKER_USERNAME }}
+          PASS: ${{ secrets.DOCKER_PASSWORD }}
+        run: npm run docker:limit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
 
   cache-docker-images:
     runs-on: ubuntu-latest
-    needs: verify-build
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -89,63 +88,63 @@ jobs:
         PASS: ${{ secrets.DOCKER_PASSWORD }}
       run: npm run docker:limit
 
-  linux-unit-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+  # linux-unit-tests:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       node-version: [18.19.1, 20.11.1, 22.2.0]
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
 
-      - name: Install and build packages
-        run: yarn setup
-        env:
-          YARN_SETUP_ARGS: "--prod=false --silent"
+  #     - name: Install and build packages
+  #       run: yarn setup
+  #       env:
+  #         YARN_SETUP_ARGS: "--prod=false --silent"
 
-      - name: Test
-        run: yarn --silent test -- --suite unit --
+  #     - name: Test
+  #       run: yarn --silent test -- --suite unit --
 
-  linux-unit-esm-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+  # linux-unit-esm-tests:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       node-version: [18.19.1, 20.11.1, 22.2.0]
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
 
-      - name: Install and build packages
-        run: yarn setup
-        env:
-          YARN_SETUP_ARGS: "--prod=false --silent"
+  #     - name: Install and build packages
+  #       run: yarn setup
+  #       env:
+  #         YARN_SETUP_ARGS: "--prod=false --silent"
 
-      - name: Test
-        run: yarn --silent test -- --suite unit-esm --
-        env:
-          NODE_OPTIONS: '--experimental-vm-modules'
+  #     - name: Test
+  #       run: yarn --silent test -- --suite unit-esm --
+  #       env:
+  #         NODE_OPTIONS: '--experimental-vm-modules'
 
   teraslice-elasticsearch-tests:
     runs-on: ubuntu-latest
-    needs: cache-docker-images
+    needs: [verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
-        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
+        node-version: [18.19.1] #, 20.11.1, 22.2.0]
+        search-version: [elasticsearch6] #, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -196,133 +195,133 @@ jobs:
           PASS: ${{ secrets.DOCKER_PASSWORD }}
         run: npm run docker:limit
 
-  elasticsearch-store-tests:
-    runs-on: ubuntu-latest
-    needs: cache-docker-images
-    strategy:
-      # opensearch is finiky, keep testing others if it fails
-      fail-fast: false
-      matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
-        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+  # elasticsearch-store-tests:
+  #   runs-on: ubuntu-latest
+  #   needs: cache-docker-images
+  #   strategy:
+  #     # opensearch is finiky, keep testing others if it fails
+  #     fail-fast: false
+  #     matrix:
+  #       node-version: [18.19.1, 20.11.1, 22.2.0]
+  #       search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
 
-      # we login to docker to avoid docker pull limit rates
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+  #     # we login to docker to avoid docker pull limit rates
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Check docker.hub limit start
-        env:
-          USER: ${{ secrets.DOCKER_USERNAME }}
-          PASS: ${{ secrets.DOCKER_PASSWORD }}
-        run: npm run docker:limit
+  #     - name: Check docker.hub limit start
+  #       env:
+  #         USER: ${{ secrets.DOCKER_USERNAME }}
+  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
+  #       run: npm run docker:limit
 
-      - name: Install and build packages
-        run: yarn setup
-        env:
-          YARN_SETUP_ARGS: "--prod=false --silent"
+  #     - name: Install and build packages
+  #       run: yarn setup
+  #       env:
+  #         YARN_SETUP_ARGS: "--prod=false --silent"
 
-      - name: Create Docker Image List
-        run: |
-          yarn docker:listImages
-          cat ./images/image-list.txt
+  #     - name: Create Docker Image List
+  #       run: |
+  #         yarn docker:listImages
+  #         cat ./images/image-list.txt
 
-      - name: Restore Docker image cache
-        id: docker-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker_cache
-          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+  #     - name: Restore Docker image cache
+  #       id: docker-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/docker_cache
+  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-      - name: Test ${{ matrix.search-version }}
-        run: yarn --silent test:${{ matrix.search-version }}
-        working-directory: ./packages/elasticsearch-store
+  #     - name: Test ${{ matrix.search-version }}
+  #       run: yarn --silent test:${{ matrix.search-version }}
+  #       working-directory: ./packages/elasticsearch-store
 
-      - name: Check docker.hub limit end of job
-        env:
-          USER: ${{ secrets.DOCKER_USERNAME }}
-          PASS: ${{ secrets.DOCKER_PASSWORD }}
-        run: npm run docker:limit
+  #     - name: Check docker.hub limit end of job
+  #       env:
+  #         USER: ${{ secrets.DOCKER_USERNAME }}
+  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
+  #       run: npm run docker:limit
 
-  elasticsearch-api-tests:
-    runs-on: ubuntu-latest
-    needs: cache-docker-images
-    strategy:
-      # opensearch is finiky, keep testing others if it fails
-      fail-fast: false
-      matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
-        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+  # elasticsearch-api-tests:
+  #   runs-on: ubuntu-latest
+  #   needs: cache-docker-images
+  #   strategy:
+  #     # opensearch is finiky, keep testing others if it fails
+  #     fail-fast: false
+  #     matrix:
+  #       node-version: [18.19.1, 20.11.1, 22.2.0]
+  #       search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
 
-      # we login to docker to avoid docker pull limit rates
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+  #     # we login to docker to avoid docker pull limit rates
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Check docker.hub limit start
-        env:
-          USER: ${{ secrets.DOCKER_USERNAME }}
-          PASS: ${{ secrets.DOCKER_PASSWORD }}
-        run: npm run docker:limit
+  #     - name: Check docker.hub limit start
+  #       env:
+  #         USER: ${{ secrets.DOCKER_USERNAME }}
+  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
+  #       run: npm run docker:limit
 
-      - name: Install and build packages
-        run: yarn setup
-        env:
-          YARN_SETUP_ARGS: "--prod=false --silent"
+  #     - name: Install and build packages
+  #       run: yarn setup
+  #       env:
+  #         YARN_SETUP_ARGS: "--prod=false --silent"
 
-      - name: Create Docker Image List
-        run: |
-          yarn docker:listImages
-          cat ./images/image-list.txt
+  #     - name: Create Docker Image List
+  #       run: |
+  #         yarn docker:listImages
+  #         cat ./images/image-list.txt
 
-      - name: Restore Docker image cache
-        id: docker-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker_cache
-          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+  #     - name: Restore Docker image cache
+  #       id: docker-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/docker_cache
+  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-      - name: Test ${{ matrix.search-version }}
-        run: yarn --silent test:${{ matrix.search-version }}
-        working-directory: ./packages/elasticsearch-api
+  #     - name: Test ${{ matrix.search-version }}
+  #       run: yarn --silent test:${{ matrix.search-version }}
+  #       working-directory: ./packages/elasticsearch-api
 
-      - name: Check docker.hub limit end of job
-        env:
-          USER: ${{ secrets.DOCKER_USERNAME }}
-          PASS: ${{ secrets.DOCKER_PASSWORD }}
-        run: npm run docker:limit
+  #     - name: Check docker.hub limit end of job
+  #       env:
+  #         USER: ${{ secrets.DOCKER_USERNAME }}
+  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
+  #       run: npm run docker:limit
 
   e2e-tests:
     runs-on: ubuntu-latest
-    needs: cache-docker-images
+    needs: [verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
-        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
+        node-version: [18.19.1] #, 20.11.1, 22.2.0]
+        search-version: [elasticsearch6] #, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -339,6 +338,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Check docker.hub limit start
+        env:
+          USER: ${{ secrets.DOCKER_USERNAME }}
+          PASS: ${{ secrets.DOCKER_PASSWORD }}
+        run: npm run docker:limit
 
       - name: Install and build packages
         run: yarn setup
@@ -373,12 +378,12 @@ jobs:
 
   e2e-k8s-tests:
     runs-on: ubuntu-latest
-    needs: cache-docker-images
+    needs: [verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
+        node-version: [18.19.1] #, 20.11.1, 22.2.0]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -395,6 +400,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Check docker.hub limit start
+        env:
+          USER: ${{ secrets.DOCKER_USERNAME }}
+          PASS: ${{ secrets.DOCKER_PASSWORD }}
+        run: npm run docker:limit
 
       - name: Install and build packages
         run: yarn setup
@@ -432,187 +443,205 @@ jobs:
           PASS: ${{ secrets.DOCKER_PASSWORD }}
         run: npm run docker:limit
 
-  e2e-k8s-v2-tests:
-    runs-on: ubuntu-latest
-    needs: cache-docker-images
-    strategy:
-      # opensearch is finiky, keep testing others if it fails
-      fail-fast: false
-      matrix:
-        node-version: [18.19.1, 20.11.1]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+  # e2e-k8s-v2-tests:
+  #   runs-on: ubuntu-latest
+  #   needs: cache-docker-images
+  #   strategy:
+  #     # opensearch is finiky, keep testing others if it fails
+  #     fail-fast: false
+  #     matrix:
+  #       node-version: [18.19.1, 20.11.1]
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
 
-      # we login to docker to avoid docker pull limit rates
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+  #     # we login to docker to avoid docker pull limit rates
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Install and build packages
-        run: yarn setup
-        env:
-          YARN_SETUP_ARGS: "--prod=false --silent"
+  #     - name: Check docker.hub limit start
+  #       env:
+  #         USER: ${{ secrets.DOCKER_USERNAME }}
+  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
+  #       run: npm run docker:limit
 
-      - name: Create Docker Image List
-        run: |
-          yarn docker:listImages
-          cat ./images/image-list.txt
+  #     - name: Install and build packages
+  #       run: yarn setup
+  #       env:
+  #         YARN_SETUP_ARGS: "--prod=false --silent"
 
-      - name: Restore Docker image cache
-        id: docker-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker_cache
-          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+  #     - name: Create Docker Image List
+  #       run: |
+  #         yarn docker:listImages
+  #         cat ./images/image-list.txt
 
-      - name: Compile e2e code
-        run: yarn build
-        working-directory: ./e2e
+  #     - name: Restore Docker image cache
+  #       id: docker-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/docker_cache
+  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-      - name: Install Kind and Kubectl
-        uses: helm/kind-action@v1.8.0
-        with:
-          install_only: "true"
+  #     - name: Compile e2e code
+  #       run: yarn build
+  #       working-directory: ./e2e
 
-      - name: Test k8s V2 elasticsearch7
-        run: yarn --silent test:k8sV2 --node-version ${{ matrix.node-version }}
-        working-directory: ./e2e
+  #     - name: Install Kind and Kubectl
+  #       uses: helm/kind-action@v1.10.0
+  #       with:
+  #         install_only: "true"
 
-      - name: Check docker.hub limit end of job
-        env:
-          USER: ${{ secrets.DOCKER_USERNAME }}
-          PASS: ${{ secrets.DOCKER_PASSWORD }}
-        run: npm run docker:limit
+  #     - name: Test k8s V2 elasticsearch7
+  #       run: yarn --silent test:k8sV2 --node-version ${{ matrix.node-version }}
+  #       working-directory: ./e2e
 
-  e2e-external-storage-tests:
-    runs-on: ubuntu-latest
-    needs: cache-docker-images
-    strategy:
-      # opensearch is finiky, keep testing others if it fails
-      fail-fast: false
-      matrix:
-        node-version: [18.19.1]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Check docker.hub limit end of job
+  #       env:
+  #         USER: ${{ secrets.DOCKER_USERNAME }}
+  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
+  #       run: npm run docker:limit
 
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+  # e2e-external-storage-tests:
+  #   runs-on: ubuntu-latest
+  #   needs: cache-docker-images
+  #   strategy:
+  #     # opensearch is finiky, keep testing others if it fails
+  #     fail-fast: false
+  #     matrix:
+  #       node-version: [18.19.1]
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      # we login to docker to avoid docker pull limit rates
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
 
-      - name: Install and build packages
-        run: yarn setup
-        env:
-          YARN_SETUP_ARGS: "--prod=false --silent"
+  #     # we login to docker to avoid docker pull limit rates
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Create Docker Image List
-        run: |
-          yarn docker:listImages
-          cat ./images/image-list.txt
+  #     - name: Check docker.hub limit start
+  #       env:
+  #         USER: ${{ secrets.DOCKER_USERNAME }}
+  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
+  #       run: npm run docker:limit
 
-      - name: Restore Docker image cache
-        id: docker-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker_cache
-          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+  #     - name: Install and build packages
+  #       run: yarn setup
+  #       env:
+  #         YARN_SETUP_ARGS: "--prod=false --silent"
 
-      - name: Compile e2e code
-        run: yarn build
-        working-directory: ./e2e
+  #     - name: Create Docker Image List
+  #       run: |
+  #         yarn docker:listImages
+  #         cat ./images/image-list.txt
 
-      - name: Test external Asset Storage opensearch1
-        run: yarn --silent test:s3AssetStorage --node-version ${{ matrix.node-version }}
-        working-directory: ./e2e
+  #     - name: Restore Docker image cache
+  #       id: docker-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/docker_cache
+  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-      - name: Check docker.hub limit end of job
-        env:
-          USER: ${{ secrets.DOCKER_USERNAME }}
-          PASS: ${{ secrets.DOCKER_PASSWORD }}
-        run: npm run docker:limit
+  #     - name: Compile e2e code
+  #       run: yarn build
+  #       working-directory: ./e2e
 
-  e2e-external-storage-tests-encrypted:
-    runs-on: ubuntu-latest
-    needs: cache-docker-images
-    strategy:
-      # opensearch is finiky, keep testing others if it fails
-      fail-fast: false
-      matrix:
-        node-version: [18.19.1]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+  #     - name: Test external Asset Storage opensearch1
+  #       run: yarn --silent test:s3AssetStorage --node-version ${{ matrix.node-version }}
+  #       working-directory: ./e2e
 
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+  #     - name: Check docker.hub limit end of job
+  #       env:
+  #         USER: ${{ secrets.DOCKER_USERNAME }}
+  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
+  #       run: npm run docker:limit
 
-      # we login to docker to avoid docker pull limit rates
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+  # e2e-external-storage-tests-encrypted:
+  #   runs-on: ubuntu-latest
+  #   needs: cache-docker-images
+  #   strategy:
+  #     # opensearch is finiky, keep testing others if it fails
+  #     fail-fast: false
+  #     matrix:
+  #       node-version: [18.19.1]
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      - name: Install and build packages
-        run: yarn setup
-        env:
-          YARN_SETUP_ARGS: "--prod=false --silent"
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
 
-      - name: Create Docker Image List
-        run: |
-          yarn docker:listImages
-          cat ./images/image-list.txt
+  #     # we login to docker to avoid docker pull limit rates
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Restore Docker image cache
-        id: docker-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker_cache
-          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+  #     - name: Check docker.hub limit start
+  #       env:
+  #         USER: ${{ secrets.DOCKER_USERNAME }}
+  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
+  #       run: npm run docker:limit
 
-      - name: Install mkcert
-        run: curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" && sudo chmod 777 mkcert-v*-linux-amd64 && sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
+  #     - name: Install and build packages
+  #       run: yarn setup
+  #       env:
+  #         YARN_SETUP_ARGS: "--prod=false --silent"
 
-      - name: Install grep
-        run: sudo apt update && sudo apt install grep
+  #     - name: Create Docker Image List
+  #       run: |
+  #         yarn docker:listImages
+  #         cat ./images/image-list.txt
 
-      - name: Check mkcert
-        run: command -v mkcert
+  #     - name: Restore Docker image cache
+  #       id: docker-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/docker_cache
+  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-      - name: Check grep
-        run: command -v grep
+  #     - name: Install mkcert
+  #       run: curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" && sudo chmod 777 mkcert-v*-linux-amd64 && sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
 
-      - name: Compile e2e code
-        run: yarn build
-        working-directory: ./e2e
+  #     - name: Install grep
+  #       run: sudo apt update && sudo apt install grep
 
-      - name: Test external Asset Storage opensearch1
-        run: ENCRYPT_MINIO=true yarn --silent test:s3AssetStorage --node-version ${{ matrix.node-version }}
-        working-directory: ./e2e
+  #     - name: Check mkcert
+  #       run: command -v mkcert
 
-      - name: Check docker.hub limit end of job
-        env:
-          USER: ${{ secrets.DOCKER_USERNAME }}
-          PASS: ${{ secrets.DOCKER_PASSWORD }}
-        run: npm run docker:limit
+  #     - name: Check grep
+  #       run: command -v grep
+
+  #     - name: Compile e2e code
+  #       run: yarn build
+  #       working-directory: ./e2e
+
+  #     - name: Test external Asset Storage opensearch1
+  #       run: ENCRYPT_MINIO=true yarn --silent test:s3AssetStorage --node-version ${{ matrix.node-version }}
+  #       working-directory: ./e2e
+
+  #     - name: Check docker.hub limit end of job
+  #       env:
+  #         USER: ${{ secrets.DOCKER_USERNAME }}
+  #         PASS: ${{ secrets.DOCKER_PASSWORD }}
+  #       run: npm run docker:limit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       id: docker-cache
       uses: actions/cache@v4
       with:
-        path: tmp/docker_cache
+        path: /tmp/docker_cache
         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
         lookup-only: true
 
@@ -79,7 +79,7 @@ jobs:
       if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
       uses: actions/cache/save@v4
       with:
-        path: tmp/docker_cache
+        path: /tmp/docker_cache
         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
     - name: Check docker.hub limit end of job
@@ -182,7 +182,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: tmp/docker_cache
+          path: /tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Test ${{ matrix.search-version }}
@@ -241,7 +241,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: tmp/docker_cache
+          path: /tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Test ${{ matrix.search-version }}
@@ -300,7 +300,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: tmp/docker_cache
+          path: /tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Test ${{ matrix.search-version }}
@@ -359,7 +359,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: tmp/docker_cache
+          path: /tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Compile e2e code
@@ -421,7 +421,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: tmp/docker_cache
+          path: /tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Compile e2e code
@@ -488,7 +488,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: tmp/docker_cache
+          path: /tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Compile e2e code
@@ -555,7 +555,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: tmp/docker_cache
+          path: /tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Compile e2e code
@@ -617,7 +617,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: tmp/docker_cache
+          path: /tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Install mkcert

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       id: docker-cache
       uses: actions/cache@v4
       with:
-        path: /images/docker_cache
+        path: ./images/docker_cache
         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
         lookup-only: true
 
@@ -79,7 +79,7 @@ jobs:
       if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
       uses: actions/cache@v4
       with:
-        path: /images/docker_cache
+        path: ./images/docker_cache
         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
     - name: Check docker.hub limit end of job
@@ -182,7 +182,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: /images/docker_cache
+          path: ./images/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Test ${{ matrix.search-version }}
@@ -241,7 +241,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: /images/docker_cache
+          path: ./images/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Test ${{ matrix.search-version }}
@@ -300,7 +300,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: /images/docker_cache
+          path: ./images/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Test ${{ matrix.search-version }}
@@ -359,7 +359,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: /images/docker_cache
+          path: ./images/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Compile e2e code
@@ -421,7 +421,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: /images/docker_cache
+          path: ./images/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Compile e2e code
@@ -488,7 +488,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: /images/docker_cache
+          path: ./images/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Compile e2e code
@@ -555,7 +555,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: /images/docker_cache
+          path: ./images/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Compile e2e code
@@ -617,7 +617,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: /images/docker_cache
+          path: ./images/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Install mkcert

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -385,7 +385,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
+        node-version: [18.19.1, 22.2.0]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -452,7 +452,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 20.11.1]
+        node-version: [18.19.1, 22.2.0]
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       id: docker-cache
       uses: actions/cache@v4
       with:
-        path: ./images/docker_cache
+        path: tmp/docker_cache
         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
         lookup-only: true
 
@@ -77,9 +77,9 @@ jobs:
 
     - name: Update Docker image cache
       if: ${{steps.docker-cache.outputs.cache-hit != 'true'}}
-      uses: actions/cache@v4
+      uses: actions/cache/save@v4
       with:
-        path: ./images/docker_cache
+        path: tmp/docker_cache
         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
     - name: Check docker.hub limit end of job
@@ -182,7 +182,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: ./images/docker_cache
+          path: tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Test ${{ matrix.search-version }}
@@ -241,7 +241,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: ./images/docker_cache
+          path: tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Test ${{ matrix.search-version }}
@@ -300,7 +300,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: ./images/docker_cache
+          path: tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Test ${{ matrix.search-version }}
@@ -359,7 +359,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: ./images/docker_cache
+          path: tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Compile e2e code
@@ -421,7 +421,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: ./images/docker_cache
+          path: tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Compile e2e code
@@ -488,7 +488,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: ./images/docker_cache
+          path: tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Compile e2e code
@@ -555,7 +555,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: ./images/docker_cache
+          path: tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Compile e2e code
@@ -617,7 +617,7 @@ jobs:
         id: docker-cache
         uses: actions/cache@v4
         with:
-          path: ./images/docker_cache
+          path: tmp/docker_cache
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Install mkcert

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.81.0",
+    "version": "0.81.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -186,4 +186,4 @@ export const {
 
 export const DOCKER_IMAGES_PATH = './images';
 export const DOCKER_IMAGE_LIST_PATH = `${DOCKER_IMAGES_PATH}/image-list.txt`;
-export const DOCKER_CACHE_PATH = `${DOCKER_IMAGES_PATH}/docker_cache`;
+export const DOCKER_CACHE_PATH = '/tmp/docker_cache';

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -184,6 +184,6 @@ export const {
     TERASLICE_IMAGE = undefined
 } = process.env;
 
-export const DOCKER_CACHE_PATH = '/tmp/docker_cache';
 export const DOCKER_IMAGES_PATH = './images';
-export const DOCKER_LIST_FILE_NAME = 'image-list.txt';
+export const DOCKER_IMAGE_LIST_PATH = `${DOCKER_IMAGES_PATH}/image-list.txt`;
+export const DOCKER_CACHE_PATH = `${DOCKER_IMAGES_PATH}/docker_cache`;

--- a/packages/scripts/src/helpers/images/index.ts
+++ b/packages/scripts/src/helpers/images/index.ts
@@ -7,22 +7,20 @@ import signale from '../signale';
 
 export async function images(action: ImagesAction): Promise<void> {
     if (action === ImagesAction.List) {
-        return createImageList(config.DOCKER_IMAGES_PATH);
+        return createImageList();
     }
 
     if (action === ImagesAction.Save) {
-        return saveImages(config.DOCKER_CACHE_PATH, config.DOCKER_IMAGES_PATH);
+        return saveImages();
     }
 }
 
 /**
  * Builds a list of all docker images needed for the teraslice CI pipeline
- * @returns Record<string, string>
+ * @returns Promise<void>
  */
-async function createImageList(imagesTxtPath: string): Promise<void> {
-    const filePath = path.join(imagesTxtPath, `${config.DOCKER_LIST_FILE_NAME}`);
-
-    signale.info(`Creating Docker image list at ${filePath}`);
+async function createImageList(): Promise<void> {
+    signale.info(`Creating Docker image list at ${config.DOCKER_IMAGE_LIST_PATH}`);
 
     const list = 'terascope/node-base:18.19.1\n'
                + 'terascope/node-base:20.11.1\n'
@@ -36,29 +34,41 @@ async function createImageList(imagesTxtPath: string): Promise<void> {
                + `${config.MINIO_DOCKER_IMAGE}:RELEASE.2020-02-07T23-28-16Z\n`
                + 'kindest/node:v1.30.0';
 
-    if (!fse.existsSync(imagesTxtPath)) {
-        await fse.emptyDir(imagesTxtPath);
+    if (!fse.existsSync(config.DOCKER_IMAGES_PATH)) {
+        await fse.emptyDir(config.DOCKER_IMAGES_PATH);
     }
-    fse.writeFileSync(filePath, list);
+    fse.writeFileSync(config.DOCKER_IMAGE_LIST_PATH, list);
 }
 
+/**
+ * Save a docker image as a tar.gz to a local directory
+ * @param {string} imageName Name of image to pull and save
+ * @param {string} imageSavePath Location where image will be saved and compressed.
+ * @returns void
+ */
 async function saveAndZip(imageName:string, imageSavePath: string) {
+    signale.info(`Saving Docker image: ${imageName}`);
     const fileName = imageName.replace(/[/:]/g, '_');
     const filePath = path.join(imageSavePath, `${fileName}.tar`);
     const command = `docker save ${imageName} | gzip > ${filePath}.gz`;
     await execa.command(command, { shell: true });
 }
 
-async function saveImages(imageSavePath: string, imageTxtPath: string): Promise<void> {
+/**
+ * Pulls all docker images from the list at config.DOCKER_IMAGE_LIST_PATH
+ * then saves and zips them to config.DOCKER_CACHE_PATH in batches of 2.
+ * @returns Promise<void>
+ */
+async function saveImages(): Promise<void> {
     try {
-        if (fse.existsSync(imageSavePath)) {
-            fse.rmSync(imageSavePath, { recursive: true, force: true });
+        if (fse.existsSync(config.DOCKER_CACHE_PATH)) {
+            fse.rmSync(config.DOCKER_CACHE_PATH, { recursive: true, force: true });
         }
-        fse.mkdirSync(imageSavePath);
-        const imagesString = fse.readFileSync(path.join(imageTxtPath, config.DOCKER_LIST_FILE_NAME), 'utf-8');
+        fse.mkdirSync(config.DOCKER_CACHE_PATH);
+        const imagesString = fse.readFileSync(config.DOCKER_IMAGE_LIST_PATH, 'utf-8');
         const imagesArray = imagesString.split('\n');
         const pullPromises = imagesArray.map(async (imageName) => {
-            signale.info(`Pulling Docker image ${imageName}`);
+            signale.info(`Pulling Docker image: ${imageName}`);
             await execa.command(`docker pull ${imageName}`);
         });
         await Promise.all(pullPromises);
@@ -66,11 +76,11 @@ async function saveImages(imageSavePath: string, imageTxtPath: string): Promise<
         for (let i = 0; i < imagesArray.length; i += 2) {
             if (typeof imagesArray[i + 1] === 'string') {
                 await Promise.all([
-                    saveAndZip(imagesArray[i], imageSavePath),
-                    saveAndZip(imagesArray[i + 1], imageSavePath)
+                    saveAndZip(imagesArray[i], config.DOCKER_CACHE_PATH),
+                    saveAndZip(imagesArray[i + 1], config.DOCKER_CACHE_PATH)
                 ]);
             } else {
-                await saveAndZip(imagesArray[i], imageSavePath);
+                await saveAndZip(imagesArray[i], config.DOCKER_CACHE_PATH);
             }
         }
     } catch (err) {

--- a/packages/scripts/src/helpers/kind.ts
+++ b/packages/scripts/src/helpers/kind.ts
@@ -92,7 +92,8 @@ export class Kind {
                 if (!fs.existsSync(filePath)) {
                     throw new Error(`No file found at ${filePath}. Have you restored the cache?`);
                 }
-                execa.command(`gunzip -d ${filePath}`);
+                subprocess = await execa.command(`gunzip -d ${filePath}`);
+                signale.info(`${subprocess.command}: successful`);
                 subprocess = await execa.command(`kind load --name ${this.clusterName} image-archive ${tarPath}`);
                 fs.rmSync(tarPath);
             } else {
@@ -101,7 +102,7 @@ export class Kind {
             signale.info(`${subprocess.command}: successful`);
         } catch (err) {
             signale.info(`The ${serviceName} docker image ${serviceImage}:${version} could not be loaded. It may not be present locally.`);
-            signale.info(`Error: ${subprocess?.stderr}`);
+            signale.info('Error: ', err);
         }
     }
 

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -471,6 +471,20 @@ export async function pgrep(name: string): Promise<string> {
     return '';
 }
 
+/**
+ * Save a docker image as a tar.gz to a local directory
+ * @param {string} imageName Name of image to pull and save
+ * @param {string} imageSavePath Location where image will be saved and compressed.
+ * @returns void
+ */
+export async function saveAndZip(imageName:string, imageSavePath: string) {
+    signale.info(`Saving Docker image: ${imageName}`);
+    const fileName = imageName.replace(/[/:]/g, '_');
+    const filePath = path.join(imageSavePath, `${fileName}.tar`);
+    const command = `docker save ${imageName} | gzip > ${filePath}.gz`;
+    await execa.command(command, { shell: true });
+}
+
 export async function getCommitHash(): Promise<string> {
     if (process.env.GIT_COMMIT_HASH) return process.env.GIT_COMMIT_HASH;
 

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -425,6 +425,12 @@ export async function dockerPush(image: string): Promise<void> {
     }
 }
 
+/**
+ * Unzips and loads a Docker image from a Docker cache
+ * If successful the image will be deleted from the cache
+ * @param {string} imageName Name of the image to load
+ * @returns {Promise<boolean>} Whether or not the image loaded successfully
+ */
 export async function loadThenDeleteImageFromCache(imageName: string): Promise<boolean> {
     signale.time(`unzip and load ${imageName}`);
     const fileName = imageName.trim().replace(/[/:]/g, '_');

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -240,14 +240,14 @@ async function runE2ETest(
     const e2eImage = `${rootInfo.name}:e2e-nodev${options.nodeVersion}`;
 
     if (isCI) {
-        // load the base docker image
-        await loadThenDeleteImageFromCache(`terascope/node-base:${options.nodeVersion}`);
-
         // load service if in native. In k8s services will be loaded directly to kind
         if (options.testPlatform === 'native') {
             await loadOrPullServiceImages(suite, options);
             await deleteDockerImageCache();
         }
+
+        // load the base docker image
+        await loadThenDeleteImageFromCache(`terascope/node-base:${options.nodeVersion}`);
     }
 
     try {

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -239,16 +239,15 @@ async function runE2ETest(
     const rootInfo = getRootInfo();
     const e2eImage = `${rootInfo.name}:e2e-nodev${options.nodeVersion}`;
 
-    if (isCI && options.testPlatform === 'native') {
-        const promises = [];
-
-        // load the services from cache or pull if not found
-        promises.push(loadOrPullServiceImages(suite, options));
-
+    if (isCI) {
         // load the base docker image
-        promises.push(loadThenDeleteImageFromCache(`terascope/node-base:${options.nodeVersion}`));
+        loadThenDeleteImageFromCache(`terascope/node-base:${options.nodeVersion}`);
 
-        await Promise.all([...promises]);
+        // load service if in native. In k8s services will be loaded directly to kind
+        if (options.testPlatform === 'native') {
+            loadOrPullServiceImages(suite, options);
+        }
+
         await deleteDockerImageCache();
     }
 

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -285,6 +285,8 @@ async function runE2ETest(
         tracker.addError(err);
     }
 
+    await deleteDockerImageCache();
+
     if (!tracker.hasErrors()) {
         const timeLabel = `test suite "${suite}"`;
         signale.time(timeLabel);

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -241,14 +241,13 @@ async function runE2ETest(
 
     if (isCI) {
         // load the base docker image
-        loadThenDeleteImageFromCache(`terascope/node-base:${options.nodeVersion}`);
+        await loadThenDeleteImageFromCache(`terascope/node-base:${options.nodeVersion}`);
 
         // load service if in native. In k8s services will be loaded directly to kind
         if (options.testPlatform === 'native') {
-            loadOrPullServiceImages(suite, options);
+            await loadOrPullServiceImages(suite, options);
+            await deleteDockerImageCache();
         }
-
-        await deleteDockerImageCache();
     }
 
     try {

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -15,7 +15,8 @@ import {
     k8sStartService,
     k8sStopService,
     loadThenDeleteImageFromCache,
-    dockerPull
+    dockerPull,
+    deleteDockerImageCache
 } from '../scripts';
 import { Kind } from '../kind';
 import { TestOptions } from './interfaces';
@@ -819,6 +820,7 @@ async function startService(options: TestOptions, service: Service): Promise<() 
     if (options.testPlatform === 'kubernetes' || options.testPlatform === 'kubernetesV2') {
         const kind = new Kind(options.k8sVersion, options.kindClusterName);
         await kind.loadServiceImage(service, services[service].image, version);
+        await deleteDockerImageCache();
         await k8sStopService(service);
         await k8sStartService(service, services[service].image, version, kind);
         return () => { };

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -15,8 +15,7 @@ import {
     k8sStartService,
     k8sStopService,
     loadThenDeleteImageFromCache,
-    dockerPull,
-    deleteDockerImageCache
+    dockerPull
 } from '../scripts';
 import { Kind } from '../kind';
 import { TestOptions } from './interfaces';

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -820,7 +820,6 @@ async function startService(options: TestOptions, service: Service): Promise<() 
     if (options.testPlatform === 'kubernetes' || options.testPlatform === 'kubernetesV2') {
         const kind = new Kind(options.k8sVersion, options.kindClusterName);
         await kind.loadServiceImage(service, services[service].image, version);
-        await deleteDockerImageCache();
         await k8sStopService(service);
         await k8sStartService(service, services[service].image, version, kind);
         return () => { };

--- a/packages/scripts/src/index.ts
+++ b/packages/scripts/src/index.ts
@@ -3,3 +3,4 @@ export * from './helpers/misc';
 export * from './helpers/scripts';
 export * from './helpers/interfaces';
 export * from './helpers/k8s-env/k8s';
+export * from './helpers/images';

--- a/packages/scripts/test/images-spec.ts
+++ b/packages/scripts/test/images-spec.ts
@@ -1,0 +1,39 @@
+import 'jest-extended';
+import fs from 'node:fs';
+import { createImageList, saveImages } from '../src/helpers/images';
+import * as scripts from '../src/helpers/scripts';
+import * as config from '../src/helpers/config';
+
+describe('images', () => {
+    describe('list', () => {
+        it('should create a txt file containing a list of images', async () => {
+            await createImageList();
+            expect(fs.existsSync(config.DOCKER_IMAGE_LIST_PATH)).toBe(true);
+            const fileContents = fs.readFileSync(config.DOCKER_IMAGE_LIST_PATH, 'utf-8');
+            expect(fileContents).toBeString();
+            expect(fileContents).toContain('terascope/node-base');
+            expect(fileContents).toContain('elasticsearch');
+            expect(fileContents).toContain('opensearch');
+            expect(fileContents).toContain('kafka');
+            expect(fileContents).toContain('zookeeper');
+            expect(fileContents).toContain('minio');
+            expect(fileContents).toContain('kindest');
+        });
+    });
+
+    describe('save', () => {
+        beforeAll(() => {
+            const dockerPullMock = jest.spyOn(scripts, 'dockerPull');
+            const saveAndZipMock = jest.spyOn(scripts, 'saveAndZip');
+            dockerPullMock.mockImplementation(async () => {});
+            saveAndZipMock.mockImplementation(async () => {});
+        });
+
+        it('should call dockerPull and saveAndZip for all images from DOCKER_IMAGE_LIST_PATH', async () => {
+            await saveImages();
+            expect(fs.existsSync(config.DOCKER_CACHE_PATH)).toBe(true);
+            expect(scripts.dockerPull).toHaveBeenCalledTimes(11);
+            expect(scripts.saveAndZip).toHaveBeenCalledTimes(11);
+        });
+    });
+});

--- a/packages/scripts/test/service-spec.ts
+++ b/packages/scripts/test/service-spec.ts
@@ -27,6 +27,13 @@ describe('services', () => {
         kindClusterName: 'default'
     };
 
+    describe('loadOrPullServiceImages', () => {
+        it('should throw error if service image is invalid', async () => {
+            await expect(services.loadOrPullServiceImages('_for_testing_', options))
+                .rejects.toThrowWithMessage(TSError, /w*Failed to pull services for test suite*\w/);
+        });
+    });
+
     describe('ensureServices', () => {
         it('should throw if service has an incorrect setting', async () => {
             await expect(services.ensureServices('_for_testing_', options))


### PR DESCRIPTION
This PR makes the following changes:
- Run `verify-build` and `cache-docker-images` jobs in parallel in `test.yml` workflow. E2e tests now await both.
- Remove node 20 from e2e k8s jobs matrices
- Move `saveAndZip` function from `images` to `scripts`
- Add JSDoc style comments to functions
- Add tests for `images` command and `loadOrPullServiceImages` function
- Load kind image at proper time and load service images directly into kind correctly.
- Change error handling on `kindLoadImages` so errors aren't swallowed.