### PR TITLE
[teraslice] fix serial job starts in kubernetesV2

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -45,7 +45,7 @@
     "devDependencies": {
         "@terascope/types": "~1.3.1",
         "bunyan": "~1.8.15",
-        "elasticsearch-store": "~1.4.2",
+        "elasticsearch-store": "~1.4.3",
         "fs-extra": "~11.2.0",
         "ms": "~2.1.3",
         "nanoid": "~5.0.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.9.1",
+    "version": "2.9.2",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -30,9 +30,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "~1.4.1",
+        "@terascope/data-types": "~1.4.2",
         "@terascope/types": "~1.3.1",
-        "@terascope/utils": "~1.4.1",
+        "@terascope/utils": "~1.4.2",
         "@types/validator": "~13.12.2",
         "awesome-phonenumber": "~7.2.0",
         "date-fns": "~4.1.0",
@@ -46,7 +46,7 @@
         "uuid": "~11.0.3",
         "valid-url": "~1.0.9",
         "validator": "~13.12.0",
-        "xlucene-parser": "~1.4.2"
+        "xlucene-parser": "~1.4.3"
     },
     "devDependencies": {
         "@types/ip6addr": "~0.2.6",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.3.1",
-        "@terascope/utils": "~1.4.1",
+        "@terascope/utils": "~1.4.2",
         "graphql": "~16.9.0",
         "lodash": "~4.17.21",
         "yargs": "~17.7.2"

--- a/packages/docker-compose-js/package.json
+++ b/packages/docker-compose-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/docker-compose-js",
     "displayName": "Docker Compose Js",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "Node.js driver for controlling docker-compose testing environments.",
     "keywords": [
         "docker",

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "4.4.1",
+    "version": "4.4.2",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -25,7 +25,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.3.1",
-        "@terascope/utils": "~1.4.1",
+        "@terascope/utils": "~1.4.2",
         "bluebird": "~3.7.2",
         "setimmediate": "~1.0.5"
     },
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "~1.2.0",
         "@types/elasticsearch": "~5.0.43",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.4.2",
+        "elasticsearch-store": "~1.4.3",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@~7.17.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@~8.15.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,10 +30,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.4.2",
-        "@terascope/data-types": "~1.4.1",
+        "@terascope/data-mate": "~1.4.3",
+        "@terascope/data-types": "~1.4.2",
         "@terascope/types": "~1.3.1",
-        "@terascope/utils": "~1.4.1",
+        "@terascope/utils": "~1.4.2",
         "ajv": "~8.17.1",
         "ajv-formats": "~3.0.1",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
@@ -43,7 +43,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@~2.12.0",
         "setimmediate": "~1.0.5",
         "uuid": "~11.0.3",
-        "xlucene-translator": "~1.4.2"
+        "xlucene-translator": "~1.4.3"
     },
     "devDependencies": {
         "@types/uuid": "~10.0.0"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/eslint-config",
     "displayName": "Terascope ESLint Config",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "A shared eslint config based on eslint-config-airbnb",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/eslint-config#readme",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.3.1",
-        "@terascope/utils": "~1.4.1",
+        "@terascope/utils": "~1.4.2",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
-        "@terascope/utils": "~1.4.1",
+        "@terascope/utils": "~1.4.2",
         "codecov": "~3.8.3",
         "execa": "~9.5.2",
         "fs-extra": "~11.2.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -30,14 +30,14 @@
     "dependencies": {
         "@terascope/file-asset-apis": "~1.0.3",
         "@terascope/types": "~1.3.1",
-        "@terascope/utils": "~1.4.1",
+        "@terascope/utils": "~1.4.2",
         "bluebird": "~3.7.2",
         "bunyan": "~1.8.15",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.4.2",
+        "elasticsearch-store": "~1.4.3",
         "express": "~4.21.2",
         "js-yaml": "~4.1.0",
         "nanoid": "~5.0.9",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -43,7 +43,7 @@
     "devDependencies": {
         "@terascope/fetch-github-release": "~1.0.0",
         "@terascope/types": "~1.3.1",
-        "@terascope/utils": "~1.4.1",
+        "@terascope/utils": "~1.4.2",
         "@types/decompress": "~4.2.7",
         "@types/diff": "~6.0.0",
         "@types/ejs": "~3.1.5",
@@ -67,7 +67,7 @@
         "pretty-bytes": "~6.1.1",
         "prompts": "~2.4.2",
         "signale": "~1.4.0",
-        "teraslice-client-js": "~1.4.1",
+        "teraslice-client-js": "~1.4.2",
         "tmp": "~0.2.0",
         "tty-table": "~4.2.3",
         "yargs": "~17.7.2"

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.3.1",
-        "@terascope/utils": "~1.4.1",
+        "@terascope/utils": "~1.4.2",
         "auto-bind": "~5.0.1",
         "got": "~13.0.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.3.1",
-        "@terascope/utils": "~1.4.1",
+        "@terascope/utils": "~1.4.2",
         "ms": "~2.1.3",
         "nanoid": "~5.0.9",
         "p-event": "~6.0.1",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -24,8 +24,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "~4.4.1",
-        "@terascope/utils": "~1.4.1"
+        "@terascope/elasticsearch-api": "~4.4.2",
+        "@terascope/utils": "~1.4.2"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "~11.2.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "~1.6.2"
+        "@terascope/job-components": "~1.6.3"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=1.6.2"
+        "@terascope/job-components": ">=1.6.3"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.9.1",
+    "version": "2.9.2",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -39,11 +39,11 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
-        "@terascope/elasticsearch-api": "~4.4.1",
-        "@terascope/job-components": "~1.6.2",
-        "@terascope/teraslice-messaging": "~1.7.1",
+        "@terascope/elasticsearch-api": "~4.4.2",
+        "@terascope/job-components": "~1.6.3",
+        "@terascope/teraslice-messaging": "~1.7.2",
         "@terascope/types": "~1.3.1",
-        "@terascope/utils": "~1.4.1",
+        "@terascope/utils": "~1.4.2",
         "async-mutex": "~0.5.0",
         "barbe": "~3.0.16",
         "body-parser": "~1.20.2",
@@ -63,7 +63,7 @@
         "semver": "~7.6.3",
         "socket.io": "~1.7.4",
         "socket.io-client": "~1.7.4",
-        "terafoundation": "~1.6.2",
+        "terafoundation": "~1.6.3",
         "uuid": "~11.0.3"
     },
     "devDependencies": {

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/index.ts
@@ -189,14 +189,6 @@ export class KubernetesClusterBackendV2 {
             () => this.k8s.nonEmptyJobList(selector), getRetryConfig()
         );
 
-        /// Wait for ex readiness probe to return 'Ready'
-        await this.k8s.waitForSelectedPod(
-            selector,
-            'readiness-probe',
-            undefined,
-            this.context.sysconfig.teraslice.slicer_timeout
-        );
-
         if (!jobs.items[0].metadata.uid) {
             throw new Error('Required field uid missing from kubernetes job metadata');
         }

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/index.ts
@@ -138,32 +138,6 @@ export class KubernetesClusterBackendV2 {
 
         this.logger.debug(jobResult, 'k8s slicer job submitted');
 
-        if (!jobResult.spec.selector?.matchLabels) {
-            throw new Error('Required field matchLabels missing from jobResult.spec.selector');
-        }
-
-        let controllerLabel: string;
-        if (jobResult.spec.selector.matchLabels['controller-uid'] !== undefined) {
-            /// If running on kubernetes < v1.27.0
-            controllerLabel = 'controller-uid';
-        } else {
-            /// If running on kubernetes v1.27.0 or later
-            controllerLabel = 'batch.kubernetes.io/controller-uid';
-        }
-
-        const controllerUid = jobResult.spec.selector.matchLabels[controllerLabel];
-
-        const pod = await this.k8s.waitForSelectedPod(
-            `${controllerLabel}=${controllerUid}`,
-            'pod-status',
-            undefined,
-            this.context.sysconfig.teraslice.slicer_timeout
-        );
-
-        if (!pod.status?.podIP) {
-            const error = new Error('pod.status.podIP must be defined');
-            return Promise.reject(error);
-        }
         const exServiceName = serviceResult.metadata.name;
         const exServiceHostName = `${exServiceName}.${this.k8s.defaultNamespace}`;
         this.logger.debug(`Slicer is using host name: ${exServiceHostName}`);

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -36,9 +36,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.4.2",
+        "@terascope/data-mate": "~1.4.3",
         "@terascope/types": "~1.3.1",
-        "@terascope/utils": "~1.4.1",
+        "@terascope/utils": "~1.4.2",
         "awesome-phonenumber": "~7.2.0",
         "graphlib": "~2.1.8",
         "jexl": "~2.3.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.3.1",
-        "@terascope/utils": "~1.4.1",
+        "@terascope/utils": "~1.4.2",
         "peggy": "~4.2.0",
         "ts-pegjs": "~4.2.1"
     },

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -30,9 +30,9 @@
     },
     "dependencies": {
         "@terascope/types": "~1.3.1",
-        "@terascope/utils": "~1.4.1",
+        "@terascope/utils": "~1.4.2",
         "@types/elasticsearch": "~5.0.43",
-        "xlucene-parser": "~1.4.2"
+        "xlucene-parser": "~1.4.3"
     },
     "devDependencies": {
         "elasticsearch": "~15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "~1.4.1"
+        "@terascope/utils": "~1.4.2"
     },
     "devDependencies": {
         "@terascope/types": "~1.3.1"


### PR DESCRIPTION
This PR makes the following changes:
- Remove the call to `k8s.waitForSelectedPod()` in `allocateWorkers()`, which was waiting for the executionController readiness probe to be ready before creating a worker deployment.
- Remove all code related to getting the `podIP` from `allocateSlicer()` as it is not needed since we now connect to the executionController using a kubernetes service.
- Bump teraslice from v2.9.1 to v2.9.2

ref: #3868 
