### PR TITLE
Add yarn to run jest command

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -150,7 +150,11 @@ export async function runJest(
     extraArgs?: string[],
     debug?: boolean
 ): Promise<void> {
-    const args = mapToArgs(argsMap);
+    // When running jest in yarn3 PnP with ESM we must call 'yarn jest <...args>'
+    // to prevent module not found errors. Therefore we will call fork with the yarn
+    // command and set jest to the first argument.
+    const args = ['jest'];
+    args.push(...mapToArgs(argsMap));
     if (extraArgs) {
         extraArgs.forEach((extraArg) => {
             if (extraArg.startsWith('-') && args.includes(extraArg)) {
@@ -168,7 +172,7 @@ export async function runJest(
     }
 
     await fork({
-        cmd: 'jest',
+        cmd: 'yarn',
         cwd,
         args,
         env,


### PR DESCRIPTION
This PR makes the following changes:
- Changes the `runJest` script to call `yarn` with `jest` as the first argument rather than calling `jest` on its own. This allows the test runner to run tests in a package using `yarn3 PnP` and ESM modules without getting module not found errors.
- Bump scripts from 1.0.0 to 1.0.1 