### PR TITLE
[scripts] Change rabbitmq image to 3.13.7-management

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -74,7 +74,7 @@ export const MINIO_DOCKER_IMAGE = process.env.MINIO_DOCKER_IMAGE || 'minio/minio
 export const MINIO_ACCESS_KEY = process.env.MINIO_ACCESS_KEY || 'minioadmin';
 export const MINIO_SECRET_KEY = process.env.MINIO_SECRET_KEY || 'minioadmin';
 
-export const RABBITMQ_VERSION = process.env.RABBITMQ_VERSION || '3.13.7-debian-12-r4';
+export const RABBITMQ_VERSION = process.env.RABBITMQ_VERSION || '3.13.7-management';
 export const RABBITMQ_DOCKER_IMAGE = process.env.RABBITMQ_DOCKER_IMAGE || 'rabbitmq';
 export const RABBITMQ_NAME = process.env.RABBITMQ_NAME || 'rabbitmq';
 export const RABBITMQ_PORT = process.env.RABBITMQ_PORT || 45672;


### PR DESCRIPTION
This PR makes the following changes:

# @terascope/scripts
## Patch Changes
- Updates default rabbitmq image to `3.13.7-management`
- Bump from `v1.3.2` to `v1.3.3` 