### PR TITLE
Dependency update 2024-11-13

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -48,7 +48,7 @@
         "elasticsearch-store": "~1.4.0",
         "fs-extra": "~11.2.0",
         "ms": "~2.1.3",
-        "nanoid": "~5.0.7",
+        "nanoid": "~5.0.8",
         "semver": "~7.6.3",
         "signale": "~1.4.0",
         "uuid": "~10.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "test": "ts-scripts test"
     },
     "resolutions": {
-        "@types/lodash": "~4.17.7",
+        "@types/lodash": "~4.17.13",
         "debug": "~4.3.7",
         "ms": "~2.1.3",
         "nan": "~2.19.0"
@@ -56,7 +56,7 @@
         "@types/elasticsearch": "~5.0.43",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~29.5.14",
-        "@types/lodash": "~4.17.7",
+        "@types/lodash": "~4.17.13",
         "@types/node": "~18.14.2",
         "@types/uuid": "~10.0.0",
         "eslint": "~9.12.0",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -34,7 +34,7 @@
         "yargs": "~17.7.2"
     },
     "devDependencies": {
-        "@types/lodash": "~4.17.7",
+        "@types/lodash": "~4.17.13",
         "@types/yargs": "~17.0.33"
     },
     "engines": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -18,7 +18,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@eslint/compat": "~1.2.0",
+        "@eslint/compat": "~1.2.2",
         "@eslint/js": "~9.14.0",
         "@stylistic/eslint-plugin": "~2.9.0",
         "@types/eslint__js": "~8.42.3",
@@ -28,8 +28,8 @@
         "eslint-plugin-import": "~2.31.0",
         "eslint-plugin-jest": "~28.8.3",
         "eslint-plugin-jest-dom": "~5.4.0",
-        "eslint-plugin-jsx-a11y": "~6.10.0",
-        "eslint-plugin-react": "~7.37.1",
+        "eslint-plugin-jsx-a11y": "~6.10.2",
+        "eslint-plugin-react": "~7.37.2",
         "eslint-plugin-react-hooks": "~5.0.0",
         "eslint-plugin-testing-library": "~6.3.0",
         "globals": "~15.9.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -58,7 +58,7 @@
     },
     "devDependencies": {
         "@types/ip": "~1.1.3",
-        "@types/lodash": "~4.17.7",
+        "@types/lodash": "~4.17.13",
         "@types/micromatch": "~4.0.9",
         "@types/ms": "~0.7.34",
         "@types/semver": "~7.5.6",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -40,7 +40,7 @@
         "elasticsearch-store": "~1.4.0",
         "express": "~4.21.1",
         "js-yaml": "~4.1.0",
-        "nanoid": "~5.0.7",
+        "nanoid": "~5.0.8",
         "node-webhdfs": "~1.0.2",
         "prom-client": "~15.1.3",
         "yargs": "~17.7.2"

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -69,7 +69,7 @@
         "@types/yargs": "~17.0.33",
         "decompress": "~4.2.1",
         "jest-fixtures": "~0.6.0",
-        "nock": "~13.5.5"
+        "nock": "~13.5.6"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -38,7 +38,7 @@
         "got": "~13.0.0"
     },
     "devDependencies": {
-        "nock": "~13.5.5"
+        "nock": "~13.5.6"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -38,7 +38,7 @@
         "@terascope/types": "~1.3.0",
         "@terascope/utils": "~1.4.0",
         "ms": "~2.1.3",
-        "nanoid": "~5.0.7",
+        "nanoid": "~5.0.8",
         "p-event": "~6.0.1",
         "porty": "~3.1.1",
         "socket.io": "~1.7.4",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -58,7 +58,7 @@
         "kubernetes-client": "~9.0.0",
         "lodash": "~4.17.21",
         "ms": "~2.1.3",
-        "nanoid": "~5.0.7",
+        "nanoid": "~5.0.8",
         "porty": "~3.1.1",
         "semver": "~7.6.3",
         "socket.io": "~1.7.4",
@@ -77,7 +77,7 @@
         "convict-format-with-validator": "~6.2.0",
         "jest-fixtures": "~0.6.0",
         "js-yaml": "~4.1.0",
-        "nock": "~13.5.5"
+        "nock": "~13.5.6"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -42,7 +42,7 @@
         "awesome-phonenumber": "~7.2.0",
         "graphlib": "~2.1.8",
         "jexl": "~2.2.2",
-        "nanoid": "~5.0.7",
+        "nanoid": "~5.0.8",
         "valid-url": "~1.0.9",
         "validator": "~13.12.0",
         "yargs": "~17.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1042,10 +1042,10 @@
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.11.1.tgz#a547badfc719eb3e5f4b556325e542fbe9d7a18f"
   integrity sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==
 
-"@eslint/compat@~1.2.0":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@eslint/compat/-/compat-1.2.2.tgz#46d02898df7e32ccc04166b6ea2689c52dee10da"
-  integrity sha512-jhgiIrsw+tRfcBQ4BFl2C3vCrIUw2trCY0cnDvGZpwTtKCEDmZhAtMfrEUP/KpnwM6PrO0T+Ltm+ccW74olG3Q==
+"@eslint/compat@~1.2.2":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@eslint/compat/-/compat-1.2.3.tgz#9c9bb9dfc8502be84427237f15b005b6b8d60757"
+  integrity sha512-wlZhwlDFxkxIZ571aH0FoK4h4Vwx7P3HJx62Gp8hTc10bfpwT2x0nULuAHmQSJBOWPgPeVf+9YtnD4j50zVHmA==
 
 "@eslint/config-array@^0.18.0":
   version "0.18.0"
@@ -2739,7 +2739,7 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash@*", "@types/lodash@~4.17.7":
+"@types/lodash@*", "@types/lodash@~4.17.13":
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.13.tgz#786e2d67cfd95e32862143abe7463a7f90c300eb"
   integrity sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==
@@ -4951,7 +4951,7 @@ eslint-plugin-jest@~28.8.3:
   dependencies:
     "@typescript-eslint/utils" "^6.0.0 || ^7.0.0 || ^8.0.0"
 
-eslint-plugin-jsx-a11y@~6.10.0:
+eslint-plugin-jsx-a11y@~6.10.2:
   version "6.10.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz#d2812bb23bf1ab4665f1718ea442e8372e638483"
   integrity sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==
@@ -4977,7 +4977,7 @@ eslint-plugin-react-hooks@~5.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0.tgz#72e2eefbac4b694f5324154619fee44f5f60f101"
   integrity sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==
 
-eslint-plugin-react@~7.37.1:
+eslint-plugin-react@~7.37.2:
   version "7.37.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.37.2.tgz#cd0935987876ba2900df2f58339f6d92305acc7a"
   integrity sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==
@@ -7618,7 +7618,7 @@ nan@^2.14.0, nan@^2.18.0, nan@~2.19.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
   integrity sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==
 
-nanoid@~5.0.7:
+nanoid@~5.0.8:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.8.tgz#7610003f6b3b761b5c244bb342c112c5312512bf"
   integrity sha512-TcJPw+9RV9dibz1hHUzlLVy8N4X9TnwirAjrU08Juo6BNKggzVfP2ZJ/3ZUSq15Xl5i85i+Z89XBO90pB2PghQ==
@@ -7643,7 +7643,7 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-nock@~13.5.5:
+nock@~13.5.6:
   version "13.5.6"
   resolved "https://registry.yarnpkg.com/nock/-/nock-13.5.6.tgz#5e693ec2300bbf603b61dae6df0225673e6c4997"
   integrity sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==


### PR DESCRIPTION
This PR makes the following dependency updates: 

## Top level Teraslice 
- **@types/lodash** from `v4.17.7` to `v4.17.13`

## e2e
- **nanoid** from `v5.0.7` to `v5.0.8`

## data-types
- **@types/lodash** from `v4.17.7` to `v4.17.13`

## eslint-config
- **@eslint/compat** from `v1.2.0` to `v1.2.2`
- **eslint-plugin-jsx-a11y** from `v6.10.0` to `v6.10.2`
- **eslint-plugin-react** from `v7.37.1` to `v7.37.2`

## scripts
- **@types/lodash** from `v4.17.7` to `v4.17.13`

## terafoundation
- **nanoid** from `v5.0.7` to `v5.0.8`

## teraslice-cli
- **nock** from `v13.5.5` to `v13.5.6`

## teraslice-client-js
- **nock** from `v13.5.5` to `v13.5.6`

## teraslice-messaging 
- **nanoid** from `v5.0.7` to `v5.0.8`

## teraslice
- **nanoid** from `v5.0.7` to `v5.0.8`
- **nock** from `v13.5.5` to `v13.5.6`

## ts-transforms
- **nanoid** from `v5.0.7` to `v5.0.8`