### PR TITLE
[teraslice] fix 'teraslice_version' and 'version' prom metrics labels

### DIFF
--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -658,11 +658,14 @@ export class ApiService {
      * @return {Promise<void>}
      */
     private async _updatePromMetrics() {
-        function extractVersionFromImageTag(imageTag: string): string {
-            // Define the version number regex pattern
-            const versionRegex = /(\d+\.\d+\.\d+)/;
-            const match = imageTag.match(versionRegex);
-            return match ? match[0] : 'Version number not available';
+        function extractVersionFromImage(image: string): string {
+            let version = '';
+
+            if (image.includes(':')) {
+                version = image.split(':')[1].split('_')[0];
+            }
+
+            return version;
         }
 
         const { terafoundation, teraslice } = this.context.sysconfig;
@@ -695,7 +698,7 @@ export class ApiService {
                                 name,
                                 node_version: process.version,
                                 platform: this.context.platform,
-                                teraslice_version: getPackageJSON().version
+                                teraslice_version: `v${getPackageJSON().version}`
                             },
                             1
                         );
@@ -880,7 +883,7 @@ export class ApiService {
                                             ex_id: worker.ex_id,
                                             job_id: worker.job_id,
                                             image: worker.image,
-                                            version: extractVersionFromImageTag(worker.image)
+                                            version: extractVersionFromImage(worker.image)
 
                                         };
                                         this.context.apis.foundation.promMetrics.set(

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -1214,7 +1214,8 @@ export class ExecutionController {
                     name: this.context.sysconfig.teraslice.name,
                     node_version: process.version,
                     platform: this.context.platform,
-                    teraslice_version: getPackageJSON().version
+                    teraslice_version: `v${getPackageJSON().version}`
+
                 },
                 1
             );

--- a/packages/teraslice/src/lib/workers/worker/index.ts
+++ b/packages/teraslice/src/lib/workers/worker/index.ts
@@ -451,7 +451,7 @@ export class Worker {
                     name: this.context.sysconfig.teraslice.name,
                     node_version: process.version,
                     platform: this.context.platform,
-                    teraslice_version: getPackageJSON().version
+                    teraslice_version: `v${getPackageJSON().version}`
                 },
                 1
             );


### PR DESCRIPTION
This PR makes the following changes to match the external prom-metrics exporter exactly:
- The `teraslice_version` label value should start with a `v`
- The `version` label should be the complete docker image tag unless there is an `_`. In that case the tag will be everything before the underscore.

ref: #3743 