### PR TITLE
[teraslice] Add ex info option to teraslice v1 jobs api

### DIFF
--- a/docs/management-apis/endpoints-json.md
+++ b/docs/management-apis/endpoints-json.md
@@ -250,6 +250,7 @@ Returns an array of all jobs listed in `${clusterName}__jobs` index.
 - `from: number = 0`
 - `size: number = 100`
 - `sort: string = "_updated:desc"`
+- `ex: string = [execution controller field options]`
 
 Setting `active` to `true` will return only the jobs considered active, which
 includes the jobs that have `active` set to `true` as well as those that do not
@@ -263,6 +264,8 @@ Setting `deleted` to `true` will return all `_deleted: true` jobs.
 
 The parameter `size` is the number of documents returned, `from` is how many
 documents in and `sort` is a lucene query.
+
+Refer to the returned object in [GET v1/ex](#get-v1ex) for valid `ex` parameter fields. This option is also used [here](#get-v1jobsjobid) and described in more detail.
 
 **Usage:**
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -271,7 +271,7 @@ export class ApiService {
         });
 
         v1routes.get('/jobs', (req, res) => {
-            const { active = '', deleted = 'false' } = req.query;
+            const { active = '', deleted = 'false', ex } = req.query;
             const { size, from, sort } = getSearchOptions(req as TerasliceRequest);
 
             const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not retrieve list of jobs');
@@ -280,8 +280,9 @@ export class ApiService {
 
                 const partialQuery = createJobActiveQuery(active as string);
                 const query = addDeletedToQuery(deleted as string, partialQuery);
-
-                return this.jobsStorage.search(query, from, size, sort as string);
+                return typeof ex === 'string'
+                    ? this.jobsService.getJobsWithExInfo(query, from, size, sort as string, ex.split(','))
+                    : this.jobsStorage.search(query, from, size, sort as string);
             });
         });
 

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -389,6 +389,31 @@ export class JobsService {
     }
 
     /**
+     * Get a list of jobs with the latest ex status for each one
+     *
+     * @param {string} query
+     * @param {number} from
+     * @param {number} size
+     * @param {string} sort
+     * @param {string} [ex_fields]
+     * @returns {Promise<JobConfig>}
+    */
+    async getJobsWithExInfo(
+        query: string | Record<string, any>,
+        from?: number,
+        size?: number,
+        sort?: string,
+        ex_fields?: string[]
+    ): Promise<JobConfig[]> {
+        const jobList = await this.jobsStorage.search(query, from, size, sort);
+        const finalList: JobConfig[] = [];
+        for (const job of jobList) {
+            finalList.push(await this.getJobWithExInfo(job.job_id, ex_fields));
+        }
+        return finalList;
+    }
+
+    /**
      * Get the active execution
      *
      * @param {string} jobId


### PR DESCRIPTION
This PR makes the following changes:

## New Features
- Adds a feature introduced on #3792 into the `v1/jobs` endpoint
  - Now you can list several jobs with their associated ex information in one api call

## Documentation
- Updated `management api` docs to reflect changes to `v1/jobs` endpoint

## Bumps
- **teraslice** from `v2.6.1` to `v2.6.2`

Ref to issue #3770