### PR TITLE
[ts-scripts] add skip-image-deletion option to test-runner

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/cmds/test.ts
+++ b/packages/scripts/src/cmds/test.ts
@@ -22,6 +22,7 @@ type Options = {
     packages?: PackageInfo[];
     'ignore-mount': boolean;
     'test-platform': string;
+    'skip-image-deletion': boolean;
 };
 
 const jestArgs = getExtraArgs();
@@ -101,6 +102,11 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
                 default: config.TEST_PLATFORM,
                 choices: ['native', 'kubernetes', 'kubernetesV2']
             })
+            .option('skip-image-deletion', {
+                description: 'Skip the deletion of docker images from cache after loading into docker.\n This is useful if a CI job calls `ts-scripts test` more than once.',
+                type: 'boolean',
+                default: config.SKIP_IMAGE_DELETION,
+            })
             .positional('packages', {
                 description: 'Runs the tests for one or more package and/or an asset, if none specified it will run all of the tests',
                 coerce(arg) {
@@ -126,6 +132,7 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
         const ignoreMount = hoistJestArg(argv, 'ignore-mount', 'boolean');
         const testPlatform = hoistJestArg(argv, 'test-platform', 'string') as 'native' | 'kubernetes' | 'kubernetesV2';
         const kindClusterName = testPlatform === 'native' ? 'default' : 'k8s-e2e';
+        const skipImageDeletion = hoistJestArg(argv, 'skip-image-deletion', 'boolean');
 
         if (debug && watch) {
             throw new Error('--debug and --watch conflict, please set one or the other');
@@ -147,6 +154,7 @@ const cmd: CommandModule<GlobalCMDOptions, Options> = {
             ignoreMount,
             testPlatform,
             kindClusterName,
+            skipImageDeletion
         });
     },
 };

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -206,3 +206,4 @@ export const {
 export const DOCKER_IMAGES_PATH = './images';
 export const DOCKER_IMAGE_LIST_PATH = `${DOCKER_IMAGES_PATH}/image-list.txt`;
 export const DOCKER_CACHE_PATH = '/tmp/docker_cache';
+export const SKIP_IMAGE_DELETION = toBoolean(process.env.SKIP_IMAGE_DELETION) || false;

--- a/packages/scripts/src/helpers/k8s-env/index.ts
+++ b/packages/scripts/src/helpers/k8s-env/index.ts
@@ -106,7 +106,8 @@ export async function launchK8sEnv(options: K8sEnvOptions) {
         reportCoverage: false,
         useExistingServices: false,
         ignoreMount: false,
-        testPlatform: options.clusteringType
+        testPlatform: options.clusteringType,
+        skipImageDeletion: false
     });
 
     try {

--- a/packages/scripts/src/helpers/kind.ts
+++ b/packages/scripts/src/helpers/kind.ts
@@ -80,7 +80,7 @@ export class Kind {
 
     // TODO: check that image is loaded before we continue
     async loadServiceImage(
-        serviceName: string, serviceImage: string, version: string
+        serviceName: string, serviceImage: string, version: string, skipDelete: boolean
     ): Promise<void> {
         let subprocess;
         try {
@@ -95,7 +95,9 @@ export class Kind {
                 subprocess = await execaCommand(`gunzip -d ${filePath}`);
                 signale.info(`${subprocess.command}: successful`);
                 subprocess = await execaCommand(`kind load --name ${this.clusterName} image-archive ${tarPath}`);
-                fs.rmSync(tarPath);
+                if (!skipDelete) {
+                    fs.rmSync(tarPath);
+                }
             } else {
                 subprocess = await execaCommand(`kind load --name ${this.clusterName} docker-image ${serviceImage}:${version}`);
             }

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -456,11 +456,15 @@ async function dockerImageRm(image: string): Promise<void> {
 
 /**
  * Unzips and loads a Docker image from a Docker cache
- * If successful the image will be deleted from the cache
+ * If successful and skipDelete is false the image will be deleted from the cache
  * @param {string} imageName Name of the image to load
+ * @param {boolean} skipDelete Skip removal of docker image from cache
  * @returns {Promise<boolean>} Whether or not the image loaded successfully
  */
-export async function loadThenDeleteImageFromCache(imageName: string): Promise<boolean> {
+export async function loadThenDeleteImageFromCache(
+    imageName: string,
+    skipDelete = false
+): Promise<boolean> {
     signale.time(`unzip and load ${imageName}`);
     const fileName = imageName.trim().replace(/[/:]/g, '_');
     const filePath = path.join(config.DOCKER_CACHE_PATH, `${fileName}.tar.gz`);
@@ -478,7 +482,11 @@ export async function loadThenDeleteImageFromCache(imageName: string): Promise<b
         return false;
     }
 
-    fs.rmSync(filePath);
+    if (!skipDelete) {
+        signale.info(`Deleting ${imageName} from docker image cache.`);
+        fs.rmSync(filePath);
+    }
+
     signale.timeEnd(`unzip and load ${imageName}`);
 
     return true;

--- a/packages/scripts/src/helpers/test-runner/interfaces.ts
+++ b/packages/scripts/src/helpers/test-runner/interfaces.ts
@@ -16,6 +16,7 @@ export type TestOptions = {
     ignoreMount: boolean;
     testPlatform: 'native' | 'kubernetes' | 'kubernetesV2';
     kindClusterName: string;
+    skipImageDeletion: boolean;
 };
 
 export type GroupedPackages = {

--- a/packages/scripts/test/service-spec.ts
+++ b/packages/scripts/test/service-spec.ts
@@ -110,7 +110,8 @@ describe('services', () => {
         encryptMinio: false,
         ignoreMount: false,
         testPlatform: 'native',
-        kindClusterName: 'default'
+        kindClusterName: 'default',
+        skipImageDeletion: false
     };
     let services: any;
 

--- a/packages/scripts/test/test-runner-spec.ts
+++ b/packages/scripts/test/test-runner-spec.ts
@@ -21,7 +21,8 @@ describe('Test Runner Helpers', () => {
         encryptMinio: false,
         ignoreMount: true,
         testPlatform: 'native',
-        kindClusterName: 'default'
+        kindClusterName: 'default',
+        skipImageDeletion: false
     };
 
     function makeTestOptions(input: Partial<TestOptions>): TestOptions {


### PR DESCRIPTION
This PR makes the following changes:
- Add a new flag to ts-scripts test command called `skip-image-deletion` which will skip any command to delete the docker cache or a docker image within the docker cache.
- Add SKIP_IMAGE_DELETION variable to `scripts/src/helpers/config.ts`
-bump scripts from v1.4.2 to v1.5.0

ref: #3811 