### PR TITLE
[scripts] k8s-env automatically switches to es7 on Arm Macs obsolete 

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.0.0",
+    "version": "1.5.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:

## Scripts

### New features

- Introduces a check within `k8s-env` command that checks the host system’s architecture and the Elasticsearch version. If the host architecture matches ARM and the Elasticsearch version is 6.x, `k8s-env` will automatically switch the Elasticsearch version to `7.9.3` to ensure compatibility.

### Bumps

- @terascope/scripts from `v` to `v1.5.1`