### PR TITLE
[scripts] Add tmpfs option to opensearch testing

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -83,8 +83,8 @@ const services: Readonly<Record<Service, Readonly<DockerRunOptions>>> = {
         image: config.OPENSEARCH_DOCKER_IMAGE,
         name: `${config.TEST_NAMESPACE}_${config.OPENSEARCH_NAME}`,
         tmpfs: config.SERVICES_USE_TMPFS
-        ? ['/usr/share/opensearch/data:uid=1000,gid=1000']
-        : undefined,
+            ? ['/usr/share/opensearch/data:uid=1000,gid=1000']
+            : undefined,
         ports: [`${config.OPENSEARCH_PORT}:${config.OPENSEARCH_PORT}`],
         env: {
             OPENSEARCH_JAVA_OPTS: config.SERVICE_HEAP_OPTS,

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -70,7 +70,7 @@ const services: Readonly<Record<Service, Readonly<DockerRunOptions>>> = {
         name: `${config.TEST_NAMESPACE}_${config.OPENSEARCH_NAME}`,
         ports: [`${config.RESTRAINED_OPENSEARCH_PORT}:${config.RESTRAINED_OPENSEARCH_PORT}`],
         env: {
-            ES_JAVA_OPTS: config.SERVICE_HEAP_OPTS,
+            OPENSEARCH_JAVA_OPTS: config.SERVICE_HEAP_OPTS,
             'network.host': '0.0.0.0',
             'http.port': config.RESTRAINED_OPENSEARCH_PORT,
             'discovery.type': 'single-node',

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -83,6 +83,9 @@ const services: Readonly<Record<Service, Readonly<DockerRunOptions>>> = {
         image: config.OPENSEARCH_DOCKER_IMAGE,
         name: `${config.TEST_NAMESPACE}_${config.OPENSEARCH_NAME}`,
         ports: [`${config.OPENSEARCH_PORT}:${config.OPENSEARCH_PORT}`],
+        tmpfs: config.SERVICES_USE_TMPFS
+            ? ['/usr/share/elasticsearch/data']
+            : undefined,
         env: {
             ES_JAVA_OPTS: config.SERVICE_HEAP_OPTS,
             'network.host': '0.0.0.0',

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -84,7 +84,7 @@ const services: Readonly<Record<Service, Readonly<DockerRunOptions>>> = {
         name: `${config.TEST_NAMESPACE}_${config.OPENSEARCH_NAME}`,
         ports: [`${config.OPENSEARCH_PORT}:${config.OPENSEARCH_PORT}`],
         tmpfs: config.SERVICES_USE_TMPFS
-            ? ['/usr/share/elasticsearch/data']
+            ? ['/usr/share/opensearch/data']
             : undefined,
         env: {
             ES_JAVA_OPTS: config.SERVICE_HEAP_OPTS,

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -84,7 +84,7 @@ const services: Readonly<Record<Service, Readonly<DockerRunOptions>>> = {
         name: `${config.TEST_NAMESPACE}_${config.OPENSEARCH_NAME}`,
         ports: [`${config.OPENSEARCH_PORT}:${config.OPENSEARCH_PORT}`],
         tmpfs: config.SERVICES_USE_TMPFS
-            ? ['/usr/share/opensearch/data:uid=1000,gid=1000’']
+            ? ['/usr/share/opensearch/data:uid=1000,gid=1000']
             : undefined,
         env: {
             ES_JAVA_OPTS: config.SERVICE_HEAP_OPTS,

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -87,7 +87,7 @@ const services: Readonly<Record<Service, Readonly<DockerRunOptions>>> = {
             ? ['/usr/share/opensearch/data:uid=1000,gid=1000']
             : undefined,
         env: {
-            ES_JAVA_OPTS: config.SERVICE_HEAP_OPTS,
+            OPENSEARCH_JAVA_OPTS: config.SERVICE_HEAP_OPTS,
             'network.host': '0.0.0.0',
             'http.port': config.OPENSEARCH_PORT,
             'discovery.type': 'single-node',

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -82,10 +82,10 @@ const services: Readonly<Record<Service, Readonly<DockerRunOptions>>> = {
     [Service.Opensearch]: {
         image: config.OPENSEARCH_DOCKER_IMAGE,
         name: `${config.TEST_NAMESPACE}_${config.OPENSEARCH_NAME}`,
-        ports: [`${config.OPENSEARCH_PORT}:${config.OPENSEARCH_PORT}`],
         tmpfs: config.SERVICES_USE_TMPFS
-            ? ['/usr/share/opensearch/data:uid=1000,gid=1000']
-            : undefined,
+        ? ['/usr/share/opensearch/data:uid=1000,gid=1000']
+        : undefined,
+        ports: [`${config.OPENSEARCH_PORT}:${config.OPENSEARCH_PORT}`],
         env: {
             OPENSEARCH_JAVA_OPTS: config.SERVICE_HEAP_OPTS,
             'network.host': '0.0.0.0',

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -84,7 +84,7 @@ const services: Readonly<Record<Service, Readonly<DockerRunOptions>>> = {
         name: `${config.TEST_NAMESPACE}_${config.OPENSEARCH_NAME}`,
         ports: [`${config.OPENSEARCH_PORT}:${config.OPENSEARCH_PORT}`],
         tmpfs: config.SERVICES_USE_TMPFS
-            ? ['/usr/share/opensearch/data']
+            ? ['/usr/share/opensearch/data:uid=1000,gid=1000’']
             : undefined,
         env: {
             ES_JAVA_OPTS: config.SERVICE_HEAP_OPTS,


### PR DESCRIPTION
This PR makes the following changes:

- Adds `tmpfs` option to opensearch testing in `ts-scripts`
- Bumps `@terascope/scripts` from `v1.7.0` to `v1.7.1`