### PR TITLE
[terafoundation] Prom metrics exporter doesn't reset metrics between updates

### DIFF
--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -43,6 +43,7 @@ NOTE: All `asset_storage` related fields are deprecated. Please use the fields i
 | **prom_metrics_enabled** | `Boolean` |  `false` | Create prometheus exporters. Kubernetes clustering only |
 | **prom_metrics_port** | `Number` |  `3333` | Port of prometheus exporter server. Kubernetes clustering only. Metrics will be visible at `http://localhost:<PORT>/metrics` |
 | **prom_metrics_add_default** | `Boolean` |  `true` | Display default node metrics in prom exporter. Kubernetes clustering only |
+| **prom_metrics_display_url** | `String` |  `""` | Value to display as url label for prometheus metrics |
 |   **workers**   |  `Number`  |       `4`       |                             Number of workers per server                              |
 
 ## Teraslice Configuration Reference

--- a/docs/development/k8s.md
+++ b/docs/development/k8s.md
@@ -368,6 +368,7 @@ The `PromMetrics` class lives within `packages/terafoundation/src/api/prom-metri
 | hasMetric | check if a metric exists | `(name: string) => boolean` |
 | deleteMetric | delete a metric from the metric list | `(name: string) => Promise<boolean>` |
 | verifyAPI | verfiy that the API is running | `() => boolean` |
+| resetMetrics | reset the values of all metrics | `() => void` |
 | shutdown | disable API and shutdown exporter server | `() => Promise<void>` |
 | getDefaultLabels | retrieve the default labels set at init | `() => Record<string, string>` |
 

--- a/docs/management-apis/endpoints-json.md
+++ b/docs/management-apis/endpoints-json.md
@@ -83,6 +83,55 @@ $ curl 'localhost:5678/v1/cluster/controllers'
 ]
 ```
 
+## GET /v1/cluster/stats
+
+Returns a json object containing cluster analytics.
+
+**NOTE:** The slicer object is identical to controllers and is present for backwards compatibility.
+
+**Usage:**
+
+```sh
+$ curl 'http://localhost:5678/v1/cluster/stats'
+{
+    "controllers": {
+        "processed": 2,
+        "failed": 0,
+        "queued": 0,
+        "job_duration": 3,
+        "workers_joined": 1,
+        "workers_disconnected": 0,
+        "workers_reconnected": 0
+    },
+    "slicer": {
+        "processed": 2,
+        "failed": 0,
+        "queued": 0,
+        "job_duration": 3,
+        "workers_joined": 1,
+        "workers_disconnected": 0,
+        "workers_reconnected": 0
+    }
+}
+```
+
+Include the following header to receive stats in "prometheus exporter mode":
+```sh
+$ curl -H "Accept: application/openmetrics-text;" -sS http://localhost:5678/cluster/stats
+# TYPE teraslice_slices_processed counter
+teraslice_slices_processed{cluster="teraslice-dev1"} 2
+# TYPE teraslice_slices_failed counter
+teraslice_slices_failed{cluster="teraslice-dev1"} 0
+# TYPE teraslice_slices_queued counter
+teraslice_slices_queued{cluster="teraslice-dev1"} 0
+# TYPE teraslice_workers_joined counter
+teraslice_workers_joined{cluster="teraslice-dev1"} 1
+# TYPE teraslice_workers_disconnected counter
+teraslice_workers_disconnected{cluster="teraslice-dev1"} 0
+# TYPE teraslice_workers_reconnected counter
+teraslice_workers_reconnected{cluster="teraslice-dev1"} 0
+```
+
 ## GET /v1/assets
 
 Retreives a list of assets

--- a/packages/job-components/src/test-helpers.ts
+++ b/packages/job-components/src/test-helpers.ts
@@ -499,6 +499,11 @@ export class TestContext implements i.Context {
                     verifyAPI(): boolean {
                         return ctx.mockPromMetrics !== null;
                     },
+                    resetMetrics() {
+                        if (ctx.mockPromMetrics) {
+                            ctx.mockPromMetrics.metricList = {};
+                        }
+                    },
                     async shutdown(): Promise<void> {
                         ctx.mockPromMetrics = null;
                     }

--- a/packages/job-components/src/test-helpers.ts
+++ b/packages/job-components/src/test-helpers.ts
@@ -159,6 +159,7 @@ export class TestContext implements i.Context {
                 prom_metrics_enabled: false,
                 prom_metrics_port: 3333,
                 prom_metrics_add_default: true,
+                prom_metrics_display_url: 'http://localhost',
             },
             teraslice: {
                 action_timeout: 10000,

--- a/packages/job-components/test/test-helpers-spec.ts
+++ b/packages/job-components/test/test-helpers-spec.ts
@@ -142,6 +142,7 @@ describe('Test Helpers', () => {
             tf_prom_metrics_enabled: true,
             tf_prom_metrics_port: 3333,
             tf_prom_metrics_add_default: false,
+            prom_metrics_display_url: 'http://localhost'
         };
 
         it('should be able to init a mock prom_metrics_api', async () => {

--- a/packages/job-components/test/test-helpers-spec.ts
+++ b/packages/job-components/test/test-helpers-spec.ts
@@ -215,6 +215,11 @@ describe('Test Helpers', () => {
                 .toThrow('Metric missing_test_histogram is not setup');
         });
 
+        it('should reset metrics', () => {
+            context.apis.foundation.promMetrics.resetMetrics();
+            expect(context.mockPromMetrics?.metricList).toBeEmptyObject();
+        })
+
         it('should shutdown', async () => {
             await context.apis.foundation.promMetrics.shutdown();
             expect(context.mockPromMetrics).toBeNull();

--- a/packages/terafoundation/src/api/prom-metrics/exporter.ts
+++ b/packages/terafoundation/src/api/prom-metrics/exporter.ts
@@ -48,4 +48,8 @@ export default class Exporter {
     async deleteMetric(name: string): Promise<void> {
         promClient.register.removeSingleMetric(name);
     }
+
+    resetMetrics() {
+        promClient.register.resetMetrics();
+    }
 }

--- a/packages/terafoundation/src/api/prom-metrics/prom-metrics-api.ts
+++ b/packages/terafoundation/src/api/prom-metrics/prom-metrics-api.ts
@@ -41,7 +41,7 @@ export class PromMetrics {
         const {
             assignment, job_prom_metrics_add_default, job_prom_metrics_enabled,
             job_prom_metrics_port, tf_prom_metrics_add_default, tf_prom_metrics_enabled,
-            tf_prom_metrics_port, labels, prefix, terasliceName
+            tf_prom_metrics_port, labels, prefix, terasliceName, prom_metrics_display_url
         } = config;
 
         const portToUse = job_prom_metrics_port || tf_prom_metrics_port;
@@ -67,6 +67,7 @@ export class PromMetrics {
             this.default_labels = {
                 name: terasliceName,
                 assignment: apiConfig.assignment,
+                url: prom_metrics_display_url,
                 ...apiConfig.labels
             };
             await this.createAPI(apiConfig);

--- a/packages/terafoundation/src/api/prom-metrics/prom-metrics-api.ts
+++ b/packages/terafoundation/src/api/prom-metrics/prom-metrics-api.ts
@@ -405,6 +405,10 @@ export class PromMetrics {
         return this.apiRunning;
     }
 
+    resetMetrics() {
+        this.metricExporter.resetMetrics();
+    }
+
     async shutdown(): Promise<void> {
         this.logger.info('prom_metrics_API exporter shutdown');
         try {

--- a/packages/terafoundation/src/schema.ts
+++ b/packages/terafoundation/src/schema.ts
@@ -83,6 +83,11 @@ export function foundationSchema() {
             doc: 'Display default node metrics in prom exporter',
             default: true,
             format: Boolean
+        },
+        prom_metrics_display_url: {
+            doc: 'Value to display as url label for prometheus metrics',
+            default: '',
+            format: String
         }
     };
 

--- a/packages/terafoundation/test/apis/prom-metrics-spec.ts
+++ b/packages/terafoundation/test/apis/prom-metrics-spec.ts
@@ -17,7 +17,8 @@ describe('promMetrics foundation API', () => {
                             log_level: 'debug',
                             prom_metrics_enabled: true,
                             prom_metrics_port: 3333,
-                            prom_metrics_add_default: true
+                            prom_metrics_add_default: true,
+                            prom_metrics_display_url: 'http://localhost'
                         },
                         teraslice: {
                             cluster_manager_type: 'kubernetes',
@@ -33,7 +34,8 @@ describe('promMetrics foundation API', () => {
                     tf_prom_metrics_port: terafoundation.prom_metrics_port,
                     tf_prom_metrics_add_default: terafoundation.prom_metrics_add_default,
                     logger: debugLogger('prom-metrics-spec-logger'),
-                    assignment: 'worker'
+                    assignment: 'worker',
+                    prom_metrics_display_url: terafoundation.prom_metrics_display_url
                 };
 
                 beforeAll(() => {
@@ -58,7 +60,7 @@ describe('promMetrics foundation API', () => {
 
                 it('should have correct default labels', async () => {
                     const labels = await context.apis.foundation.promMetrics.getDefaultLabels();
-                    expect(labels).toEqual({ assignment: 'worker', name: 'tera-test' });
+                    expect(labels).toEqual({ assignment: 'worker', name: 'tera-test', url: 'http://localhost' });
                 });
 
                 it('should throw an error if promMetricsAPI is already initialized', async () => {

--- a/packages/terafoundation/test/test-context-spec.ts
+++ b/packages/terafoundation/test/test-context-spec.ts
@@ -76,7 +76,8 @@ describe('TestContext', () => {
             tf_prom_metrics_port: 3333,
             tf_prom_metrics_add_default: false,
             logger: context.logger,
-            assignment: 'master'
+            assignment: 'master',
+            prom_metrics_display_url: context.sysconfig.terafoundation.prom_metrics_display_url
         };
         expect(await context.apis.foundation.promMetrics.init(config)).toBe(true);
     });

--- a/packages/teraslice/src/lib/cluster/cluster_master.ts
+++ b/packages/teraslice/src/lib/cluster/cluster_master.ts
@@ -12,7 +12,6 @@ import {
 } from './services/index.js';
 import { JobsStorage, ExecutionStorage, StateStorage } from '../storage/index.js';
 import { ClusterMasterContext } from '../../interfaces.js';
-import { getPackageJSON } from '../utils/file_utils.js';
 
 export class ClusterMaster {
     context: ClusterMasterContext;
@@ -374,19 +373,6 @@ export class ClusterMaster {
                     ['ex_id', 'job_id', 'job_name'],
                 ),
             ]);
-
-            this.context.apis.foundation.promMetrics.set(
-                'master_info',
-                {
-                    arch: this.context.arch,
-                    clustering_type: this.context.sysconfig.teraslice.cluster_manager_type,
-                    name: this.context.sysconfig.teraslice.name,
-                    node_version: process.version,
-                    platform: this.context.platform,
-                    teraslice_version: getPackageJSON().version
-                },
-                1
-            );
         }
     }
 }

--- a/packages/teraslice/src/lib/cluster/cluster_master.ts
+++ b/packages/teraslice/src/lib/cluster/cluster_master.ts
@@ -153,7 +153,8 @@ export class ClusterMaster {
                     tf_prom_metrics_port: terafoundation.prom_metrics_port,
                     logger: this.logger,
                     assignment: 'master',
-                    prefix: 'teraslice_'
+                    prefix: 'teraslice_',
+                    prom_metrics_display_url: terafoundation.prom_metrics_display_url
                 });
 
                 await this.setupPromMetrics();
@@ -239,6 +240,36 @@ export class ClusterMaster {
                     'master_info',
                     'Information about Teraslice cluster master',
                     ['arch', 'clustering_type', 'name', 'node_version', 'platform', 'teraslice_version']
+                ),
+                this.context.apis.foundation.promMetrics.addGauge(
+                    'slices_processed',
+                    'Total slices processed across the cluster',
+                    []
+                ),
+                this.context.apis.foundation.promMetrics.addGauge(
+                    'slices_failed',
+                    'Total slices failed across the cluster',
+                    []
+                ),
+                this.context.apis.foundation.promMetrics.addGauge(
+                    'slices_queued',
+                    'Total slices queued across the cluster',
+                    []
+                ),
+                this.context.apis.foundation.promMetrics.addGauge(
+                    'workers_joined',
+                    'Total workers joined across the cluster',
+                    []
+                ),
+                this.context.apis.foundation.promMetrics.addGauge(
+                    'workers_disconnected',
+                    'Total workers disconnected across the cluster',
+                    []
+                ),
+                this.context.apis.foundation.promMetrics.addGauge(
+                    'workers_reconnected',
+                    'Total workers reconnected across the cluster',
+                    []
                 ),
                 this.context.apis.foundation.promMetrics.addGauge(
                     'controller_workers_active',

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -693,6 +693,43 @@ export class ApiService {
                     try {
                         this.logger.trace('Updating cluster_master prom metrics..');
                         const controllers = await this.executionService.getControllerStats();
+                        const stats = this.executionService.getClusterAnalytics();
+
+                        this.context.apis.foundation.promMetrics.set(
+                            'slices_processed',
+                            {},
+                            stats.controllers.processed
+                        );
+
+                        this.context.apis.foundation.promMetrics.set(
+                            'slices_failed',
+                            {},
+                            stats.controllers.failed
+                        );
+
+                        this.context.apis.foundation.promMetrics.set(
+                            'slices_queued',
+                            {},
+                            stats.controllers.queued
+                        );
+
+                        this.context.apis.foundation.promMetrics.set(
+                            'workers_joined',
+                            {},
+                            stats.controllers.workers_joined
+                        );
+
+                        this.context.apis.foundation.promMetrics.set(
+                            'workers_disconnected',
+                            {},
+                            stats.controllers.workers_disconnected
+                        );
+
+                        this.context.apis.foundation.promMetrics.set(
+                            'workers_reconnected',
+                            {},
+                            stats.controllers.workers_reconnected
+                        );
 
                         for (const controller of controllers) {
                             const controllerLabels = {
@@ -828,9 +865,9 @@ export class ApiService {
 
                         /// Filter out information about kubernetes ex pods
                         const filteredExecutions = {};
-                        for (const cluster in clusterState) {
-                            if (clusterState[cluster].active) {
-                                for (const worker of clusterState[cluster].active) {
+                        for (const node in clusterState) {
+                            if (clusterState[node].active) {
+                                for (const worker of clusterState[node].active) {
                                     if (!filteredExecutions[worker.ex_id]) {
                                         filteredExecutions[worker.ex_id] = worker.ex_id;
                                         const exLabel = {

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -694,6 +694,20 @@ export class ApiService {
                         this.logger.trace('Updating cluster_master prom metrics..');
                         const controllers = await this.executionService.getControllerStats();
                         const stats = this.executionService.getClusterAnalytics();
+                        const { cluster_manager_type, name } = this.context.sysconfig.teraslice;
+
+                        this.context.apis.foundation.promMetrics.set(
+                            'master_info',
+                            {
+                                arch: this.context.arch,
+                                clustering_type: cluster_manager_type,
+                                name,
+                                node_version: process.version,
+                                platform: this.context.platform,
+                                teraslice_version: getPackageJSON().version
+                            },
+                            1
+                        );
 
                         this.context.apis.foundation.promMetrics.set(
                             'slices_processed',

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -689,6 +689,7 @@ export class ApiService {
             /// Interval is hardcoded to refresh metrics every 10 seconds
             if (this.context.apis.foundation.promMetrics.verifyAPI()) {
                 setInterval(async () => {
+                    this.context.apis.foundation.promMetrics.resetMetrics();
                     try {
                         this.logger.trace('Updating cluster_master prom metrics..');
                         const controllers = await this.executionService.getControllerStats();
@@ -746,7 +747,8 @@ export class ApiService {
                                 controller.slicers
                             );
                         }
-                        const exList = await this.executionStorage.search('ex_id:*');
+                        const query = this.executionStorage.getLivingStatuses().map((str) => `_status:${str}`).join(' OR ');
+                        const exList = await this.executionStorage.search(query, undefined, 10000);
                         for (const ex of exList) {
                             const controllerLabels = {
                                 ex_id: ex.ex_id,

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -159,7 +159,9 @@ export class ExecutionController {
                     ex_id: exId,
                     job_id: jobId,
                     job_name: config.name,
-                }
+                },
+                prom_metrics_display_url: terafoundation.prom_metrics_display_url
+
             });
             await this.setupPromMetrics();
         }

--- a/packages/teraslice/src/lib/workers/worker/index.ts
+++ b/packages/teraslice/src/lib/workers/worker/index.ts
@@ -107,7 +107,8 @@ export class Worker {
                     ex_id: exId,
                     job_id: jobId,
                     job_name: config.name,
-                }
+                },
+                prom_metrics_display_url: terafoundation.prom_metrics_display_url
             });
             await this.setupPromMetrics();
         }

--- a/packages/types/src/terafoundation.ts
+++ b/packages/types/src/terafoundation.ts
@@ -205,6 +205,7 @@ export interface PromMetrics {
     hasMetric: (name: string) => boolean;
     deleteMetric: (name: string) => Promise<boolean>;
     verifyAPI: () => boolean;
+    resetMetrics: () => void;
     shutdown: () => Promise<void>;
     getDefaultLabels: () => Record<string, string>;
 }

--- a/packages/types/src/terafoundation.ts
+++ b/packages/types/src/terafoundation.ts
@@ -133,6 +133,7 @@ export interface TerafoundationConfig {
     prom_metrics_enabled: boolean;
     prom_metrics_port: number;
     prom_metrics_add_default: boolean;
+    prom_metrics_display_url: string;
 }
 
 export type SysConfig<S> = {
@@ -177,6 +178,7 @@ export interface PromMetricsInitConfig {
     job_prom_metrics_add_default?: boolean;
     labels?: Record<string, string>;
     prefix?: string;
+    prom_metrics_display_url: string;
 }
 
 export interface PromMetricsAPIConfig {


### PR DESCRIPTION
This PR makes the following changes:
- The `PromMetrics` class needs to reset it's list of metrics on each scrape. If it doesn't do this, then all the executions are listed, not just the active ones. `resetMetrics()` functions were added to `PromMetrics` and `Exporter` to reset the `prom-client` register.
- Add `prom_metrics_display_url` field to terafoundation. This value will be used as the `url` default label added to all prom metrics. Defaults to an empty string, making it more obvious that this field is missing from the config.
- Include cluster analytics metrics (GET '/cluster/stats' endpoint results) in the cluster master

ref: #3743 