### PR TITLE
Add execution info query to job api

### DIFF
--- a/docs/management-apis/endpoints-json.md
+++ b/docs/management-apis/endpoints-json.md
@@ -290,6 +290,15 @@ $ curl 'localhost:5678/v1/jobs'
 
 Returns the job that matches given job id.
 
+**Query Options:**
+
+- `ex: string = [execution controller field options]`
+
+You can pass in a query using `ex` which takes field options for what you want returned in the `ex` object. This gives information on the current execution accociated with the specified job. If no execution is present, it will return the `ex` field with an empty object. If no fields are passed in, it will return all fields. Fields MUST be separated with commas. Example: `localhost:5678/v1/jobs/<job_id>?ex=_status,assets`
+
+Look at the returned object in [GET v1/ex](#get-v1ex) for valid field names.
+
+
 **Usage:**
 
 ```sh
@@ -307,6 +316,30 @@ $ curl 'localhost:5678/v1/jobs/5a50580c-4a50-48d9-80f8-ac70a00f3dbd'
     "_created": "2018-09-21T17:49:05.029Z",
     "_updated": "2018-11-01T13:15:22.743Z",
     "_context": "job"
+}
+```
+When getting a job with current execution info:
+```sh
+$ curl 'localhost:5678/v1/jobs/5a50580c-4a50-48d9-80f8-ac70a00f3dbd?ex=assets,_status'
+{
+    "name": "Example",
+    "lifecycle": "persistent",
+    "workers": 1,
+    "operations": [
+        {
+            "_op": "noop"
+        }
+    ]
+    "job_id": "5a50580c-4a50-48d9-80f8-ac70a00f3dbd",
+    "_created": "2018-09-21T17:49:05.029Z",
+    "_updated": "2018-11-01T13:15:22.743Z",
+    "_context": "job",
+    "ex": {
+        "assets": [
+            "74dcba12408fc02868d8c88b15be8a386092091b"
+        ],
+        "_status": "running"
+    }
 }
 ```
 
@@ -952,3 +985,5 @@ $ curl 'localhost:5678/v1/ex/1cb20d4c-520a-44fe-a802-313f41dd5b05/controller'
     }
 ]
 ```
+
+## test /stuff

--- a/docs/management-apis/endpoints-json.md
+++ b/docs/management-apis/endpoints-json.md
@@ -986,4 +986,3 @@ $ curl 'localhost:5678/v1/ex/1cb20d4c-520a-44fe-a802-313f41dd5b05/controller'
 ]
 ```
 
-## test /stuff

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -286,12 +286,12 @@ export class ApiService {
         });
 
         v1routes.get('/jobs/:jobId', (req, res) => {
-            const include = (typeof req.query.include === 'string') ? req.query.include : '';
+            const includeEx = req.query.ex;
             const { jobId } = req.params;
             // @ts-expect-error
             const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not retrieve job');
-            include.includes('ex_status')
-                ? requestHandler(async () => this.jobsService.getJobWithExInfo(jobId))
+            typeof includeEx === 'string'
+                ? requestHandler(async () => this.jobsService.getJobWithExInfo(jobId, includeEx.split(',')))
                 : requestHandler(async () => this.jobsStorage.get(jobId));
         });
 

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -286,12 +286,12 @@ export class ApiService {
         });
 
         v1routes.get('/jobs/:jobId', (req, res) => {
-            const includeEx = req.query.ex;
+            const { ex } = req.query;
             const { jobId } = req.params;
             // @ts-expect-error
             const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not retrieve job');
-            typeof includeEx === 'string'
-                ? requestHandler(async () => this.jobsService.getJobWithExInfo(jobId, includeEx.split(',')))
+            typeof ex === 'string'
+                ? requestHandler(async () => this.jobsService.getJobWithExInfo(jobId, ex.split(',')))
                 : requestHandler(async () => this.jobsStorage.get(jobId));
         });
 

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -286,10 +286,13 @@ export class ApiService {
         });
 
         v1routes.get('/jobs/:jobId', (req, res) => {
+            const include = (typeof req.query.include === 'string') ? req.query.include : '';
             const { jobId } = req.params;
             // @ts-expect-error
             const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not retrieve job');
-            requestHandler(async () => this.jobsStorage.get(jobId));
+            include.includes('ex_status')
+                ? requestHandler(async () => this.jobsService.getJobWithExInfo(jobId))
+                : requestHandler(async () => this.jobsStorage.get(jobId));
         });
 
         v1routes.put('/jobs/:jobId', (req, res) => {

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -358,6 +358,40 @@ export class JobsService {
     }
 
     /**
+     * Get the job with the latest ex status
+     *
+     * @param {string} jobId
+     * @param {string} [query]
+     * @returns {Promise<JobConfig>}
+    */
+    async getJobWithExInfo(
+        jobId: string,
+        // We could use this later to only pull what we want form the ex
+        query?: string,
+    ): Promise<JobConfig> {
+        if (!jobId || !isString(jobId)) {
+            throw new TSError(`Invalid job id, got ${getTypeOf(jobId)}`);
+        }
+
+        const job = await this.jobsStorage.get(jobId);
+
+        const ex = await this.executionStorage.search(
+            query || `job_id: "${jobId}"`, undefined, 1, '_created:desc'
+        ) as ExecutionConfig[];
+
+        if (!ex.length || ex[0]._deleted === true) {
+            job.ex = {};
+            return job;
+        }
+
+        job.ex = {
+            _status: ex[0]._status
+        };
+
+        return job;
+    }
+
+    /**
      * Get the active execution
      *
      * @param {string} jobId

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -361,13 +361,12 @@ export class JobsService {
      * Get the job with the latest ex status
      *
      * @param {string} jobId
-     * @param {string} [query]
+     * @param {string} [fields]
      * @returns {Promise<JobConfig>}
     */
     async getJobWithExInfo(
         jobId: string,
-        // We could use this later to only pull what we want form the ex
-        query?: string,
+        fields?: string[],
     ): Promise<JobConfig> {
         if (!jobId || !isString(jobId)) {
             throw new TSError(`Invalid job id, got ${getTypeOf(jobId)}`);
@@ -376,7 +375,7 @@ export class JobsService {
         const job = await this.jobsStorage.get(jobId);
 
         const ex = await this.executionStorage.search(
-            query || `job_id: "${jobId}"`, undefined, 1, '_created:desc'
+            `job_id: "${jobId}"`, undefined, 1, '_created:desc', fields || undefined
         ) as ExecutionConfig[];
 
         if (!ex.length || ex[0]._deleted === true) {
@@ -384,9 +383,7 @@ export class JobsService {
             return job;
         }
 
-        job.ex = {
-            _status: ex[0]._status
-        };
+        job.ex = ex[0];
 
         return job;
     }

--- a/packages/types/src/teraslice.ts
+++ b/packages/types/src/teraslice.ts
@@ -72,6 +72,7 @@ export interface JobConfig extends ValidatedJobConfig {
     _updated: string | Date;
     _deleted?: boolean;
     _deleted_on?: string | Date;
+    ex?: any;
 }
 
 export enum RecoveryCleanupType {


### PR DESCRIPTION
This PR makes the following changes:

# teraslice
## New Features
- Adds `ex` query parameter to the `v1/jobs/:job_id` api endpoint
  - It's now possible to to get a job with specific information about the current execution in one request
## Documentation
- Adds docs on how to use new `ex` query parameter in v1 jobs api endpoint 