### PR TITLE
[data-mate, ts-transforms, utils] update awesome-phonenumber from 2.70.0 to 7.1.0

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -34,7 +34,7 @@
         "@terascope/types": "^1.1.0",
         "@terascope/utils": "^1.2.0",
         "@types/validator": "^13.12.2",
-        "awesome-phonenumber": "^2.70.0",
+        "awesome-phonenumber": "^7.1.0",
         "date-fns": "^2.30.0",
         "ip-bigint": "^3.0.3",
         "ip6addr": "^0.2.5",

--- a/packages/data-mate/src/transforms/field-transform.ts
+++ b/packages/data-mate/src/transforms/field-transform.ts
@@ -1,7 +1,7 @@
 import * as ts from '@terascope/utils';
 import { FieldType } from '@terascope/types';
 import crypto from 'node:crypto';
-import PhoneValidator from 'awesome-phonenumber';
+import { parsePhoneNumber as _parsePhoneNumber } from 'awesome-phonenumber';
 import { format as dateFormat, parse } from 'date-fns';
 import { ReplaceLiteralConfig, ReplaceRegexConfig, ExtractFieldConfig } from './interfaces.js';
 import {
@@ -599,7 +599,7 @@ function parsePhoneNumber(str: any) {
     // needs to start with a +
     if (testNumber.charAt(0) !== '+') testNumber = `+${testNumber}`;
 
-    const fullNumber = new PhoneValidator(testNumber).getNumber();
+    const fullNumber = _parsePhoneNumber(testNumber).number?.e164;
     if (fullNumber) return String(fullNumber).slice(1);
 
     throw Error('Could not determine the incoming phone number');

--- a/packages/data-mate/src/validations/field-validator.ts
+++ b/packages/data-mate/src/validations/field-validator.ts
@@ -2,7 +2,7 @@ import * as ts from '@terascope/utils';
 import ipaddr from 'ipaddr.js';
 import { isIP as _isIP, isIPv6 } from 'is-ip';
 import ip6addr from 'ip6addr';
-import PhoneValidator from 'awesome-phonenumber';
+import { parsePhoneNumber } from 'awesome-phonenumber';
 import validator from 'validator';
 import url from 'valid-url';
 import { FieldType, GeoShapePoint, MACDelimiter } from '@terascope/types';
@@ -675,15 +675,15 @@ export function isISDN(input: unknown, _parentContext?: unknown): boolean {
     if (ts.isNil(input)) return false;
     if (isArray(input)) {
         const fn = (data: any) => {
-            const phoneNumber = new PhoneValidator(`+${data}`);
-            return phoneNumber.isValid();
+            const phoneNumber = parsePhoneNumber(`+${data}`);
+            return phoneNumber.valid;
         };
 
         return _lift(fn, input, _parentContext);
     }
 
-    const phoneNumber = new PhoneValidator(`+${input}`);
-    return phoneNumber.isValid();
+    const phoneNumber = parsePhoneNumber(`+${input}`);
+    return phoneNumber.valid;
 }
 
 interface MACAddressArgs {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -39,7 +39,7 @@
         "@terascope/data-mate": "^1.2.0",
         "@terascope/types": "^1.1.0",
         "@terascope/utils": "^1.2.0",
-        "awesome-phonenumber": "^2.70.0",
+        "awesome-phonenumber": "^7.1.0",
         "graphlib": "^2.1.8",
         "is-ip": "^5.0.1",
         "jexl": "^2.2.2",

--- a/packages/ts-transforms/src/operations/lib/validations/isdn.ts
+++ b/packages/ts-transforms/src/operations/lib/validations/isdn.ts
@@ -1,4 +1,4 @@
-import PhoneValidator from 'awesome-phonenumber';
+import { parsePhoneNumber } from 'awesome-phonenumber';
 import ValidationOpBase from './base.js';
 import { PostProcessConfig } from '../../../interfaces.js';
 
@@ -8,14 +8,14 @@ export default class ISDN extends ValidationOpBase<any> {
     }
 
     normalize(data: any) {
-        const phoneNumber = new PhoneValidator(`+${data}`);
-        const fullNumber = phoneNumber.getNumber();
+        const phoneNumber = parsePhoneNumber(`+${data}`);
+        const fullNumber = phoneNumber.number?.e164;
         if (fullNumber) return String(fullNumber).slice(1);
         throw Error('could not normalize');
     }
 
     validate(value: string) {
-        if (!new PhoneValidator(`+${value}`).isValid()) return false;
+        if (!parsePhoneNumber(`+${value}`).valid) return false;
         return true;
     }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -44,7 +44,7 @@
         "@turf/line-to-polygon": "^7.1.0",
         "@types/lodash-es": "^4.17.12",
         "@types/validator": "^13.12.2",
-        "awesome-phonenumber": "^2.70.0",
+        "awesome-phonenumber": "^7.1.0",
         "date-fns": "^2.30.0",
         "date-fns-tz": "^1.3.7",
         "datemath-parser": "^1.0.6",

--- a/packages/utils/src/phone-number.ts
+++ b/packages/utils/src/phone-number.ts
@@ -1,4 +1,4 @@
-import PhoneValidator from 'awesome-phonenumber';
+import { parsePhoneNumber as _parsePhoneNumber } from 'awesome-phonenumber';
 import { toString, isString } from './strings.js';
 
 import { isNumber, inNumberRange } from './numbers.js';
@@ -6,8 +6,7 @@ import { isNumber, inNumberRange } from './numbers.js';
 export function parsePhoneNumber(input: string | number): string {
     const preppedInput = _prepPhoneNumber(toString(input).trim());
 
-    const fullNumber = new PhoneValidator(preppedInput).getNumber();
-
+    const fullNumber = _parsePhoneNumber(preppedInput).number?.e164;
     if (fullNumber) return String(fullNumber).slice(1);
 
     throw Error('Could not determine the incoming phone number');
@@ -25,9 +24,9 @@ function _prepPhoneNumber(input: string): string {
 
 export function isISDN(input: unknown, country?: string): boolean {
     if (isString(input) || isNumber(input)) {
-        const isdn = country ? new PhoneValidator(toString(input), country) : new PhoneValidator(`+${input}`);
+        const isdn = country ? _parsePhoneNumber(toString(input), { regionCode: country }) : _parsePhoneNumber(`+${input}`);
 
-        return isdn.isValid();
+        return isdn.valid;
     }
 
     return false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3785,10 +3785,10 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-awesome-phonenumber@^2.70.0:
-  version "2.73.0"
-  resolved "https://registry.yarnpkg.com/awesome-phonenumber/-/awesome-phonenumber-2.73.0.tgz#c921f47450ba10bb2e4a6305cc85d802f57a96cf"
-  integrity sha512-zirkzWFUheNnnPY1QE05PQd+5drn+5kVy76gZ3WyXnLwzXOguw6sqksyZGO1qyNnYj3Y/SDITXnS/TCk/hJXpQ==
+awesome-phonenumber@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/awesome-phonenumber/-/awesome-phonenumber-7.1.0.tgz#700be60aa6dff96c45ce35a3389304d283cb381d"
+  integrity sha512-i/pC5xvaNVrduufGtnw8O+abLWq70wd6YutiPYR2NqrnwtjBMk7rG/vJTktnAivSok+ZqlkFZzuVICgObpQi4w==
 
 aws-sign2@~0.7.0:
   version "0.7.0"


### PR DESCRIPTION
This PR makes the following changes:
- update `awesome-phonenumber` from 2.70.0 to 7.1.0
- import `parsePhoneNumber` instead of default import. This is now a function that returns an object, not a class with functions to call. `valid() and getNumber() are replaced with accessing the data on the return object.