### PR TITLE
Unpin node versions in CI

### DIFF
--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -3,6 +3,7 @@ name: Daily Docker Cache
 on:
   schedule:
     - cron: '0 12 * * 1-5' # Monday - Friday at 5am Arizona Time
+  workflow_dispatch:
 
 jobs:
   cache-docker-images:
@@ -18,7 +19,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 18.19.1
+        node-version: 18
         cache: 'yarn'
 
     # we login to docker to avoid docker pull limit rates

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version:  18.19.1
+          node-version:  18
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version:  18.19.1
+          node-version:  18
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version:  18.19.1
+          node-version:  18
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
+        node-version: [18, 20, 22]
     steps:
       # we login to docker to publish new teraslice image
       - name: Login to Docker Hub

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22.4.1]
     steps:
       # we login to docker to publish new teraslice image
       - name: Login to Docker Hub

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 18.19.1
+        node-version: 18
         cache: 'yarn'
 
     - name: Install and build packages
@@ -37,7 +37,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 18.19.1
+        node-version: 18
         cache: 'yarn'
 
     # we login to docker to avoid docker pull limit rates
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
+        node-version: [18, 20, 22]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
+        node-version: [18, 20, 22]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -143,7 +143,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
+        node-version: [18, 20, 22]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -202,7 +202,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
+        node-version: [18, 20, 22]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -261,7 +261,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
+        node-version: [18, 20, 22]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -320,7 +320,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 20.11.1, 22.2.0]
+        node-version: [18, 20, 22]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -383,7 +383,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 22.2.0]
+        node-version: [18, 22]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -450,7 +450,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1, 22.2.0]
+        node-version: [18, 22]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -517,7 +517,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1]
+        node-version: [18]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -579,7 +579,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18.19.1]
+        node-version: [18]
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22.4.1]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22.4.1]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -143,7 +143,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22.4.1]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -202,7 +202,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22.4.1]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -261,7 +261,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22.4.1]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -320,7 +320,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22.4.1]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -383,7 +383,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18, 22]
+        node-version: [18, 22.4.1]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -450,7 +450,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18, 22]
+        node-version: [18, 22.4.1]
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # NODE_VERSION is set by default in the config.ts, the following value will only
 # be used if you build images by default with docker build
-ARG NODE_VERSION=18.19.1
+ARG NODE_VERSION=18
 FROM terascope/node-base:${NODE_VERSION}
 
 ARG TERASLICE_VERSION

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 # NODE_VERSION is set by default in the config.ts, the following value will only
 # be used if you build images by default with docker build
-ARG NODE_VERSION=18.19.1
+ARG NODE_VERSION=18
 FROM terascope/node-base:${NODE_VERSION}
 
 ENV NODE_ENV production

--- a/docs/development/node.md
+++ b/docs/development/node.md
@@ -17,7 +17,7 @@ https://github.com/terascope/base-docker-image
 
 The workflow for the base image tags is closely linked to the Node.js version used in the image. Here's a simple breakdown of how it works:
 
-**Major Version Tag:** The base image will either grab the latest available version of a specific major Node.js release from the node alpine image(e.g., Node 18) or it will be pinned to the latest node version thats compatible with the base image. This image is tagged with the major version number (e.g., 18). So in some cases this version will be pinned and not completley up to date with a node release. This tag is always overwritten on release.
+**Major Version Tag:** The base image will either grab the latest available version of a specific major Node.js release from the node alpine image(e.g., Node 18) or it will be pinned to the latest node version that is compatible with the base image. This image is tagged with the major version number (e.g., 18). So in some cases this version will be pinned and not completely up to date with a node release. This tag is always overwritten on release.
 
 **Major-Minor Version Tag:** Next, it will retag and include both the major and minor version numbers (e.g., 18.14). This tag is updated to reflect the latest minor release within the specified major version. This tag will get overwritten in the case of a node-base change or if a new patch is relased for this minor version of node.
 

--- a/docs/development/node.md
+++ b/docs/development/node.md
@@ -13,6 +13,15 @@ Start by modifying the CI YAML files in the base-docker-image repository.
 
 https://github.com/terascope/base-docker-image
 
+### Note on how tags and node versions work in the base image
+
+The workflow for the base image tags is closely linked to the Node.js version used in the image. Here's a simple breakdown of how it works:
+
+**Major Version Tag:** The base image will grab the latest available version of a specific major Node.js release from the node alpine image(e.g., Node 18). This image is tagged with the major version number (e.g., 18). This tag will always point to the latest build of that major version, ensuring you have the most up-to-date version within that major release.
+
+**Major-Minor Version Tag:** Next, it will retag and include both the major and minor version numbers (e.g., 18.14). This tag is updated to reflect the latest minor release within the specified major version.
+
+**Major-Minor-Patch Version Tag:** Finally, the image will be re-tagged again with the complete version number, including the major, minor, and patch versions (e.g., 18.14.2). This tag points to a specific, immutable version of the Node.js release, ensuring consistency and reliability if you need to use a specific version.
 
 #### Modify CI YAML Files
 

--- a/docs/development/node.md
+++ b/docs/development/node.md
@@ -17,11 +17,11 @@ https://github.com/terascope/base-docker-image
 
 The workflow for the base image tags is closely linked to the Node.js version used in the image. Here's a simple breakdown of how it works:
 
-**Major Version Tag:** The base image will grab the latest available version of a specific major Node.js release from the node alpine image(e.g., Node 18). This image is tagged with the major version number (e.g., 18). This tag will always point to the latest build of that major version, ensuring you have the most up-to-date version within that major release.
+**Major Version Tag:** The base image will either grab the latest available version of a specific major Node.js release from the node alpine image(e.g., Node 18) or it will be pinned to the latest node version thats compatible with the base image. This image is tagged with the major version number (e.g., 18). So in some cases this version will be pinned and not completley up to date with a node release. This tag is always overwritten on release.
 
-**Major-Minor Version Tag:** Next, it will retag and include both the major and minor version numbers (e.g., 18.14). This tag is updated to reflect the latest minor release within the specified major version.
+**Major-Minor Version Tag:** Next, it will retag and include both the major and minor version numbers (e.g., 18.14). This tag is updated to reflect the latest minor release within the specified major version. This tag will get overwritten in the case of a node-base change or if a new patch is relased for this minor version of node.
 
-**Major-Minor-Patch Version Tag:** Finally, the image will be re-tagged again with the complete version number, including the major, minor, and patch versions (e.g., 18.14.2). This tag points to a specific, immutable version of the Node.js release, ensuring consistency and reliability if you need to use a specific version.
+**Major-Minor-Patch Version Tag:** Finally, the image will be re-tagged again with the complete version number, including the major, minor, and patch versions (e.g., 18.14.2). This tag points to a specific version of the Node.js release. This image only gets overwritten on a change to the node-base image that isn't node version related.
 
 #### Modify CI YAML Files
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.81.2",
+    "version": "0.81.3",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -173,7 +173,7 @@ if (testElasticsearch) {
 
 export const SEARCH_TEST_HOST = testHost;
 
-const defaultNodeVersion = '18.19.1';
+const defaultNodeVersion = '18';
 // This overrides the value in the Dockerfile
 export const NODE_VERSION = process.env.NODE_VERSION || defaultNodeVersion;
 

--- a/packages/scripts/src/helpers/images/index.ts
+++ b/packages/scripts/src/helpers/images/index.ts
@@ -21,9 +21,9 @@ export async function images(action: ImagesAction): Promise<void> {
 export async function createImageList(): Promise<void> {
     signale.info(`Creating Docker image list at ${config.DOCKER_IMAGE_LIST_PATH}`);
 
-    const list = 'terascope/node-base:18.19.1\n'
-               + 'terascope/node-base:20.11.1\n'
-               + 'terascope/node-base:22.2.0\n'
+    const list = 'terascope/node-base:18\n'
+               + 'terascope/node-base:20\n'
+               + 'terascope/node-base:22\n'
                + `${config.ELASTICSEARCH_DOCKER_IMAGE}:6.8.6\n`
                + `${config.ELASTICSEARCH_DOCKER_IMAGE}:7.9.3\n`
                + `${config.OPENSEARCH_DOCKER_IMAGE}:1.3.10\n`

--- a/scripts/check-latest-node-version.sh
+++ b/scripts/check-latest-node-version.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Function to check if Docker is installed
+check_docker() {
+    if ! command -v docker &> /dev/null
+    then
+        echo "Docker command could not be found. Please install Docker first."
+        exit 1
+    fi
+}
+
+# Function to prompt the user for a node tag. Over time we will need to update
+# this as we discontinue and add major node versions.
+prompt_tag() {
+    echo "Please choose a node version to check what the latest version the base image is using: [18, 20, 22]"
+    read -p "Enter the tag: " tag
+
+    case $tag in
+        18|20|22)
+            echo "You have chosen major version: $tag"
+            ;;
+        *)
+            echo "Invalid option. Please choose from [18, 20, 22]."
+            prompt_tag
+            ;;
+    esac
+}
+
+# Check if Docker is installed
+check_docker
+
+# Prompt the user for a tag
+prompt_tag
+
+# Change this image if the base-image name changes.
+image="terascope/node-base"
+
+# Pull the docker image and create a container with image to run "node -v"
+echo Pulling image "$image:$tag"...
+docker pull "$image:$tag" &> /dev/null
+
+node_version=$(docker run -it "$image:$tag" node -v)
+echo The current node "$tag" version in "$image:$tag" is "$node_version"


### PR DESCRIPTION
This PR makes the following changes:
- Changes node versions across `teraslice` to use major versions of node as a valid node version
  - This is because the env variable `NODE_VERSION` used in e2e is tied to a valid tag in [terascope/node-base](https://hub.docker.com/r/terascope/node-base/tags)
- Added `workflow_dispatch` to the `daily-docker-cache.yml` to allow for manual workflow trigger
- Added `check-latest-node-version.sh` script for devs to find out which node version is currently used in the base image
  - This is a convenience utility script that could be used somewhere else later to pop up a warning.
- Bumped ` @terascope/scripts` from `v0.81.2` to `v0.81.3` 
- Updated docs to explain how tagging works in the base image repo

Ref to issue #3683