### PR TITLE
[teraslice-cli] add earl jobs export command

### DIFF
--- a/docs/packages/teraslice-cli/overview.md
+++ b/docs/packages/teraslice-cli/overview.md
@@ -398,6 +398,18 @@ teraslice-cli jobs view <cluster> <job_id>
 teraslice-cli jobs view local 99999999-9999-9999-9999-999999999999
 ```
 
+### jobs export
+
+Export job on a cluster to a json file. By default the file is saved to the current working directory as <job.name>.json
+
+```sh
+teraslice-cli jobs export <cluster> <job_id>
+# export job to current directory
+teraslice-cli jobs export local 99999999-9999-9999-9999-999999999999
+# export job to custom directory
+teraslice-cli jobs export local 99999999-9999-9999-9999-999999999999 --outdir ~/my_jobs
+```
+
 ### jobs recover
 
 Recover a crashed jobs

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"

--- a/packages/teraslice-cli/src/cmds/jobs/export.ts
+++ b/packages/teraslice-cli/src/cmds/jobs/export.ts
@@ -8,34 +8,19 @@ const yargsOptions = new YargsOptions();
 
 export default {
     command: 'export <cluster-alias> <job-id...>',
-    describe: 'Export job on a cluster to a json file. By default the file is saved as ~/.teraslice/export/<cluster-alias>/<job.name>.json\n',
+    describe: 'Export job on a cluster to a json file. By default the file is saved to current working directory as <job.name>.json\n',
     builder(yargs: any) {
         yargs.positional('job-id', yargsOptions.buildPositional('job-id'));
         yargs.options('config-dir', yargsOptions.buildOption('config-dir'));
-        yargs.options('export-dir', yargsOptions.buildOption('export-dir'));
-        yargs.options('output', yargsOptions.buildOption('output'));
-        yargs.options('file-name', yargsOptions.buildOption('file-name'));
+        yargs.options('outdir', yargsOptions.buildOption('outdir'));
         yargs.options('status', yargsOptions.buildOption('jobs-status'));
         yargs.options('yes', yargsOptions.buildOption('yes'));
-        yargs.check((argv: { jobId: string[]; fileName: string[]; }) => {
-            if (argv.fileName && argv.fileName.length !== argv.jobId.length) {
-                throw new Error('The number of job IDs must match the number of file names');
-            }
-            return true;
-        });
-        yargs.check((argv: { jobId: string[]; fileName: string[]; }) => {
-            if (argv.jobId.includes('all') && argv.fileName) {
-                throw new Error('Cannot use custom file names when exporting all.');
-            }
-            return true;
-        });
         yargs.strict()
             .example('$0 jobs export CLUSTER_ALIAS JOB1', 'exports job config as a tjm compatible JSON file')
             .example('$0 jobs export CLUSTER_ALIAS JOB1 JOB2', 'exports job config for two jobs')
-            .example('$0 jobs export CLUSTER_ALIAS JOB1 JOB2 --file-name name1.json name2.json', 'exports two jobs with custom file names')
-            .example('$0 jobs export CLUSTER_ALIAS JOB1 --export-dir ./my_jobs -f job_1.json', 'exports a job to ./my_jobs/job_1.json')
-            .example('$0 jobs export CLUSTER_ALIAS all --status failing', 'exports all failing jobs on a cluster')
-            .example('$0 jobs export CLUSTER_ALIAS all -y', 'exports all jobs on a cluster and bypasses the prompt');
+            .example('$0 jobs export CLUSTER_ALIAS JOB1 --outdir ./my_jobs', 'exports a job to ./my_jobs/<job.name>.json')
+            .example('$0 jobs export CLUSTER_ALIAS all --status failing', 'exports all failing jobs on a cluster (maximum 100)')
+            .example('$0 jobs export CLUSTER_ALIAS all -y', 'exports all jobs on a cluster (maximum 100) and bypasses any prompts');
         return yargs;
     },
     async handler(argv: any) {

--- a/packages/teraslice-cli/src/cmds/jobs/export.ts
+++ b/packages/teraslice-cli/src/cmds/jobs/export.ts
@@ -8,28 +8,28 @@ const yargsOptions = new YargsOptions();
 
 export default {
     command: 'export <cluster-alias> <job-id...>',
-    describe: 'Export job or jobs on a cluster to a json file. By default the file is saved as ~/.teraslice/export/<cluster-alias>/<job.name>.json\n',
+    describe: 'Export job on a cluster to a json file. By default the file is saved as ~/.teraslice/export/<cluster-alias>/<job.name>.json\n',
     builder(yargs: any) {
         yargs.positional('job-id', yargsOptions.buildPositional('job-id'));
         yargs.options('config-dir', yargsOptions.buildOption('config-dir'));
         yargs.options('export-dir', yargsOptions.buildOption('export-dir'));
         yargs.options('output', yargsOptions.buildOption('output'));
         yargs.options('file-name', yargsOptions.buildOption('file-name'));
+        yargs.options('status', yargsOptions.buildOption('jobs-status'));
+        yargs.options('yes', yargsOptions.buildOption('yes'));
         yargs.check((argv: { jobId: string[]; fileName: string[]; }) => {
-            if (argv.fileName && argv.jobId.length !== argv.fileName.length) {
+            if (argv.fileName && argv.fileName.length !== argv.jobId.length) {
                 throw new Error('The number of job IDs must match the number of file names');
             }
             return true;
         });
-        // yargs.options('yes', yargsOptions.buildOption('yes'));
-        // yargs.options('status', yargsOptions.buildOption('jobs-status'));
         yargs.strict()
             .example('$0 jobs export CLUSTER_ALIAS JOB1', 'exports job config as a tjm compatible JSON file')
             .example('$0 jobs export CLUSTER_ALIAS JOB1 JOB2', 'exports job config for two jobs')
             .example('$0 jobs export CLUSTER_ALIAS JOB1 JOB2 --file-name name1.json name2.json', 'exports two jobs with custom file names')
-            .example('$0 jobs export CLUSTER_ALIAS JOB1 --export-dir ./my_jobs --f job_1.json', 'exports ajob to ./my_jobs/job_1.json');
-            // .example('$0 jobs export CLUSTER_ALIAS all --status failing', 'exports all failing jobs on a cluster')
-            // .example('$0 jobs export CLUSTER_ALIAS all -y', 'exports all jobs on a cluster and bypasses the prompt');
+            .example('$0 jobs export CLUSTER_ALIAS JOB1 --export-dir ./my_jobs -f job_1.json', 'exports a job to ./my_jobs/job_1.json')
+            .example('$0 jobs export CLUSTER_ALIAS all --status failing', 'exports all failing jobs on a cluster')
+            .example('$0 jobs export CLUSTER_ALIAS all -y', 'exports all jobs on a cluster and bypasses the prompt');
         return yargs;
     },
     async handler(argv: any) {

--- a/packages/teraslice-cli/src/cmds/jobs/export.ts
+++ b/packages/teraslice-cli/src/cmds/jobs/export.ts
@@ -24,7 +24,7 @@ export default {
             return true;
         });
         yargs.check((argv: { jobId: string[]; fileName: string[]; }) => {
-            if (argv.jobId.includes('all') && argv.fileName.length > 0) {
+            if (argv.jobId.includes('all') && argv.fileName) {
                 throw new Error('Cannot use custom file names when exporting all.');
             }
             return true;

--- a/packages/teraslice-cli/src/cmds/jobs/export.ts
+++ b/packages/teraslice-cli/src/cmds/jobs/export.ts
@@ -23,6 +23,12 @@ export default {
             }
             return true;
         });
+        yargs.check((argv: { jobId: string[]; fileName: string[]; }) => {
+            if (argv.jobId.includes('all') && argv.fileName.length > 0) {
+                throw new Error('Cannot use custom file names when exporting all.');
+            }
+            return true;
+        });
         yargs.strict()
             .example('$0 jobs export CLUSTER_ALIAS JOB1', 'exports job config as a tjm compatible JSON file')
             .example('$0 jobs export CLUSTER_ALIAS JOB1 JOB2', 'exports job config for two jobs')

--- a/packages/teraslice-cli/src/cmds/jobs/export.ts
+++ b/packages/teraslice-cli/src/cmds/jobs/export.ts
@@ -1,0 +1,46 @@
+import { CMD } from '../../interfaces.js';
+import Config from '../../helpers/config.js';
+import YargsOptions from '../../helpers/yargs-options.js';
+import Jobs from '../../helpers/jobs.js';
+import reply from '../../helpers/reply.js';
+
+const yargsOptions = new YargsOptions();
+
+export default {
+    command: 'export <cluster-alias> <job-id...>',
+    describe: 'Export job or jobs on a cluster to a json file. By default the file is saved as ~/.teraslice/export/<cluster-alias>/<job.name>.json\n',
+    builder(yargs: any) {
+        yargs.positional('job-id', yargsOptions.buildPositional('job-id'));
+        yargs.options('config-dir', yargsOptions.buildOption('config-dir'));
+        yargs.options('export-dir', yargsOptions.buildOption('export-dir'));
+        yargs.options('output', yargsOptions.buildOption('output'));
+        yargs.options('file-name', yargsOptions.buildOption('file-name'));
+        yargs.check((argv: { jobId: string[]; fileName: string[]; }) => {
+            if (argv.fileName && argv.jobId.length !== argv.fileName.length) {
+                throw new Error('The number of job IDs must match the number of file names');
+            }
+            return true;
+        });
+        // yargs.options('yes', yargsOptions.buildOption('yes'));
+        // yargs.options('status', yargsOptions.buildOption('jobs-status'));
+        yargs.strict()
+            .example('$0 jobs export CLUSTER_ALIAS JOB1', 'exports job config as a tjm compatible JSON file')
+            .example('$0 jobs export CLUSTER_ALIAS JOB1 JOB2', 'exports job config for two jobs')
+            .example('$0 jobs export CLUSTER_ALIAS JOB1 JOB2 --file-name name1.json name2.json', 'exports two jobs with custom file names')
+            .example('$0 jobs export CLUSTER_ALIAS JOB1 --export-dir ./my_jobs --f job_1.json', 'exports ajob to ./my_jobs/job_1.json');
+            // .example('$0 jobs export CLUSTER_ALIAS all --status failing', 'exports all failing jobs on a cluster')
+            // .example('$0 jobs export CLUSTER_ALIAS all -y', 'exports all jobs on a cluster and bypasses the prompt');
+        return yargs;
+    },
+    async handler(argv: any) {
+        const cliConfig = new Config(argv);
+        const jobs = new Jobs(cliConfig);
+
+        try {
+            await jobs.initialize();
+            await jobs.export();
+        } catch (e) {
+            reply.fatal(e);
+        }
+    }
+} as CMD;

--- a/packages/teraslice-cli/src/cmds/jobs/export.ts
+++ b/packages/teraslice-cli/src/cmds/jobs/export.ts
@@ -8,7 +8,7 @@ const yargsOptions = new YargsOptions();
 
 export default {
     command: 'export <cluster-alias> <job-id...>',
-    describe: 'Export job on a cluster to a json file. By default the file is saved to current working directory as <job.name>.json\n',
+    describe: 'Export job on a cluster to a json file. By default the file is saved to the current working directory as <job.name>.json\n',
     builder(yargs: any) {
         yargs.positional('job-id', yargsOptions.buildPositional('job-id'));
         yargs.options('config-dir', yargsOptions.buildOption('config-dir'));
@@ -17,8 +17,8 @@ export default {
         yargs.options('yes', yargsOptions.buildOption('yes'));
         yargs.strict()
             .example('$0 jobs export CLUSTER_ALIAS JOB1', 'exports job config as a tjm compatible JSON file')
-            .example('$0 jobs export CLUSTER_ALIAS JOB1 JOB2', 'exports job config for two jobs')
-            .example('$0 jobs export CLUSTER_ALIAS JOB1 --outdir ./my_jobs', 'exports a job to ./my_jobs/<job.name>.json')
+            .example('$0 jobs export CLUSTER_ALIAS JOB1 JOB2', 'exports job configs for two jobs')
+            .example('$0 jobs export CLUSTER_ALIAS JOB1 --outdir ~/my_jobs', 'exports a job to ~/my_jobs/<job.name>.json')
             .example('$0 jobs export CLUSTER_ALIAS all --status failing', 'exports all failing jobs on a cluster (maximum 100)')
             .example('$0 jobs export CLUSTER_ALIAS all -y', 'exports all jobs on a cluster (maximum 100) and bypasses any prompts');
         return yargs;

--- a/packages/teraslice-cli/src/cmds/jobs/index.ts
+++ b/packages/teraslice-cli/src/cmds/jobs/index.ts
@@ -2,6 +2,7 @@ import { CMD } from '../../interfaces.js';
 import awaitCmd from './await.js';
 import deleteJob from './delete.js';
 import errors from './errors.js';
+import exportJob from './export.js';
 import list from './list.js';
 import pause from './pause.js';
 import recover from './recover.js';
@@ -19,6 +20,7 @@ const commandList = [
     awaitCmd,
     deleteJob,
     errors,
+    exportJob,
     list,
     pause,
     recover,

--- a/packages/teraslice-cli/src/helpers/config.ts
+++ b/packages/teraslice-cli/src/helpers/config.ts
@@ -66,12 +66,20 @@ export default class Config {
         }
     }
 
-    get aliasesFile(): string {
-        return `${this.configDir}/aliases.yaml`;
+    /**
+     * Returns the user provided export directory or a
+     * default directory at <configDir>/export/<clusterAlias>
+     */
+    get exportDir(): string {
+        if (this.args.exportDir) {
+            return this.args.exportDir;
+        } else {
+            return `${this.configDir}/export/${this.args.clusterAlias}`;
+        }
     }
 
-    get defaultExportDir(): string {
-        return `${this.configDir}/export/${this.args.clusterAlias}`;
+    get aliasesFile(): string {
+        return `${this.configDir}/aliases.yaml`;
     }
 
     get jobStateDir(): string {
@@ -90,7 +98,7 @@ export default class Config {
         return [
             this.jobStateDir,
             this.assetDir,
-            this.defaultExportDir,
+            this.exportDir,
         ];
     }
 
@@ -104,10 +112,6 @@ export default class Config {
                 fs.mkdirSync(dir, { recursive: true });
             }
         });
-
-        if (this.args.exportDir && !fs.existsSync(this.args.exportDir)) {
-            fs.mkdirSync(this.args.exportDir, { recursive: true });
-        }
     }
 
     private _addJobAction() {

--- a/packages/teraslice-cli/src/helpers/config.ts
+++ b/packages/teraslice-cli/src/helpers/config.ts
@@ -70,6 +70,10 @@ export default class Config {
         return `${this.configDir}/aliases.yaml`;
     }
 
+    get defaultExportDir(): string {
+        return `${this.configDir}/export/${this.args.clusterAlias}`;
+    }
+
     get jobStateDir(): string {
         return `${this.configDir}/job_state_files`;
     }
@@ -85,7 +89,8 @@ export default class Config {
     get allSubDirs(): string[] {
         return [
             this.jobStateDir,
-            this.assetDir
+            this.assetDir,
+            this.defaultExportDir,
         ];
     }
 
@@ -96,9 +101,13 @@ export default class Config {
 
         this.allSubDirs.forEach((dir) => {
             if (!fs.existsSync(dir)) {
-                fs.mkdirSync(dir);
+                fs.mkdirSync(dir, { recursive: true });
             }
         });
+
+        if (this.args.exportDir && !fs.existsSync(this.args.exportDir)) {
+            fs.mkdirSync(this.args.exportDir, { recursive: true });
+        }
     }
 
     private _addJobAction() {

--- a/packages/teraslice-cli/src/helpers/config.ts
+++ b/packages/teraslice-cli/src/helpers/config.ts
@@ -66,20 +66,20 @@ export default class Config {
         }
     }
 
-    /**
-     * Returns the user provided export directory or a
-     * default directory at <configDir>/export/<clusterAlias>
-     */
-    get exportDir(): string {
-        if (this.args.exportDir) {
-            return this.args.exportDir;
-        } else {
-            return `${this.configDir}/export/${this.args.clusterAlias}`;
-        }
-    }
-
     get aliasesFile(): string {
         return `${this.configDir}/aliases.yaml`;
+    }
+
+    /**
+     * Returns the user provided output directory or
+     * the current directory as default
+     */
+    get outdir(): string {
+        if (this.args.outdir) {
+            return this.args.outdir;
+        } else {
+            return process.cwd();
+        }
     }
 
     get jobStateDir(): string {
@@ -98,7 +98,7 @@ export default class Config {
         return [
             this.jobStateDir,
             this.assetDir,
-            this.exportDir,
+            this.outdir,
         ];
     }
 

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -10,7 +10,7 @@ import { Job } from 'teraslice-client-js';
 import TerasliceUtil from './teraslice-util.js';
 import Display from './display.js';
 import reply from './reply.js';
-import { getJobConfigFromFile } from './tjm-util.js';
+import { getJobConfigFromFile, saveJobConfigToFile } from './tjm-util.js';
 import Config from './config.js';
 import {
     JobMetadata,
@@ -804,6 +804,22 @@ export default class Jobs {
         }
 
         this.printDiff(diffObject, showUpdateField);
+    }
+
+    async export() {
+        await pMap(
+            this.jobs,
+            (job) => this.exportOne(job.config),
+            { concurrency: this.concurrency }
+        );
+    }
+
+    async exportOne(jobConfig: Teraslice.JobConfig) {
+        const dirName = this.config.args.exportDir || this.config.defaultExportDir;
+        const fileNameIndex = this.config.args.jobId.indexOf(jobConfig.job_id);
+        const fileName = this.config.args.fileName[fileNameIndex] || `${jobConfig.name}.json`;
+        const fullPath = path.join(dirName, fileName);
+        await saveJobConfigToFile(jobConfig, fullPath);
     }
 
     /**

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -828,29 +828,31 @@ export default class Jobs {
     }
 
     /**
-     * Using the name from a jobConfig and the outdir from this.config,
-     * creates a unique file path where a job can be exported.
-     * Spaces in the job name are replaced with underscores. If the file name
-     * exists a '-N' suffix will be added to the name.
-     * ex: First export: '~/my_current_directory/my_job_name.json'
-     *    Second export: '~/my_current_directory/my_job_name-1.json'
      * @param { string } jobConfigName
      * @returns {string} A unique file path
+     *
+     * Using the name from a jobConfig and the outdir,
+     * creates a unique file path where a job can be exported.
+     * Spaces in the job name are replaced with underscores.
+     * If the file name exists a '-N' suffix will be added to the name.
+     *     ex: First export: '~/my_current_directory/my_job_name.json'
+     *        Second export: '~/my_current_directory/my_job_name-1.json'
      */
     private createUniqueFilePath(jobConfigName: string) {
         const dirName = this.config.outdir;
         const fileName = `${jobConfigName.replaceAll(' ', '_')}.json`;
-        const fullPath = path.join(dirName, fileName);
-        let uniquePath = fullPath;
+        const filePath = path.join(dirName, fileName);
+        let uniquePath = filePath;
         let i = 1;
 
         while (fs.existsSync(uniquePath)) {
-            uniquePath = `${fullPath.slice(0, -5)}-${i}.json`;
+            uniquePath = `${filePath.slice(0, -5)}-${i}.json`;
             i++;
         }
 
         return uniquePath;
     }
+
     /**
      * @param args action and final property, final indicates if it is part of a series of commands
      * @param job job metadata

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -817,7 +817,7 @@ export default class Jobs {
     async exportOne(jobConfig: Teraslice.JobConfig) {
         const dirName = this.config.args.exportDir || this.config.defaultExportDir;
         const fileNameIndex = this.config.args.jobId.indexOf(jobConfig.job_id);
-        const fileName = this.config.args.fileName[fileNameIndex] || `${jobConfig.name}.json`;
+        const fileName = this.config.args.fileName ? this.config.args.fileName[fileNameIndex] : `${jobConfig.name}.json`;
         const fullPath = path.join(dirName, fileName);
         await saveJobConfigToFile(jobConfig, fullPath);
     }

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -809,7 +809,7 @@ export default class Jobs {
     async export() {
         const jobIds = this.jobs.map((job) => job.id);
 
-        reply.yellow(`Saving jobFile for ${jobIds.join(', ')} on ${this.config.args.clusterAlias}`);
+        reply.yellow(`Saving jobFile(s) for ${jobIds.join(', ')} on ${this.config.args.clusterAlias}`);
 
         await pMap(
             this.jobs,
@@ -817,7 +817,7 @@ export default class Jobs {
             { concurrency: this.concurrency }
         );
 
-        reply.green(`Saved jobFile to ${this.config.outdir}`);
+        reply.green(`Saved jobFile(s) to ${this.config.outdir}`);
     }
 
     async exportOne(jobConfig: Teraslice.JobConfig) {

--- a/packages/teraslice-cli/src/helpers/tjm-util.ts
+++ b/packages/teraslice-cli/src/helpers/tjm-util.ts
@@ -227,5 +227,9 @@ export async function saveJobConfigToFile(
 
     addMetaData(jobConfigCopy, jobConfig.job_id, clusterUrl);
 
-    await fs.writeJSON(filePath, jobConfigCopy);
+    if (!fs.existsSync(filePath)) {
+        await fs.writeJSON(filePath, jobConfigCopy);
+    } else {
+        throw new Error(`File already exists at ${filePath}`);
+    }
 }

--- a/packages/teraslice-cli/src/helpers/tjm-util.ts
+++ b/packages/teraslice-cli/src/helpers/tjm-util.ts
@@ -4,8 +4,10 @@ import {
     has,
     set,
     unset,
-    get
+    get,
+    cloneDeep
 } from '@terascope/utils';
+import { Teraslice } from '@terascope/types';
 import Config from './config.js';
 import Jobs from './jobs.js';
 import { getPackage } from './utils.js';
@@ -207,4 +209,17 @@ export function saveConfig(
 
 function hasMetadata(jobConfig: Record<string, any>): boolean {
     return has(jobConfig, '__metadata');
+}
+
+export async function saveJobConfigToFile(jobConfig: Teraslice.JobConfig, filePath: string) {
+    const jobConfigCopy = {};
+    const keysToSkip = ['_created', '_updated', '_deleted', '_deleted_on', '_context', 'job_id'];
+
+    for (const key of Object.keys(jobConfig)) {
+        if (!keysToSkip.includes(key)) {
+            jobConfigCopy[key] = cloneDeep(jobConfig[key]);
+        }
+    }
+
+    await fs.writeJSON(filePath, jobConfigCopy);
 }

--- a/packages/teraslice-cli/src/helpers/tjm-util.ts
+++ b/packages/teraslice-cli/src/helpers/tjm-util.ts
@@ -211,15 +211,21 @@ function hasMetadata(jobConfig: Record<string, any>): boolean {
     return has(jobConfig, '__metadata');
 }
 
-export async function saveJobConfigToFile(jobConfig: Teraslice.JobConfig, filePath: string) {
+export async function saveJobConfigToFile(
+    jobConfig: Teraslice.JobConfig,
+    filePath: string,
+    clusterUrl: string
+) {
     const jobConfigCopy = {};
-    const keysToSkip = ['_created', '_updated', '_deleted', '_deleted_on', '_context', 'job_id'];
+    const keysToSkip = ['job_id', '_created', '_context', '_updated', '_deleted', '_deleted_on']
 
     for (const key of Object.keys(jobConfig)) {
         if (!keysToSkip.includes(key)) {
             jobConfigCopy[key] = cloneDeep(jobConfig[key]);
         }
     }
+
+    addMetaData(jobConfigCopy, jobConfig.job_id, clusterUrl);
 
     await fs.writeJSON(filePath, jobConfigCopy);
 }

--- a/packages/teraslice-cli/src/helpers/yargs-options.ts
+++ b/packages/teraslice-cli/src/helpers/yargs-options.ts
@@ -233,6 +233,17 @@ export default class Options {
             default: false,
             type: 'boolean'
         }),
+        'export-dir': () => ({
+            describe: 'Directory where exported job file will be saved',
+            type: 'string',
+            nargs: 1,
+        }),
+        'file-name': () => ({
+            alias: 'f',
+            describe: 'Names that files will be exported as. Ensure same order as job IDs',
+            type: 'string',
+            array: true
+        }),
         'active-job': () => ({
             describe: 'List active jobs',
             type: 'boolean'

--- a/packages/teraslice-cli/src/helpers/yargs-options.ts
+++ b/packages/teraslice-cli/src/helpers/yargs-options.ts
@@ -233,7 +233,8 @@ export default class Options {
             default: false,
             type: 'boolean'
         }),
-        'export-dir': () => ({
+        'outdir': () => ({
+            alias: 'o',
             describe: 'Directory where exported job file will be saved',
             type: 'string',
             nargs: 1,

--- a/packages/teraslice-cli/src/helpers/yargs-options.ts
+++ b/packages/teraslice-cli/src/helpers/yargs-options.ts
@@ -240,7 +240,7 @@ export default class Options {
         }),
         'file-name': () => ({
             alias: 'f',
-            describe: 'Names that files will be exported as. Ensure same order as job IDs',
+            describe: 'Name to use for exported file. If exporting multiple files ensure same order as job IDs',
             type: 'string',
             array: true
         }),

--- a/packages/teraslice-cli/src/helpers/yargs-options.ts
+++ b/packages/teraslice-cli/src/helpers/yargs-options.ts
@@ -239,16 +239,9 @@ export default class Options {
             type: 'string',
             nargs: 1,
         }),
-        'file-name': () => ({
-            alias: 'f',
-            describe: 'Name to use for exported file. If exporting multiple files ensure same order as job IDs',
-            type: 'string',
-            array: true
-        }),
         'active-job': () => ({
             describe: 'List active jobs',
             type: 'boolean'
-
         }),
         'show-deleted': () => ({
             describe: 'List deleted records',

--- a/packages/teraslice-cli/test/cmds/jobs/export-spec.ts
+++ b/packages/teraslice-cli/test/cmds/jobs/export-spec.ts
@@ -1,0 +1,35 @@
+import yargs from 'yargs';
+import exportJob from '../../../src/cmds/jobs/export.js';
+
+describe('jobs export', () => {
+    describe('-> parse', () => {
+        it('should parse properly', () => {
+            const yargsCmd = yargs().command(
+                // @ts-expect-error
+                exportJob.command,
+                exportJob.describe,
+                exportJob.builder,
+                () => true
+            );
+            const yargsResult = yargsCmd.parseSync(
+                'export ts-test1 all', {}
+            );
+            expect(yargsResult.clusterAlias).toEqual('ts-test1');
+        });
+
+        it('should parse properly with an id specifed', () => {
+            const yargsCmd = yargs().command(
+                // @ts-expect-error
+                exportJob.command,
+                exportJob.describe,
+                exportJob.builder,
+                () => true
+            );
+            const yargsResult = yargsCmd.parseSync(
+                'export ts-test1 99999999-9999-9999-9999-999999999999', {}
+            );
+            expect(yargsResult.clusterAlias).toEqual('ts-test1');
+            expect(yargsResult.jobId).toEqual(['99999999-9999-9999-9999-999999999999']);
+        });
+    });
+});

--- a/packages/teraslice-cli/test/fixtures/job_saves/aliases.yaml
+++ b/packages/teraslice-cli/test/fixtures/job_saves/aliases.yaml
@@ -5,3 +5,5 @@ clusters:
     host: http://test-host
   save_jobs2:
     host: http://test-host
+  export_jobs1:
+    host: http://test-host

--- a/packages/teraslice-cli/test/helpers/config-spec.ts
+++ b/packages/teraslice-cli/test/helpers/config-spec.ts
@@ -64,6 +64,27 @@ describe('config', () => {
         });
     });
 
+    describe('-> outdir', () => {
+        test('default directory should be defined', () => {
+            const edir = process.cwd();
+            expect(testConfig.outdir).toBe(edir);
+        });
+
+        test('custom directory should be defined', () => {
+            cliArgs = {
+                'cluster-manager-type': 'native',
+                'output-style': 'txt',
+                'config-dir': path.join(dirname, '../fixtures/config_dir'),
+                'cluster-alias': 'localhost',
+                'outdir': '/tmp/exportTest/test1'
+            };
+            testConfig = new Config(cliArgs);
+
+            const edir = path.join('/','tmp', 'exportTest', 'test1');
+            expect(testConfig.outdir).toBe(edir);
+        });
+    });
+
     describe('-> jobStateDir', () => {
         test('should be defined', () => {
             const adir = path.join(cliArgs['config-dir'], 'job_state_files');
@@ -83,9 +104,11 @@ describe('config', () => {
         test('should be defined', () => {
             const jdir = path.join(cliArgs['config-dir'], 'job_state_files');
             const adir = path.join(cliArgs['config-dir'], 'assets');
+            const edir = process.cwd();
             expect(testConfig.allSubDirs).toBeDefined();
             expect(testConfig.allSubDirs[0]).toBe(jdir);
             expect(testConfig.allSubDirs[1]).toBe(adir);
+            expect(testConfig.allSubDirs[2]).toBe(edir);
         });
     });
 

--- a/packages/teraslice-cli/test/helpers/config-spec.ts
+++ b/packages/teraslice-cli/test/helpers/config-spec.ts
@@ -66,8 +66,8 @@ describe('config', () => {
 
     describe('-> outdir', () => {
         test('default directory should be defined', () => {
-            const edir = process.cwd();
-            expect(testConfig.outdir).toBe(edir);
+            const odir = process.cwd();
+            expect(testConfig.outdir).toBe(odir);
         });
 
         test('custom directory should be defined', () => {
@@ -104,11 +104,11 @@ describe('config', () => {
         test('should be defined', () => {
             const jdir = path.join(cliArgs['config-dir'], 'job_state_files');
             const adir = path.join(cliArgs['config-dir'], 'assets');
-            const edir = process.cwd();
+            const odir = process.cwd();
             expect(testConfig.allSubDirs).toBeDefined();
             expect(testConfig.allSubDirs[0]).toBe(jdir);
             expect(testConfig.allSubDirs[1]).toBe(adir);
-            expect(testConfig.allSubDirs[2]).toBe(edir);
+            expect(testConfig.allSubDirs[2]).toBe(odir);
         });
     });
 

--- a/packages/teraslice-cli/test/helpers/jobs-spec.ts
+++ b/packages/teraslice-cli/test/helpers/jobs-spec.ts
@@ -944,4 +944,186 @@ describe('Job helper class', () => {
             expect(reply.error).toHaveBeenCalledWith(expect.stringContaining('Job is in non-terminal status running, cannot delete. Skipping'))
         });
     });
+
+    describe('export', () => {
+        const action = 'export';
+
+        const exportPath = path.join(dirname, '..', 'fixtures', 'job_exports');
+
+        beforeEach(() => {
+            fs.mkdirSync(exportPath);
+        })
+
+        afterEach(async () => {
+            fs.removeSync(exportPath);
+        });
+
+        it('should export a job to the default directory', async () => {
+            const [jobId] = makeJobIds(1);
+
+            const jobController = clusterControllers([jobId]);
+            const jobExecution = getJobExecution(jobId);
+
+            tsClient
+                .get(`/v1/jobs/${jobId}/ex`)
+                .reply(200, { _status: 'running' })
+                .get(`/v1/jobs/${jobId}`)
+                .reply(200, testJobConfig(jobId))
+                .get(`/v1/jobs/${jobId}/controller`)
+                .reply(200, () => Promise.resolve(jobController))
+                .get(`/v1/jobs/${jobId}/ex`)
+                .reply(200, () => Promise.resolve(jobExecution));
+
+            const alias = 'export_jobs1';
+
+            const config = buildCLIConfig(
+                action,
+                {
+                    'job-id': [jobId],
+                    jobId: [jobId],
+                    clusterAlias: alias
+                }
+            );
+
+            const job = new Jobs(config);
+
+            await job.initialize();
+
+            const originalDirectory = process.cwd();
+            fs.mkdirSync(path.join(exportPath, 'current'));
+            process.chdir(path.join(exportPath, 'current'));
+
+            await job.export();
+
+            const jobFile = fs.readJsonSync(path.join(process.cwd(), 'test-job.json'));
+
+            expect(jobFile.__metadata.cli.job_id).toBe(jobId);
+            expect(jobFile.assets).toEqual(['asset1:2.7.4', 'asset2:0.14.1']);
+            process.chdir(originalDirectory);
+        });
+
+        it('should export a job to a custom directory', async () => {
+            const customDir = path.join(exportPath, 'custom1');
+            const [jobId] = makeJobIds(1);
+
+            const jobController = clusterControllers([jobId]);
+            const jobExecution = getJobExecution(jobId);
+
+            tsClient
+                .get(`/v1/jobs/${jobId}/ex`)
+                .reply(200, { _status: 'running' })
+                .get(`/v1/jobs/${jobId}`)
+                .reply(200, testJobConfig(jobId))
+                .get(`/v1/jobs/${jobId}/controller`)
+                .reply(200, () => Promise.resolve(jobController))
+                .get(`/v1/jobs/${jobId}/ex`)
+                .reply(200, () => Promise.resolve(jobExecution));
+
+            const alias = 'export_jobs1';
+
+            const config = buildCLIConfig(
+                action,
+                {
+                    'job-id': [jobId],
+                    jobId: [jobId],
+                    clusterAlias: alias,
+                    outdir: customDir
+                }
+            );
+
+            const job = new Jobs(config);
+
+            await job.initialize();
+
+            await job.export();
+
+            const jobFile = fs.readJsonSync(path.join(customDir, 'test-job.json'));
+
+            expect(jobFile.__metadata.cli.job_id).toBe(jobId);
+            expect(jobFile.assets).toEqual(['asset1:2.7.4', 'asset2:0.14.1']);
+        });
+
+        it('should export all jobs to a custom directory', async () => {
+            const customDir = path.join(exportPath, 'custom2');
+
+            const jobIds = makeJobIds(3);
+            console.log('@@@@ jobIds: ', jobIds);
+            const [job1, job2, job3] = jobIds;
+            const jobsList = [{ job_id: job1}, { job_id: job2}, { job_id: job3}]
+            const jobControllers = clusterControllers(jobIds);
+
+            const [jobC1, jobC2, jobC3] = jobControllers;
+
+            const jobEx1 = getJobExecution(job1);
+            const jobEx2 = getJobExecution(job2);
+            const jobEx3 = getJobExecution(job3);
+
+            tsClient
+                .get('/v1/jobs')
+                .reply(200, () => Promise.resolve(jobsList))
+                .get(`/v1/jobs/${job1}/ex`)
+                .reply(200, { _status: 'running' })
+                .get(`/v1/jobs/${job2}/ex`)
+                .reply(200, { _status: 'running' })
+                .get(`/v1/jobs/${job3}/ex`)
+                .reply(200, { _status: 'running' })
+                .get(`/v1/jobs/${job1}`)
+                .reply(200, testJobConfig(job1))
+                .get(`/v1/jobs/${job2}`)
+                .reply(200, testJobConfig(job2))
+                .get(`/v1/jobs/${job3}`)
+                .reply(200, testJobConfig(job3))
+                .get(`/v1/jobs/${job1}/controller`)
+                .reply(200, () => Promise.resolve([jobC1]))
+                .get(`/v1/jobs/${job1}/ex`)
+                .reply(200, () => Promise.resolve(jobEx1))
+                .get(`/v1/jobs/${job2}/controller`)
+                .reply(200, () => Promise.resolve([jobC2]))
+                .get(`/v1/jobs/${job2}/ex`)
+                .reply(200, () => Promise.resolve(jobEx2))
+                .get(`/v1/jobs/${job3}/controller`)
+                .reply(200, () => Promise.resolve([jobC3]))
+                .get(`/v1/jobs/${job3}/ex`)
+                .reply(200, () => Promise.resolve(jobEx3));
+
+            const alias = 'export_jobs1';
+
+            const config = buildCLIConfig(
+                action,
+                {
+                    'job-id': ['all'],
+                    jobId: ['all'],
+                    clusterAlias: alias,
+                    outdir: customDir,
+                    yes: true,
+                    y: true
+                }
+            );
+
+            const job = new Jobs(config);
+
+            await job.initialize();
+
+            await job.export();
+
+            // Since all 3 jobs have the same file name, and exportOne() is called concurrently on
+            // each job, 2 of the jobs may have to call createUniqueFilePath() a second or third time
+            // as the original file name given will be taken by file creation time. This means there is
+            // no order to the file names.
+            const jobFiles = [];
+            jobFiles.push(fs.readJsonSync(path.join(customDir, 'test-job.json')));
+            jobFiles.push(fs.readJsonSync(path.join(customDir, 'test-job-1.json')));
+            jobFiles.push(fs.readJsonSync(path.join(customDir, 'test-job-2.json')));
+
+            expect(jobFiles).toEqual(expect.arrayContaining([
+                expect.objectContaining({ __metadata: { cli: expect.objectContaining({ job_id: job1 })}}),
+                expect.objectContaining({ __metadata: { cli: expect.objectContaining({ job_id: job2 })}}),
+                expect.objectContaining({ __metadata: { cli: expect.objectContaining({ job_id: job3 })}})
+            ]));
+        });
+
+        it('should not create a file with spaces', async () => {
+
+        });
+    });
 });

--- a/packages/teraslice-client-js/test/jobs-spec.ts
+++ b/packages/teraslice-client-js/test/jobs-spec.ts
@@ -179,7 +179,7 @@ describe('Teraslice Jobs', () => {
             });
         });
 
-        describe('when called with an query and search objects', () => {
+        describe('when called with a query and search objects', () => {
             const searchOptions = { headers: { 'Some-Header': 'yes' } };
             const queryOptions = { active: true, size: 10 };
 

--- a/packages/teraslice-client-js/test/jobs-spec.ts
+++ b/packages/teraslice-client-js/test/jobs-spec.ts
@@ -181,7 +181,7 @@ describe('Teraslice Jobs', () => {
 
         describe('when called with an query and search objects', () => {
             const searchOptions = { headers: { 'Some-Header': 'yes' } };
-            const queryOptions = { active: true } as const;
+            const queryOptions = { active: true, size: 10 };
 
             beforeEach(() => {
                 scope.get('/jobs')


### PR DESCRIPTION
This PR makes the following changes:
- Add `jobs export` command to teraslice-cli
  - Creates a `Jobs` class using the provided jobIds, extracts the jobConfig for each job, and saves each config to the local file system. 
  - Each job is saved to `./<job.name>.json` by default. If a file name already exists `-N` will be appended to the file name.
  - `--outdir` flag will set a custom directory where job files are saved.
  - A job-id of `all` will export all jobs. This can be combined with `--status` to export all jobs with executions of a specific status.

Ref: #3695