### PR TITLE
Include fix deps script in npm package

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -45,7 +45,7 @@
     "devDependencies": {
         "@terascope/types": "^1.0.0",
         "bunyan": "^1.8.15",
-        "elasticsearch-store": "^1.0.1",
+        "elasticsearch-store": "^1.0.2",
         "fs-extra": "^11.2.0",
         "ms": "^2.1.3",
         "nanoid": "^3.3.4",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -47,7 +47,7 @@
         "uuid": "^9.0.1",
         "valid-url": "^1.0.9",
         "validator": "^13.12.0",
-        "xlucene-parser": "^1.0.1"
+        "xlucene-parser": "^1.0.2"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.6",

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "^1.2.0",
         "@types/elasticsearch": "^5.0.43",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^1.0.1",
+        "elasticsearch-store": "^1.0.2",
         "elasticsearch6": "npm:@elastic/elasticsearch@^6.7.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@^7.0.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@^8.0.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,7 +30,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^1.0.1",
+        "@terascope/data-mate": "^1.0.2",
         "@terascope/data-types": "^1.0.0",
         "@terascope/types": "^1.0.0",
         "@terascope/utils": "^1.0.0",
@@ -42,7 +42,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@^2.2.1",
         "setimmediate": "^1.0.5",
         "uuid": "^9.0.1",
-        "xlucene-translator": "^1.0.1"
+        "xlucene-translator": "^1.0.2"
     },
     "devDependencies": {
         "@types/uuid": "^9.0.8"

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -37,7 +37,7 @@
         "convict-format-with-moment": "^6.2.0",
         "convict-format-with-validator": "^6.2.0",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^1.0.1",
+        "elasticsearch-store": "^1.0.2",
         "express": "^4.19.2",
         "js-yaml": "^4.1.0",
         "nanoid": "^3.3.4",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -63,7 +63,7 @@
         "semver": "^7.6.2",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^1.2.1",
+        "terafoundation": "^1.2.2",
         "uuid": "^9.0.1"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -36,7 +36,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^1.0.1",
+        "@terascope/data-mate": "^1.0.2",
         "@terascope/types": "^1.0.0",
         "@terascope/utils": "^1.0.0",
         "awesome-phonenumber": "^2.70.0",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -34,13 +34,13 @@
     },
     "dependencies": {
         "@terascope/types": "^1.0.0",
-        "@terascope/utils": "^1.0.0"
+        "@terascope/utils": "^1.0.0",
+        "ts-pegjs": "^4.2.1"
     },
     "devDependencies": {
         "@turf/invariant": "^6.2.0",
         "@turf/random": "^6.4.0",
-        "peggy": "~4.0.3",
-        "ts-pegjs": "^4.2.1"
+        "peggy": "~4.0.3"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -35,12 +35,12 @@
     "dependencies": {
         "@terascope/types": "^1.0.0",
         "@terascope/utils": "^1.0.0",
-        "ts-pegjs": "^4.2.1"
+        "ts-pegjs": "^4.2.1",
+        "peggy": "~4.0.3"
     },
     "devDependencies": {
         "@turf/invariant": "^6.2.0",
-        "@turf/random": "^6.4.0",
-        "peggy": "~4.0.3"
+        "@turf/random": "^6.4.0"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -35,8 +35,8 @@
     "dependencies": {
         "@terascope/types": "^1.0.0",
         "@terascope/utils": "^1.0.0",
-        "ts-pegjs": "^4.2.1",
-        "peggy": "~4.0.3"
+        "peggy": "~4.0.3",
+        "ts-pegjs": "^4.2.1"
     },
     "devDependencies": {
         "@turf/invariant": "^6.2.0",

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -32,7 +32,7 @@
         "@terascope/types": "^1.0.0",
         "@terascope/utils": "^1.0.0",
         "@types/elasticsearch": "^5.0.43",
-        "xlucene-parser": "^1.0.1"
+        "xlucene-parser": "^1.0.2"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"


### PR DESCRIPTION
Move `ts-pegjs` and `peggy` from dev-dependencies to regular dependencies within the `xlucene-parser` package
Bump `xlucene-parser` from 1.0.1 to 1.0.2