### PR TITLE
[teraslice] fix multi-job deletion bug in force job stop

### DIFF
--- a/e2e/k8s/kindConfigDefaultPorts.yaml
+++ b/e2e/k8s/kindConfigDefaultPorts.yaml
@@ -3,6 +3,7 @@ name: k8s-env
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  image: kindest/node:v1.28.12@sha256:fa0e48b1e83bb8688a5724aa7eebffbd6337abd7909ad089a2700bf08c30c6ea
   extraPortMappings:
   - containerPort: 30200 # Map internal elasticsearch service to host port
     hostPort: 9200

--- a/e2e/k8s/kindConfigDefaultPortsDev.yaml
+++ b/e2e/k8s/kindConfigDefaultPortsDev.yaml
@@ -7,6 +7,7 @@ name: k8s-env
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  image: kindest/node:v1.28.12@sha256:fa0e48b1e83bb8688a5724aa7eebffbd6337abd7909ad089a2700bf08c30c6ea
   extraPortMappings:
   - containerPort: 30200 # Map internal elasticsearch service to host port
     hostPort: 9200

--- a/e2e/k8s/kindConfigTestPorts.yaml
+++ b/e2e/k8s/kindConfigTestPorts.yaml
@@ -3,6 +3,7 @@ name: k8s-e2e
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  image: kindest/node:v1.28.12@sha256:fa0e48b1e83bb8688a5724aa7eebffbd6337abd7909ad089a2700bf08c30c6ea
   extraPortMappings:
   - containerPort: 30200 # Map internal elasticsearch service to host port
     hostPort: 49200

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^11.2.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^1.3.0"
+        "@terascope/job-components": "^1.3.1"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=1.3.0"
+        "@terascope/job-components": ">=1.3.1"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -40,7 +40,7 @@
     "dependencies": {
         "@kubernetes/client-node": "^0.21.0",
         "@terascope/elasticsearch-api": "^4.1.0",
-        "@terascope/job-components": "^1.3.0",
+        "@terascope/job-components": "^1.3.1",
         "@terascope/teraslice-messaging": "^1.4.0",
         "@terascope/types": "^1.1.0",
         "@terascope/utils": "^1.1.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetes/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetes/index.ts
@@ -227,7 +227,7 @@ export class KubernetesClusterBackend {
      */
     async listResourcesForJobId(jobId: string) {
         const resources = [];
-        const resourceTypes = ['pods', 'deployments', 'services', 'jobs'];
+        const resourceTypes = ['pods', 'deployments', 'services', 'jobs', 'replicasets'];
         for (const type of resourceTypes) {
             const list = await this.k8s.list(`teraslice.terascope.io/jobId=${jobId}`, type);
             if (list.items.length > 0) {

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetes/k8s.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetes/k8s.ts
@@ -338,6 +338,7 @@ export class K8s {
                 return res;
             } catch (e) {
                 if (e.statusCode) {
+                    // 404 should be an acceptable response to a delete request, not an error
                     if (e.statusCode === 404) {
                         this.logger.info(`No ${objType} with name ${name} found while attempting to delete.`);
                         return e;

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetes/k8s.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetes/k8s.ts
@@ -430,7 +430,7 @@ export class K8s {
         }
 
         if (!isEmpty(objList.items)) {
-            // this assumes only one item will ever be in objList
+            // TODO: this assumes only one item will ever be in objList
             const name: string = get(objList, 'items[0].metadata.name');
             this.logger.info(`k8s._deleteObjByExId: ${exId} ${nodeType} ${objType} deleting: ${name}`);
 

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/index.ts
@@ -259,11 +259,12 @@ export class KubernetesClusterBackendV2 {
     /**
      * Returns a list of all k8s resources associated with a job ID
      * @param {string}         jobId   The job ID of the job to list associated resources
-     * @returns {Array<any>}
+     * @returns {Array<K8sClient.V1PodList | K8sClient.V1DeploymentList | K8sClient.V1ServiceList
+     *  | K8sClient.V1JobList | K8sClient.V1ReplicaSetList>}
      */
     async listResourcesForJobId(jobId: string) {
         const resources = [];
-        const resourceTypes = ['pods', 'deployments', 'services', 'jobs'];
+        const resourceTypes = ['pods', 'deployments', 'services', 'jobs', 'replicasets'];
         for (const type of resourceTypes) {
             const list = await this.k8s.list(`teraslice.terascope.io/jobId=${jobId}`, type);
             if (list.items.length > 0) {

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
@@ -449,14 +449,14 @@ export class K8s {
             throw new Error('deleteExecution requires an executionId');
         }
 
-        await this._deleteObjByExId(exId, 'execution_controller', 'jobs', force);
-
         if (force) {
-            await this._deleteObjByExId(exId, 'execution_controller', 'services', force);
-            await this._deleteObjByExId(exId, 'execution_controller', 'pods', force);
-            await this._deleteObjByExId(exId, 'worker', 'deployments', force);
             await this._deleteObjByExId(exId, 'worker', 'pods', force);
+            await this._deleteObjByExId(exId, 'worker', 'deployments', force);
+            await this._deleteObjByExId(exId, 'execution_controller', 'pods', force);
+            await this._deleteObjByExId(exId, 'execution_controller', 'services', force);
         }
+
+        await this._deleteObjByExId(exId, 'execution_controller', 'jobs', force);
     }
 
     /**
@@ -488,13 +488,22 @@ export class K8s {
 
         for (const obj of objList.items) {
             const name = obj.metadata?.name;
+            const deletionTimestamp = obj.metadata?.deletionTimestamp;
+
             if (!name) {
                 const err = new Error(`Cannot delete ${objType} for ExId: ${exId} by name because it has no name`);
                 this.logger.error(err);
                 return Promise.reject(err);
             }
-            this.logger.info(`k8s._deleteObjByExId: ${exId} ${nodeType} ${objType} deleting: ${name}`);
 
+            // If deletionTimestamp is present then the resource is already terminating.
+            // K8s will not change the grace period in this case, so force deletion is not possible
+            if (force && deletionTimestamp) {
+                this.logger.warn(`Cannot force delete ${name} for ExId: ${exId}. It will finish deleting gracefully by ${deletionTimestamp}`);
+                return Promise.resolve();
+            }
+
+            this.logger.info(`k8s._deleteObjByExId: ${exId} ${nodeType} ${objType} ${force ? 'force' : ''} deleting: ${name}`);
             try {
                 deleteResponses.push(await this.delete(name, objType, force));
             } catch (e) {

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
@@ -345,6 +345,10 @@ export class K8s {
      * @return {Object}                k8s delete response body.
      */
     async delete(name: string, objType: string, force?: boolean) {
+        if (name === undefined || name.trim() === '') {
+            throw new Error(`Name of resource to delete must be specified. Received: "${name}".`);
+        }
+
         let responseObj: {
             response: IncomingMessage,
             body: k8s.V1Status | k8s.V1Pod | k8s.V1Service

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
@@ -511,6 +511,7 @@ export class K8s {
             }
         }
 
+        // TODO: this assumes only one item will ever be in objList
         const name = objList.items[0].metadata?.name;
         if (name === undefined) {
             const err = new Error(`Cannot delete ${objType} for ExId: ${exId} by name because it has no name`);

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
@@ -339,7 +339,7 @@ export class K8s {
      * Deletes k8s object of specified objType
      * @param  {String}  name          Name of the resource to delete
      * @param  {String}  objType       Type of k8s object to get, valid options:
-     *                                 'deployments', 'services', 'jobs'
+     *                                 'deployments', 'services', 'jobs', 'pods'
      * @param  {Boolean} force         Forcefully delete resource by setting gracePeriodSeconds to 1
      *                                 to be forcefully stopped.
      * @return {Object}                k8s delete response body.
@@ -367,55 +367,65 @@ export class K8s {
             deleteOptions.gracePeriodSeconds = 1;
         }
 
+        const params: [
+            string,
+            string,
+            string | undefined,
+            string | undefined,
+            number | undefined,
+            boolean | undefined,
+            string | undefined,
+            k8s.V1DeleteOptions | undefined
+        ] = [
+            name,
+            this.defaultNamespace,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            deleteOptions
+        ]
+
+        const deleteWithErrorHandling = async (deleteFn: () => Promise<{
+                response: IncomingMessage,
+                body: k8s.V1Status | k8s.V1Pod | k8s.V1Service
+        }>) => {
+            try {
+                const res = await deleteFn();
+                return res;
+            } catch (e) {
+                if (e.statusCode) {
+                    // 404 should be an acceptable response to a delete request, not an error
+                    if (e.statusCode === 404) {
+                        this.logger.info(`No ${objType} with name ${name} found while attempting to delete.`);
+                        return e;
+                    }
+
+                    if (e.statusCode >= 400) {
+                        const err = new TSError(`Unexpected response code (${e.statusCode}), when deleting name: ${name}`);
+                        this.logger.error(err);
+                        err.code = e.statusCode.toString();
+                        return Promise.reject(err);
+                    }
+                }
+                throw e;
+            }
+        }
+
         try {
             if (objType === 'services') {
-                responseObj = await pRetry(() => this.k8sCoreV1Api
-                    .deleteNamespacedService(
-                        name,
-                        this.defaultNamespace,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        deleteOptions
-                    ), getRetryConfig());
+                responseObj = await pRetry(() => deleteWithErrorHandling(() => this.k8sCoreV1Api
+                    .deleteNamespacedService(...params)), getRetryConfig());
             } else if (objType === 'deployments') {
-                responseObj = await pRetry(() => this.k8sAppsV1Api
-                    .deleteNamespacedDeployment(
-                        name,
-                        this.defaultNamespace,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        deleteOptions
-                    ), getRetryConfig());
+                responseObj = await pRetry(() => deleteWithErrorHandling(() => this.k8sAppsV1Api
+                    .deleteNamespacedDeployment(...params)), getRetryConfig());
             } else if (objType === 'jobs') {
-                responseObj = await pRetry(() => this.k8sBatchV1Api
-                    .deleteNamespacedJob(
-                        name,
-                        this.defaultNamespace,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        deleteOptions
-                    ), getRetryConfig());
+                responseObj = await pRetry(() => deleteWithErrorHandling(() => this.k8sBatchV1Api
+                    .deleteNamespacedJob(...params)), getRetryConfig());
             } else if (objType === 'pods') {
-                responseObj = await pRetry(() => this.k8sCoreV1Api
-                    .deleteNamespacedPod(
-                        name,
-                        this.defaultNamespace,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        deleteOptions
-                    ), getRetryConfig());
+                responseObj = await pRetry(() => deleteWithErrorHandling(() => this.k8sCoreV1Api
+                    .deleteNamespacedPod(...params)), getRetryConfig());
             } else {
                 throw new Error(`Invalid objType: ${objType}`);
             }
@@ -425,20 +435,13 @@ export class K8s {
             return Promise.reject(err);
         }
 
-        if (responseObj.response.statusCode && responseObj.response.statusCode >= 400) {
-            const err = new TSError(`Unexpected response code (${responseObj.response.statusCode}), when deleting name: ${name}`);
-            this.logger.error(err);
-            err.code = responseObj.response.statusCode.toString();
-            return Promise.reject(err);
-        }
-
         return responseObj.body;
     }
 
     /**
      * Delete all of Kubernetes resources related to the specified exId
      * @param  {String}   exId    ID of the execution
-     * @param  {Boolean}  force   Forcefully stop all related pod, deployment, and job resources
+     * @param  {Boolean}  force   Forcefully stop all pod, deployment, service and job resources
      * @return {Promise}
      */
     async deleteExecution(exId: string, force = false) {
@@ -447,21 +450,27 @@ export class K8s {
         }
 
         await this._deleteObjByExId(exId, 'execution_controller', 'jobs', force);
+
+        if (force) {
+            await this._deleteObjByExId(exId, 'execution_controller', 'services', force);
+            await this._deleteObjByExId(exId, 'execution_controller', 'pods', force);
+            await this._deleteObjByExId(exId, 'worker', 'deployments', force);
+            await this._deleteObjByExId(exId, 'worker', 'pods', force);
+        }
     }
 
     /**
-     * Finds the k8s object by nodeType and exId and then deletes it
+     * Finds the k8s objects by nodeType and exId and then deletes them
      * @param  {String}  exId     Execution ID
      * @param  {String}  nodeType valid Teraslice k8s node type:
      *                            'worker', 'execution_controller'
      * @param  {String}  objType  valid object type: `services`, `deployments`,
-     *                            'jobs'
-     * @param  {Boolean}  force    Forcefully stop all related pod, deployment, and job resources
+     *                            `jobs`, `pods`
+     * @param  {Boolean}  force    Forcefully stop all resources
      * @return {Promise}
      */
     async _deleteObjByExId(exId: string, nodeType: string, objType: string, force?: boolean) {
         let objList: K8sObjectList;
-        let forcePodsList: k8s.V1PodList | undefined;
         const deleteResponses: Array<k8s.V1Pod[] | k8s.V1Pod | k8s.V1Service | k8s.V1Status> = [];
 
         try {
@@ -472,65 +481,29 @@ export class K8s {
             return Promise.reject(err);
         }
 
-        if (force) {
+        if (isEmpty(objList.items)) {
+            this.logger.info(`k8s._deleteObjByExId: ${exId} ${nodeType} ${objType} has already been deleted`);
+            return Promise.resolve();
+        }
+
+        for (const obj of objList.items) {
+            const name = obj.metadata?.name;
+            if (!name) {
+                const err = new Error(`Cannot delete ${objType} for ExId: ${exId} by name because it has no name`);
+                this.logger.error(err);
+                return Promise.reject(err);
+            }
+            this.logger.info(`k8s._deleteObjByExId: ${exId} ${nodeType} ${objType} deleting: ${name}`);
+
             try {
-                forcePodsList = await this.list(`teraslice.terascope.io/exId=${exId}`, 'pods') as k8s.V1PodList;
+                deleteResponses.push(await this.delete(name, objType, force));
             } catch (e) {
-                const err = new Error(`Request pods list in _deleteObjByExId with exId: ${exId} failed with: ${e}`);
+                const err = new Error(`Request k8s.delete in _deleteObjByExId with name: ${name} failed with: ${e}`);
                 this.logger.error(err);
                 return Promise.reject(err);
             }
         }
 
-        if (isEmpty(objList.items) && isEmpty(forcePodsList?.items)) {
-            this.logger.info(`k8s._deleteObjByExId: ${exId} ${nodeType} ${objType} has already been deleted`);
-            return Promise.resolve();
-        }
-
-        const deletePodResponses: k8s.V1Pod[] = [];
-        if (forcePodsList?.items) {
-            this.logger.info(`k8s._deleteObjByExId: ${exId} force deleting all pods`);
-            for (const pod of forcePodsList.items) {
-                if (!pod.metadata) {
-                    this.logger.error('Cannot delete pod by metadata.name because it has no metadata');
-                    continue;
-                }
-                if (!pod.metadata.name) {
-                    this.logger.error(`Cannot delete pod with labels ${pod.metadata.labels} by name because it has no name`);
-                    continue;
-                }
-                const podName = pod.metadata.name;
-                try {
-                    const V1Pod = await this.delete(podName, 'pods', force) as k8s.V1Pod;
-                    deletePodResponses.push(V1Pod);
-                } catch (e) {
-                    const err = new Error(`Request k8s.delete in _deleteObjByExId with name: ${podName} failed with: ${e}`);
-                    this.logger.error(err);
-                    return Promise.reject(err);
-                }
-            }
-        }
-
-        // TODO: this assumes only one item will ever be in objList
-        const name = objList.items[0].metadata?.name;
-        if (name === undefined) {
-            const err = new Error(`Cannot delete ${objType} for ExId: ${exId} by name because it has no name`);
-            this.logger.error(err);
-            return Promise.reject(err);
-        }
-        this.logger.info(`k8s._deleteObjByExId: ${exId} ${nodeType} ${objType} deleting: ${name}`);
-
-        try {
-            deleteResponses.push(await this.delete(name, objType, force));
-        } catch (e) {
-            const err = new Error(`Request k8s.delete in _deleteObjByExId with name: ${name} failed with: ${e}`);
-            this.logger.error(err);
-            return Promise.reject(err);
-        }
-
-        if (deletePodResponses.length > 0) {
-            deleteResponses.push(deletePodResponses);
-        }
         return deleteResponses;
     }
 

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -162,8 +162,7 @@ export class JobsService {
             const exIdsArr = Array.from(exIdsSet);
             const exIdsString = exIdsArr.join(', ');
             throw new TSError(`There are orphaned resources for job: ${jobId}, exId: ${exIdsString}.
-            To remove orphaned resources:
-                curl -XPOST <teraslice host>/v1/jobs/${jobId}/_stop?force=true`);
+            Please wait for Kubernetes to clean up orphaned resources.`);
         }
 
         const jobSpec = await this.jobsStorage.get(jobId);

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8s-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8s-spec.ts
@@ -171,8 +171,8 @@ describe('k8s', () => {
 
     describe('->delete', () => {
         it('will throw if name is undefined', async () => {
-            await expect(k8s.delete('', 'deployments'))
-                .rejects.toThrow('Name of resource to delete must be specified. Received: "".');
+            await expect(k8s.delete(undefined as unknown as string, 'deployments'))
+                .rejects.toThrow('Name of resource to delete must be specified. Received: "undefined".');
         });
 
         it('will throw if name is an empty string', async () => {

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8s-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8s-spec.ts
@@ -103,6 +103,16 @@ describe('k8s', () => {
             const jobs = await k8s.list('app=teraslice', 'jobs');
             expect(jobs.kind).toEqual('JobList');
         });
+
+        it('can get ReplicaSetList', async () => {
+            nock(_url)
+                .get('/apis/apps/v1/namespaces/default/replicasets/')
+                .query({ labelSelector: 'app=teraslice' })
+                .reply(200, { kind: 'ReplicaSetList' });
+
+            const jobs = await k8s.list('app=teraslice', 'replicasets');
+            expect(jobs.kind).toEqual('ReplicaSetList');
+        });
     });
 
     describe('->nonEmptyList', () => {
@@ -213,6 +223,15 @@ describe('k8s', () => {
                 .reply(200, {});
 
             const response = await k8s.delete('test1', 'pods');
+            expect(response).toEqual({});
+        });
+
+        it('can delete a replicaset by name', async () => {
+            nock(_url)
+                .delete('/apis/apps/v1/namespaces/default/replicasets/test1')
+                .reply(200, {});
+
+            const response = await k8s.delete('test1', 'replicasets');
             expect(response).toEqual({});
         });
 

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8s-v2-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8s-v2-spec.ts
@@ -181,10 +181,20 @@ describe('k8s', () => {
     });
 
     describe('->delete', () => {
+        it('will throw if name is undefined', async () => {
+            await expect(k8s.delete('', 'deployments'))
+                .rejects.toThrow('Name of resource to delete must be specified. Received: "".');
+        });
+
+        it('will throw if name is an empty string', async () => {
+            await expect(k8s.delete('', 'deployments'))
+                .rejects.toThrow('Name of resource to delete must be specified. Received: "".');
+        });
+
         it('can delete a deployment by name', async () => {
             nock(_url)
                 .delete('/apis/apps/v1/namespaces/default/deployments/test1')
-                .reply(200, { });
+                .reply(200, {});
 
             const response = await k8s.delete('test1', 'deployments');
             expect(response).toEqual({});
@@ -193,7 +203,7 @@ describe('k8s', () => {
         it('can delete a service by name', async () => {
             nock(_url)
                 .delete('/api/v1/namespaces/default/services/test1')
-                .reply(200, { });
+                .reply(200, {});
 
             const response = await k8s.delete('test1', 'services');
             expect(response).toEqual({});
@@ -202,7 +212,7 @@ describe('k8s', () => {
         it('can delete a job by name', async () => {
             nock(_url)
                 .delete('/apis/batch/v1/namespaces/default/jobs/test1')
-                .reply(200, { });
+                .reply(200, {});
 
             const response = await k8s.delete('test1', 'jobs');
             expect(response).toEqual({});
@@ -216,6 +226,41 @@ describe('k8s', () => {
             const response = await k8s.delete('test1', 'pods');
             expect(response).toEqual({});
         });
+
+        it('will throw on a reponse code >= 400, excluding 404', async () => {
+            nock(_url)
+                .delete('/api/v1/namespaces/default/pods/bad-response')
+                .replyWithError({ statusCode: 400 })
+                .delete('/api/v1/namespaces/default/pods/bad-response')
+                .replyWithError({ statusCode: 400 })
+                .delete('/api/v1/namespaces/default/pods/bad-response')
+                .replyWithError({ statusCode: 400 });
+
+            await expect(k8s.delete('bad-response', 'pods'))
+                .rejects.toThrow('Request k8s.delete with name: bad-response failed with: TSError: Unexpected response code (400), when deleting name: bad-response');
+        });
+
+        it('will succeed on a 404 response code', async () => {
+            const notFoundResponse = {
+                body: {
+                    kind: 'Status',
+                    apiVersion: 'v1',
+                    metadata: {},
+                    status: 'Failure',
+                    message: 'pods "non-existent" not found',
+                    reason: 'NotFound',
+                    details: { name: 'non-existent', kind: 'pods' },
+                    code: 404
+                },
+                statusCode: 404
+            }
+            nock(_url)
+                .delete('/api/v1/namespaces/default/pods/non-existent')
+                .replyWithError(notFoundResponse);
+
+            const response = await k8s.delete('non-existent', 'pods');
+            expect(response).toEqual(notFoundResponse.body);
+        });
     });
 
     describe('->_deletObjByExId', () => {
@@ -225,16 +270,22 @@ describe('k8s', () => {
             metadata: { name: 'testJob1' }
         };
 
-        const exPod = {
-            apiVersion: 'v1',
-            kind: 'Pod',
-            metadata: { name: 'testEx1' }
+        const jobNoName = {
+            apiVersion: '1.0.0',
+            kind: 'Job',
+            metadata: { name: undefined }
         };
 
-        const wkrPod = {
+        const testPod1 = {
             apiVersion: 'v1',
             kind: 'Pod',
-            metadata: { name: 'testWkr1' }
+            metadata: { name: 'testPod1' }
+        };
+
+        const testPod2 = {
+            apiVersion: 'v1',
+            kind: 'Pod',
+            metadata: { name: 'testPod2' }
         };
 
         const status = {
@@ -249,36 +300,86 @@ describe('k8s', () => {
             status: 'Success'
         };
 
-        it('can force delete a job', async () => {
+        it('will throw if name is undefined', async () => {
+            nock(_url)
+                .get('/apis/batch/v1/namespaces/default/jobs')
+                .query({ labelSelector: /app\.kubernetes\.io\/component=execution_controller,teraslice\.terascope\.io\/exId=.*/ })
+                .reply(200, {
+                    kind: 'JobList',
+                    items: [jobNoName]
+                });
+
+            await expect(k8s._deleteObjByExId('no-name', 'execution_controller', 'jobs'))
+                .rejects.toThrow('Cannot delete jobs for ExId: no-name by name because it has no name');
+
+        });
+
+        it('can delete a single object', async () => {
             nock(_url)
                 .get('/apis/batch/v1/namespaces/default/jobs')
                 .query({ labelSelector: /app\.kubernetes\.io\/component=execution_controller,teraslice\.terascope\.io\/exId=.*/ })
                 .reply(200, {
                     kind: 'JobList',
                     items: [job]
-                })
-                .get('/api/v1/namespaces/default/pods')
-                .query({ labelSelector: /teraslice\.terascope\.io\/exId=.*/ })
-                .reply(200, {
-                    kind: 'PodList',
-                    items: [exPod, wkrPod]
-                })
-                .delete('/api/v1/namespaces/default/pods/testEx1')
-                .reply(200, exPod)
-                .delete('/api/v1/namespaces/default/pods/testWkr1')
-                .reply(200, wkrPod)
+                });
+
+            nock(_url)
                 .delete('/apis/batch/v1/namespaces/default/jobs/testJob1')
                 .reply(200, status);
 
-            const response = await k8s._deleteObjByExId('testJob1', 'execution_controller', 'jobs', true);
-            expect(response).toEqual([
-                expect.objectContaining(status),
-                [
-                    expect.objectContaining(exPod),
-                    expect.objectContaining(wkrPod)
-                ]
-            ]);
+            const response = await k8s._deleteObjByExId('testJob1', 'execution_controller', 'jobs');
+            expect(response).toEqual([expect.objectContaining(status)]);
         });
+
+        it('can delete a multiple objects', async () => {
+            nock(_url)
+                .get('/api/v1/namespaces/default/pods')
+                .query({ labelSelector: /app\.kubernetes\.io\/component=worker,teraslice\.terascope\.io\/exId=.*/ })
+                .reply(200, {
+                    kind: 'PodList',
+                    items: [
+                        { metadata: { name: 'testPod1' } },
+                        { metadata: { name: 'testPod2' } }
+                    ]
+                })
+                .delete('/api/v1/namespaces/default/pods/testPod1')
+                .reply(200, testPod1)
+                .delete('/api/v1/namespaces/default/pods/testPod2')
+                .reply(200, testPod2);
+
+            const response = await k8s._deleteObjByExId('testPods', 'worker', 'pods');
+            expect(response).toEqual([expect.objectContaining(testPod1), expect.objectContaining(testPod2)]);
+        });
+        // it('can force delete a job', async () => {
+        //     nock(_url)
+        //         .get('/apis/batch/v1/namespaces/default/jobs')
+        //         .query({ labelSelector: /app\.kubernetes\.io\/component=execution_controller,teraslice\.terascope\.io\/exId=.*/ })
+        //         .reply(200, {
+        //             kind: 'JobList',
+        //             items: [job]
+        //         })
+        //         .get('/api/v1/namespaces/default/pods')
+        //         .query({ labelSelector: /teraslice\.terascope\.io\/exId=.*/ })
+        //         .reply(200, {
+        //             kind: 'PodList',
+        //             items: [exPod, wkrPod]
+        //         })
+        //         .delete('/api/v1/namespaces/default/pods/testEx1')
+        //         .reply(200, exPod)
+        //         .delete('/api/v1/namespaces/default/pods/testWkr1')
+        //         .reply(200, wkrPod)
+        //         .delete('/apis/batch/v1/namespaces/default/jobs/testJob1')
+        //         .reply(200, status);
+
+        //     const response = await k8s._deleteObjByExId('testJob1', 'execution_controller', 'jobs', true);
+        //     expect(response).toEqual([
+        //         expect.objectContaining(status),
+        //         [
+        //             expect.objectContaining(exPod),
+        //             expect.objectContaining(wkrPod)
+        //         ]
+        //     ]);
+        // });
     });
 
     describe('->scaleExecution', () => {

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8s-v2-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8s-v2-spec.ts
@@ -103,6 +103,16 @@ describe('k8s', () => {
             const jobs = await k8s.list('app=teraslice', 'jobs');
             expect(jobs.kind).toEqual('JobList');
         });
+
+        it('can get ReplicaSetList', async () => {
+            nock(_url)
+                .get('/apis/apps/v1/namespaces/default/replicasets')
+                .query({ labelSelector: 'app=teraslice' })
+                .reply(200, { kind: 'ReplicaSetList' });
+
+            const jobs = await k8s.list('app=teraslice', 'replicasets');
+            expect(jobs.kind).toEqual('ReplicaSetList');
+        });
     });
 
     describe('->nonEmptyList', () => {
@@ -224,6 +234,15 @@ describe('k8s', () => {
                 .reply(200, {});
 
             const response = await k8s.delete('test1', 'pods');
+            expect(response).toEqual({});
+        });
+
+        it('can delete a replicaset by name', async () => {
+            nock(_url)
+                .delete('/apis/apps/v1/namespaces/default/replicasets/test1')
+                .reply(200, {});
+
+            const response = await k8s.delete('test1', 'replicasets');
             expect(response).toEqual({});
         });
 

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8s-v2-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8s-v2-spec.ts
@@ -182,8 +182,8 @@ describe('k8s', () => {
 
     describe('->delete', () => {
         it('will throw if name is undefined', async () => {
-            await expect(k8s.delete('', 'deployments'))
-                .rejects.toThrow('Name of resource to delete must be specified. Received: "".');
+            await expect(k8s.delete(undefined as unknown as string, 'deployments'))
+                .rejects.toThrow('Name of resource to delete must be specified. Received: "undefined".');
         });
 
         it('will throw if name is an empty string', async () => {
@@ -350,36 +350,6 @@ describe('k8s', () => {
             const response = await k8s._deleteObjByExId('testPods', 'worker', 'pods');
             expect(response).toEqual([expect.objectContaining(testPod1), expect.objectContaining(testPod2)]);
         });
-        // it('can force delete a job', async () => {
-        //     nock(_url)
-        //         .get('/apis/batch/v1/namespaces/default/jobs')
-        //         .query({ labelSelector: /app\.kubernetes\.io\/component=execution_controller,teraslice\.terascope\.io\/exId=.*/ })
-        //         .reply(200, {
-        //             kind: 'JobList',
-        //             items: [job]
-        //         })
-        //         .get('/api/v1/namespaces/default/pods')
-        //         .query({ labelSelector: /teraslice\.terascope\.io\/exId=.*/ })
-        //         .reply(200, {
-        //             kind: 'PodList',
-        //             items: [exPod, wkrPod]
-        //         })
-        //         .delete('/api/v1/namespaces/default/pods/testEx1')
-        //         .reply(200, exPod)
-        //         .delete('/api/v1/namespaces/default/pods/testWkr1')
-        //         .reply(200, wkrPod)
-        //         .delete('/apis/batch/v1/namespaces/default/jobs/testJob1')
-        //         .reply(200, status);
-
-        //     const response = await k8s._deleteObjByExId('testJob1', 'execution_controller', 'jobs', true);
-        //     expect(response).toEqual([
-        //         expect.objectContaining(status),
-        //         [
-        //             expect.objectContaining(exPod),
-        //             expect.objectContaining(wkrPod)
-        //         ]
-        //     ]);
-        // });
     });
 
     describe('->scaleExecution', () => {


### PR DESCRIPTION
This PR makes the following changes:
- Ensure that `K8s._deleteObjByExId()` contains an object in `objList.items[]` before calling `K8s.deleted()`.
- Throw if `K8s.delete()` receives a `name` argument that is undefined or an empty string.
- Refactor `K8s._deleteObjByExId()` to delete multiple objects and not handle `force logic`
- Refactor `k8s.deleteExecution() to handle `force` logic by calling `K8s._deleteObjByExId()` on multiple resources.
- bump teraslice from version 2.3.1 to 2.3.2
- pin the kind image used by k8s to: `kindest/node:v1.28.12@sha256:fa0e48b1e83bb8688a5724aa7eebffbd6337abd7909ad089a2700bf08c30c6ea`. Note that the version in the image tag refers to the kubernetes server version that will be used. We should keep this in sync with prod.

ref: #3750 