### PR TITLE
[teraslice] Add "relocatable" statuses for ex controller

### DIFF
--- a/packages/teraslice/src/lib/storage/execution.ts
+++ b/packages/teraslice/src/lib/storage/execution.ts
@@ -9,7 +9,7 @@ import { makeLogger } from '../workers/helpers/terafoundation.js';
 import { TerasliceElasticsearchStorage, TerasliceESStorageConfig } from './backends/elasticsearch_store.js';
 
 const INIT_STATUS = ['pending', 'scheduling', 'initializing'];
-const RUNNING_STATUS = ['recovering', 'running', 'failing', 'paused', 'stopping'];
+const RUNNING_STATUS = ['recovering', 'running', 'failing', 'paused', 'stopping', 'relocating'];
 const TERMINAL_STATUS = ['completed', 'stopped', 'rejected', 'failed', 'terminated'];
 
 const VALID_STATUS = INIT_STATUS.concat(RUNNING_STATUS).concat(TERMINAL_STATUS);

--- a/packages/teraslice/src/lib/storage/execution.ts
+++ b/packages/teraslice/src/lib/storage/execution.ts
@@ -9,7 +9,9 @@ import { makeLogger } from '../workers/helpers/terafoundation.js';
 import { TerasliceElasticsearchStorage, TerasliceESStorageConfig } from './backends/elasticsearch_store.js';
 
 const INIT_STATUS = ['pending', 'scheduling', 'initializing'];
-const RUNNING_STATUS = ['recovering', 'running', 'failing', 'paused', 'stopping', 'relocating'];
+const RUNNING_STATUS = [
+    'recovering', 'running', 'failing',
+    'paused', 'stopping', 'relocating-resume', 'relocating-paused'];
 const TERMINAL_STATUS = ['completed', 'stopped', 'rejected', 'failed', 'terminated'];
 
 const VALID_STATUS = INIT_STATUS.concat(RUNNING_STATUS).concat(TERMINAL_STATUS);

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -8,7 +8,7 @@ import type { EventEmitter } from 'node:events';
 import {
     TSError, includes, get,
     pDelay, getFullErrorStack, logError,
-    pWhile, makeISODate, Logger
+    pWhile, makeISODate, Logger, isFunction
 } from '@terascope/utils';
 import {
     Context, SlicerExecutionContext, Slice, isPromAvailable
@@ -957,9 +957,10 @@ export class ExecutionController {
             ) {
                 // Check to see if `isRelocatable` exists.
                 // Allows for older assets to work with k8sV2
-                if (this.executionContext.slicer().isRelocatable) {
+                const currentSlicer = this.executionContext.slicer();
+                if (isFunction(currentSlicer.isRelocatable)) {
                     this.logger.info(`Execution ${this.exId} detected to have been restarted..`);
-                    const relocatable = this.executionContext.slicer().isRelocatable();
+                    const relocatable = currentSlicer.isRelocatable();
                     if (relocatable) {
                         this.logger.info(`Execution ${this.exId} is relocatable and will continue reinitializing...`);
                     } else {

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -320,6 +320,8 @@ export class ExecutionController {
         this.server.executionReady = true;
         if (this.startOnPaused) {
             await this.pause();
+            /// We need to set the status back to paused
+            await this.executionStorage.setStatus(this.exId, 'paused');
         }
     }
 

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -428,16 +428,24 @@ export class ExecutionController {
             this.context.sysconfig.teraslice.cluster_manager_type === 'kubernetesV2'
             && eventType === 'SIGTERM'
         ) {
-            await this.stateStorage.refresh();
-            const status = await this.executionStorage.getStatus(this.exId);
-            const runningStatuses = this.executionStorage.getRunningStatuses();
-            this.logger.debug(`Execution ${this.exId} is currently in a ${status} state`);
-            /// This is an indication that the cluster_master did not call for this
-            /// shutdown. We want to restart in this case.
-            if (status !== 'stopping' && includes(runningStatuses, status)) {
-                this.logger.info('Skipping shutdown to allow for relocation...');
-                return;
+            if (this.executionContext.slicer().isRelocatable) {
+                if (this.executionContext.slicer().isRelocatable()) {
+                    await this.stateStorage.refresh();
+                    const status = await this.executionStorage.getStatus(this.exId);
+                    const runningStatuses = this.executionStorage.getRunningStatuses();
+                    this.logger.debug(`Execution ${this.exId} is currently in a ${status} state`);
+                    /// This is an indication that the cluster_master did not call for this
+                    /// shutdown. We want to relocate in this case.
+                    if (status !== 'stopping' && includes(runningStatuses, status)) {
+                        this.logger.info('Setting  execution status to relocating');
+                        await this.executionStorage.setStatus(this.exId, 'relocating');
+                        this.logger.info('Skipping shutdown to allow for relocation...');
+                        return;
+                    }
+                }
             }
+            this.logger.warn('This slicer is not relocatable and will continue to shutdown.');
+
         }
 
         if (this.isShutdown) return;
@@ -941,12 +949,12 @@ export class ExecutionController {
         if (includes(terminalStatuses, status)) {
             error = new Error(invalidStateMsg('terminal'));
         } else if (includes(runningStatuses, status)) {
-            // In the case of a running status on startup we
+            // In the case of a relocating status on startup we
             // want to continue to start up. Only in V2.
-            // Right now we will depend on kubernetes `crashloopbackoff` in the case of
-            // an unexpected exit to the ex process. Ex: an OOM
-            // NOTE: If this becomes an issue we may want to add a new state. Maybe `interrupted`
-            if (this.context.sysconfig.teraslice.cluster_manager_type === 'kubernetesV2') {
+            if (
+                this.context.sysconfig.teraslice.cluster_manager_type === 'kubernetesV2'
+                && status === 'relocating'
+            ) {
                 // Check to see if `isRelocatable` exists.
                 // Allows for older assets to work with k8sV2
                 if (this.executionContext.slicer().isRelocatable) {
@@ -959,6 +967,7 @@ export class ExecutionController {
                     }
                     return relocatable;
                 }
+                this.logger.warn('The slicer cannot relocate because it is not relocatable. Shutting down.');
             }
             error = new Error(invalidStateMsg('running'));
             // If in a running status the execution process

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -428,8 +428,9 @@ export class ExecutionController {
             this.context.sysconfig.teraslice.cluster_manager_type === 'kubernetesV2'
             && eventType === 'SIGTERM'
         ) {
-            if (this.executionContext.slicer().isRelocatable) {
-                if (this.executionContext.slicer().isRelocatable()) {
+            const currentSlicer = this.executionContext.slicer();
+            if (isFunction(currentSlicer.isRelocatable)) {
+                if (currentSlicer.isRelocatable()) {
                     await this.stateStorage.refresh();
                     const status = await this.executionStorage.getStatus(this.exId);
                     const runningStatuses = this.executionStorage.getRunningStatuses();


### PR DESCRIPTION
This PR makes the following changes:

## New Features
- Adds two new execution controller status:
  - `relocating-resume` state is when the execution controller pod that was in a `running` state is in the act of relocating to a new pod somewhere else on the cluster. Once it established, the execution will resume and go back to a `running` state
  - `relocating-paused` state is when the execution controller pod that was in a `paused` state is in the act of relocating to a new pod somewhere else on the cluster. Once it established, the execution will go back to a `paused` state

Ref to issue #3762