### PR TITLE
create default import for elasticsearch-api

### DIFF
--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-api/types/index.d.ts
+++ b/packages/elasticsearch-api/types/index.d.ts
@@ -5,7 +5,7 @@ import { ClientParams, ClientResponse } from '@terascope/types';
 import { Logger } from '@terascope/utils';
 import { ClientMetadata } from '@terascope/types'
 
-export = elasticsearchAPI;
+export default elasticsearchAPI;
 
 declare function elasticsearchAPI(client: Client, logger: Logger, config?: elasticsearchAPI.Config): elasticsearchAPI.Client;
 

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^4.0.0",
+        "@terascope/elasticsearch-api": "^4.0.1",
         "@terascope/utils": "^1.0.0"
     },
     "engines": {

--- a/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
+++ b/packages/teraslice-state-storage/src/elasticsearch-state-storage/index.ts
@@ -3,7 +3,7 @@ import {
     chunk, pMap
 } from '@terascope/utils';
 import { ClientParams, ClientResponse } from '@terascope/types';
-import esApi, { Client, BulkRecord } from '@terascope/elasticsearch-api';
+import esApi from '@terascope/elasticsearch-api';
 import { ESStateStorageConfig, MGetCacheResponse } from '../interfaces.js';
 import CachedStateStorage from '../cached-state-storage/index.js';
 
@@ -15,11 +15,11 @@ export default class ESCachedStateStorage {
     private chunkSize: number;
     private persist: boolean;
     private metaKey: string;
-    private es: Client;
+    private es: esApi.Client;
     private logger: Logger;
     public cache: CachedStateStorage<DataEntity>;
 
-    constructor(client: Client, logger: Logger, config: ESStateStorageConfig) {
+    constructor(client: esApi.Client, logger: Logger, config: ESStateStorageConfig) {
         this.index = config.index;
         this.type = config.type;
         this.concurrency = config.concurrency;
@@ -228,7 +228,7 @@ export default class ESCachedStateStorage {
         return this.es.mget(request);
     }
 
-    private _esBulkUpdatePrep(dataArray: DataEntity[]): BulkRecord[] {
+    private _esBulkUpdatePrep(dataArray: DataEntity[]): esApi.BulkRecord[] {
         return dataArray.map((doc) => ({
             action: {
                 index: {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -39,7 +39,7 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "^0.21.0",
-        "@terascope/elasticsearch-api": "^4.0.0",
+        "@terascope/elasticsearch-api": "^4.0.1",
         "@terascope/job-components": "^1.2.0",
         "@terascope/teraslice-messaging": "^1.3.0",
         "@terascope/types": "^1.0.0",


### PR DESCRIPTION
This PR makes the following changes:
- Update `index.d.ts` within `elasticsearch-api` to have a default export.
- Bump elasticsearch-api from 4.0.0 to 4.0.1
- Bump teraslice-state-storage from 1.0.0 to 1.0.1