### PR TITLE
[teraslice] - Add execution controller restart logic in kubernetesV2

### DIFF
--- a/packages/job-components/src/operations/core/slicer-core.ts
+++ b/packages/job-components/src/operations/core/slicer-core.ts
@@ -148,6 +148,14 @@ export default abstract class SlicerCore<T = OpConfig>
     }
 
     /**
+     * Used to indicate whether this slicer is restartable. Only relevant for
+     * kubernetesV2 backend
+     */
+    isRestartable(): boolean {
+        return false;
+    }
+
+    /**
      * Used to determine the maximum number of slices queued.
      * Defaults to 10000
      * NOTE: if you want to base of the number of

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sResource.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sResource.ts
@@ -89,7 +89,7 @@ export class K8sResource {
             if (process.env.MOUNT_LOCAL_TERASLICE !== undefined) {
                 this._mountLocalTeraslice(resourceName);
             }
-            this._setEnvVariables(resourceName);
+            this._setEnvVariables();
             this._setAssetsVolume();
             this._setImagePullSecret();
             this._setEphemeralStorage();
@@ -114,17 +114,7 @@ export class K8sResource {
         }
     }
 
-    _setEnvVariables(resourceName: string) {
-        // Pass in env var to let ex know it can restart in
-        // certain scenarios
-        if (resourceName === 'execution_controller') {
-            this.resource.spec.template.spec.containers[0].env.push(
-                {
-                    name: 'ALLOW_EX_RESTART',
-                    value: 'true'
-                }
-            );
-        }
+    _setEnvVariables() {
     }
 
     _mountLocalTeraslice(contextType: string): void {

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sResource.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sResource.ts
@@ -89,7 +89,7 @@ export class K8sResource {
             if (process.env.MOUNT_LOCAL_TERASLICE !== undefined) {
                 this._mountLocalTeraslice(resourceName);
             }
-            this._setEnvVariables();
+            this._setEnvVariables(resourceName);
             this._setAssetsVolume();
             this._setImagePullSecret();
             this._setEphemeralStorage();
@@ -114,15 +114,17 @@ export class K8sResource {
         }
     }
 
-    _setEnvVariables() {
+    _setEnvVariables(resourceName: string) {
         // Pass in env var to let ex know it can restart in
         // certain scenarios
-        this.resource.spec.template.spec.containers[0].env.push(
-            {
-                name: 'ALLOW_EX_RESTART',
-                value: 'true'
-            }
-        );
+        if (resourceName === 'execution_controller') {
+            this.resource.spec.template.spec.containers[0].env.push(
+                {
+                    name: 'ALLOW_EX_RESTART',
+                    value: 'true'
+                }
+            );
+        }
     }
 
     _mountLocalTeraslice(contextType: string): void {

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sResource.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sResource.ts
@@ -115,7 +115,14 @@ export class K8sResource {
     }
 
     _setEnvVariables() {
-        /// TODO: Use this later when we need to set env vars in workers/ex controllers
+        // Pass in env var to let ex know it can restart in
+        // certain scenarios
+        this.resource.spec.template.spec.containers[0].env.push(
+            {
+                name: 'ALLOW_EX_RESTART',
+                value: 'true'
+            }
+        );
     }
 
     _mountLocalTeraslice(contextType: string): void {
@@ -292,14 +299,14 @@ export class K8sResource {
                 // eslint-disable-next-line max-len
                 this.resource.spec.template.spec.priorityClassName = this.terasliceConfig.kubernetes_priority_class_name;
                 if (this.execution.stateful) {
-                     
+
                     this.resource.spec.template.metadata.labels[`${this.jobPropertyLabelPrefix}/stateful`] = 'true';
                 }
             }
             if (this.nodeType === 'worker' && this.execution.stateful) {
                 // eslint-disable-next-line max-len
                 this.resource.spec.template.spec.priorityClassName = this.terasliceConfig.kubernetes_priority_class_name;
-                 
+
                 this.resource.spec.template.metadata.labels[`${this.jobPropertyLabelPrefix}/stateful`] = 'true';
             }
         }

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -434,7 +434,10 @@ export class ExecutionController {
             /// shutdown. We want to restart in this case.
             if (status !== 'stopping' && includes(runningStatuses, status)) {
                 this.logger.info('Skipping shutdown to allow restart...');
-                await this.executionStorage.setStatus(this.exId, 'paused');
+                await this.executionStorage.setStatus(this.exId, 'paused')
+                .catch((err) => {
+                    logError(this.logger, err, 'failure to set status to paused while restarting..');
+                });
                 return;
             }
         }

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -941,6 +941,9 @@ export class ExecutionController {
         } else if (includes(runningStatuses, status)) {
             // In the case of a running status on startup we
             // want to continue to start up. Only in V2.
+            // Right now we will depend on kubernetes `crashloopbackoff` in the case of
+            // an unexpected exit to the ex process. Ex: an OOM
+            // NOTE: If this becomes an issue we may want to add a new state. Maybe `interrupted`
             if (this.context.sysconfig.teraslice.cluster_manager_type === 'kubernetesV2') {
                 // Check to see if `isRestartable` exists.
                 // Allows for older assets to work with k8sV2

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -422,7 +422,10 @@ export class ExecutionController {
         }
 
         /// This only applies to kubernetesV2
-        if (process.env.ALLOW_EX_RESTART === 'true') {
+        if (
+            this.context.sysconfig.teraslice.cluster_manager_type === 'kubernetesV2'
+            && eventType === 'SIGTERM'
+        ) {
             await this.stateStorage.refresh();
             const status = await this.executionStorage.getStatus(this.exId);
             this.logger.debug(`Execution ${this.exId} is currently in a ${status} state`);
@@ -937,7 +940,7 @@ export class ExecutionController {
         } else if (includes(runningStatuses, status)) {
             // In the case of a `running` state on startup we
             // want to continue to start up. Only in V2.
-            if (process.env.ALLOW_EX_RESTART === 'true') {
+            if (this.context.sysconfig.teraslice.cluster_manager_type === 'kubernetesV2') {
                 // Check to see if `isRestartable` exists.
                 // Allows for older assets to work with k8sV2
                 if (this.executionContext.slicer().isRestartable) {

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -428,11 +428,13 @@ export class ExecutionController {
         ) {
             await this.stateStorage.refresh();
             const status = await this.executionStorage.getStatus(this.exId);
+            const runningStatuses = this.executionStorage.getRunningStatuses();
             this.logger.debug(`Execution ${this.exId} is currently in a ${status} state`);
             /// This is an indication that the cluster_master did not call for this
             /// shutdown. We want to restart in this case.
-            if (status === 'running') {
+            if (status !== 'stopping' && includes(runningStatuses, status)) {
                 this.logger.info('Skipping shutdown to allow restart...');
+                await this.executionStorage.setStatus(this.exId, 'paused');
                 return;
             }
         }
@@ -938,9 +940,12 @@ export class ExecutionController {
         if (includes(terminalStatuses, status)) {
             error = new Error(invalidStateMsg('terminal'));
         } else if (includes(runningStatuses, status)) {
-            // In the case of a `running` state on startup we
+            // In the case of a `paused` state on startup we
             // want to continue to start up. Only in V2.
-            if (this.context.sysconfig.teraslice.cluster_manager_type === 'kubernetesV2') {
+            if (
+                this.context.sysconfig.teraslice.cluster_manager_type === 'kubernetesV2'
+                && status === 'paused'
+            ) {
                 // Check to see if `isRestartable` exists.
                 // Allows for older assets to work with k8sV2
                 if (this.executionContext.slicer().isRestartable) {

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -434,10 +434,6 @@ export class ExecutionController {
             /// shutdown. We want to restart in this case.
             if (status !== 'stopping' && includes(runningStatuses, status)) {
                 this.logger.info('Skipping shutdown to allow restart...');
-                await this.executionStorage.setStatus(this.exId, 'paused')
-                .catch((err) => {
-                    logError(this.logger, err, 'failure to set status to paused while restarting..');
-                });
                 return;
             }
         }
@@ -943,12 +939,9 @@ export class ExecutionController {
         if (includes(terminalStatuses, status)) {
             error = new Error(invalidStateMsg('terminal'));
         } else if (includes(runningStatuses, status)) {
-            // In the case of a `paused` state on startup we
+            // In the case of a running status on startup we
             // want to continue to start up. Only in V2.
-            if (
-                this.context.sysconfig.teraslice.cluster_manager_type === 'kubernetesV2'
-                && status === 'paused'
-            ) {
+            if (this.context.sysconfig.teraslice.cluster_manager_type === 'kubernetesV2') {
                 // Check to see if `isRestartable` exists.
                 // Allows for older assets to work with k8sV2
                 if (this.executionContext.slicer().isRestartable) {

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -937,7 +937,11 @@ export class ExecutionController {
             // In the case of a `running` state on startup we
             // want to continue to start up. Only in V2.
             if (process.env.ALLOW_EX_RESTART === 'true') {
-                return true;
+                // Check to see if `isRestartable` exists.
+                // Allows for older assets to work with k8sV2
+                if (this.executionContext.slicer().isRestartable) {
+                    return this.executionContext.slicer().isRestartable();
+                }
             }
             error = new Error(invalidStateMsg('running'));
             // If in a running status the execution process

--- a/packages/teraslice/src/lib/workers/helpers/worker-shutdown.ts
+++ b/packages/teraslice/src/lib/workers/helpers/worker-shutdown.ts
@@ -44,7 +44,12 @@ export function shutdownHandler(
     const isProcessRestart = process.env.process_restart;
     // everything but the k8s execution_controller should not be allowed be allowed to
     // set a non-zero exit code (to avoid being restarted)
-    const allowNonZeroExitCode = !(isK8s && assignment === 'execution_controller');
+    // This is overridden in V2 because it can restart
+    const allowNonZeroExitCode = !(
+        isK8s
+        && assignment === 'execution_controller'
+        && process.env.ALLOW_EX_RESTART !== 'true'
+    );
     const api = {
         exiting: false,
         exit

--- a/packages/teraslice/src/lib/workers/helpers/worker-shutdown.ts
+++ b/packages/teraslice/src/lib/workers/helpers/worker-shutdown.ts
@@ -48,7 +48,7 @@ export function shutdownHandler(
     const allowNonZeroExitCode = !(
         isK8s
         && assignment === 'execution_controller'
-        && process.env.ALLOW_EX_RESTART !== 'true'
+        && context.sysconfig.teraslice.cluster_manager_type === 'kubernetesV2'
     );
     const api = {
         exiting: false,


### PR DESCRIPTION
This PR makes the following changes:

## New features
- Teraslice running  in `KubernetesV2`  will have the ability to restart in a new pod automatically under certain conditions
  - These conditions include receiving a `SIGTERM` signal not associated with a job shutdown, and the slicer being restartable.
- Added new function `isRestartable()` to the base slicer 
  - `isRestartable()` will return a `boolean` to tell wether the slicer is compatible with the restartable feature or not. This allows for an initial implementation for `kafka` slicers without having to worry about the complexity of other slicers.

refs: #1007 