### PR TITLE
[teraslice-messaging, teraslice] Add abortController for use with sendSliceComplete()

### DIFF
--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {

--- a/packages/teraslice-messaging/src/messenger/client.ts
+++ b/packages/teraslice-messaging/src/messenger/client.ts
@@ -278,7 +278,7 @@ export class Client extends Core {
             respondBy,
         };
 
-        const responseMsg = this.handleSendResponse(message);
+        const responseMsg = this.handleSendResponse(message, options.signal);
         this.socket.emit(eventName, message);
         return responseMsg;
     }

--- a/packages/teraslice-messaging/src/messenger/core.ts
+++ b/packages/teraslice-messaging/src/messenger/core.ts
@@ -2,7 +2,7 @@ import ms from 'ms';
 import { pEvent } from 'p-event';
 import { EventEmitter } from 'node:events';
 import {
-    toString, isInteger, debugLogger, Logger
+    toString, isInteger, debugLogger, Logger, TSError
 } from '@terascope/utils';
 import * as i from './interfaces.js';
 
@@ -51,7 +51,10 @@ export class Core extends EventEmitter {
 
         // server shutdown
         if (signal?.aborted) {
-            throw new Error(`Messaging server shutdown before responding to message "${sent.eventName}"`);
+            const msg = sent.eventName === 'worker:slice:complete'
+                ? `Execution controller shutdown before receiving worker slice analytics. Event: "${sent.eventName}"`
+                : `Execution controller shutdown before receiving "${sent.eventName}" event`;
+            throw new TSError(msg, { retryable: false });
         }
 
         // it is a timeout

--- a/packages/teraslice-messaging/src/messenger/core.ts
+++ b/packages/teraslice-messaging/src/messenger/core.ts
@@ -2,7 +2,8 @@ import ms from 'ms';
 import { pEvent } from 'p-event';
 import { EventEmitter } from 'node:events';
 import {
-    toString, isInteger, debugLogger, Logger, TSError
+    toString, isInteger, debugLogger,
+    Logger, TSError
 } from '@terascope/utils';
 import * as i from './interfaces.js';
 

--- a/packages/teraslice-messaging/src/messenger/interfaces.ts
+++ b/packages/teraslice-messaging/src/messenger/interfaces.ts
@@ -57,6 +57,7 @@ export interface SendOptions {
     volatile?: boolean;
     response?: boolean;
     timeout?: number;
+    signal?: AbortSignal;
 }
 
 export interface ConnectedClient {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -41,7 +41,7 @@
         "@kubernetes/client-node": "~0.22.0",
         "@terascope/elasticsearch-api": "~4.4.0",
         "@terascope/job-components": "~1.6.0",
-        "@terascope/teraslice-messaging": "~1.7.0",
+        "@terascope/teraslice-messaging": "~1.7.1",
         "@terascope/types": "~1.3.0",
         "@terascope/utils": "~1.4.0",
         "async-mutex": "~0.5.0",

--- a/packages/teraslice/src/lib/workers/worker/index.ts
+++ b/packages/teraslice/src/lib/workers/worker/index.ts
@@ -349,6 +349,9 @@ export class Worker {
             } catch (err) {
                 if (this.isShuttingDown) {
                     throw err;
+                } else if (err.retryable === false) {
+                    this.logger.warn(`${err}, will not retry.`);
+                    return true;
                 } else {
                     this.logger.warn(err);
                 }


### PR DESCRIPTION
This PR makes the following changes:
- The execution-controller `Client` now creates an `abortController`. Every call to `Client.sendSliceComplete()` now includes a reference to `abortController.signal` allowing for the `pEvent` in the messenger `Core.onceWithTimeout()` to be aborted.
- A new listener is added for the `server:shutdown` event that calls `abortController.abort()`. This prevents a worker from still waiting for a response to `sendSliceComplete()` after the server is shutdown.
- bump teraslice-messaging from 1.7.0 to 1.7.1

ref: #2106