### PR TITLE
Migrate teraslice image from docker.hub to ghcr.io registry

### DIFF
--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -16,13 +16,6 @@ jobs:
       - name: Verify npm authentication
         run: npm whoami
 
-      # we login to docker to publish new teraslice image
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Check out code
         uses: actions/checkout@v4
 

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -45,14 +45,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22.4.1]
+        node-version: [18, 20, 22]
     steps:
       # we login to docker to publish new teraslice image
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22.4.1]
+        node-version: [18, 20, 22]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22.4.1]
+        node-version: [18, 20, 22]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -143,7 +143,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22.4.1]
+        node-version: [18, 20, 22]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -202,7 +202,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22.4.1]
+        node-version: [18, 20, 22]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -261,7 +261,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22.4.1]
+        node-version: [18, 20, 22]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -320,7 +320,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22.4.1]
+        node-version: [18, 20, 22]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -383,7 +383,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18, 22.4.1]
+        node-version: [18, 22]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -450,7 +450,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [18, 22.4.1]
+        node-version: [18, 22]
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # NODE_VERSION is set by default in the config.ts, the following value will only
 # be used if you build images by default with docker build
 ARG NODE_VERSION=18
-FROM terascope/node-base:${NODE_VERSION}
+FROM ghcr.io/terascope/node-base:${NODE_VERSION}
 
 ARG TERASLICE_VERSION
 ARG BUILD_TIMESTAMP

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 # NODE_VERSION is set by default in the config.ts, the following value will only
 # be used if you build images by default with docker build
 ARG NODE_VERSION=18
-FROM terascope/node-base:${NODE_VERSION}
+FROM ghcr.io/terascope/node-base:${NODE_VERSION}
 
 ENV NODE_ENV production
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
         },
         "docker": {
             "registries": [
-                "terascope/teraslice"
+                "ghcr.io/terascope/teraslice"
             ]
         },
         "npm": {

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -96,6 +96,8 @@ async function publishToDocker(options: PublishOptions) {
     for (const registry of registries) {
         let imageToBuild = '';
 
+        /// NOTE: When publishing images, we always want the full node semver version
+        /// on the tag
         const nodeVersionSuffix = `node${await getNodeVersionFromImage(devImage)}`;
 
         if (options.type === PublishType.Latest) {

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -16,7 +16,8 @@ import {
     remoteDockerImageExists,
     dockerBuild,
     dockerPush,
-    yarnPublishV2
+    yarnPublishV2,
+    getNodeVersionFromImage
 } from '../scripts';
 import { getRootInfo, getDevDockerImage, formatList } from '../misc';
 import signale from '../signale';
@@ -94,7 +95,8 @@ async function publishToDocker(options: PublishOptions) {
     let err: any|undefined;
     for (const registry of registries) {
         let imageToBuild = '';
-        const nodeVersionSuffix = `nodev${options.nodeVersion}`;
+
+        const nodeVersionSuffix = `node${await getNodeVersionFromImage(devImage)}`;
 
         if (options.type === PublishType.Latest) {
             imageToBuild = `${registry}:latest-${nodeVersionSuffix}`;

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -209,18 +209,15 @@ export async function dockerTag(from: string, to: string): Promise<void> {
 }
 
 export async function getNodeVersionFromImage(image: string): Promise<string> {
-    let nodeVersion:string;
     try {
         const { stdout } = await execa(
             'docker',
             ['run', image, 'node', '-v']
         );
-        nodeVersion = stdout;
+        return stdout;
     } catch (err) {
         throw new Error(`Unable to get node version from image due to Error: ${err}`);
     }
-
-    return nodeVersion;
 }
 
 export async function getContainerInfo(name: string): Promise<any> {

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -208,6 +208,21 @@ export async function dockerTag(from: string, to: string): Promise<void> {
     signale.success(`Image ${from} re-tagged as ${to}`);
 }
 
+export async function getNodeVersionFromImage(image: string): Promise<string> {
+    let nodeVersion:string;
+    try {
+        const { stdout } = await execa(
+            'docker',
+            ['run', image, 'node', '-v']
+        );
+        nodeVersion = stdout;
+    } catch (err) {
+        throw new Error(`Unable to get node version from image due to Error: ${err}`);
+    }
+
+    return nodeVersion;
+}
+
 export async function getContainerInfo(name: string): Promise<any> {
     const result = await exec({
         cmd: 'docker',


### PR DESCRIPTION
This PR makes the following changes:

- Moves `teraslice` images to be published in the `ghcr.io` registry instead of `docker.hub`
- Teraslice images are now built off the `node-base` image in the `ghcr.io` registry 
- Unpins node 22