### PR TITLE
[e2e] Prevent the dockerUp function from failing by retrying when node version check returns undefined

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,7 +1,7 @@
 {
     "name": "e2e",
     "displayName": "E2E Tests",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "private": true,
     "description": "Teraslice integration test suite",
     "keywords": [


### PR DESCRIPTION
This PR makes the following changes:
- Wrap node version check in a pRetry and throw if undefined. Occasionally e2e tests will fail because using docker compose to exec into the teraslice master and checking the node version will return undefined. It is most likely a timing issue, so we will now attempt this 3 times and then throw if we still get undefined.
- Bump scripts from 0.7.0 to 0.7.1