### PR TITLE
Fix data mate import copy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   NODE_VERSIONS_EXT_STORAGE: '[18]'
 
 jobs:
-  compute:
+  compute-node-version-vars:
     runs-on: ubuntu-latest
     outputs:
       NODE_VERSIONS: ${{ steps.step1.outputs.NODE_VERSIONS }}
@@ -29,7 +29,7 @@ jobs:
 
   verify-build:
     runs-on: ubuntu-latest
-    needs: compute
+    needs: compute-node-version-vars
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ fromJSON(needs.compute.outputs.NODE_VERSION_MAIN) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSION_MAIN) }}
         cache: 'yarn'
 
     - name: Install and build packages
@@ -56,10 +56,10 @@ jobs:
 
   linux-unit-tests:
     runs-on: ubuntu-latest
-    needs: compute
+    needs: compute-node-version-vars
     strategy:
       matrix:
-        node-version: ${{ fromJSON(needs.compute.outputs.NODE_VERSIONS) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -80,10 +80,10 @@ jobs:
 
   linux-unit-esm-tests:
     runs-on: ubuntu-latest
-    needs: compute
+    needs: compute-node-version-vars
     strategy:
       matrix:
-        node-version: ${{ fromJSON(needs.compute.outputs.NODE_VERSIONS) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -106,12 +106,12 @@ jobs:
 
   teraslice-elasticsearch-tests:
     runs-on: ubuntu-latest
-    needs: [compute, verify-build, cache-docker-images]
+    needs: [compute-node-version-vars, verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: ${{ fromJSON(needs.compute.outputs.NODE_VERSIONS) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -153,12 +153,12 @@ jobs:
 
   elasticsearch-store-tests:
     runs-on: ubuntu-latest
-    needs: [compute, verify-build, cache-docker-images]
+    needs: [compute-node-version-vars, verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: ${{ fromJSON(needs.compute.outputs.NODE_VERSIONS) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -200,7 +200,7 @@ jobs:
 
   lint-and-sync:
     runs-on: ubuntu-latest
-    needs: [compute, verify-build, cache-docker-images]
+    needs: [compute-node-version-vars, verify-build, cache-docker-images]
     # will remove the checkout, build and setup when the artifact is made to just
     # test the linting and syncing of the codebase
     steps:
@@ -210,7 +210,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ fromJSON(needs.compute.outputs.NODE_VERSION_MAIN) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSION_MAIN) }}
         cache: 'yarn'
 
     - name: Install and build packages
@@ -226,12 +226,12 @@ jobs:
 
   elasticsearch-api-tests:
     runs-on: ubuntu-latest
-    needs: [compute, verify-build, cache-docker-images]
+    needs: [compute-node-version-vars, verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: ${{ fromJSON(needs.compute.outputs.NODE_VERSIONS) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -273,12 +273,12 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-latest
-    needs: [compute, verify-build, cache-docker-images]
+    needs: [compute-node-version-vars, verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: ${{ fromJSON(needs.compute.outputs.NODE_VERSIONS) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code
@@ -324,12 +324,12 @@ jobs:
 
   e2e-k8s-tests:
     runs-on: ubuntu-latest
-    needs: [compute, verify-build, cache-docker-images]
+    needs: [compute-node-version-vars, verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: ${{ fromJSON(needs.compute.outputs.NODE_VERSIONS_EXT_K8S) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_K8S) }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -379,12 +379,12 @@ jobs:
 
   e2e-k8s-v2-tests:
     runs-on: ubuntu-latest
-    needs: [compute, verify-build, cache-docker-images]
+    needs: [compute-node-version-vars, verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: ${{ fromJSON(needs.compute.outputs.NODE_VERSIONS_EXT_K8S) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_K8S) }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -434,12 +434,12 @@ jobs:
 
   e2e-external-storage-tests:
     runs-on: ubuntu-latest
-    needs: [compute, verify-build, cache-docker-images]
+    needs: [compute-node-version-vars, verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: ${{ fromJSON(needs.compute.outputs.NODE_VERSIONS_EXT_STORAGE) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_STORAGE) }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -484,12 +484,12 @@ jobs:
 
   e2e-external-storage-tests-encrypted:
     runs-on: ubuntu-latest
-    needs: [compute, verify-build, cache-docker-images]
+    needs: [compute-node-version-vars, verify-build, cache-docker-images]
     strategy:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: ${{ fromJSON(needs.compute.outputs.NODE_VERSIONS_EXT_STORAGE) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_STORAGE) }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -45,7 +45,7 @@
     "devDependencies": {
         "@terascope/types": "^1.0.0",
         "bunyan": "^1.8.15",
-        "elasticsearch-store": "^1.0.2",
+        "elasticsearch-store": "^1.0.3",
         "fs-extra": "^11.2.0",
         "ms": "^2.1.3",
         "nanoid": "^3.3.4",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-mate/src/index.ts
+++ b/packages/data-mate/src/index.ts
@@ -11,7 +11,7 @@ import { AggregationFrame } from './aggregation-frame/AggregationFrame.js';
 import { FieldTransformInterface, RecordTransformInterface } from './interfaces.js';
 
 // import are immutable, so we rename and clone to alter methods
-const tmpFieldTransform = { };
+const tmpFieldTransform = {};
 for (const key of Object.keys(FTransform)) {
     tmpFieldTransform[key] = FTransform[key];
 }

--- a/packages/data-mate/src/index.ts
+++ b/packages/data-mate/src/index.ts
@@ -12,20 +12,22 @@ import { AggregationFrame } from './aggregation-frame/AggregationFrame.js';
 import { FieldTransformInterface, RecordTransformInterface } from './interfaces.js';
 
 // import are immutable, so we rename and clone to alter methods
-const FieldTransform: FieldTransformInterface = { repository: cloneDeep(RTransform.repository) };
+const tempFieldTransform = { repository: cloneDeep(RTransform.repository) };
 for (const key of Object.keys(FTransform)) {
-    FieldTransform[key] = FTransform[key];
+    tempFieldTransform[key] = FTransform[key];
 }
-FieldTransform.repository.extract = extractConfig;
-FieldTransform.extract = extract;
+tempFieldTransform.repository.extract = extractConfig;
+(tempFieldTransform as FieldTransformInterface).extract = extract;
+const FieldTransform: FieldTransformInterface = tempFieldTransform as FieldTransformInterface;
 
-const RecordTransform: RecordTransformInterface = { repository: cloneDeep(FTransform.repository) };
+const tempRecordTransform = { repository: cloneDeep(FTransform.repository) };
 for (const key of Object.keys(RTransform)) {
-    RecordTransform[key] = RTransform[key];
+    tempRecordTransform[key] = RTransform[key];
 }
 
-RecordTransform.repository.transformRecord = transformRecordConfig;
-RecordTransform.transformRecord = transformRecord;
+tempRecordTransform.repository.transformRecord = transformRecordConfig;
+(tempRecordTransform as RecordTransformInterface).transformRecord = transformRecord;
+const RecordTransform: RecordTransformInterface = tempRecordTransform as RecordTransformInterface;
 
 declare module './aggregation-frame/AggregationFrame' {
     interface AggregationFrame<T extends Record<string, any>> {

--- a/packages/data-mate/src/index.ts
+++ b/packages/data-mate/src/index.ts
@@ -9,13 +9,20 @@ import {
     RecordTransform as RTransform
 } from './transforms/index.js';
 import { AggregationFrame } from './aggregation-frame/AggregationFrame.js';
+import { FieldTransformInterface, RecordTransformInterface } from './interfaces.js';
 
 // import are immutable, so we rename and clone to alter methods
-const FieldTransform = cloneDeep(FTransform);
-const RecordTransform = cloneDeep(RTransform);
-
+const FieldTransform: FieldTransformInterface = { repository: cloneDeep(RTransform.repository) };
+for (const key of Object.keys(FTransform)) {
+    FieldTransform[key] = FTransform[key];
+}
 FieldTransform.repository.extract = extractConfig;
 FieldTransform.extract = extract;
+
+const RecordTransform: RecordTransformInterface = { repository: cloneDeep(FTransform.repository) };
+for (const key of Object.keys(RTransform)) {
+    RecordTransform[key] = RTransform[key];
+}
 
 RecordTransform.repository.transformRecord = transformRecordConfig;
 RecordTransform.transformRecord = transformRecord;

--- a/packages/data-mate/src/index.ts
+++ b/packages/data-mate/src/index.ts
@@ -1,4 +1,3 @@
-import { cloneDeep } from '@terascope/utils';
 import { DataFrame } from './data-frame/index.js';
 import {
     jexl, extract, extractConfig,
@@ -16,7 +15,6 @@ const tmpFieldTransform = { };
 for (const key of Object.keys(FTransform)) {
     tmpFieldTransform[key] = FTransform[key];
 }
-(tmpFieldTransform as FieldTransformInterface).repository = cloneDeep(RTransform.repository);
 (tmpFieldTransform as FieldTransformInterface).repository.extract = extractConfig;
 (tmpFieldTransform as FieldTransformInterface).extract = extract;
 const FieldTransform: FieldTransformInterface = tmpFieldTransform as FieldTransformInterface;
@@ -25,7 +23,6 @@ const tmpRecordTransform = {};
 for (const key of Object.keys(RTransform)) {
     tmpRecordTransform[key] = RTransform[key];
 }
-(tmpRecordTransform as RecordTransformInterface).repository = cloneDeep(FTransform.repository);
 (tmpRecordTransform as RecordTransformInterface).repository.transformRecord = transformRecordConfig;
 (tmpRecordTransform as RecordTransformInterface).transformRecord = transformRecord;
 const RecordTransform: RecordTransformInterface = tmpRecordTransform as RecordTransformInterface;

--- a/packages/data-mate/src/index.ts
+++ b/packages/data-mate/src/index.ts
@@ -8,24 +8,19 @@ import {
     RecordTransform as RTransform
 } from './transforms/index.js';
 import { AggregationFrame } from './aggregation-frame/AggregationFrame.js';
-import { FieldTransformInterface, RecordTransformInterface } from './interfaces.js';
 
 // import are immutable, so we rename and clone to alter methods
-const tmpFieldTransform = {};
-for (const key of Object.keys(FTransform)) {
-    tmpFieldTransform[key] = FTransform[key];
-}
-(tmpFieldTransform as FieldTransformInterface).repository.extract = extractConfig;
-(tmpFieldTransform as FieldTransformInterface).extract = extract;
-const FieldTransform: FieldTransformInterface = tmpFieldTransform as FieldTransformInterface;
+const FieldTransform = {
+    ...FTransform
+};
+FieldTransform.repository.extract = extractConfig;
+FieldTransform.extract = extract;
 
-const tmpRecordTransform = {};
-for (const key of Object.keys(RTransform)) {
-    tmpRecordTransform[key] = RTransform[key];
-}
-(tmpRecordTransform as RecordTransformInterface).repository.transformRecord = transformRecordConfig;
-(tmpRecordTransform as RecordTransformInterface).transformRecord = transformRecord;
-const RecordTransform: RecordTransformInterface = tmpRecordTransform as RecordTransformInterface;
+const RecordTransform = {
+    ...RTransform
+};
+RecordTransform.repository.transformRecord = transformRecordConfig;
+RecordTransform.transformRecord = transformRecord;
 
 declare module './aggregation-frame/AggregationFrame' {
     interface AggregationFrame<T extends Record<string, any>> {

--- a/packages/data-mate/src/index.ts
+++ b/packages/data-mate/src/index.ts
@@ -12,22 +12,23 @@ import { AggregationFrame } from './aggregation-frame/AggregationFrame.js';
 import { FieldTransformInterface, RecordTransformInterface } from './interfaces.js';
 
 // import are immutable, so we rename and clone to alter methods
-const tempFieldTransform = { repository: cloneDeep(RTransform.repository) };
+const tmpFieldTransform = { };
 for (const key of Object.keys(FTransform)) {
-    tempFieldTransform[key] = FTransform[key];
+    tmpFieldTransform[key] = FTransform[key];
 }
-tempFieldTransform.repository.extract = extractConfig;
-(tempFieldTransform as FieldTransformInterface).extract = extract;
-const FieldTransform: FieldTransformInterface = tempFieldTransform as FieldTransformInterface;
+(tmpFieldTransform as FieldTransformInterface).repository = cloneDeep(RTransform.repository);
+(tmpFieldTransform as FieldTransformInterface).repository.extract = extractConfig;
+(tmpFieldTransform as FieldTransformInterface).extract = extract;
+const FieldTransform: FieldTransformInterface = tmpFieldTransform as FieldTransformInterface;
 
-const tempRecordTransform = { repository: cloneDeep(FTransform.repository) };
+const tmpRecordTransform = {};
 for (const key of Object.keys(RTransform)) {
-    tempRecordTransform[key] = RTransform[key];
+    tmpRecordTransform[key] = RTransform[key];
 }
-
-tempRecordTransform.repository.transformRecord = transformRecordConfig;
-(tempRecordTransform as RecordTransformInterface).transformRecord = transformRecord;
-const RecordTransform: RecordTransformInterface = tempRecordTransform as RecordTransformInterface;
+(tmpRecordTransform as RecordTransformInterface).repository = cloneDeep(FTransform.repository);
+(tmpRecordTransform as RecordTransformInterface).repository.transformRecord = transformRecordConfig;
+(tmpRecordTransform as RecordTransformInterface).transformRecord = transformRecord;
+const RecordTransform: RecordTransformInterface = tmpRecordTransform as RecordTransformInterface;
 
 declare module './aggregation-frame/AggregationFrame' {
     interface AggregationFrame<T extends Record<string, any>> {

--- a/packages/data-mate/src/interfaces.ts
+++ b/packages/data-mate/src/interfaces.ts
@@ -35,3 +35,55 @@ export interface ExtractFieldConfig {
     start?: any;
     end?: any;
 }
+
+export interface FieldTransformInterface {
+    decodeBase64?: any,
+    decodeHex?: any,
+    decodeURL?: any,
+    encodeBase64?: any,
+    encodeHex?: any,
+    encodeMD5?: any,
+    encodeSHA?: any,
+    encodeSHA1?: any,
+    encodeURL?: any,
+    extract?: any,
+    formatDate?: any,
+    map?: any,
+    parseDate?: any,
+    parseJSON?: any,
+    replaceLiteral?: any,
+    replaceRegex?: any,
+    repository: Repository,
+    setDefault?: any,
+    setField?: any,
+    splitString?: any,
+    toBoolean?: any,
+    toCamelCase?: any,
+    toGeoPoint?: any,
+    toISDN?: any,
+    toISO8601?: any,
+    toJSON?: any,
+    toKebabCase?: any,
+    toLowerCase?: any,
+    toNumber?: any,
+    toPascalCase?: any,
+    toSnakeCase?: any,
+    toString?: any,
+    toTitleCase?: any,
+    toUnixTime?: any,
+    toUpperCase?: any,
+    trim?: any,
+    trimEnd?: any,
+    trimStart?: any,
+    truncate?:any
+}
+
+export interface RecordTransformInterface {
+    copyField?: any
+    dedupe?: any
+    dropFields?: any
+    renameField?: any
+    repository: Repository
+    setField?: any
+    transformRecord?: any
+}

--- a/packages/data-mate/src/interfaces.ts
+++ b/packages/data-mate/src/interfaces.ts
@@ -1,5 +1,4 @@
 import { DataTypeFieldConfig, FieldType } from '@terascope/types';
-import { FieldTransform, RecordTransform } from './transforms/index.js';
 
 export type ArgSchema = Config & { description?: string };
 
@@ -35,56 +34,4 @@ export interface ExtractFieldConfig {
     jexlExp?: string;
     start?: any;
     end?: any;
-}
-
-export interface FieldTransformInterface {
-    decodeBase64: typeof FieldTransform.decodeBase64;
-    decodeHex: typeof FieldTransform.decodeHex;
-    decodeURL: typeof FieldTransform.decodeURL;
-    encodeBase64: typeof FieldTransform.encodeBase64;
-    encodeHex: typeof FieldTransform.encodeHex;
-    encodeMD5: typeof FieldTransform.encodeMD5;
-    encodeSHA: typeof FieldTransform.encodeSHA;
-    encodeSHA1: typeof FieldTransform.encodeSHA1;
-    encodeURL: typeof FieldTransform.encodeURL;
-    extract: typeof FieldTransform.extract;
-    formatDate: typeof FieldTransform.formatDate;
-    map: typeof FieldTransform.map;
-    parseDate: typeof FieldTransform.parseDate;
-    parseJSON: typeof FieldTransform.parseJSON;
-    replaceLiteral: typeof FieldTransform.replaceLiteral;
-    replaceRegex: typeof FieldTransform.replaceRegex;
-    repository: Repository;
-    setDefault: typeof FieldTransform.setDefault;
-    setField: typeof FieldTransform.setField;
-    splitString: typeof FieldTransform.splitString;
-    toBoolean: typeof FieldTransform.toBoolean;
-    toCamelCase: typeof FieldTransform.toCamelCase;
-    toGeoPoint: typeof FieldTransform.toGeoPoint;
-    toISDN: typeof FieldTransform.toISDN;
-    toISO8601: typeof FieldTransform.toISO8601;
-    toJSON: typeof FieldTransform.toJSON;
-    toKebabCase: typeof FieldTransform.toKebabCase;
-    toLowerCase: typeof FieldTransform.toLowerCase;
-    toNumber: typeof FieldTransform.toNumber;
-    toPascalCase: typeof FieldTransform.toPascalCase;
-    toSnakeCase: typeof FieldTransform.toSnakeCase;
-    toString: typeof FieldTransform.toString;
-    toTitleCase: typeof FieldTransform.toTitleCase;
-    toUnixTime: typeof FieldTransform.toUnixTime;
-    toUpperCase: typeof FieldTransform.toUpperCase;
-    trim: typeof FieldTransform.trim;
-    trimEnd: typeof FieldTransform.trimEnd;
-    trimStart: typeof FieldTransform.trimStart;
-    truncate:typeof FieldTransform.truncate;
-}
-
-export interface RecordTransformInterface {
-    copyField: typeof RecordTransform.copyField;
-    dedupe: typeof RecordTransform.dedupe;
-    dropFields: typeof RecordTransform.dropFields;
-    renameField: typeof RecordTransform.renameField;
-    repository: Repository;
-    setField: typeof RecordTransform.setField;
-    transformRecord: typeof RecordTransform.transformRecord;
 }

--- a/packages/data-mate/src/interfaces.ts
+++ b/packages/data-mate/src/interfaces.ts
@@ -1,5 +1,5 @@
 import { DataTypeFieldConfig, FieldType } from '@terascope/types';
-import { FieldTransform, RecordTransform } from './transforms';
+import { FieldTransform, RecordTransform } from './transforms/index.js';
 
 export type ArgSchema = Config & { description?: string };
 

--- a/packages/data-mate/src/interfaces.ts
+++ b/packages/data-mate/src/interfaces.ts
@@ -1,4 +1,5 @@
 import { DataTypeFieldConfig, FieldType } from '@terascope/types';
+import { FieldTransform, RecordTransform } from './transforms';
 
 export type ArgSchema = Config & { description?: string };
 
@@ -37,53 +38,53 @@ export interface ExtractFieldConfig {
 }
 
 export interface FieldTransformInterface {
-    decodeBase64?: any,
-    decodeHex?: any,
-    decodeURL?: any,
-    encodeBase64?: any,
-    encodeHex?: any,
-    encodeMD5?: any,
-    encodeSHA?: any,
-    encodeSHA1?: any,
-    encodeURL?: any,
-    extract?: any,
-    formatDate?: any,
-    map?: any,
-    parseDate?: any,
-    parseJSON?: any,
-    replaceLiteral?: any,
-    replaceRegex?: any,
-    repository: Repository,
-    setDefault?: any,
-    setField?: any,
-    splitString?: any,
-    toBoolean?: any,
-    toCamelCase?: any,
-    toGeoPoint?: any,
-    toISDN?: any,
-    toISO8601?: any,
-    toJSON?: any,
-    toKebabCase?: any,
-    toLowerCase?: any,
-    toNumber?: any,
-    toPascalCase?: any,
-    toSnakeCase?: any,
-    toString?: any,
-    toTitleCase?: any,
-    toUnixTime?: any,
-    toUpperCase?: any,
-    trim?: any,
-    trimEnd?: any,
-    trimStart?: any,
-    truncate?:any
+    decodeBase64: typeof FieldTransform.decodeBase64;
+    decodeHex: typeof FieldTransform.decodeHex;
+    decodeURL: typeof FieldTransform.decodeURL;
+    encodeBase64: typeof FieldTransform.encodeBase64;
+    encodeHex: typeof FieldTransform.encodeHex;
+    encodeMD5: typeof FieldTransform.encodeMD5;
+    encodeSHA: typeof FieldTransform.encodeSHA;
+    encodeSHA1: typeof FieldTransform.encodeSHA1;
+    encodeURL: typeof FieldTransform.encodeURL;
+    extract: typeof FieldTransform.extract;
+    formatDate: typeof FieldTransform.formatDate;
+    map: typeof FieldTransform.map;
+    parseDate: typeof FieldTransform.parseDate;
+    parseJSON: typeof FieldTransform.parseJSON;
+    replaceLiteral: typeof FieldTransform.replaceLiteral;
+    replaceRegex: typeof FieldTransform.replaceRegex;
+    repository: Repository;
+    setDefault: typeof FieldTransform.setDefault;
+    setField: typeof FieldTransform.setField;
+    splitString: typeof FieldTransform.splitString;
+    toBoolean: typeof FieldTransform.toBoolean;
+    toCamelCase: typeof FieldTransform.toCamelCase;
+    toGeoPoint: typeof FieldTransform.toGeoPoint;
+    toISDN: typeof FieldTransform.toISDN;
+    toISO8601: typeof FieldTransform.toISO8601;
+    toJSON: typeof FieldTransform.toJSON;
+    toKebabCase: typeof FieldTransform.toKebabCase;
+    toLowerCase: typeof FieldTransform.toLowerCase;
+    toNumber: typeof FieldTransform.toNumber;
+    toPascalCase: typeof FieldTransform.toPascalCase;
+    toSnakeCase: typeof FieldTransform.toSnakeCase;
+    toString: typeof FieldTransform.toString;
+    toTitleCase: typeof FieldTransform.toTitleCase;
+    toUnixTime: typeof FieldTransform.toUnixTime;
+    toUpperCase: typeof FieldTransform.toUpperCase;
+    trim: typeof FieldTransform.trim;
+    trimEnd: typeof FieldTransform.trimEnd;
+    trimStart: typeof FieldTransform.trimStart;
+    truncate:typeof FieldTransform.truncate;
 }
 
 export interface RecordTransformInterface {
-    copyField?: any
-    dedupe?: any
-    dropFields?: any
-    renameField?: any
-    repository: Repository
-    setField?: any
-    transformRecord?: any
+    copyField: typeof RecordTransform.copyField;
+    dedupe: typeof RecordTransform.dedupe;
+    dropFields: typeof RecordTransform.dropFields;
+    renameField: typeof RecordTransform.renameField;
+    repository: Repository;
+    setField: typeof RecordTransform.setField;
+    transformRecord: typeof RecordTransform.transformRecord;
 }

--- a/packages/data-mate/src/transforms/field-transform.ts
+++ b/packages/data-mate/src/transforms/field-transform.ts
@@ -1294,7 +1294,7 @@ export function toISO8601(
     return _makeIso(input, args);
 }
 
-interface FormatDateConfig {
+export interface FormatDateConfig {
     format: string;
     resolution?: 'seconds' | 'milliseconds';
 }
@@ -1355,7 +1355,7 @@ export function formatDate(
     return _formatDate(input, args);
 }
 
-interface ParseDateConfig {
+export interface ParseDateConfig {
     format: string;
 }
 

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "^1.2.0",
         "@types/elasticsearch": "^5.0.43",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^1.0.2",
+        "elasticsearch-store": "^1.0.3",
         "elasticsearch6": "npm:@elastic/elasticsearch@^6.7.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@^7.0.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@^8.0.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,7 +30,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^1.0.2",
+        "@terascope/data-mate": "^1.0.3",
         "@terascope/data-types": "^1.0.0",
         "@terascope/types": "^1.0.0",
         "@terascope/utils": "^1.0.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -37,7 +37,7 @@
         "convict-format-with-moment": "^6.2.0",
         "convict-format-with-validator": "^6.2.0",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^1.0.2",
+        "elasticsearch-store": "^1.0.3",
         "express": "^4.19.2",
         "js-yaml": "^4.1.0",
         "nanoid": "^3.3.4",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -63,7 +63,7 @@
         "semver": "^7.6.2",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^1.2.2",
+        "terafoundation": "^1.2.3",
         "uuid": "^9.0.1"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -36,7 +36,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^1.0.2",
+        "@terascope/data-mate": "^1.0.3",
         "@terascope/types": "^1.0.0",
         "@terascope/utils": "^1.0.0",
         "awesome-phonenumber": "^2.70.0",


### PR DESCRIPTION
This PR makes the following changes:
- Modify `packages/data-mate/src/index.ts` to copy each property from the `FTransform` and `RTransform` imports to a new object instead of using `cloneDeep`. This avoids a type error that occurs when `teraslice-cli assets build` tries to build an ESM asset that imports `data-mate` 
- Bump data-mate from 1.0.2 to 1.0.3, elasticsearch-store from 1.0.2 to 1.0.3, terafoundation from 1.2.2 to 1.2.3, ts-transforms from 1.0.2 to 1.0.3 

See here for details: #3725 