### PR TITLE
[teraslice] Fix ex controller non-zero exit code bug in k8s backend 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/workers/helpers/worker-shutdown.ts
+++ b/packages/teraslice/src/lib/workers/helpers/worker-shutdown.ts
@@ -48,7 +48,7 @@ export function shutdownHandler(
     const allowNonZeroExitCode = !(
         isK8s
         && assignment === 'execution_controller'
-        && context.sysconfig.teraslice.cluster_manager_type === 'kubernetesV2'
+        && context.sysconfig.teraslice.cluster_manager_type === 'kubernetes'
     );
     const api = {
         exiting: false,


### PR DESCRIPTION
This PR makes the following changes:

### Bug Fixes
- Changes execution controller exit logic to allow non-zero exit codes when in `kubernetesV2` and to **NOT** allow non-zero exit codes when in `kubernetes`
  - This resolves an issue introduced in teraslice `v2.3.0` where the kubernetes V1 execution controller exit process is unintentionally changed. This PR restores it's original functionality while allowing `kubernetesV2` to gain its intended functionality.

#3755