### PR TITLE
[docs] Escape special characters in md file

### DIFF
--- a/docs/packages/teraslice-cli/overview.md
+++ b/docs/packages/teraslice-cli/overview.md
@@ -400,7 +400,7 @@ teraslice-cli jobs view local 99999999-9999-9999-9999-999999999999
 
 ### jobs export
 
-Export job on a cluster to a json file. By default the file is saved to the current working directory as <job.name>.json
+Export job on a cluster to a json file. By default the file is saved to the current working directory as \<job.name\>.json
 
 ```sh
 teraslice-cli jobs export <cluster> <job_id>


### PR DESCRIPTION
A few special characters were added a documentation change in my recent PR: #3717
After merging the docs build failed because docusuarus could not parse the .md file properly.
This PR escapes those characters properly.