### PR TITLE
Asset upload response

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -43,9 +43,9 @@
         "ms": "^2.1.3"
     },
     "devDependencies": {
-        "@terascope/types": "^1.1.0",
+        "@terascope/types": "^1.2.0",
         "bunyan": "^1.8.15",
-        "elasticsearch-store": "^1.2.0",
+        "elasticsearch-store": "^1.3.0",
         "fs-extra": "^11.2.0",
         "ms": "^2.1.3",
         "nanoid": "^5.0.7",

--- a/e2e/test/cases/assets/simple-spec.ts
+++ b/e2e/test/cases/assets/simple-spec.ts
@@ -37,11 +37,15 @@ describe('assets', () => {
 
         // save the asset ID that was submitted to terslice
         const assetId = result.asset_id;
+        // TODO: remove this in teraslice V3
+        const oldAssetId = result._id;
+
         const response = await terasliceHarness.teraslice.assets.remove(assetId);
 
         // ensure the deleted asset's ID matches that of
         // the saved asset
         expect(assetId).toEqual(response.asset_id);
+        expect(oldAssetId).toEqual(response.asset_id);
     });
 
     // Test a bad asset
@@ -82,6 +86,8 @@ describe('assets', () => {
             blocking: true
         });
         const assetId = assetResponse.asset_id;
+        // TODO: remove this in teraslice V3
+        const oldAssetId = assetResponse._id;
 
         const ex = await terasliceHarness.submitAndStart(jobSpec);
 
@@ -93,7 +99,9 @@ describe('assets', () => {
         expect(waitResponse).toEqual(workers);
 
         const execution = await ex.config();
+
         expect(execution.assets[0]).toEqual(assetId);
+        expect(execution.assets[0]).toEqual(oldAssetId);
 
         await ex.stop({ blocking: true });
     });

--- a/e2e/test/cases/assets/simple-spec.ts
+++ b/e2e/test/cases/assets/simple-spec.ts
@@ -36,12 +36,12 @@ describe('assets', () => {
         );
 
         // save the asset ID that was submitted to terslice
-        const assetId = result._id;
+        const assetId = result.asset_id;
         const response = await terasliceHarness.teraslice.assets.remove(assetId);
 
         // ensure the deleted asset's ID matches that of
         // the saved asset
-        expect(assetId).toEqual(response._id);
+        expect(assetId).toEqual(response.asset_id);
     });
 
     // Test a bad asset
@@ -81,7 +81,7 @@ describe('assets', () => {
         const assetResponse = await terasliceHarness.teraslice.assets.upload(fileStream, {
             blocking: true
         });
-        const assetId = assetResponse._id;
+        const assetId = assetResponse.asset_id;
 
         const ex = await terasliceHarness.submitAndStart(jobSpec);
 
@@ -171,7 +171,7 @@ describe('s3 asset storage', () => {
             const assetResponse = await terasliceHarness.teraslice.assets.upload(fileStream, {
                 blocking: true
             });
-            assetId = assetResponse._id;
+            assetId = assetResponse.asset_id;
 
             const response = await getS3Object(s3client, { Bucket: bucketName, Key: `${assetId}.zip` });
             const base64 = await response.Body?.transformToString('base64');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -30,9 +30,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "^1.2.0",
-        "@terascope/types": "^1.1.0",
-        "@terascope/utils": "^1.2.0",
+        "@terascope/data-types": "^1.3.0",
+        "@terascope/types": "^1.2.0",
+        "@terascope/utils": "^1.3.0",
         "@types/validator": "^13.12.2",
         "awesome-phonenumber": "^7.2.0",
         "date-fns": "^4.1.0",
@@ -47,7 +47,7 @@
         "uuid": "^10.0.0",
         "valid-url": "^1.0.9",
         "validator": "^13.12.0",
-        "xlucene-parser": "^1.2.0"
+        "xlucene-parser": "^1.3.0"
     },
     "devDependencies": {
         "@types/ip6addr": "^0.2.6",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -27,8 +27,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^1.1.0",
-        "@terascope/utils": "^1.2.0",
+        "@terascope/types": "^1.2.0",
+        "@terascope/utils": "^1.3.0",
         "graphql": "^16.9.0",
         "lodash": "^4.17.21",
         "yargs": "^17.7.2"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "4.2.0",
+    "version": "4.3.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -24,8 +24,8 @@
         "test:watch": "TEST_RESTRAINED_ELASTICSEARCH='true' ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^1.1.0",
-        "@terascope/utils": "^1.2.0",
+        "@terascope/types": "^1.2.0",
+        "@terascope/utils": "^1.3.0",
         "bluebird": "^3.7.2",
         "setimmediate": "^1.0.5"
     },
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "^1.2.0",
         "@types/elasticsearch": "^5.0.43",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^1.2.0",
+        "elasticsearch-store": "^1.3.0",
         "elasticsearch6": "npm:@elastic/elasticsearch@^6.7.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@^7.0.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@^8.0.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,10 +30,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^1.2.0",
-        "@terascope/data-types": "^1.2.0",
-        "@terascope/types": "^1.1.0",
-        "@terascope/utils": "^1.2.0",
+        "@terascope/data-mate": "^1.3.0",
+        "@terascope/data-types": "^1.3.0",
+        "@terascope/types": "^1.2.0",
+        "@terascope/utils": "^1.3.0",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "elasticsearch6": "npm:@elastic/elasticsearch@^6.7.0",
@@ -43,7 +43,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@^2.2.1",
         "setimmediate": "^1.0.5",
         "uuid": "^10.0.0",
-        "xlucene-translator": "^1.2.0"
+        "xlucene-translator": "^1.3.0"
     },
     "devDependencies": {
         "@types/uuid": "^10.0.0"

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -32,8 +32,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^1.1.0",
-        "@terascope/utils": "^1.2.0",
+        "@terascope/types": "^1.2.0",
+        "@terascope/utils": "^1.3.0",
         "convict": "^6.2.4",
         "convict-format-with-moment": "^6.2.0",
         "convict-format-with-validator": "^6.2.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.3.3",
+    "version": "1.4.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "^0.22.0",
-        "@terascope/utils": "^1.2.0",
+        "@terascope/utils": "^1.3.0",
         "codecov": "^3.8.3",
         "execa": "9.4.0",
         "fs-extra": "^11.2.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -29,15 +29,15 @@
     },
     "dependencies": {
         "@terascope/file-asset-apis": "^1.0.2",
-        "@terascope/types": "^1.1.0",
-        "@terascope/utils": "^1.2.0",
+        "@terascope/types": "^1.2.0",
+        "@terascope/utils": "^1.3.0",
         "bluebird": "^3.7.2",
         "bunyan": "^1.8.15",
         "convict": "^6.2.4",
         "convict-format-with-moment": "^6.2.0",
         "convict-format-with-validator": "^6.2.0",
         "elasticsearch": "^15.4.1",
-        "elasticsearch-store": "^1.2.0",
+        "elasticsearch-store": "^1.3.0",
         "express": "^4.21.0",
         "js-yaml": "^4.1.0",
         "nanoid": "^5.0.7",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -38,8 +38,8 @@
     },
     "dependencies": {
         "@terascope/fetch-github-release": "^1.0.0",
-        "@terascope/types": "^1.1.0",
-        "@terascope/utils": "^1.2.0",
+        "@terascope/types": "^1.2.0",
+        "@terascope/utils": "^1.3.0",
         "chalk": "^5.3.0",
         "cli-table3": "^0.6.4",
         "diff": "^7.0.0",
@@ -54,7 +54,7 @@
         "pretty-bytes": "^6.1.1",
         "prompts": "^2.4.2",
         "signale": "^1.4.0",
-        "teraslice-client-js": "^1.2.0",
+        "teraslice-client-js": "^1.3.0",
         "tmp": "^0.2.0",
         "tty-table": "^4.2.3",
         "yargs": "^17.7.2",

--- a/packages/teraslice-cli/src/cmds/assets/deploy.ts
+++ b/packages/teraslice-cli/src/cmds/assets/deploy.ts
@@ -198,7 +198,8 @@ export default {
                 const resp = await terasliceClient.assets.upload(assetZip, {
                     blocking: cliConfig.args.blocking
                 });
-                reply.green(`Asset posted to ${cliConfig.args.clusterAlias}: ${resp.asset_id}`);
+                const assetID = resp.asset_id ?? resp._id;
+                reply.green(`Asset posted to ${cliConfig.args.clusterAlias}: ${assetID}`);
             } catch (err) {
                 reply.fatal(`Error posting asset: ${err.message}`);
             }

--- a/packages/teraslice-cli/src/cmds/assets/deploy.ts
+++ b/packages/teraslice-cli/src/cmds/assets/deploy.ts
@@ -198,7 +198,7 @@ export default {
                 const resp = await terasliceClient.assets.upload(assetZip, {
                     blocking: cliConfig.args.blocking
                 });
-                reply.green(`Asset posted to ${cliConfig.args.clusterAlias}: ${resp._id}`);
+                reply.green(`Asset posted to ${cliConfig.args.clusterAlias}: ${resp.asset_id}`);
             } catch (err) {
                 reply.fatal(`Error posting asset: ${err.message}`);
             }

--- a/packages/teraslice-cli/test/servers/teraslice-server.ts
+++ b/packages/teraslice-cli/test/servers/teraslice-server.ts
@@ -12,7 +12,7 @@ const rootResponse: Teraslice.ApiRootResponse = {
 };
 
 const postAssetResponse: Teraslice.AssetIDResponse = {
-    _id: 'assset_test_id'
+    asset_id: 'assset_test_id'
 };
 
 export default class TerasliceServer {

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -32,8 +32,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^1.1.0",
-        "@terascope/utils": "^1.2.0",
+        "@terascope/types": "^1.2.0",
+        "@terascope/utils": "^1.3.0",
         "auto-bind": "^5.0.1",
         "got": "^13.0.0"
     },

--- a/packages/teraslice-client-js/src/assets.ts
+++ b/packages/teraslice-client-js/src/assets.ts
@@ -38,7 +38,8 @@ export default class Assets extends Client {
             });
         }
 
-        const results = await this.delete(`/assets/${id}`, searchOptions);
+        const results = await this.delete<Teraslice.AssetIDResponse>(`/assets/${id}`, searchOptions);
+
         return this.parse(results);
     }
 

--- a/packages/teraslice-client-js/test/assets-spec.ts
+++ b/packages/teraslice-client-js/test/assets-spec.ts
@@ -56,7 +56,7 @@ describe('Teraslice Assets', () => {
 
         describe('when called with a string', () => {
             const contents = 'example-input';
-            const idResponse: AssetIDResponse = { _id: 'some-asset-id' };
+            const idResponse: AssetIDResponse = { asset_id: 'some-asset-id' };
 
             beforeEach(async () => {
                 scope.post('/assets', contents)
@@ -76,7 +76,7 @@ describe('Teraslice Assets', () => {
         describe.skip('when called with a stream', () => {
             const testFilePath = path.join(dirname, 'fixtures', 'test.txt');
             const contents = fs.readFileSync(testFilePath, 'utf-8');
-            const idResponse: AssetIDResponse = { _id: 'some-asset-id' };
+            const idResponse: AssetIDResponse = { asset_id: 'some-asset-id' };
 
             beforeEach(() => {
                 scope.post('/assets', (body) => contents === body)
@@ -336,7 +336,7 @@ describe('Teraslice Assets', () => {
     });
 
     describe('->remove', () => {
-        const idResponse: AssetIDResponse = { _id: 'someId' };
+        const idResponse: AssetIDResponse = { asset_id: 'someId' };
 
         beforeEach(() => {
             scope.delete('/assets/some-asset-id')

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -35,8 +35,8 @@
         "ms": "^2.1.3"
     },
     "dependencies": {
-        "@terascope/types": "^1.1.0",
-        "@terascope/utils": "^1.2.0",
+        "@terascope/types": "^1.2.0",
+        "@terascope/utils": "^1.3.0",
         "ms": "^2.1.3",
         "nanoid": "^5.0.7",
         "p-event": "^6.0.1",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -24,8 +24,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "^4.2.0",
-        "@terascope/utils": "^1.2.0"
+        "@terascope/elasticsearch-api": "^4.3.0",
+        "@terascope/utils": "^1.3.0"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^11.2.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^1.4.0"
+        "@terascope/job-components": "^1.5.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=1.4.0"
+        "@terascope/job-components": ">=1.5.0"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -39,11 +39,11 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "^0.22.0",
-        "@terascope/elasticsearch-api": "^4.2.0",
-        "@terascope/job-components": "^1.4.0",
-        "@terascope/teraslice-messaging": "^1.5.0",
-        "@terascope/types": "^1.1.0",
-        "@terascope/utils": "^1.2.0",
+        "@terascope/elasticsearch-api": "^4.3.0",
+        "@terascope/job-components": "^1.5.0",
+        "@terascope/teraslice-messaging": "^1.6.0",
+        "@terascope/types": "^1.2.0",
+        "@terascope/utils": "^1.3.0",
         "async-mutex": "^0.5.0",
         "barbe": "^3.0.16",
         "body-parser": "^1.20.2",
@@ -63,7 +63,7 @@
         "semver": "^7.6.3",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^1.4.0",
+        "terafoundation": "^1.5.0",
         "uuid": "^10.0.0"
     },
     "devDependencies": {

--- a/packages/teraslice/src/lib/cluster/services/assets.ts
+++ b/packages/teraslice/src/lib/cluster/services/assets.ts
@@ -95,7 +95,6 @@ export class AssetsService {
                         error: `asset ${assetId} is not formatted correctly, please provide the full asset_id`
                     });
                 } else {
-
                     const assetResponse: Teraslice.AssetIDResponse = {
                         asset_id: assetId,
                         _id: assetId

--- a/packages/teraslice/src/lib/cluster/services/assets.ts
+++ b/packages/teraslice/src/lib/cluster/services/assets.ts
@@ -3,6 +3,7 @@ import {
     TSError, parseErrorInfo, logError,
     toBoolean, Logger
 } from '@terascope/utils';
+import { Teraslice } from '@terascope/types';
 import type { Context } from '@terascope/job-components';
 import { makeLogger } from '../../workers/helpers/terafoundation.js';
 import { AssetsStorage } from '../../storage/index.js';
@@ -57,20 +58,24 @@ export class AssetsService {
                     results.push(buff);
                 });
 
-                req.on('end', () => {
-                    const data = Buffer.concat(results);
-                    this.assetsStorage.save(data, blocking)
-                        .then(({ assetId, created }) => {
-                            const code = created ? 201 : 200;
-                            res.status(code).json({
-                                _id: assetId
-                            });
-                        })
-                        .catch((err) => {
-                            const { statusCode, message } = parseErrorInfo(err);
-                            logError(this.logger, err, 'failure saving assets via proxy request');
-                            sendError(res, statusCode, message, this.logger);
-                        });
+                req.on('end', async () => {
+                    try {
+                        const data = Buffer.concat(results);
+
+                        const { assetId, created } = await this.assetsStorage.save(data, blocking);
+
+                        const code = created ? 201 : 200;
+                        const assetResponse: Teraslice.AssetIDResponse = {
+                            asset_id: assetId,
+                            _id: assetId
+                        };
+
+                        res.status(code).json(assetResponse);
+                    } catch (err) {
+                        const { statusCode, message } = parseErrorInfo(err);
+                        logError(this.logger, err, 'failure saving assets via proxy request');
+                        sendError(res, statusCode, message, this.logger);
+                    }
                 });
 
                 req.on('error', (err) => {
@@ -90,9 +95,15 @@ export class AssetsService {
                         error: `asset ${assetId} is not formatted correctly, please provide the full asset_id`
                     });
                 } else {
+
+                    const assetResponse: Teraslice.AssetIDResponse = {
+                        asset_id: assetId,
+                        _id: assetId
+                    };
+
                     requestHandler(async () => {
                         await this.assetsStorage.remove(assetId);
-                        return { _id: assetId };
+                        return assetResponse;
                     });
                 }
             });
@@ -206,7 +217,9 @@ export class AssetsService {
                 record.id = asset._id;
                 return record;
             });
+
             const { assetConnectionType } = getBackendConfig(this.context, this.logger);
+
             if (assetConnectionType === 's3') {
                 const s3Assets = await this.assetsStorage.grabS3Info();
                 const updatedAssets = this.getS3AssetStatus(s3Assets, assets);

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -36,9 +36,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "^1.2.0",
-        "@terascope/types": "^1.1.0",
-        "@terascope/utils": "^1.2.0",
+        "@terascope/data-mate": "^1.3.0",
+        "@terascope/types": "^1.2.0",
+        "@terascope/utils": "^1.3.0",
         "awesome-phonenumber": "^7.2.0",
         "graphlib": "^2.1.8",
         "is-ip": "^5.0.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/types",
     "displayName": "Types",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "A collection of typescript interfaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/types#readme",
     "bugs": {

--- a/packages/types/src/teraslice.ts
+++ b/packages/types/src/teraslice.ts
@@ -19,8 +19,13 @@ export interface AssetStatusResponse {
 }
 
 export type AssetIDResponse = {
-    _id: string;
+    asset_id: string;
+    /**
+        @deprecated Use asset_id instead
+    */
+    _id?: string;
 };
+
 // On asset upload
 export interface AssetUploadQuery {
     blocking?: boolean;

--- a/packages/types/src/teraslice.ts
+++ b/packages/types/src/teraslice.ts
@@ -21,7 +21,7 @@ export interface AssetStatusResponse {
 export type AssetIDResponse = {
     asset_id: string;
     /**
-        @deprecated Use asset_id instead
+        @deprecated Use asset_id instead, will be removed in teraslice v3
     */
     _id?: string;
 };

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {
@@ -29,7 +29,7 @@
         "debug": "^4.3.7"
     },
     "dependencies": {
-        "@terascope/types": "^1.1.0",
+        "@terascope/types": "^1.2.0",
         "@turf/bbox": "^7.1.0",
         "@turf/bbox-polygon": "^7.1.0",
         "@turf/boolean-contains": "^7.1.0",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -33,8 +33,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^1.1.0",
-        "@terascope/utils": "^1.2.0",
+        "@terascope/types": "^1.2.0",
+        "@terascope/utils": "^1.3.0",
         "peggy": "~4.0.3",
         "ts-pegjs": "^4.2.1"
     },

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,10 +29,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "^1.1.0",
-        "@terascope/utils": "^1.2.0",
+        "@terascope/types": "^1.2.0",
+        "@terascope/utils": "^1.3.0",
         "@types/elasticsearch": "^5.0.43",
-        "xlucene-parser": "^1.2.0"
+        "xlucene-parser": "^1.3.0"
     },
     "devDependencies": {
         "elasticsearch": "^15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -24,10 +24,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "^1.2.0"
+        "@terascope/utils": "^1.3.0"
     },
     "devDependencies": {
-        "@terascope/types": "^1.1.0"
+        "@terascope/types": "^1.2.0"
     },
     "engines": {
         "node": ">=18.18.0",


### PR DESCRIPTION
- make the response consistent with our other api responses
- `_id` => `asset_id`
- this change is backwards compatible but `_id` is marked as deprecated.