### PR TITLE
rework generateTSConfig

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.82.0",
+    "version": "0.82.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "0.82.1",
+    "version": "0.83.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/misc.ts
+++ b/packages/scripts/src/helpers/misc.ts
@@ -108,6 +108,12 @@ export function getRootInfo(): RootPackageInfo {
     return _rootInfo;
 }
 
+export function getRootTsConfig(): Record<string, any> {
+    const rootTsConfig = path.join(getRootDir(), 'tsconfig.json');
+    if (!fse.existsSync(rootTsConfig)) return { };
+    return fse.readJSONSync(rootTsConfig);
+}
+
 export function getAvailableTestSuites(): string[] {
     return Object.keys(getRootInfo().terascope.tests.suites);
 }

--- a/packages/scripts/src/helpers/sync/configs.ts
+++ b/packages/scripts/src/helpers/sync/configs.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { isString } from '@terascope/utils';
-import { getRootInfo, writeIfChanged } from '../misc';
+import { getRootInfo, getRootTsConfig, writeIfChanged } from '../misc';
 import { PackageInfo } from '../interfaces';
 
 export async function generateTSConfig(
@@ -19,57 +18,7 @@ export async function generateTSConfig(
         }));
 
     const tsconfig = {
-        compilerOptions: {
-            baseUrl: '.',
-            module: 'commonjs',
-            moduleResolution: 'node',
-            target: rootInfo.terascope.target,
-            skipLibCheck: true,
-            experimentalDecorators: true,
-            strict: true,
-            // FIXME we should enable this someday
-            useUnknownInCatchVariables: false,
-            noFallthroughCasesInSwitch: true,
-            preserveConstEnums: true,
-            esModuleInterop: true,
-            resolveJsonModule: true,
-            forceConsistentCasingInFileNames: true,
-            suppressImplicitAnyIndexErrors: true,
-            ignoreDeprecations: '5.0',
-
-            // Require project settings
-            composite: true,
-            declaration: true,
-            declarationMap: true,
-            sourceMap: true,
-            isolatedModules: true,
-            // https://www.typescriptlang.org/tsconfig#disableReferencedProjectLoad
-            disableReferencedProjectLoad: true,
-            ...(rootInfo.terascope.version !== 2 ? {
-                typeRoots: [
-                    fs.existsSync(path.join(rootInfo.dir, './types'))
-                        ? './types'
-                        : undefined,
-                    fs.existsSync('./node_modules/@types')
-                        ? './node_modules/@types'
-                        : undefined
-                ].filter(isString),
-                paths: {
-                    '*': ['*', './types/*']
-                }
-            } : {}),
-            ...rootInfo.terascope.compilerOptions
-        },
-        include: [],
-        exclude: [
-            fs.existsSync('./node_modules')
-                ? '**/node_modules'
-                : undefined,
-            '**/.*/',
-            rootInfo.terascope.version === 2 ? '.yarn/releases/*' : undefined,
-            '**/build/**/*'
-        ].filter(isString),
-        // these project references should be ordered by dependents first
+        ...getRootTsConfig(),
         references
     };
 


### PR DESCRIPTION
The generateTSConfig writes to commonjs.

Ideas were to... 
A) check the package.json and adjust the compilerOptions to module/target/resolution to nodenext/esnext if it's a module
B) remove generateTSConfig completely
C) keep some options 

We looked at the git history and weren't completely clear why generating a tsconfig is needed since we already do what it's doing in the tsconfigs, so decided maybe keeping the references and just allow the original options for the rest.