### PR TITLE
Fix node version check in k8s --dev mode

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.83.0",
+    "version": "0.83.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/k8s-env/index.ts
+++ b/packages/scripts/src/helpers/k8s-env/index.ts
@@ -78,11 +78,14 @@ export async function launchK8sEnv(options: K8sEnvOptions) {
             const { stdout } = await execa('docker', ['run', e2eImage, 'node', '-v']);
             imageVersion = stdout;
         } catch (err) {
+            await kind.destroyCluster();
             throw new Error(`Problem running docker command to check node version: ${err}`);
         }
         if (process.version !== imageVersion) {
-            throw new Error(`The node version this process is running on (${process.version}) does not match
+            signale.fatal(`The node version this process is running on (${process.version}) does not match
             the version set in k8s-env image (${imageVersion}). Check your version by running "node -v"`);
+            await kind.destroyCluster();
+            process.exit(1);
         }
         signale.info(`Running yarn setup with node ${process.version}...`);
         try {

--- a/packages/scripts/src/helpers/k8s-env/index.ts
+++ b/packages/scripts/src/helpers/k8s-env/index.ts
@@ -5,6 +5,7 @@ import {
     isKubectlInstalled,
     k8sStartService,
     k8sStopService,
+    getNodeVersionFromImage
 } from '../scripts';
 import { Kind } from '../kind';
 import { K8sEnvOptions } from './interfaces';
@@ -75,8 +76,7 @@ export async function launchK8sEnv(options: K8sEnvOptions) {
     if (options.dev) {
         let imageVersion:string;
         try {
-            const { stdout } = await execa('docker', ['run', e2eImage, 'node', '-v']);
-            imageVersion = stdout;
+            imageVersion = await getNodeVersionFromImage(e2eImage);
         } catch (err) {
             await kind.destroyCluster();
             throw new Error(`Problem running docker command to check node version: ${err}`);


### PR DESCRIPTION
This PR makes the following changes:

- Fixes bug when running `ts-scripts k8s --dev` that will fail when env variable `NODE_VERSION` is a major version
  - Before, this check only expected full semver versions
- Added kind cleanup in error scenarios
- Bumps **@terascope/scripts** from `v0.83.0` to `v0.83.1`