### PR TITLE
add retry to asset downloads

### DIFF
--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -37,7 +37,7 @@
         "test:watch": "NODE_OPTIONS='--experimental-vm-modules' ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/fetch-github-release": "^0.8.10",
+        "@terascope/fetch-github-release": "^1.0.0",
         "@terascope/types": "^0.18.0",
         "@terascope/utils": "^0.60.0",
         "chalk": "^4.1.2",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -31,7 +31,7 @@
         "test:watch": "NODE_OPTIONS='--experimental-vm-modules' ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/fetch-github-release": "^0.8.10",
+        "@terascope/fetch-github-release": "^1.0.0",
         "decompress": "^4.2.1",
         "fs-extra": "^11.2.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2314,10 +2314,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terascope/fetch-github-release@^0.8.10":
-  version "0.8.10"
-  resolved "https://registry.yarnpkg.com/@terascope/fetch-github-release/-/fetch-github-release-0.8.10.tgz#243b8a50f963f4c2c5771689e2b94e94265db179"
-  integrity sha512-bTLmiEotEca8YTi+PcvznisIHMEKYLU0Uj322rkbMJlr6LqXFvIKv2dzuwMhSADO7eUeKlC4mXUs8Nt2ftpdWA==
+"@terascope/fetch-github-release@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@terascope/fetch-github-release/-/fetch-github-release-1.0.0.tgz#72a19cda75c389081f48646a86595087ade348bc"
+  integrity sha512-4I89IyfaL74Ssk60VfAl4dtCS5qdUstIW8fd7x8BD2BJpiw12PYhC6Q8rMmxjPohKWuk6TC/A76TfkkjZJxiOw==
   dependencies:
     extract-zip "^2.0.1"
     got "^11.4.0"


### PR DESCRIPTION
This PR makes the following changes:
- In e2e tests, adds retry functionality within each promise that is attempting to download an asset. 
- Parses any `got.HTTPError` from `downloadRelease()` and determines the delay between retries based on the response headers from github.
- Updates `fetch-github-release` from 0.8.10 to 1.0.0

See: https://github.com/terascope/fetch-github-release/issues/300