### PR TITLE
Create repo specific images lists

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.81.4",
+    "version": "0.82.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/cmds/images.ts
+++ b/packages/scripts/src/cmds/images.ts
@@ -14,6 +14,11 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
         return yargs
             .example('$0 images list', 'Get the list of docker images needed for a test.')
             .example('$0 images save', 'Save the docker images needed for a test.')
+            .option('repo', {
+                description: 'Create a repository specific image list',
+                type: 'string',
+                default: 'teraslice'
+            })
             .positional('action', {
                 description: 'The action to take',
                 choices: Object.values(ImagesAction),
@@ -25,7 +30,7 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
     },
     async handler(argv) {
         if (argv.action) {
-            await images(argv.action);
+            await images(argv.action, argv.repo as string);
         }
     },
 };

--- a/packages/scripts/src/cmds/images.ts
+++ b/packages/scripts/src/cmds/images.ts
@@ -14,11 +14,6 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
         return yargs
             .example('$0 images list', 'Get the list of docker images needed for a test.')
             .example('$0 images save', 'Save the docker images needed for a test.')
-            .option('repo', {
-                description: 'Create a repository specific image list',
-                type: 'string',
-                default: 'teraslice'
-            })
             .positional('action', {
                 description: 'The action to take',
                 choices: Object.values(ImagesAction),
@@ -30,7 +25,7 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
     },
     async handler(argv) {
         if (argv.action) {
-            await images(argv.action, argv.repo as string);
+            await images(argv.action);
         }
     },
 };

--- a/packages/scripts/src/helpers/images/index.ts
+++ b/packages/scripts/src/helpers/images/index.ts
@@ -3,10 +3,11 @@ import * as config from '../config';
 import { ImagesAction } from './interfaces';
 import signale from '../signale';
 import { dockerPull, saveAndZip } from '../scripts';
+import { getRootInfo } from '../misc';
 
-export async function images(action: ImagesAction, repo: string): Promise<void> {
+export async function images(action: ImagesAction): Promise<void> {
     if (action === ImagesAction.List) {
-        return createImageList(repo);
+        return createImageList();
     }
 
     if (action === ImagesAction.Save) {
@@ -18,21 +19,21 @@ export async function images(action: ImagesAction, repo: string): Promise<void> 
  * Builds a list of all docker images needed for the teraslice CI pipeline
  * @returns Promise<void>
  */
-export async function createImageList(repo: string): Promise<void> {
+export async function createImageList(): Promise<void> {
     signale.info(`Creating Docker image list at ${config.DOCKER_IMAGE_LIST_PATH}`);
-
+    const repo = getRootInfo().name;
     let list;
-    if (repo === 'elasticsearch') {
+    if (repo === 'elasticsearch-assets') {
         list = `${config.ELASTICSEARCH_DOCKER_IMAGE}:${config.__DEFAULT_ELASTICSEARCH6_VERSION}\n`
                + `${config.ELASTICSEARCH_DOCKER_IMAGE}:${config.__DEFAULT_ELASTICSEARCH7_VERSION}\n`
                + `${config.OPENSEARCH_DOCKER_IMAGE}:${config.__DEFAULT_OPENSEARCH1_VERSION}\n`
                + `${config.OPENSEARCH_DOCKER_IMAGE}:${config.__DEFAULT_OPENSEARCH2_VERSION}`;
-    } else if (repo === 'kafka') {
+    } else if (repo === 'kafka-asset-bundle') {
         list = `${config.KAFKA_DOCKER_IMAGE}:${config.KAFKA_IMAGE_VERSION}\n`
                + `${config.ZOOKEEPER_DOCKER_IMAGE}:${config.KAFKA_IMAGE_VERSION}`;
-    } else if (repo === 'file') {
+    } else if (repo === 'file-assets-bundle') {
         list = `${config.MINIO_DOCKER_IMAGE}:${config.MINIO_VERSION}`;
-    } else if (repo === 'teraslice') {
+    } else if (repo === 'teraslice-workspace') {
         const baseImages: string = config.TEST_NODE_VERSIONS
             .reduce((acc: string, version: string) => `${acc}${config.BASE_DOCKER_IMAGE}:${version}\n`, '');
 

--- a/packages/scripts/test/images-spec.ts
+++ b/packages/scripts/test/images-spec.ts
@@ -5,6 +5,12 @@ import * as scripts from '../src/helpers/scripts';
 import * as config from '../src/helpers/config';
 
 describe('images', () => {
+    afterEach(() => {
+        if (fs.existsSync(config.DOCKER_IMAGES_PATH)) {
+            fs.rmSync(config.DOCKER_IMAGES_PATH, { recursive: true, force: true });
+        }
+    });
+
     describe('list', () => {
         it('should create a txt file containing a list of images for teraslice testing', async () => {
             await createImageList('teraslice');
@@ -56,6 +62,7 @@ describe('images', () => {
         });
 
         it('should call dockerPull and saveAndZip for all images from DOCKER_IMAGE_LIST_PATH', async () => {
+            await createImageList('teraslice');
             await saveImages();
             expect(fs.existsSync(config.DOCKER_CACHE_PATH)).toBe(true);
             expect(scripts.dockerPull).toHaveBeenCalledTimes(11);

--- a/packages/scripts/test/images-spec.ts
+++ b/packages/scripts/test/images-spec.ts
@@ -28,6 +28,23 @@ describe('images', () => {
             expect(fileContents).toContain('elasticsearch');
             expect(fileContents).toContain('opensearch');
         });
+
+        it('should create a txt file containing a list of images for kafka assets testing', async () => {
+            await createImageList('kafka');
+            expect(fs.existsSync(config.DOCKER_IMAGE_LIST_PATH)).toBe(true);
+            const fileContents = fs.readFileSync(config.DOCKER_IMAGE_LIST_PATH, 'utf-8');
+            expect(fileContents).toBeString();
+            expect(fileContents).toContain('kafka');
+            expect(fileContents).toContain('zookeeper');
+        });
+
+        it('should create a txt file containing a list of images for file assets testing', async () => {
+            await createImageList('file');
+            expect(fs.existsSync(config.DOCKER_IMAGE_LIST_PATH)).toBe(true);
+            const fileContents = fs.readFileSync(config.DOCKER_IMAGE_LIST_PATH, 'utf-8');
+            expect(fileContents).toBeString();
+            expect(fileContents).toContain('minio');
+        });
     });
 
     describe('save', () => {

--- a/packages/scripts/test/images-spec.ts
+++ b/packages/scripts/test/images-spec.ts
@@ -13,7 +13,7 @@ describe('images', () => {
 
     describe('list', () => {
         it('should create a txt file containing a list of images for teraslice testing', async () => {
-            await createImageList('teraslice');
+            await createImageList();
             expect(fs.existsSync(config.DOCKER_IMAGE_LIST_PATH)).toBe(true);
             const fileContents = fs.readFileSync(config.DOCKER_IMAGE_LIST_PATH, 'utf-8');
             expect(fileContents).toBeString();
@@ -24,32 +24,6 @@ describe('images', () => {
             expect(fileContents).toContain(config.ZOOKEEPER_DOCKER_IMAGE);
             expect(fileContents).toContain(config.MINIO_DOCKER_IMAGE);
             expect(fileContents).toContain(config.KIND_DOCKER_IMAGE);
-        });
-
-        it('should create a txt file containing a list of images for elasticsearch assets testing', async () => {
-            await createImageList('elasticsearch');
-            expect(fs.existsSync(config.DOCKER_IMAGE_LIST_PATH)).toBe(true);
-            const fileContents = fs.readFileSync(config.DOCKER_IMAGE_LIST_PATH, 'utf-8');
-            expect(fileContents).toBeString();
-            expect(fileContents).toContain('elasticsearch');
-            expect(fileContents).toContain('opensearch');
-        });
-
-        it('should create a txt file containing a list of images for kafka assets testing', async () => {
-            await createImageList('kafka');
-            expect(fs.existsSync(config.DOCKER_IMAGE_LIST_PATH)).toBe(true);
-            const fileContents = fs.readFileSync(config.DOCKER_IMAGE_LIST_PATH, 'utf-8');
-            expect(fileContents).toBeString();
-            expect(fileContents).toContain('kafka');
-            expect(fileContents).toContain('zookeeper');
-        });
-
-        it('should create a txt file containing a list of images for file assets testing', async () => {
-            await createImageList('file');
-            expect(fs.existsSync(config.DOCKER_IMAGE_LIST_PATH)).toBe(true);
-            const fileContents = fs.readFileSync(config.DOCKER_IMAGE_LIST_PATH, 'utf-8');
-            expect(fileContents).toBeString();
-            expect(fileContents).toContain('minio');
         });
     });
 
@@ -62,7 +36,7 @@ describe('images', () => {
         });
 
         it('should call dockerPull and saveAndZip for all images from DOCKER_IMAGE_LIST_PATH', async () => {
-            await createImageList('teraslice');
+            await createImageList();
             await saveImages();
             expect(fs.existsSync(config.DOCKER_CACHE_PATH)).toBe(true);
             expect(scripts.dockerPull).toHaveBeenCalledTimes(11);

--- a/packages/scripts/test/images-spec.ts
+++ b/packages/scripts/test/images-spec.ts
@@ -6,8 +6,8 @@ import * as config from '../src/helpers/config';
 
 describe('images', () => {
     describe('list', () => {
-        it('should create a txt file containing a list of images', async () => {
-            await createImageList();
+        it('should create a txt file containing a list of images for teraslice testing', async () => {
+            await createImageList('teraslice');
             expect(fs.existsSync(config.DOCKER_IMAGE_LIST_PATH)).toBe(true);
             const fileContents = fs.readFileSync(config.DOCKER_IMAGE_LIST_PATH, 'utf-8');
             expect(fileContents).toBeString();
@@ -18,6 +18,15 @@ describe('images', () => {
             expect(fileContents).toContain(config.ZOOKEEPER_DOCKER_IMAGE);
             expect(fileContents).toContain(config.MINIO_DOCKER_IMAGE);
             expect(fileContents).toContain(config.KIND_DOCKER_IMAGE);
+        });
+
+        it('should create a txt file containing a list of images for elasticsearch assets testing', async () => {
+            await createImageList('elasticsearch');
+            expect(fs.existsSync(config.DOCKER_IMAGE_LIST_PATH)).toBe(true);
+            const fileContents = fs.readFileSync(config.DOCKER_IMAGE_LIST_PATH, 'utf-8');
+            expect(fileContents).toBeString();
+            expect(fileContents).toContain('elasticsearch');
+            expect(fileContents).toContain('opensearch');
         });
     });
 


### PR DESCRIPTION
This PR makes the following changes:
- Add ability to get the repo name out of the root `package.json`. This allows other repos that use ts-scripts to get a custom docker image list to use to create a cache specific to that repo. Valid repos are `elasticsearch-assets`, `kafka-asset-bundle`, `file-asssets-bundle`, and `teraslice-workspace`.
- Update tests 
- Bump scripts from version 0.81.4 to 0.82.0