### PR TITLE
Improve error message in Asset loader when asset blob is undefined

### DIFF
--- a/packages/teraslice/src/lib/workers/assets/loader.ts
+++ b/packages/teraslice/src/lib/workers/assets/loader.ts
@@ -63,8 +63,8 @@ export class AssetLoader {
                 } else {
                     if (!assetRecord.blob) {
                         throw new Error(`No asset blob found in elasticsearch index for asset identifier: ${assetIdentifier}.\n`
-                            + `Confirm that "teraslice.ASSET_STORAGE_CONNECTION_TYPE" should be ${connectionType}`
-                            + 'Then try deleting and redeploying the asset\n.'
+                            + `Confirm that "teraslice.ASSET_STORAGE_CONNECTION_TYPE" should be ${connectionType}.\n`
+                            + 'Then try deleting and redeploying the asset.'
                         );
                     }
                     buff = Buffer.from(assetRecord.blob as string, 'base64');

--- a/packages/teraslice/src/lib/workers/assets/loader.ts
+++ b/packages/teraslice/src/lib/workers/assets/loader.ts
@@ -56,11 +56,16 @@ export class AssetLoader {
                 this.logger.info(`loading assets: ${assetIdentifier}`);
                 let buff: Buffer;
 
-                if (getBackendConfig(this.context, this.logger).assetConnectionType === 's3') {
+                const { context, logger } = this;
+                const connectionType = getBackendConfig(context, logger).assetConnectionType;
+                if (connectionType === 's3') {
                     buff = assetRecord.blob as Buffer;
                 } else {
                     if (!assetRecord.blob) {
-                        throw new Error(`No asset blob found in elasticsearch index for asset identifier: ${assetIdentifier}`);
+                        throw new Error(`No asset blob found in elasticsearch index for asset identifier: ${assetIdentifier}.\n`
+                            + `Confirm that "teraslice.ASSET_STORAGE_CONNECTION_TYPE" should be ${connectionType}`
+                            + 'Then try deleting and redeploying the asset\n.'
+                        );
                     }
                     buff = Buffer.from(assetRecord.blob as string, 'base64');
                 }

--- a/packages/teraslice/src/lib/workers/assets/loader.ts
+++ b/packages/teraslice/src/lib/workers/assets/loader.ts
@@ -59,6 +59,9 @@ export class AssetLoader {
                 if (getBackendConfig(this.context, this.logger).assetConnectionType === 's3') {
                     buff = assetRecord.blob as Buffer;
                 } else {
+                    if (!assetRecord.blob) {
+                        throw new Error(`No asset blob found in elasticsearch index for asset identifier: ${assetIdentifier}`);
+                    }
                     buff = Buffer.from(assetRecord.blob as string, 'base64');
                 }
 


### PR DESCRIPTION
If an asset is deployed to teraslice with `teraslice.ASSET_STORAGE_CONNECTION_TYPE` set to `s3`, but then the connection type is switched to `elasticsearch`, job registration will fail. This PR improves the error message to tell the user to double check the connection type and then delete and redeploy assets.

ref: #3692 