### PR TITLE
Add --diff option teraslice-cli

### DIFF
--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -42,6 +42,7 @@
         "@terascope/utils": "^0.60.0",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.4",
+        "diff": "^5.2.0",
         "easy-table": "^1.2.0",
         "ejs": "^3.1.10",
         "esbuild": "^0.21.5",
@@ -62,6 +63,7 @@
     },
     "devDependencies": {
         "@types/decompress": "^4.2.7",
+        "@types/diff": "^5.2.1",
         "@types/easy-table": "^1.2.0",
         "@types/ejs": "^3.1.5",
         "@types/js-yaml": "^4.0.9",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"

--- a/packages/teraslice-cli/src/cmds/tjm/view.ts
+++ b/packages/teraslice-cli/src/cmds/tjm/view.ts
@@ -14,8 +14,10 @@ export default {
         yargs.option('src-dir', yargsOptions.buildOption('src-dir'));
         yargs.option('config-dir', yargsOptions.buildOption('config-dir'));
         yargs.options('status', yargsOptions.buildOption('jobs-status'));
+        yargs.option('diff', yargsOptions.buildOption('diff'));
         yargs
             .example('$0 tjm view JOB_FILE.json', 'displays job config on job cluster')
+            .example('$0 tjm view JOB_FILE.json --diff', 'displays diff between job config on job cluster and the local json file')
             .example('$0 tjm view JOB_FILE1.json JOB_FILE2.json', 'displays config for multiple job files');
         return yargs;
     },

--- a/packages/teraslice-cli/src/cmds/tjm/view.ts
+++ b/packages/teraslice-cli/src/cmds/tjm/view.ts
@@ -17,7 +17,7 @@ export default {
         yargs.option('diff', yargsOptions.buildOption('diff'));
         yargs
             .example('$0 tjm view JOB_FILE.json', 'displays job config on job cluster')
-            .example('$0 tjm view JOB_FILE.json --diff', 'displays diff between job config on job cluster and the local json file')
+            .example('$0 tjm view JOB_FILE.json --diff', 'Shows diff between the local json file and whats currently on the cluster')
             .example('$0 tjm view JOB_FILE1.json JOB_FILE2.json', 'displays config for multiple job files');
         return yargs;
     },

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -691,7 +691,7 @@ export default class Jobs {
             const filePath = path.join(srcDir, file);
             const jobConfig: JobConfigFile = JSON.parse(fs.readFileSync(filePath, { encoding: 'utf-8' }));
             const formattedJobConfig = this.formatJobConfig(jobConfig);
-            localJobConfigs[formatedJobConfig.job_id as string] = formattedJobConfig;
+            localJobConfigs[formattedJobConfig.job_id as string] = formattedJobConfig;
         }
         return localJobConfigs;
     }

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -690,8 +690,8 @@ export default class Jobs {
         for (const file of files) {
             const filePath = path.join(srcDir, file);
             const jobConfig: JobConfigFile = JSON.parse(fs.readFileSync(filePath, { encoding: 'utf-8' }));
-            const formatedJobConfig = this.formatJobConfig(jobConfig);
-            localJobConfigs[formatedJobConfig.job_id as string] = formatedJobConfig;
+            const formattedJobConfig = this.formatJobConfig(jobConfig);
+            localJobConfigs[formatedJobConfig.job_id as string] = formattedJobConfig;
         }
         return localJobConfigs;
     }

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -672,8 +672,8 @@ export default class Jobs {
         }
     }
 
-    formatJobConfig(jobConfig: any) {
-        const finalJobConfig: any = {};
+    formatJobConfig(jobConfig: JobConfigFile) {
+        const finalJobConfig: Partial<Teraslice.JobConfig> = {};
         Object.keys(jobConfig).forEach((key) => {
             if (key === '__metadata') {
                 finalJobConfig.job_id = jobConfig[key].cli.job_id;
@@ -689,9 +689,9 @@ export default class Jobs {
         const localJobConfigs = {};
         for (const file of files) {
             const filePath = path.join(srcDir, file);
-            const jobConfig = JSON.parse(fs.readFileSync(filePath, { encoding: 'utf-8' }));
+            const jobConfig: JobConfigFile = JSON.parse(fs.readFileSync(filePath, { encoding: 'utf-8' }));
             const formatedJobConfig = this.formatJobConfig(jobConfig);
-            localJobConfigs[formatedJobConfig.job_id] = formatedJobConfig;
+            localJobConfigs[formatedJobConfig.job_id as string] = formatedJobConfig;
         }
         return localJobConfigs;
     }

--- a/packages/teraslice-cli/src/helpers/yargs-options.ts
+++ b/packages/teraslice-cli/src/helpers/yargs-options.ts
@@ -228,6 +228,11 @@ export default class Options {
             describe: 'Silence non-error logging.',
             type: 'boolean'
         }),
+        diff: () => ({
+            describe: 'Shows diff on a job in a cluster and a job file',
+            default: false,
+            type: 'boolean'
+        })
     };
 
     private positionals: Record<string, (...args: any[]) => yargs.PositionalOptions> = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2682,6 +2682,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/diff@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@types/diff/-/diff-5.2.1.tgz#cceae9c4b2dae5c6b8ab1ce1263601c255d87fb3"
+  integrity sha512-uxpcuwWJGhe2AR1g8hD9F5OYGCqjqWnBUQFD8gMZsDbv8oPHzxJF6iMO6n8Tk0AdzlxoaaoQhOYlIg/PukVU8g==
+
 "@types/easy-table@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/easy-table/-/easy-table-1.2.0.tgz#d7153551a2c3f6571dddff974b05aa2fb1a4a948"
@@ -5214,7 +5219,7 @@ diff-sequences@^29.6.3:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
-diff@^5.0.0:
+diff@^5.0.0, diff@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
   integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==


### PR DESCRIPTION
This PR makes the following changes: 

- Adds `--diff` option to `teraslice cli view` that will compare the local `json` job file with what teraslice has on the state cluster
- Bumps `teraslice-cli` from `v2.1.0` to `v2.2.0`

Ref to issue #3694