### PR TITLE
Fix failed docker publish in CI workflow

### DIFF
--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -24,8 +24,9 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR makes the following changes:

- Resolves issue where CI can't publish docker images because of unauthorized credentials