### PR TITLE
[workspace, scripts, teraslice-cli] Update default node version to 22

### DIFF
--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version:  18
+          node-version:  22
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version:  18
+          node-version:  22
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version:  18
+          node-version:  22
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,9 @@ on:
     branches: [ master ]
 env:
   NODE_VERSIONS: '[18, 20, 22]'
-  NODE_VERSION_MAIN: '18'
+  NODE_VERSION_MAIN: '22'
   NODE_VERSIONS_K8S: '[18, 22]'
-  NODE_VERSIONS_EXT_STORAGE: '[18]'
+  NODE_VERSIONS_EXT_STORAGE: '[22]'
 
 jobs:
   compute-node-version-vars:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # NODE_VERSION is set by default in the config.ts, the following value will only
 # be used if you build images by default with docker build
-ARG NODE_VERSION=18
+ARG NODE_VERSION=22
 FROM ghcr.io/terascope/node-base:${NODE_VERSION}
 
 ARG TERASLICE_VERSION

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 # NODE_VERSION is set by default in the config.ts, the following value will only
 # be used if you build images by default with docker build
-ARG NODE_VERSION=18
+ARG NODE_VERSION=22
 FROM ghcr.io/terascope/node-base:${NODE_VERSION}
 
 ENV NODE_ENV production

--- a/docs/development/node.md
+++ b/docs/development/node.md
@@ -41,9 +41,9 @@ Once the changes are merged and a new release is made, the CI will create new ba
 
 #### Verify New Docker Images
 
-The new Docker images will be available on Docker Hub here:
+The new Docker images will be available on the Github container registry here:
 
-https://hub.docker.com/r/terascope/node-base/tags
+https://github.com/terascope/base-docker-image/pkgs/container/node-base
 
 ### 2. Updating node in assets
 
@@ -90,3 +90,19 @@ Add the new node version to all the spots needed inside each file in `.github/wo
 - test.yml
 
 Once the node version has been added to the arrays of all the workflow .yml files, pushing the branch and making a new PR should trigger CI to run new tests with the added node version. Once all tests are passing, then a new node version has been succesfully introduced to teraslice.
+
+## Changing the default node version
+
+Although multiple node versions are supported, there is always a "default" version.
+To set a new default version make changes to the following:
+  ### 1. In workflows repo:
+  - .github/workflows/asset-build-and-publish.yml - assets-upload job `node-version` variable
+  - .github/workflows/asset-test.yml - test-macos job `node-version` variable
+  - .github/workflows/refresh-docker-cache.yml and .github/workflows/cache-docker-images.yml - `node-version` variable
+  ### 2. In teraslice repo:
+  - Update all .github/workflows that use the workflows repo with the new commit hash from step 1
+  - Dockerfile and Dockerfile.dev - `NODE_VERSION` variable
+  - .github/workflows/publish-master.yml and .github/workflows/publish-tag.yml - `node-version` variable
+  - .github/workflows/test.yml - set `NODE_VERSION_MAIN` and `NODE_VERSION_EXT_STORAGE` variables (used by verify-build, lint-and-sync , and e2e-external-storage-tests jobs)
+  - packages/scripts/src/helpers/config.ts - `DEFAULT_NODE_VERSION` variable
+  - packages/teraslice-cli/src/helpers/asset-src.ts - `bundleTarget` default in the constructor

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -192,7 +192,7 @@ if (testElasticsearch) {
 export const SEARCH_TEST_HOST = testHost;
 
 export const TEST_NODE_VERSIONS = ['18', '20', '22'];
-export const DEFAULT_NODE_VERSION = '18';
+export const DEFAULT_NODE_VERSION = '22';
 // This overrides the value in the Dockerfile
 export const NODE_VERSION = process.env.NODE_VERSION || DEFAULT_NODE_VERSION;
 

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"

--- a/packages/teraslice-cli/src/helpers/asset-src.ts
+++ b/packages/teraslice-cli/src/helpers/asset-src.ts
@@ -61,7 +61,7 @@ export class AssetSrc {
         devMode = false,
         debug = false,
         bundle = true,
-        bundleTarget = 'node18',
+        bundleTarget = 'node22',
         overwrite = false
     ) {
         if (bundle === false) {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -34,6 +34,7 @@
             "development/tests",
             "development/e2e",
             "development/k8s",
+            "development/node",
             "development/contributing"
         ]
     },


### PR DESCRIPTION
This PR makes the following changes:
- `test.yml` - set `NODE_VERSION_MAIN` and `NODE_VERSION_EXT_STORAGE` to 22 (used by verify-build, lint-and-sync , and e2e-external-storage-tests jobs)
- `publish-master.yml` - node-version to 22
- `publish-tag.yml` - node-version to 22
- `Dockerfile` and `Dockerfile.dev` - NODE_VERSION to 22
- scripts `config.ts` - DEFAULT_NODE_VERSION to 22
- teraslice-cli `asset-src.ts` - bundleTarget defaults to node22

ref: #3771 