### PR TITLE
[terasclice] Ensure asset uploads are zip files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.6.3",
+    "version": "2.6.4",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.6.3",
+    "version": "2.6.4",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/storage/assets.ts
+++ b/packages/teraslice/src/lib/storage/assets.ts
@@ -224,13 +224,26 @@ export class AssetsStorage {
     }
 
     /**
+     * Check if a buffer contains a zip file
+     * @param {Buffer} buffer A buffer containing a file file
+     * @returns {boolean}
+     */
+    isZipFile(buffer: Buffer) {
+        const zipSignature = [0x50, 0x4B, 0x03, 0x04];
+        return zipSignature.every((byte, index) => buffer[index] === byte);
+    }
+
+    /**
      * Save an asset to disk and upload to elasticsearch or s3
      *
-     * @param data {Buffer} A buffer of the asset file (zipped)
-     * @param blocking {boolean=true} If false, save the asset in the background
+     * @param {Buffer}         data A buffer of the asset file (zipped)
+     * @param {boolean=true}   blocking If false, save the asset in the background
      * @returns {Promise<{ assetId: string; created: boolean }>}
     */
     async save(data: Buffer, blocking = true) {
+        if (!this.isZipFile(data)) {
+            throw new Error('Failed to save asset. File type not recognized as zip.');
+        }
         const esData = data.toString('base64');
         const id = crypto.createHash('sha1').update(esData)
             .digest('hex');

--- a/packages/teraslice/src/lib/utils/file_utils.ts
+++ b/packages/teraslice/src/lib/utils/file_utils.ts
@@ -168,3 +168,13 @@ export async function saveAsset(
         logger, assetsPath, id, binaryData, metaCheck
     ));
 }
+
+/**
+ * Check if a buffer contains a zip file
+ * @param {Buffer} buffer A buffer containing a file file
+ * @returns {boolean}
+ */
+export function isZipFile(buffer: Buffer) {
+    const zipSignature = [0x50, 0x4B, 0x03, 0x04];
+    return zipSignature.every((byte, index) => buffer[index] === byte);
+}

--- a/packages/teraslice/src/lib/utils/file_utils.ts
+++ b/packages/teraslice/src/lib/utils/file_utils.ts
@@ -170,7 +170,10 @@ export async function saveAsset(
 }
 
 /**
- * Check if a buffer contains a zip file
+ * Check if a buffer contains a zip file.
+ * Note that file extension and mime type are not checked.
+ * Any file type that is actually a zip (.xlsx, .jar, .apk,
+ * .epub) will return true.
  * @param {Buffer} buffer A buffer containing a file file
  * @returns {boolean}
  */

--- a/packages/teraslice/test/storage/assets_storage-spec.ts
+++ b/packages/teraslice/test/storage/assets_storage-spec.ts
@@ -59,6 +59,13 @@ describe('AssetsStorage using S3 backend', () => {
         await storage.initialize();
     }, 30000);
 
+    it('will reject an asset that isn\'t in zip format', async () => {
+        const filePath = 'e2e/test/fixtures/assets/fake_zip.zip';
+        const buffer = fs.readFileSync(filePath);
+        const result = await storage.save(buffer);
+        expect(result.assetId).toBe('caf0e5ce7cf1edc864f306b1d9edbad0f7060545');
+    });
+
     it('can save an asset to S3', async () => {
         const filePath = 'e2e/test/fixtures/assets/example_asset_1.zip';
         const buffer = fs.readFileSync(filePath);

--- a/packages/teraslice/test/storage/assets_storage-spec.ts
+++ b/packages/teraslice/test/storage/assets_storage-spec.ts
@@ -62,8 +62,7 @@ describe('AssetsStorage using S3 backend', () => {
     it('will reject an asset that isn\'t in zip format', async () => {
         const filePath = 'e2e/test/fixtures/assets/fake_zip.zip';
         const buffer = fs.readFileSync(filePath);
-        const result = await storage.save(buffer);
-        expect(result.assetId).toBe('caf0e5ce7cf1edc864f306b1d9edbad0f7060545');
+        await expect(() => storage.save(buffer)).rejects.toThrow('Failed to save asset. File type not recognized as zip.');
     });
 
     it('can save an asset to S3', async () => {


### PR DESCRIPTION
This PR makes the following changes:
- Add `isZipFile()` to `file_utils` which checks the magic numbers at the beginning of a buffer to see if they match those of a zip file.
- `AssetStorage.save()` uses `isZipFile()` to check if the uploaded asset is a zip and throws an error if it isn't.
- Add `fake_zip.zip` and add a test that calls `AssetStorage.save()` on it.