### PR TITLE
[job-components, terafoundation, teraslice] Remove prom metrics assignment default label, exclude master pod from active execution list

### DIFF
--- a/docs/development/k8s.md
+++ b/docs/development/k8s.md
@@ -388,6 +388,7 @@ await config.context.apis.foundation.promMetrics.init({
         ex_id: this.exId,
         job_id: this.jobId,
         job_name: this.config.name,
+        assignment: 'execution_controller',
     }
 });
 ```

--- a/e2e/k8s/masterConfig/teraslice.yaml
+++ b/e2e/k8s/masterConfig/teraslice.yaml
@@ -1,6 +1,10 @@
 terafoundation:
   environment: "development"
   log_level: debug
+  prom_metrics_enabled: false
+  prom_metrics_add_default: true
+  prom_metrics_port: 3333
+  prom_metrics_display_url: 'localhost'
   connectors:
     elasticsearch-next:
       default:

--- a/e2e/k8s/workerConfig/teraslice.yaml
+++ b/e2e/k8s/workerConfig/teraslice.yaml
@@ -1,6 +1,10 @@
 terafoundation:
   environment: "development"
   log_level: debug
+  prom_metrics_enabled: false
+  prom_metrics_port: 3333
+  prom_metrics_add_default: true
+  prom_metrics_display_url: 'localhost'
   connectors:
     elasticsearch-next:
       default:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/job-components/src/test-helpers.ts
+++ b/packages/job-components/src/test-helpers.ts
@@ -260,11 +260,10 @@ export class TestContext implements i.Context {
 
                         const defaultLabels = {
                             name: 'mockPromMetrics',
-                            assignment,
                             ...labels
                         };
 
-                        const finalPrefix = prefix || `teraslice_${config.assignment}_`;
+                        const finalPrefix = prefix || `teraslice_${assignment}_`;
 
                         if (useDefaultMetrics) {
                             const defaultMetricsConfig = {

--- a/packages/job-components/test/test-helpers-spec.ts
+++ b/packages/job-components/test/test-helpers-spec.ts
@@ -155,7 +155,7 @@ describe('Test Helpers', () => {
         });
 
         it('should add, inc and delete counter', async () => {
-            await context.apis.foundation.promMetrics.addCounter('test_counter', 'test_counter help string', ['uuid', 'name', 'assignment'], function collect() {
+            await context.apis.foundation.promMetrics.addCounter('test_counter', 'test_counter help string', ['uuid', 'name'], function collect() {
                 this.inc({ uuid: 'e&vgv%56' }, 1);
             });
             context.apis.foundation.promMetrics.inc('test_counter', { uuid: 'e&vgv%56' }, 1);
@@ -164,7 +164,7 @@ describe('Test Helpers', () => {
         });
 
         it('should inc, dec, and set gauge', async () => {
-            await context.apis.foundation.promMetrics.addGauge('test_gauge', 'help string', ['uuid', 'name', 'assignment']);
+            await context.apis.foundation.promMetrics.addGauge('test_gauge', 'help string', ['uuid', 'name']);
             context.apis.foundation.promMetrics.set('test_gauge', { uuid: '437Ev89h' }, 10);
             context.apis.foundation.promMetrics.inc('test_gauge', { uuid: '437Ev89h' }, 1);
             context.apis.foundation.promMetrics.dec('test_gauge', { uuid: '437Ev89h' }, 2);
@@ -188,7 +188,7 @@ describe('Test Helpers', () => {
                 .toThrow('Metric missing_test_gauge is not setup');
         });
         it('should add and observe summary', async () => {
-            await context.apis.foundation.promMetrics.addSummary('test_summary', 'test_summary help string', ['uuid', 'name', 'assignment']);
+            await context.apis.foundation.promMetrics.addSummary('test_summary', 'test_summary help string', ['uuid', 'name']);
             context.apis.foundation.promMetrics.observe('test_summary', { uuid: '34rhEqrX' }, 12);
             context.apis.foundation.promMetrics.observe('test_summary', { uuid: '34rhEqrX' }, 5);
             context.apis.foundation.promMetrics.observe('test_summary', { uuid: '34rhEqrX' }, 18);
@@ -200,7 +200,7 @@ describe('Test Helpers', () => {
         });
 
         it('should add and observe histogram', async () => {
-            await context.apis.foundation.promMetrics.addHistogram('test_histogram', 'test_histogram help string', ['uuid', 'name', 'assignment']);
+            await context.apis.foundation.promMetrics.addHistogram('test_histogram', 'test_histogram help string', ['uuid', 'name']);
             context.apis.foundation.promMetrics.observe('test_histogram', { uuid: 'dEF4Kby6' }, 10);
             context.apis.foundation.promMetrics.observe('test_histogram', { uuid: 'dEF4Kby6' }, 30);
             context.apis.foundation.promMetrics.observe('test_histogram', { uuid: 'dEF4Kby6' }, 2);

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/terafoundation/src/api/prom-metrics/prom-metrics-api.ts
+++ b/packages/terafoundation/src/api/prom-metrics/prom-metrics-api.ts
@@ -373,7 +373,7 @@ export class PromMetrics {
     private _setPodName(): void {
         // in a pod the hostname is the pod name
         const host = os.hostname();
-        if (host.startsWith('ts-wkr-')) {
+        if (host.startsWith('ts-wkr-') || host.startsWith('ts-exc-')) {
             this.default_labels.pod_name = host;
         }
     }

--- a/packages/terafoundation/src/api/prom-metrics/prom-metrics-api.ts
+++ b/packages/terafoundation/src/api/prom-metrics/prom-metrics-api.ts
@@ -66,7 +66,6 @@ export class PromMetrics {
 
             this.default_labels = {
                 name: terasliceName,
-                assignment: apiConfig.assignment,
                 url: prom_metrics_display_url,
                 ...apiConfig.labels
             };

--- a/packages/terafoundation/test/apis/prom-metrics-spec.ts
+++ b/packages/terafoundation/test/apis/prom-metrics-spec.ts
@@ -59,7 +59,7 @@ describe('promMetrics foundation API', () => {
 
                 it('should have correct default labels', async () => {
                     const labels = await context.apis.foundation.promMetrics.getDefaultLabels();
-                    expect(labels).toEqual({ assignment: 'worker', name: 'tera-test', url: 'http://localhost' });
+                    expect(labels).toEqual({ name: 'tera-test', url: 'http://localhost' });
                 });
 
                 it('should throw an error if promMetricsAPI is already initialized', async () => {
@@ -659,7 +659,6 @@ describe('promMetrics foundation API', () => {
         it('should get all the default labels', () => {
             expect(context.apis.foundation.promMetrics.getDefaultLabels()).toEqual({
                 name: 'tera-test-labels',
-                assignment: 'master',
                 default1: 'value1'
             });
         });

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "^11.2.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "^1.5.1"
+        "@terascope/job-components": "^1.5.2"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=1.5.1"
+        "@terascope/job-components": ">=1.5.2"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -40,7 +40,7 @@
     "dependencies": {
         "@kubernetes/client-node": "^0.22.0",
         "@terascope/elasticsearch-api": "^4.3.1",
-        "@terascope/job-components": "^1.5.1",
+        "@terascope/job-components": "^1.5.2",
         "@terascope/teraslice-messaging": "^1.6.1",
         "@terascope/types": "^1.2.0",
         "@terascope/utils": "^1.3.1",
@@ -63,7 +63,7 @@
         "semver": "^7.6.3",
         "socket.io": "^1.7.4",
         "socket.io-client": "^1.7.4",
-        "terafoundation": "^1.5.1",
+        "terafoundation": "^1.5.2",
         "uuid": "^10.0.0"
     },
     "devDependencies": {

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -873,7 +873,7 @@ export class ApiService {
                         for (const node in clusterState) {
                             if (clusterState[node].active) {
                                 for (const worker of clusterState[node].active) {
-                                    if (!filteredExecutions[worker.ex_id]) {
+                                    if (worker.ex_id && !filteredExecutions[worker.ex_id]) {
                                         filteredExecutions[worker.ex_id] = worker.ex_id;
                                         const exLabel = {
                                             ex_id: worker.ex_id,

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -159,7 +159,9 @@ export class ExecutionController {
                     ex_id: exId,
                     job_id: jobId,
                     job_name: config.name,
+                    assignment: 'execution_controller'
                 },
+                prefix: 'teraslice_job_',
                 prom_metrics_display_url: terafoundation.prom_metrics_display_url
 
             });
@@ -1186,7 +1188,7 @@ export class ExecutionController {
             const { context, executionAnalytics } = this;
             await Promise.all([
                 this.context.apis.foundation.promMetrics.addGauge(
-                    'info',
+                    'execution_controller_info',
                     'Information about Teraslice execution controller',
                     ['arch', 'clustering_type', 'name', 'node_version', 'platform', 'teraslice_version'],
                 ),
@@ -1205,7 +1207,7 @@ export class ExecutionController {
             ]);
 
             this.context.apis.foundation.promMetrics.set(
-                'info',
+                'execution_controller_info',
                 {
                     arch: this.context.arch,
                     clustering_type: this.context.sysconfig.teraslice.cluster_manager_type,

--- a/packages/teraslice/src/lib/workers/worker/index.ts
+++ b/packages/teraslice/src/lib/workers/worker/index.ts
@@ -107,7 +107,9 @@ export class Worker {
                     ex_id: exId,
                     job_id: jobId,
                     job_name: config.name,
+                    assignment: 'worker'
                 },
+                prefix: 'teraslice_job_',
                 prom_metrics_display_url: terafoundation.prom_metrics_display_url
             });
             await this.setupPromMetrics();
@@ -423,7 +425,7 @@ export class Worker {
             const self = this;
             await Promise.all([
                 this.context.apis.foundation.promMetrics.addGauge(
-                    'info',
+                    'worker_info',
                     'Information about Teraslice worker',
                     ['arch', 'clustering_type', 'name', 'node_version', 'platform', 'teraslice_version'],
                 ),
@@ -442,7 +444,7 @@ export class Worker {
             ]);
 
             this.context.apis.foundation.promMetrics.set(
-                'info',
+                'worker_info',
                 {
                     arch: this.context.arch,
                     clustering_type: this.context.sysconfig.teraslice.cluster_manager_type,


### PR DESCRIPTION
This PR makes the following changes:
- Remove prom metrics `assignment` default label. This should never have been included.
- Exclude master pod from active execution list. We didn't realize this was included in the `cluster/state` endpoint `active` array for the node that had the master.
- bump teraslice from 2.6.0 to 2.6.1
- bump terafoundation from 1.5.1 to 1.5.2
- bump job-components from 1.5.1 to 1.5.2

Ref: #3743 