### PR TITLE
[ci, scripts] Remove duplicate unused unit tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,32 +78,6 @@ jobs:
       - name: Test
         run: yarn --silent test -- --suite unit --
 
-  linux-unit-esm-tests:
-    runs-on: ubuntu-latest
-    needs: compute-node-version-vars
-    strategy:
-      matrix:
-        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-
-      - name: Install and build packages
-        run: yarn setup
-        env:
-          YARN_SETUP_ARGS: "--prod=false --silent"
-
-      - name: Test
-        run: yarn --silent test -- --suite unit-esm --
-        env:
-          NODE_OPTIONS: '--experimental-vm-modules'
-
   teraslice-elasticsearch-tests:
     runs-on: ubuntu-latest
     needs: [compute-node-version-vars, verify-build, cache-docker-images]

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
                 "search": [],
                 "restrained": [],
                 "unit": [],
-                "unit-esm": [],
                 "_for_testing_": [
                     "elasticsearch"
                 ],

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -66,6 +66,6 @@
     "srcMain": "src/index.ts",
     "terascope": {
         "enableTypedoc": true,
-        "testSuite": "unit-esm"
+        "testSuite": "unit"
     }
 }

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -48,6 +48,6 @@
     "srcMain": "src/index.ts",
     "terascope": {
         "enableTypedoc": true,
-        "testSuite": "unit-esm"
+        "testSuite": "unit"
     }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -46,6 +46,6 @@
     },
     "terascope": {
         "enableTypedoc": false,
-        "testSuite": "unit-esm"
+        "testSuite": "unit"
     }
 }

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -58,6 +58,6 @@
     "srcMain": "src/index.ts",
     "terascope": {
         "enableTypedoc": true,
-        "testSuite": "unit-esm"
+        "testSuite": "unit"
     }
 }

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -84,6 +84,6 @@
     "srcMain": "src/index.ts",
     "terascope": {
         "enableTypedoc": false,
-        "testSuite": "unit-esm"
+        "testSuite": "unit"
     }
 }

--- a/packages/scripts/test/test-runner-spec.ts
+++ b/packages/scripts/test/test-runner-spec.ts
@@ -85,14 +85,8 @@ describe('Test Runner Helpers', () => {
                     suite: ['unit']
                 }));
 
-                const unitEsmTests = filterBySuite(packages, makeTestOptions({
-                    all: true,
-                    suite: ['unit-esm']
-                }));
-
                 const unitAndESPackages = [
                     ...unitTests,
-                    ...unitEsmTests,
                     ...restrainedTests,
                     ...opensearchTests,
                     ...elasticsearchTests

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -62,6 +62,6 @@
     },
     "terascope": {
         "enableTypedoc": true,
-        "testSuite": "unit-esm"
+        "testSuite": "unit"
     }
 }

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -89,7 +89,7 @@
     },
     "srcMain": "src/index.ts",
     "terascope": {
-        "testSuite": "unit-esm",
+        "testSuite": "unit",
         "enableTypedoc": true
     }
 }

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -51,6 +51,6 @@
     "srcMain": "src/index.ts",
     "terascope": {
         "enableTypedoc": true,
-        "testSuite": "unit-esm"
+        "testSuite": "unit"
     }
 }

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -60,6 +60,6 @@
     "srcMain": "src/index.ts",
     "terascope": {
         "enableTypedoc": true,
-        "testSuite": "unit-esm"
+        "testSuite": "unit"
     }
 }

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -38,6 +38,6 @@
     "srcMain": "src/index.ts",
     "terascope": {
         "enableTypedoc": true,
-        "testSuite": "unit-esm"
+        "testSuite": "unit"
     }
 }

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -52,6 +52,6 @@
     "srcMain": "src/index.ts",
     "terascope": {
         "enableTypedoc": true,
-        "testSuite": "unit-esm"
+        "testSuite": "unit"
     }
 }

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -66,6 +66,6 @@
     "srcMain": "src/index.ts",
     "terascope": {
         "enableTypedoc": true,
-        "testSuite": "unit-esm"
+        "testSuite": "unit"
     }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -84,6 +84,6 @@
     "srcMain": "src/index.ts",
     "terascope": {
         "enableTypedoc": true,
-        "testSuite": "unit-esm"
+        "testSuite": "unit"
     }
 }

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -53,6 +53,6 @@
     "srcMain": "src/index.ts",
     "terascope": {
         "enableTypedoc": true,
-        "testSuite": "unit-esm"
+        "testSuite": "unit"
     }
 }

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -48,6 +48,6 @@
     "srcMain": "src/index.ts",
     "terascope": {
         "enableTypedoc": true,
-        "testSuite": "unit-esm"
+        "testSuite": "unit"
     }
 }

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -39,7 +39,7 @@
     },
     "srcMain": "src/index.ts",
     "terascope": {
-        "testSuite": "unit-esm",
+        "testSuite": "unit",
         "enableTypedoc": true
     }
 }


### PR DESCRIPTION
This PR makes the following changes:

- Migrates all unit tests from `unit-esm` back to `unit`
- Removes `linux-unit-esm-tests` from ci
  - This is no longer needed because all tests have been migrated to `linux-unit-tests` 

Ref to issue #3858