### PR TITLE
release: (patch) Teraslice v2.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:

- Bumps Teraslice from `v2.9.0` to `v2.9.1`
  - This release is issued because of an update to the base image that bumped `terafoundation-kafka-connector`