### PR TITLE
[scripts] Fix rabbitmq version bug

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -202,7 +202,7 @@ export async function loadOrPullServiceImages(suite: string): Promise<void> {
         }
 
         if (launchServices.includes(Service.RabbitMQ)) {
-            const image = `${config.RABBITMQ_DOCKER_IMAGE}`;
+            const image = `${config.RABBITMQ_DOCKER_IMAGE}:${config.RABBITMQ_VERSION}`;
             images.push(image);
         }
 


### PR DESCRIPTION
This PR makes the following changes:

# @terascope/scripts Changes
## Bug fixes
- Fixes bug in rabbitmq docker pull and run in scripts that won't correctly pull a specific tag
## Chores
- Bump **@terascope/scripts** from `v1.3.0` to `v1.3.1`

