### PR TITLE
[teraslice] Rename isRestartable to is isRelocatable

### DIFF
--- a/packages/job-components/src/operations/core/slicer-core.ts
+++ b/packages/job-components/src/operations/core/slicer-core.ts
@@ -148,10 +148,10 @@ export default abstract class SlicerCore<T = OpConfig>
     }
 
     /**
-     * Used to indicate whether this slicer is restartable. Only relevant for
+     * Used to indicate whether this slicer is relocatable. Only relevant for
      * kubernetesV2 backend
      */
-    isRestartable(): boolean {
+    isRelocatable(): boolean {
         return false;
     }
 

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -433,7 +433,7 @@ export class ExecutionController {
             /// This is an indication that the cluster_master did not call for this
             /// shutdown. We want to restart in this case.
             if (status !== 'stopping' && includes(runningStatuses, status)) {
-                this.logger.info('Skipping shutdown to allow restart...');
+                this.logger.info('Skipping shutdown to allow for relocation...');
                 return;
             }
         }
@@ -945,17 +945,17 @@ export class ExecutionController {
             // an unexpected exit to the ex process. Ex: an OOM
             // NOTE: If this becomes an issue we may want to add a new state. Maybe `interrupted`
             if (this.context.sysconfig.teraslice.cluster_manager_type === 'kubernetesV2') {
-                // Check to see if `isRestartable` exists.
+                // Check to see if `isRelocatable` exists.
                 // Allows for older assets to work with k8sV2
-                if (this.executionContext.slicer().isRestartable) {
+                if (this.executionContext.slicer().isRelocatable) {
                     this.logger.info(`Execution ${this.exId} detected to have been restarted..`);
-                    const restartable = this.executionContext.slicer().isRestartable();
-                    if (restartable) {
+                    const relocatable = this.executionContext.slicer().isRelocatable();
+                    if (relocatable) {
                         this.logger.info(`Execution ${this.exId} is restarable and will continue reinitializing...`);
                     } else {
                         this.logger.error(`Execution ${this.exId} is not restarable and will shutdown...`);
                     }
-                    return restartable;
+                    return relocatable;
                 }
             }
             error = new Error(invalidStateMsg('running'));

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -951,9 +951,9 @@ export class ExecutionController {
                     this.logger.info(`Execution ${this.exId} detected to have been restarted..`);
                     const relocatable = this.executionContext.slicer().isRelocatable();
                     if (relocatable) {
-                        this.logger.info(`Execution ${this.exId} is restarable and will continue reinitializing...`);
+                        this.logger.info(`Execution ${this.exId} is relocatable and will continue reinitializing...`);
                     } else {
-                        this.logger.error(`Execution ${this.exId} is not restarable and will shutdown...`);
+                        this.logger.error(`Execution ${this.exId} is not relocatable and will shutdown...`);
                     }
                     return relocatable;
                 }


### PR DESCRIPTION
This PR makes the following changes:

## Important Changes
- Renames the  `isRestartable()` function in the core slicer to `isRelocatable()` for better clarity on what this function is meant to return