### PR TITLE
[teraslice, e2e] Add Kubernetes role restrictions to teraslice master 

### DIFF
--- a/docs/configuration/clustering-k8s.md
+++ b/docs/configuration/clustering-k8s.md
@@ -50,6 +50,7 @@ metadata:
   name: master-service-account
   namespace: ts-dev1
 ```
+
 Make sure to reference this `ServiceAccount` in your master pod configuration by setting `spec.containers.serviceAccountName` to `master-service-account`.
 
 ```yaml

--- a/docs/configuration/clustering-k8s.md
+++ b/docs/configuration/clustering-k8s.md
@@ -51,7 +51,7 @@ metadata:
   namespace: ts-dev1
 ```
 
-Make sure to reference this `ServiceAccount` in your master pod configuration by setting `spec.containers.serviceAccountName` to `master-service-account`.
+Make sure to reference this `ServiceAccount` in the master deployment configuration by setting `spec.template.spec.serviceAccountName` to `master-service-account` inside of [/e2e/k8s/masterDeployment.yaml](../../e2e/k8s/masterDeployment.yaml).
 
 ```yaml
 kind: Role

--- a/docs/configuration/clustering-k8s.md
+++ b/docs/configuration/clustering-k8s.md
@@ -56,18 +56,19 @@ Make sure to reference this `ServiceAccount` in your master pod configuration by
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: teraslice-master-role-<NAMESPACE>
-  namespace: <NAMESPACE>
+  name: teraslice-master-role-ts-dev1
+  namespace: ts-dev1
 rules:
   - apiGroups: [""]  # Core API group for resources like pods, configmaps
     resources: ["pods", "configmaps", "services"]
-    verbs: ["get", "create", "delete", "list", "update"]
+    verbs: ["get", "create", "delete", "list", "update", "patch"]
   - apiGroups: ["apps"]  # Apps API group for deployments and replica sets
     resources: ["deployments", "replicasets"]
-    verbs: ["get", "create", "delete", "list", "update"]
+    verbs: ["get", "create", "delete", "list", "update", "patch"]
   - apiGroups: ["batch"]  # batch API group for jobs
     resources: ["jobs"]
-    verbs: ["get", "create", "delete", "list", "update"]
+    verbs: ["get", "create", "delete", "list", "update", "patch"]
+
 ```
 
 ```yaml

--- a/e2e/k8s/masterDeployment.yaml
+++ b/e2e/k8s/masterDeployment.yaml
@@ -42,3 +42,4 @@ spec:
             type: Directory
       imagePullSecrets:
         - name: docker-tera1-secret
+      serviceAccountName: master-service-account

--- a/e2e/k8s/masterServiceAccount.yaml
+++ b/e2e/k8s/masterServiceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: master-service-account
+  namespace: ts-dev1

--- a/e2e/k8s/role.yaml
+++ b/e2e/k8s/role.yaml
@@ -1,9 +1,15 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: teraslice-all-ts-dev1
+  name: teraslice-master-role-ts-dev1
   namespace: ts-dev1
 rules:
-  - apiGroups: ["*"]
-    resources: ["*"]
-    verbs: ["*"]
+  - apiGroups: [""]  # Core API group for resources like pods, configmaps
+    resources: ["pods", "configmaps", "services"]
+    verbs: ["get", "create", "delete", "list", "update"]
+  - apiGroups: ["apps"]  # Apps API group for deployments and replica sets
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "create", "delete", "list", "update"]
+  - apiGroups: ["batch"]  # batch API group for jobs
+    resources: ["jobs"]
+    verbs: ["get", "create", "delete", "list", "update"]

--- a/e2e/k8s/role.yaml
+++ b/e2e/k8s/role.yaml
@@ -6,10 +6,10 @@ metadata:
 rules:
   - apiGroups: [""]  # Core API group for resources like pods, configmaps
     resources: ["pods", "configmaps", "services"]
-    verbs: ["get", "create", "delete", "list", "update"]
+    verbs: ["get", "create", "delete", "list", "update", "patch"]
   - apiGroups: ["apps"]  # Apps API group for deployments and replica sets
     resources: ["deployments", "replicasets"]
-    verbs: ["get", "create", "delete", "list", "update"]
+    verbs: ["get", "create", "delete", "list", "update", "patch"]
   - apiGroups: ["batch"]  # batch API group for jobs
     resources: ["jobs"]
-    verbs: ["get", "create", "delete", "list", "update"]
+    verbs: ["get", "create", "delete", "list", "update", "patch"]

--- a/e2e/k8s/roleBinding.yaml
+++ b/e2e/k8s/roleBinding.yaml
@@ -1,13 +1,13 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: teraslice-all-ts-dev1
+  name: teraslice-master-ts-dev1
   namespace: ts-dev1
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: master-service-account
     namespace: ts-dev1
 roleRef:
   kind: Role
-  name: teraslice-all-ts-dev1
+  name: teraslice-master-role-ts-dev1
   apiGroup: "rbac.authorization.k8s.io"

--- a/packages/scripts/src/helpers/k8s-env/k8s.ts
+++ b/packages/scripts/src/helpers/k8s-env/k8s.ts
@@ -215,6 +215,15 @@ export class K8s {
         }
 
         try {
+            const yamlServiceAccount = this.loadYamlFile('masterServiceAccount.yaml') as k8sClient.V1ServiceAccount;
+            const response = await this.k8sCoreV1Api
+                .createNamespacedServiceAccount(this.terasliceNamespace, yamlServiceAccount);
+            logger.debug('deployK8sTeraslice yamlmasterServiceAccount: ', response.body);
+        } catch (err) {
+            throw new Error(`Error creating ServiceAccount: ${err}`);
+        }
+
+        try {
             const yamlRole = this.loadYamlFile('role.yaml') as k8sClient.V1Role;
             const response = await this.k8sRbacAuthorizationV1Api
                 .createNamespacedRole(this.terasliceNamespace, yamlRole);

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
@@ -65,7 +65,7 @@ export class K8s {
     }
 
     /**
-     * Rerturns the first pod matching the provided selector after it has
+     * Returns the first pod matching the provided selector after it has
      * entered the `Running` state.
      *
      * TODO: Make more generic to search for different statuses


### PR DESCRIPTION
This PR makes the following changes:

- Assigns a new, dedicated and restricted kubernetes `role` to the Teraslice `master` pod, enhancing secure access control
- Removes the default `ServiceAccount` usage, which granted all pods in the namespace full access to the Kubernetes API
- Updated documentation to reflect changes

Ref to issue #3251