### PR TITLE
[all] Update to TypeScript v5.7.2, remove "suppressImplicitAnyIndexErrors" rule

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -43,9 +43,9 @@
         "ms": "~2.1.3"
     },
     "devDependencies": {
-        "@terascope/types": "~1.3.2",
+        "@terascope/types": "~1.4.0",
         "bunyan": "~1.8.15",
-        "elasticsearch-store": "~1.6.0",
+        "elasticsearch-store": "~1.7.0",
         "fs-extra": "~11.2.0",
         "ms": "~2.1.3",
         "nanoid": "~5.0.9",

--- a/package.json
+++ b/package.json
@@ -67,10 +67,10 @@
         "jest-extended": "~4.0.2",
         "jest-watch-typeahead": "~2.2.2",
         "node-notifier": "~10.0.1",
-        "patch-package": "^8.0.0",
-        "postinstall-postinstall": "^2.1.0",
+        "patch-package": "~8.0.0",
+        "postinstall-postinstall": "~2.1.0",
         "ts-jest": "~29.2.5",
-        "typescript": "~5.2.2"
+        "typescript": "~5.7.2"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.10.0",
+    "version": "2.11.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -30,9 +30,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-types": "~1.6.0",
-        "@terascope/types": "~1.3.2",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/data-types": "~1.7.0",
+        "@terascope/types": "~1.4.0",
+        "@terascope/utils": "~1.7.0",
         "@types/validator": "~13.12.2",
         "awesome-phonenumber": "~7.2.0",
         "date-fns": "~4.1.0",
@@ -45,7 +45,7 @@
         "uuid": "~11.0.3",
         "valid-url": "~1.0.9",
         "validator": "~13.12.0",
-        "xlucene-parser": "~1.6.0"
+        "xlucene-parser": "~1.7.0"
     },
     "devDependencies": {
         "@types/ip6addr": "~0.2.6",

--- a/packages/data-mate/src/index.ts
+++ b/packages/data-mate/src/index.ts
@@ -29,6 +29,7 @@ declare module './aggregation-frame/AggregationFrame.d.ts' {
          * @returns the new columns
         */
         run(): Promise<DataFrame<T>>;
+        [key: string]: any; // fixMe: make sure this is okay
     }
 }
 
@@ -57,7 +58,7 @@ AggregationFrame.prototype.run = async function run() {
 const aggregationFrameMethods = Reflect.ownKeys(AggregationFrame.prototype);
 for (const dataFrameMethod of Reflect.ownKeys(DataFrame.prototype)) {
     if (!aggregationFrameMethods.includes(dataFrameMethod)) {
-        AggregationFrame.prototype[dataFrameMethod] = () => {
+        AggregationFrame.prototype[dataFrameMethod as keyof AggregationFrame<any>] = () => {
             throw new Error(
                 `Unsupported method on ${String(dataFrameMethod)} AggregationFrame.
 Use it before DataFrame.aggregate or after AggregationFrame.run()`

--- a/packages/data-mate/src/index.ts
+++ b/packages/data-mate/src/index.ts
@@ -29,7 +29,7 @@ declare module './aggregation-frame/AggregationFrame.d.ts' {
          * @returns the new columns
         */
         run(): Promise<DataFrame<T>>;
-        [key: string]: any; // fixMe: make sure this is okay
+        [key: string | symbol]: unknown;
     }
 }
 
@@ -58,7 +58,7 @@ AggregationFrame.prototype.run = async function run() {
 const aggregationFrameMethods = Reflect.ownKeys(AggregationFrame.prototype);
 for (const dataFrameMethod of Reflect.ownKeys(DataFrame.prototype)) {
     if (!aggregationFrameMethods.includes(dataFrameMethod)) {
-        AggregationFrame.prototype[dataFrameMethod as keyof AggregationFrame<any>] = () => {
+        AggregationFrame.prototype[dataFrameMethod] = () => {
             throw new Error(
                 `Unsupported method on ${String(dataFrameMethod)} AggregationFrame.
 Use it before DataFrame.aggregate or after AggregationFrame.run()`

--- a/packages/data-mate/tsconfig.json
+++ b/packages/data-mate/tsconfig.json
@@ -2,8 +2,7 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": ".",
-        "suppressImplicitAnyIndexErrors": false
+        "rootDir": "."
     },
     "include": ["src", "test"]
 }

--- a/packages/data-mate/tsconfig.json
+++ b/packages/data-mate/tsconfig.json
@@ -2,7 +2,8 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": "."
+        "rootDir": ".",
+        "suppressImplicitAnyIndexErrors": false
     },
     "include": ["src", "test"]
 }

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -27,8 +27,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "~1.3.2",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/types": "~1.4.0",
+        "@terascope/utils": "~1.7.0",
         "graphql": "~16.9.0",
         "yargs": "~17.7.2"
     },

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "4.6.0",
+    "version": "4.7.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -24,8 +24,8 @@
         "test:watch": "TEST_RESTRAINED_ELASTICSEARCH='true' ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "~1.3.2",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/types": "~1.4.0",
+        "@terascope/utils": "~1.7.0",
         "bluebird": "~3.7.2",
         "setimmediate": "~1.0.5"
     },
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "~1.2.0",
         "@types/elasticsearch": "~5.0.43",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.6.0",
+        "elasticsearch-store": "~1.7.0",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@~7.17.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@~8.15.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,10 +30,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.6.0",
-        "@terascope/data-types": "~1.6.0",
-        "@terascope/types": "~1.3.2",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/data-mate": "~1.7.0",
+        "@terascope/data-types": "~1.7.0",
+        "@terascope/types": "~1.4.0",
+        "@terascope/utils": "~1.7.0",
         "ajv": "~8.17.1",
         "ajv-formats": "~3.0.1",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
@@ -43,7 +43,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@~2.12.0",
         "setimmediate": "~1.0.5",
         "uuid": "~11.0.3",
-        "xlucene-translator": "~1.6.0"
+        "xlucene-translator": "~1.7.0"
     },
     "devDependencies": {
         "@types/uuid": "~10.0.0"

--- a/packages/elasticsearch-store/src/elasticsearch-client/method-helpers/search.ts
+++ b/packages/elasticsearch-store/src/elasticsearch-client/method-helpers/search.ts
@@ -41,7 +41,7 @@ export function convertSearchParams(
 }
 
 function qDependentFieldsCheck(params: ClientParams.SearchParams) {
-    const requiresQ = [
+    const requiresQ: Array<keyof ClientParams.SearchParams> = [
         'analyzer',
         'analyze_wildcard',
         'default_operator',

--- a/packages/elasticsearch-store/src/index-model.ts
+++ b/packages/elasticsearch-store/src/index-model.ts
@@ -227,7 +227,7 @@ export abstract class IndexModel<T extends i.IndexModelRecord> extends IndexStor
             const entries = Object.entries(this._sanitizeFields);
 
             for (const [field, method] of entries) {
-                if (isKey(record, field)) {
+                if (isKey(record, field) && record[field]) {
                     switch (method) {
                         case 'trim':
                             this._setStringValueOrThrow(

--- a/packages/elasticsearch-store/src/interfaces.ts
+++ b/packages/elasticsearch-store/src/interfaces.ts
@@ -245,7 +245,7 @@ export type IndexModelConfig<T extends IndexModelRecord> = Omit<
     unique_fields?: (keyof T)[];
 
     /** Sanitize / cleanup fields mapping, like trim or trimAndToLower */
-    sanitize_fields?: SanitizeFields;
+    sanitize_fields?: SanitizeFields<T>;
 
     /** Specify whether the data should be strictly validated, defaults to true */
     strict_mode?: boolean;
@@ -256,8 +256,8 @@ export type IndexModelConfig<T extends IndexModelRecord> = Omit<
     timeseries?: boolean;
 };
 
-export type SanitizeFields = {
-    [field: string]: 'trimAndToLower' | 'trim' | 'toSafeString';
+export type SanitizeFields<T> = {
+    [field in string & keyof T]: 'trimAndToLower' | 'trim' | 'toSafeString';
 };
 
 /**

--- a/packages/elasticsearch-store/src/utils/elasticsearch.ts
+++ b/packages/elasticsearch-store/src/utils/elasticsearch.ts
@@ -246,7 +246,7 @@ export type FlattenProperties = Record<string, [type: ESFieldType, extra?: strin
 export function getFlattenedNamesAndTypes(config: ESTypeMapping): FlattenProperties {
     const output: FlattenProperties = Object.create(null);
     for (const field of Object.keys(config).sort()) {
-        const { type: _type, properties, ...extra } = config[field];
+        const { type: _type, properties, ...extra } = config[field as keyof ESTypeMapping];
 
         // if there is no type, elasticsearch returns "undefined" for the type
         // but this will cause conflicts, we should set it to "object"

--- a/packages/elasticsearch-store/src/utils/model.ts
+++ b/packages/elasticsearch-store/src/utils/model.ts
@@ -2,7 +2,8 @@ import { FieldType, DataTypeFields } from '@terascope/types';
 import { DataType, LATEST_VERSION } from '@terascope/data-types';
 import {
     cloneDeep, isPlainObject, concat,
-    getWordParts, firstToUpper, isNumberLike
+    getWordParts, firstToUpper, isNumberLike,
+    isKey
 } from '@terascope/utils';
 
 /** JSON Schema */
@@ -57,18 +58,18 @@ export function addDefaultSchema(input: Record<string, any>): Record<string, any
 /**
  * Deep copy two levels deep (useful for mapping and schema)
  */
-export function mergeDefaults<T>(source: T, from: Partial<T>): T {
+export function mergeDefaults<T extends object>(source: T, from: Partial<T>): T {
     const output = cloneDeep(source);
     const _mapping = from ? cloneDeep(from) : {};
 
     for (const [key, val] of Object.entries(_mapping)) {
-        if (output[key] != null) {
+        if (isKey(output, key)) {
             if (isPlainObject(val)) {
-                output[key] = Object.assign(output[key], val);
+                output[key] = Object.assign(output[key] as object, val) as T[string & keyof T];
             } else if (Array.isArray(val)) {
-                output[key] = concat(output[key], val);
+                output[key] = concat(output[key], val) as T[string & keyof T];
             } else {
-                output[key] = val;
+                output[key] = val as T[string & keyof T];
             }
         }
     }

--- a/packages/elasticsearch-store/src/utils/model.ts
+++ b/packages/elasticsearch-store/src/utils/model.ts
@@ -63,9 +63,9 @@ export function mergeDefaults<T extends object>(source: T, from: Partial<T>): T 
     const _mapping = from ? cloneDeep(from) : {};
 
     for (const [key, val] of Object.entries(_mapping)) {
-        if (isKey(output, key)) {
+        if (isKey(output, key) && output[key] != null) {
             if (isPlainObject(val)) {
-                output[key] = Object.assign(output[key] as object, val) as T[string & keyof T];
+                output[key] = Object.assign(output[key], val);
             } else if (Array.isArray(val)) {
                 output[key] = concat(output[key], val) as T[string & keyof T];
             } else {

--- a/packages/elasticsearch-store/test/index-manager-index-setup-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-index-setup-spec.ts
@@ -162,10 +162,6 @@ describe('IndexManager->indexSetup()', () => {
                 it('should have the previous the index metadata since removed fields shouldn\'t break', async () => {
                     const mapping = await indexManager.getMapping(index);
 
-                    // const properties = esVersion === 6
-                    //     ? mapping[index].mappings[config.name].properties
-                    //     : mapping[index].mappings.properties;
-
                     let properties = undefined;
                     const { mappings } = mapping[index];
                     if (esVersion === 6) {
@@ -264,7 +260,7 @@ describe('IndexManager->indexSetup()', () => {
                 expect(
                     isKey(mapping[index].mappings, config.name)
                     && mapping[index].mappings[config.name]
-                ).toHaveProperty('_meta', { foo: 'foo' });
+                ).toHaveProperty('_meta', { bar: 'bar' });
             } else {
                 expect(mapping[index].mappings).toHaveProperty('_meta', { bar: 'bar' });
             }
@@ -361,7 +357,7 @@ describe('IndexManager->indexSetup()', () => {
                 expect(
                     isKey(newIdxMapping.foobar.mappings, config.name)
                     && newIdxMapping.foobar.mappings[config.name]
-                ).toHaveProperty('_meta', { foo: 'foo' });
+                ).toHaveProperty('_meta', { baz: 'baz' });
             } else {
                 expect(newIdxMapping.foobar.mappings).toHaveProperty('_meta', { baz: 'baz' });
             }

--- a/packages/elasticsearch-store/test/index-manager-index-setup-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-index-setup-spec.ts
@@ -1,12 +1,12 @@
 import 'jest-extended';
 import { debugLogger, get, isKey } from '@terascope/utils';
+import { MappingTypeMapping } from '@terascope/types';
 import * as simple from './helpers/simple-index.js';
 import * as template from './helpers/template-index.js';
 import {
     IndexManager, timeSeriesIndex, IndexConfig, getESVersion,
     __timeSeriesTest, ElasticsearchTestHelpers
 } from '../src/index.js';
-import { MappingTypeMapping } from '@terascope/types';
 
 const {
     makeClient, cleanupIndex, TEST_INDEX_PREFIX,

--- a/packages/elasticsearch-store/test/index-manager-index-setup-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-index-setup-spec.ts
@@ -1,11 +1,12 @@
 import 'jest-extended';
-import { debugLogger, get } from '@terascope/utils';
+import { debugLogger, get, isKey } from '@terascope/utils';
 import * as simple from './helpers/simple-index.js';
 import * as template from './helpers/template-index.js';
 import {
     IndexManager, timeSeriesIndex, IndexConfig, getESVersion,
     __timeSeriesTest, ElasticsearchTestHelpers
 } from '../src/index.js';
+import { MappingTypeMapping } from 'opensearch1/api/types.js';
 
 const {
     makeClient, cleanupIndex, TEST_INDEX_PREFIX,
@@ -70,7 +71,10 @@ describe('IndexManager->indexSetup()', () => {
             expect(mapping).toHaveProperty(index);
             if (esVersion === 6) {
                 expect(mapping[index].mappings).toHaveProperty(config.name);
-                expect(mapping[index].mappings[config.name]).toHaveProperty('_meta', { foo: 'foo' });
+                expect(
+                    isKey(mapping[index].mappings, config.name)
+                    && mapping[index].mappings[config.name]
+                ).toHaveProperty('_meta', { foo: 'foo' });
             } else {
                 expect(mapping[index].mappings).toHaveProperty('_meta', { foo: 'foo' });
             }
@@ -98,9 +102,18 @@ describe('IndexManager->indexSetup()', () => {
             it('should have updated the index metadata', async () => {
                 const mapping = await indexManager.getMapping(index);
 
-                const properties = esVersion === 6
-                    ? mapping[index].mappings[config.name].properties
-                    : mapping[index].mappings.properties;
+                let properties = undefined;
+                const { mappings } = mapping[index];
+                if (esVersion === 6) {
+                    if (isKey(mappings, config.name)) {
+                        const mappingsObj = mappings[config.name] as MappingTypeMapping;
+                        if (isKey(mappingsObj, 'properties')) {
+                            properties = mappingsObj.properties;
+                        }
+                    }
+                } else {
+                    properties = mappings.properties;
+                }
 
                 expect(properties).toMatchObject({
                     test_object: {
@@ -115,7 +128,10 @@ describe('IndexManager->indexSetup()', () => {
                     },
                 });
                 if (esVersion === 6) {
-                    expect(mapping[index].mappings[config.name]).toHaveProperty('_meta', { foo: 'foo' });
+                    expect(
+                        isKey(mapping[index].mappings, config.name)
+                        && mapping[index].mappings[config.name]
+                    ).toHaveProperty('_meta', { foo: 'foo' });
                 } else {
                     expect(mapping[index].mappings).toHaveProperty('_meta', { foo: 'foo' });
                 }
@@ -146,9 +162,22 @@ describe('IndexManager->indexSetup()', () => {
                 it('should have the previous the index metadata since removed fields shouldn\'t break', async () => {
                     const mapping = await indexManager.getMapping(index);
 
-                    const properties = esVersion === 6
-                        ? mapping[index].mappings[config.name].properties
-                        : mapping[index].mappings.properties;
+                    // const properties = esVersion === 6
+                    //     ? mapping[index].mappings[config.name].properties
+                    //     : mapping[index].mappings.properties;
+
+                    let properties = undefined;
+                    const { mappings } = mapping[index];
+                    if (esVersion === 6) {
+                        if (isKey(mappings, config.name)) {
+                            const mappingsObj = mappings[config.name] as MappingTypeMapping;
+                            if (isKey(mappingsObj, 'properties')) {
+                                properties = mappingsObj.properties;
+                            }
+                        }
+                    } else {
+                        properties = mappings.properties;
+                    }
 
                     expect(properties).toMatchObject({
                         test_object: {
@@ -163,7 +192,10 @@ describe('IndexManager->indexSetup()', () => {
                         },
                     });
                     if (esVersion === 6) {
-                        expect(mapping[index].mappings[config.name]).toHaveProperty('_meta', { foo: 'foo' });
+                        expect(
+                            isKey(mapping[index].mappings, config.name)
+                            && mapping[index].mappings[config.name]
+                        ).toHaveProperty('_meta', { foo: 'foo' });
                     } else {
                         expect(mapping[index].mappings).toHaveProperty('_meta', { foo: 'foo' });
                     }
@@ -229,7 +261,10 @@ describe('IndexManager->indexSetup()', () => {
             expect(mapping).toHaveProperty(index);
             if (esVersion === 6) {
                 expect(mapping[index].mappings).toHaveProperty(config.name);
-                expect(mapping[index].mappings[config.name]).toHaveProperty('_meta', { bar: 'bar' });
+                expect(
+                    isKey(mapping[index].mappings, config.name)
+                    && mapping[index].mappings[config.name]
+                ).toHaveProperty('_meta', { foo: 'foo' });
             } else {
                 expect(mapping[index].mappings).toHaveProperty('_meta', { bar: 'bar' });
             }
@@ -323,7 +358,10 @@ describe('IndexManager->indexSetup()', () => {
             const newIdxMapping = await indexManager.getMapping('foobar');
 
             if (esVersion === 6) {
-                expect(newIdxMapping.foobar.mappings[config.name]).toHaveProperty('_meta', { baz: 'baz' });
+                expect(
+                    isKey(newIdxMapping.foobar.mappings, config.name)
+                    && newIdxMapping.foobar.mappings[config.name]
+                ).toHaveProperty('_meta', { foo: 'foo' });
             } else {
                 expect(newIdxMapping.foobar.mappings).toHaveProperty('_meta', { baz: 'baz' });
             }

--- a/packages/elasticsearch-store/test/index-manager-index-setup-spec.ts
+++ b/packages/elasticsearch-store/test/index-manager-index-setup-spec.ts
@@ -6,7 +6,7 @@ import {
     IndexManager, timeSeriesIndex, IndexConfig, getESVersion,
     __timeSeriesTest, ElasticsearchTestHelpers
 } from '../src/index.js';
-import { MappingTypeMapping } from 'opensearch1/api/types.js';
+import { MappingTypeMapping } from '@terascope/types';
 
 const {
     makeClient, cleanupIndex, TEST_INDEX_PREFIX,

--- a/packages/elasticsearch-store/tsconfig.json
+++ b/packages/elasticsearch-store/tsconfig.json
@@ -2,8 +2,7 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": ".",
-        "suppressImplicitAnyIndexErrors": false
+        "rootDir": "."
     },
     "include": ["src", "test"]
 }

--- a/packages/elasticsearch-store/tsconfig.json
+++ b/packages/elasticsearch-store/tsconfig.json
@@ -2,7 +2,8 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": "."
+        "rootDir": ".",
+        "suppressImplicitAnyIndexErrors": false
     },
     "include": ["src", "test"]
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -33,7 +33,7 @@
         "eslint-plugin-react-hooks": "~5.1.0",
         "eslint-plugin-testing-library": "~7.1.1",
         "globals": "~15.13.0",
-        "typescript": "~5.2.2",
+        "typescript": "~5.7.2",
         "typescript-eslint": "~8.18.0"
     },
     "engines": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "1.8.0",
+    "version": "1.9.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -32,8 +32,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "~1.3.2",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/types": "~1.4.0",
+        "@terascope/utils": "~1.7.0",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",

--- a/packages/job-components/tsconfig.json
+++ b/packages/job-components/tsconfig.json
@@ -2,8 +2,7 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": ".",
-        "suppressImplicitAnyIndexErrors": false,
+        "rootDir": "."
     },
     "include": [
         "src",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -29,7 +29,7 @@
     },
     "resolutions": {
         "ms": "~2.1.3",
-        "typescript": "~5.2.2"
+        "typescript": "~5.7.2"
     },
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
@@ -64,7 +64,7 @@
         "@types/toposort": "~2.0.7"
     },
     "peerDependencies": {
-        "typescript": "~5.2.2"
+        "typescript": "~5.7.2"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.7.1",
+    "version": "1.8.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/utils": "~1.7.0",
         "codecov": "~3.8.3",
         "execa": "~9.5.2",
         "fs-extra": "~11.2.0",

--- a/packages/scripts/tsconfig.json
+++ b/packages/scripts/tsconfig.json
@@ -2,8 +2,7 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": ".",
-        "suppressImplicitAnyIndexErrors": false
+        "rootDir": "."
     },
     "include": ["src", "test"]
 }

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "1.8.0",
+    "version": "1.9.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -29,15 +29,15 @@
     },
     "dependencies": {
         "@terascope/file-asset-apis": "~1.0.3",
-        "@terascope/types": "~1.3.2",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/types": "~1.4.0",
+        "@terascope/utils": "~1.7.0",
         "bluebird": "~3.7.2",
         "bunyan": "~1.8.15",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.6.0",
+        "elasticsearch-store": "~1.7.0",
         "express": "~4.21.2",
         "js-yaml": "~4.1.0",
         "nanoid": "~5.0.9",

--- a/packages/terafoundation/tsconfig.json
+++ b/packages/terafoundation/tsconfig.json
@@ -2,8 +2,7 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": ".",
-        "suppressImplicitAnyIndexErrors": false
+        "rootDir": "."
     },
     "include": ["src", "test"]
 }

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -43,8 +43,8 @@
     },
     "devDependencies": {
         "@terascope/fetch-github-release": "~1.0.0",
-        "@terascope/types": "~1.3.2",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/types": "~1.4.0",
+        "@terascope/utils": "~1.7.0",
         "@types/decompress": "~4.2.7",
         "@types/diff": "~6.0.0",
         "@types/ejs": "~3.1.5",
@@ -68,7 +68,7 @@
         "pretty-bytes": "~6.1.1",
         "prompts": "~2.4.2",
         "signale": "~1.4.0",
-        "teraslice-client-js": "~1.6.0",
+        "teraslice-client-js": "~1.7.0",
         "tmp": "~0.2.0",
         "tty-table": "~4.2.3",
         "yargs": "~17.7.2"

--- a/packages/teraslice-cli/tsconfig.json
+++ b/packages/teraslice-cli/tsconfig.json
@@ -2,8 +2,7 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": ".",
-        "suppressImplicitAnyIndexErrors": false
+        "rootDir": "."
     },
     "include": [
         "src",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -32,8 +32,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "~1.3.2",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/types": "~1.4.0",
+        "@terascope/utils": "~1.7.0",
         "auto-bind": "~5.0.1",
         "got": "~13.0.0"
     },

--- a/packages/teraslice-client-js/tsconfig.json
+++ b/packages/teraslice-client-js/tsconfig.json
@@ -2,8 +2,7 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": ".",
-        "suppressImplicitAnyIndexErrors": false
+        "rootDir": "."
     },
     "include": [
         "src",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -35,8 +35,8 @@
         "ms": "~2.1.3"
     },
     "dependencies": {
-        "@terascope/types": "~1.3.2",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/types": "~1.4.0",
+        "@terascope/utils": "~1.7.0",
         "get-port": "~7.1.0",
         "ms": "~2.1.3",
         "nanoid": "~5.0.9",

--- a/packages/teraslice-messaging/tsconfig.json
+++ b/packages/teraslice-messaging/tsconfig.json
@@ -2,8 +2,7 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": ".",
-        "suppressImplicitAnyIndexErrors": false
+        "rootDir": "."
     },
     "include": ["src", "test"]
 }

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -24,8 +24,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "~4.6.0",
-        "@terascope/utils": "~1.6.0"
+        "@terascope/elasticsearch-api": "~4.7.0",
+        "@terascope/utils": "~1.7.0"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice-state-storage/src/cached-state-storage/index.ts
+++ b/packages/teraslice-state-storage/src/cached-state-storage/index.ts
@@ -18,7 +18,7 @@ export default class CachedStateStorage<T> extends EventEmitter {
     }
 
     mget(keyArray: (string | number)[]): MGetCacheResponse {
-        return keyArray.reduce((cachedState, key) => {
+        return keyArray.reduce((cachedState: Record<string, any>, key) => {
             const state = this.get(key);
             if (state) cachedState[key] = state;
             return cachedState;

--- a/packages/teraslice-state-storage/tsconfig.json
+++ b/packages/teraslice-state-storage/tsconfig.json
@@ -2,8 +2,7 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": ".",
-        "suppressImplicitAnyIndexErrors": false
+        "rootDir": "."
     },
     "include": ["src", "test"]
 }

--- a/packages/teraslice-state-storage/tsconfig.json
+++ b/packages/teraslice-state-storage/tsconfig.json
@@ -2,7 +2,8 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": "."
+        "rootDir": ".",
+        "suppressImplicitAnyIndexErrors": false
     },
     "include": ["src", "test"]
 }

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "~11.2.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "~1.8.0"
+        "@terascope/job-components": "~1.9.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=1.8.0"
+        "@terascope/job-components": ">=1.9.0"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.10.0",
+    "version": "2.11.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -39,11 +39,11 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
-        "@terascope/elasticsearch-api": "~4.6.0",
-        "@terascope/job-components": "~1.8.0",
-        "@terascope/teraslice-messaging": "~1.9.0",
-        "@terascope/types": "~1.3.2",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/elasticsearch-api": "~4.7.0",
+        "@terascope/job-components": "~1.9.0",
+        "@terascope/teraslice-messaging": "~1.10.0",
+        "@terascope/types": "~1.4.0",
+        "@terascope/utils": "~1.7.0",
         "async-mutex": "~0.5.0",
         "barbe": "~3.0.16",
         "body-parser": "~1.20.2",
@@ -62,7 +62,7 @@
         "semver": "~7.6.3",
         "socket.io": "~1.7.4",
         "socket.io-client": "~1.7.4",
-        "terafoundation": "~1.8.0",
+        "terafoundation": "~1.9.0",
         "uuid": "~11.0.3"
     },
     "devDependencies": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -52,7 +52,7 @@
         "event-loop-stats": "~1.4.1",
         "express": "~4.21.2",
         "fs-extra": "~11.2.0",
-        "gc-stats": "~1.4.0",
+        "gc-stats": "1.4.1",
         "get-port": "~7.1.0",
         "got": "~13.0.0",
         "ip": "~2.0.1",
@@ -68,6 +68,7 @@
     "devDependencies": {
         "@types/archiver": "~6.0.2",
         "@types/express": "~4.17.21",
+        "@types/gc-stats": "~1.4.3",
         "archiver": "~7.0.1",
         "bufferstreams": "~3.0.0",
         "chance": "~1.1.12",

--- a/packages/teraslice/src/interfaces.ts
+++ b/packages/teraslice/src/interfaces.ts
@@ -29,12 +29,18 @@ export interface ClusterMasterContext extends Context {
 }
 
 export enum ProcessAssignment {
+    node_master = 'node_master',
     cluster_master = 'cluster_master',
     assets_service = 'assets_service',
     execution_controller = 'execution_controller',
     worker = 'worker'
 
 }
+
+export function isProcessAssignment(value: string): value is ProcessAssignment {
+    return Object.values(ProcessAssignment).includes(value as ProcessAssignment);
+}
+
 interface BaseWorkerNode {
     worker_id: number;
     pid: number;
@@ -99,3 +105,10 @@ export interface ControllerStats extends ExecutionAnalytics {
     job_id: string;
     name: string;
 }
+
+export type MessagingConfigOptions = {
+    [assignment in ProcessAssignment]: {
+        networkClient: boolean;
+        ipcClient: boolean;
+    };
+};

--- a/packages/teraslice/src/interfaces.ts
+++ b/packages/teraslice/src/interfaces.ts
@@ -38,7 +38,7 @@ export enum ProcessAssignment {
 }
 
 export function isProcessAssignment(value: string): value is ProcessAssignment {
-    return Object.values(ProcessAssignment).includes(value as ProcessAssignment);
+    return value in ProcessAssignment;
 }
 
 interface BaseWorkerNode {

--- a/packages/teraslice/src/lib/cluster/node_master.ts
+++ b/packages/teraslice/src/lib/cluster/node_master.ts
@@ -399,7 +399,7 @@ export async function nodeMaster(context: ClusterMasterContext) {
         query: {
             node_id: context.sysconfig._nodeName
         }
-    } as any);
+    });
 
     if (context.sysconfig.teraslice.master) {
         logger.debug(`node ${context.sysconfig._nodeName} is creating the cluster_master`);

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -137,7 +137,7 @@ export class ApiService {
     }
 
     private async _assetRedirect(req: TerasliceRequest, res: TerasliceResponse) {
-          const options: OptionsInit & { isStream: true } = {
+        const options: OptionsInit & { isStream: true } = {
             prefixUrl: this.assetsUrl,
             headers: req.headers,
             searchParams: req.query as Record<string, any>,

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -1,5 +1,4 @@
 import { Router, Express } from 'express';
-import type { ParsedQs } from 'qs';
 import bodyParser from 'body-parser';
 import { pipeline as streamPipeline } from 'node:stream/promises';
 import { RecoveryCleanupType, TerasliceConfig } from '@terascope/job-components';
@@ -137,10 +136,10 @@ export class ApiService {
         throw error;
     }
 
-    private _parsedQsToSearchParams(parsedQs: ParsedQs) {
+    private queryToSearchParams(query: any) {
         const searchParams: Record<string, string | number | boolean> = {};
 
-        for (const [key, value] of Object.entries(parsedQs)) {
+        for (const [key, value] of Object.entries(query)) {
             if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
                 searchParams[key] = value;
             } else if (Array.isArray(value)) {
@@ -157,7 +156,7 @@ export class ApiService {
     }
 
     private async _redirect(req: TerasliceRequest, res: TerasliceResponse) {
-        const searchParams = this._parsedQsToSearchParams(req.query);
+        const searchParams = this.queryToSearchParams(req.query);
 
         const options: OptionsInit & { isStream: true } = {
             prefixUrl: this.assetsUrl,

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/index.ts
@@ -3,6 +3,7 @@ import {
     cloneDeep, pRetry, Logger
 } from '@terascope/utils';
 import type { Context, ExecutionConfig } from '@terascope/job-components';
+import { ClusterState } from '@terascope/types';
 import { makeLogger } from '../../../../../workers/helpers/terafoundation.js';
 import { gen } from './k8sState.js';
 import { K8s } from './k8s.js';
@@ -12,7 +13,6 @@ import { ResourceType } from './interfaces.js';
 import { K8sJobResource } from './k8sJobResource.js';
 import { K8sServiceResource } from './k8sServiceResource.js';
 import { K8sDeploymentResource } from './k8sDeploymentResource.js';
-import { ClusterState } from '@terascope/types';
 
 /*
  Execution Life Cycle for _status

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/index.ts
@@ -12,6 +12,7 @@ import { ResourceType } from './interfaces.js';
 import { K8sJobResource } from './k8sJobResource.js';
 import { K8sServiceResource } from './k8sServiceResource.js';
 import { K8sDeploymentResource } from './k8sDeploymentResource.js';
+import { ClusterState } from '@terascope/types';
 
 /*
  Execution Life Cycle for _status
@@ -27,7 +28,7 @@ export class KubernetesClusterBackendV2 {
     k8s: K8s;
     logger: Logger;
     private clusterStateInterval: NodeJS.Timeout | undefined;
-    clusterState: Record<string, any> = {};
+    clusterState: ClusterState = {};
     readonly clusterNameLabel: string;
 
     constructor(context: Context, clusterMasterServer: any) {

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sState.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sState.ts
@@ -1,8 +1,8 @@
 import {
     get, has, uniq, difference
 } from '@terascope/utils';
-import { TSPodList } from './interfaces';
 import { ClusterState, ProcessAssignment } from '@terascope/types';
+import { TSPodList } from './interfaces';
 
 /**
  * Given the k8s Pods API output generates the appropriate Teraslice cluster

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sState.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sState.ts
@@ -2,6 +2,7 @@ import {
     get, has, uniq, difference
 } from '@terascope/utils';
 import { TSPodList } from './interfaces';
+import { ClusterState, ProcessAssignment } from '@terascope/types';
 
 /**
  * Given the k8s Pods API output generates the appropriate Teraslice cluster
@@ -12,7 +13,7 @@ import { TSPodList } from './interfaces';
  * @param  {String} clusterNameLabel k8s label containing clusterName
  * @param  {Logger} logger           Teraslice logger
  */
-export function gen(k8sPods: TSPodList, clusterState: Record<string, any>) {
+export function gen(k8sPods: TSPodList, clusterState: ClusterState) {
     // Make sure we clean up the old
     const hostIPs = uniq(k8sPods.items.map((item) => get(item, 'status.hostIP')));
     const oldHostIps = difference(Object.keys(clusterState), hostIPs);
@@ -46,7 +47,7 @@ export function gen(k8sPods: TSPodList, clusterState: Record<string, any>) {
 
         const worker = {
             assets: [],
-            assignment: pod.metadata.labels['app.kubernetes.io/component'],
+            assignment: pod.metadata.labels['app.kubernetes.io/component'] as ProcessAssignment,
             ex_id: pod.metadata.labels['teraslice.terascope.io/exId'],
             // WARNING: This makes the assumption that the first container
             // in the pod is the teraslice container.  Currently it is the

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/native/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/native/index.ts
@@ -500,7 +500,7 @@ export class NativeClustering {
         let workerCount = workerNum;
 
         const workersData = workers.reduce((prev: Record<string, any>, curr) => {
-            if (prev[curr.node_id]) {
+            if (!prev[curr.node_id]) {
                 prev[curr.node_id] = 1;
             } else {
                 prev[curr.node_id] += 1;

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/native/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/native/index.ts
@@ -192,7 +192,7 @@ export class NativeClustering {
             throw new Error('Missing required stores');
         }
         const server = this.clusterMasterServer.httpServer;
-        // @ts-expect-error
+
         await this.messaging.listen({ server });
 
         this.clusterStateInterval = setInterval(() => {
@@ -447,7 +447,7 @@ export class NativeClustering {
     async allocateSlicer(ex: ExecutionConfig): Promise<ExecutionConfig> {
         let retryCount = 0;
         const errorNodes = {};
-        // @ts-expect-error
+
         const _allocateSlicer = async () => {
             try {
                 return await this._createSlicer(ex, errorNodes);
@@ -499,8 +499,8 @@ export class NativeClustering {
         const workers = findWorkersByExecutionID(this.clusterState, exId);
         let workerCount = workerNum;
 
-        const workersData = workers.reduce((prev, curr) => {
-            if (!prev[curr.node_id]) {
+        const workersData = workers.reduce((prev: Record<string, any>, curr) => {
+            if (prev[curr.node_id]) {
                 prev[curr.node_id] = 1;
             } else {
                 prev[curr.node_id] += 1;

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/native/messaging.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/native/messaging.ts
@@ -347,7 +347,7 @@ export class Messaging {
             this.logger.debug('client network connection is online');
         } else if (server) {
             if (typeof server === 'string' || typeof server === 'number') {
-                // test
+                // test server
                 this.io = socketIOServer(server, {
                     path: '/native-clustering',
                     pingTimeout: this.configTimeout,

--- a/packages/teraslice/src/lib/storage/backends/elasticsearch_store.ts
+++ b/packages/teraslice/src/lib/storage/backends/elasticsearch_store.ts
@@ -144,7 +144,7 @@ export class TerasliceElasticsearchStorage {
 
         if (isMultiIndex) {
             // @ts-expect-error TODO: fix this
-            const storeType = this.defaultIndexName.match(/__(.*)\*/)[1];
+            const storeType: 'analytics' | 'state' = this.defaultIndexName.match(/__(.*)\*/)[1];
             const timeseriesFormat = config.index_rollover_frequency[storeType];
             const nameSize = this.defaultIndexName.length - 1;
             newIndex = timeseriesIndex(

--- a/packages/teraslice/src/lib/storage/state.ts
+++ b/packages/teraslice/src/lib/storage/state.ts
@@ -2,7 +2,7 @@ import { Context, RecoveryCleanupType, Slice } from '@terascope/job-components';
 import {
     TSError, pRetry, toString,
     isRetryableError, parseErrorInfo, isTest,
-    times, getFullErrorStack, Logger
+    times, getFullErrorStack, Logger, isKey
 } from '@terascope/utils';
 import { timeseriesIndex, TimeseriesFormat } from '../utils/date_utils.js';
 import { makeLogger } from '../workers/helpers/terafoundation.js';
@@ -82,7 +82,7 @@ export class StateStorage {
     }
 
     private _createSliceRecord(exId: string, slice: any, state: any, error?: Error) {
-        if (!SliceState[state]) {
+        if (!isKey(SliceState, state)) {
             throw new Error(`Unknown slice state "${state}" on create`);
         }
         const { index } = timeseriesIndex(
@@ -109,7 +109,7 @@ export class StateStorage {
 
     // TODO: type this better
     async updateState(slice: Slice, state: string, error?: Error) {
-        if (!SliceState[state]) {
+        if (!isKey(SliceState, state)) {
             throw new Error(`Unknown slice state "${state}" on update`);
         }
 
@@ -283,7 +283,7 @@ export class StateStorage {
     }
 
     async countByState(exId: string, state: string) {
-        if (!SliceState[state]) {
+        if (!isKey(SliceState, state)) {
             throw new Error(`Unknown slice state "${state}" on update`);
         }
         const query = `ex_id:"${exId}" AND state:${state}`;

--- a/packages/teraslice/src/lib/utils/api_utils.ts
+++ b/packages/teraslice/src/lib/utils/api_utils.ts
@@ -117,12 +117,15 @@ export function makePrometheus(stats: ClusterMaster.ClusterAnalytics, defaultLab
     };
 
     let returnString = '';
+
     Object.entries(stats.controllers).forEach(([key, value]) => {
         if (isKey(metricMapping, key)) {
             const name = metricMapping[key];
-            returnString += `# TYPE ${name} counter\n`;
-            const labels = makePrometheusLabels(defaultLabels);
-            returnString += `${name}${labels} ${value}\n`;
+            if (name !== '') {
+                returnString += `# TYPE ${name} counter\n`;
+                const labels = makePrometheusLabels(defaultLabels);
+                returnString += `${name}${labels} ${value}\n`;
+            }
         }
     });
     return returnString;

--- a/packages/teraslice/src/lib/utils/api_utils.ts
+++ b/packages/teraslice/src/lib/utils/api_utils.ts
@@ -4,8 +4,8 @@ import {
     isString, get, toInteger, Logger,
     TSError, isKey,
 } from '@terascope/utils';
-import { TerasliceRequest, TerasliceResponse } from '../../interfaces.js';
 import type { ClusterMaster } from '@terascope/teraslice-messaging';
+import { TerasliceRequest, TerasliceResponse } from '../../interfaces.js';
 
 export function makeTable(
     req: TerasliceRequest,

--- a/packages/teraslice/src/lib/utils/api_utils.ts
+++ b/packages/teraslice/src/lib/utils/api_utils.ts
@@ -1,9 +1,11 @@
 import Table from 'easy-table';
 import {
     parseErrorInfo, parseList, logError,
-    isString, get, toInteger, Logger, TSError,
+    isString, get, toInteger, Logger,
+    TSError, isKey,
 } from '@terascope/utils';
 import { TerasliceRequest, TerasliceResponse } from '../../interfaces.js';
+import type { ClusterMaster } from '@terascope/teraslice-messaging';
 
 export function makeTable(
     req: TerasliceRequest,
@@ -103,7 +105,7 @@ export function sendError(
 
 // NOTE: This only works for counters, if you're trying to extend this, you
 // should probably switch to using prom-client.
-export function makePrometheus(stats: any, defaultLabels = {}) {
+export function makePrometheus(stats: ClusterMaster.ClusterAnalytics, defaultLabels = {}) {
     const metricMapping = {
         processed: 'teraslice_slices_processed',
         failed: 'teraslice_slices_failed',
@@ -116,8 +118,8 @@ export function makePrometheus(stats: any, defaultLabels = {}) {
 
     let returnString = '';
     Object.entries(stats.controllers).forEach(([key, value]) => {
-        const name = metricMapping[key];
-        if (name !== '') {
+        if (isKey(metricMapping, key)) {
+            const name = metricMapping[key];
             returnString += `# TYPE ${name} counter\n`;
             const labels = makePrometheusLabels(defaultLabels);
             returnString += `${name}${labels} ${value}\n`;
@@ -132,7 +134,7 @@ function makePrometheusLabels(defaults = {}) {
     if (!keys.length) return '';
 
     const labelsStr = keys.map((key) => {
-        const val = labels[key];
+        const val = labels[key as keyof typeof labels];
         return `${key}="${val}"`;
     }).join(',');
 

--- a/packages/teraslice/src/lib/utils/api_utils.ts
+++ b/packages/teraslice/src/lib/utils/api_utils.ts
@@ -117,7 +117,6 @@ export function makePrometheus(stats: ClusterMaster.ClusterAnalytics, defaultLab
     };
 
     let returnString = '';
-
     Object.entries(stats.controllers).forEach(([key, value]) => {
         if (isKey(metricMapping, key)) {
             const name = metricMapping[key];

--- a/packages/teraslice/src/lib/utils/date_utils.ts
+++ b/packages/teraslice/src/lib/utils/date_utils.ts
@@ -1,4 +1,4 @@
-import { makeISODate } from '@terascope/utils';
+import { isKey, makeISODate } from '@terascope/utils';
 
 const options = {
     year: 'y',
@@ -44,7 +44,7 @@ const formatter = {
 export type TimeseriesFormat = 'daily' | 'monthly' | 'yearly';
 
 export function dateOptions(value: string | undefined) {
-    if (value && options[value]) {
+    if (value && isKey(options, value)) {
         return options[value];
     }
 

--- a/packages/teraslice/src/lib/workers/execution-controller/execution-analytics.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/execution-analytics.ts
@@ -1,6 +1,6 @@
 import {
     makeISODate, get, has,
-    Logger, isKey
+    Logger
 } from '@terascope/utils';
 import type { EventEmitter } from 'node:events';
 import type { Context, ExecutionContext } from '@terascope/job-components';
@@ -171,15 +171,12 @@ export class ExecutionAnalytics {
         const analytics = this.getAnalytics();
 
         // save a copy of what we push so we can emit diffs
-        const diffs: Partial<AggregatedExecutionAnalytics> = {};
-        const copy: Partial<AggregatedExecutionAnalytics> = {};
+        const diffs: Record<string, any> = {};
+        const copy: Record<string, any> = {};
 
         Object.entries(this.pushedAnalytics).forEach(([field, value]) => {
-            // if field is a key of copy, it is also a key of diffs and analytics
-            if (isKey(copy, field)) {
-                diffs[field] = analytics[field] - value;
-                copy[field] = analytics[field];
-            }
+            diffs[field] = analytics[field as keyof Omit<EStats, 'started' | 'queuing_complete'>] - value;
+            copy[field] = analytics[field as keyof EStats];
         });
 
         const response = await this.client.sendClusterAnalytics(

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -43,7 +43,7 @@ export class ExecutionController {
     isExecutionDone = false;
     private workersHaveConnected = false;
 
-    private _handlers = new Map<string, (arg: any) => void>();
+    private _handlers = new Map<string, ((arg: any) => void) | null>();
     executionAnalytics: ExecutionAnalytics;
     readonly scheduler: Scheduler;
     private metrics: Metrics | null;
@@ -297,7 +297,9 @@ export class ExecutionController {
         });
 
         for (const [event, handler] of this._handlers.entries()) {
-            this.events.on(event, handler);
+            if (handler !== null) {
+                this.events.on(event, handler);
+            }
         }
 
         if (this.collectAnalytics) {
@@ -474,8 +476,10 @@ export class ExecutionController {
 
         // remove any listeners
         for (const [event, handler] of this._handlers.entries()) {
-            this.events.removeListener(event, handler);
-            this._handlers[event] = null;
+            if (handler !== null) {
+                this.events.removeListener(event, handler);
+                this._handlers.set(event, null);
+            }
         }
 
         this.isShuttingDown = true;

--- a/packages/teraslice/src/lib/workers/metrics/index.ts
+++ b/packages/teraslice/src/lib/workers/metrics/index.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'node:events';
 import {
     debugLogger, isTest, Logger
 } from '@terascope/utils';
-import GCStats from 'gc-stats';
+import type GCStats from 'gc-stats';
 
 const defaultLogger = debugLogger('metrics');
 

--- a/packages/teraslice/src/lib/workers/metrics/index.ts
+++ b/packages/teraslice/src/lib/workers/metrics/index.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events';
 import {
     debugLogger, isTest, Logger
 } from '@terascope/utils';
+import GCStats from 'gc-stats';
 
 const defaultLogger = debugLogger('metrics');
 
@@ -11,7 +12,7 @@ export class Metrics extends EventEmitter {
     private eventLoopInterval: number;
     // TODO: fix types here
     private _typesCollectedAt: Record<string, any>;
-    private gcStats: any;
+    private gcStats: GCStats.GCStatsEventEmitter | null;
     private eventLoopStats: any;
 
     constructor(config?: { logger: Logger }) {
@@ -26,12 +27,12 @@ export class Metrics extends EventEmitter {
         this.eventLoopInterval = isTest ? 100 : 5000;
         this._intervals = [];
         this._typesCollectedAt = {};
+        this.gcStats = null;
     }
 
     async initialize() {
         // never cause an unwanted error
         try {
-            // @ts-expect-error
             const module = await import('gc-stats');
             this.gcStats = module.default();
         } catch (err) {
@@ -52,7 +53,7 @@ export class Metrics extends EventEmitter {
             loopEnabled
         });
 
-        if (gcEnabled) {
+        if (this.gcStats !== null) {
             // https://github.com/dainis/node-gcstats#property-insights
             const typesToName = {
                 1: 'Scavenge',
@@ -62,7 +63,7 @@ export class Metrics extends EventEmitter {
                 15: 'All'
             };
 
-            this.gcStats.on('stats', (metrics: any) => {
+            this.gcStats.on('stats', (metrics: GCStats.GCStatistics) => {
                 // never cause an unwanted error
                 if (!metrics) {
                     this.logger.warn('invalid metrics received for gc stats', metrics);

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8sState-multicluster-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8sState-multicluster-spec.ts
@@ -1,11 +1,12 @@
 import { cloneDeep } from '@terascope/utils';
+import { ClusterState } from '@terascope/types';
 import _podsJobRunning from './files/job-running-v1-k8s-pods-multicluster.json';
 import { gen } from '../../../../../../../src/lib/cluster/services/cluster/backends/kubernetes/k8sState.js';
 
 describe('k8sState with pods from multiple clusters', () => {
     it('should generate cluster state correctly on first call', () => {
         const podsJobRunning = cloneDeep(_podsJobRunning) as any;
-        const clusterState = {};
+        const clusterState: ClusterState = {};
 
         gen(podsJobRunning, clusterState);
         // console.log(`clusterState\n\n${JSON.stringify(clusterState, null, 2)}`);
@@ -39,7 +40,7 @@ describe('k8sState with pods from multiple clusters', () => {
 
     it('should generate cluster state correctly on second call', () => {
         const podsJobRunning = cloneDeep(_podsJobRunning) as any;
-        const clusterState = {};
+        const clusterState: ClusterState = {};
 
         gen(podsJobRunning, clusterState);
         gen(podsJobRunning, clusterState);

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8sState-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/k8sState-spec.ts
@@ -1,11 +1,12 @@
 import { cloneDeep } from '@terascope/utils';
+import { ClusterState } from '@terascope/types';
 import _podsJobRunning from './files/job-running-v1-k8s-pods.json';
 import { gen } from '../../../../../../../src/lib/cluster/services/cluster/backends/kubernetes/k8sState.js';
 
 describe('k8sState', () => {
     it('should generate cluster state correctly on first call', () => {
         const podsJobRunning = cloneDeep(_podsJobRunning) as any;
-        const clusterState = {};
+        const clusterState: ClusterState = {};
 
         gen(podsJobRunning, clusterState);
         // console.log(`clusterState\n\n${JSON.stringify(clusterState, null, 2)}`);
@@ -38,7 +39,7 @@ describe('k8sState', () => {
 
     it('should generate cluster state correctly on second call', () => {
         const podsJobRunning = cloneDeep(_podsJobRunning) as any;
-        const clusterState = {};
+        const clusterState: ClusterState = {};
 
         gen(podsJobRunning, clusterState);
         gen(podsJobRunning, clusterState);
@@ -71,9 +72,16 @@ describe('k8sState', () => {
 
     it('should remove old host ips', () => {
         const podsJobRunning = cloneDeep(_podsJobRunning) as any;
-        const clusterState = {};
+        const clusterState: ClusterState = {};
         clusterState['2.2.2.2'] = {
+            node_id: '2.2.2.2',
+            hostname: '2.2.2.2',
+            pid: 'N/A',
+            node_version: 'N/A',
+            teraslice_version: 'N/A',
+            total: 'N/A',
             state: 'idk',
+            available: 'N/A',
             active: []
         };
 

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8sState-multicluster-v2-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8sState-multicluster-v2-spec.ts
@@ -1,4 +1,5 @@
 import { cloneDeep } from '@terascope/utils';
+import { ClusterState } from '@terascope/types';
 import _podsJobRunning from '../files/job-running-v1-k8s-pods-multicluster.json';
 import { gen } from '../../../../../../../../src/lib/cluster/services/cluster/backends/kubernetesV2/k8sState.js';
 import { TSPodList } from '../../../../../../../../src/lib/cluster/services/cluster/backends/kubernetesV2/interfaces.js';
@@ -6,7 +7,7 @@ import { TSPodList } from '../../../../../../../../src/lib/cluster/services/clus
 describe('k8sState with pods from multiple clusters', () => {
     it('should generate cluster state correctly on first call', () => {
         const podsJobRunning = cloneDeep<TSPodList>(_podsJobRunning as any);
-        const clusterState = {};
+        const clusterState: ClusterState = {};
 
         gen(podsJobRunning, clusterState);
         // console.log(`clusterState\n\n${JSON.stringify(clusterState, null, 2)}`);
@@ -40,7 +41,7 @@ describe('k8sState with pods from multiple clusters', () => {
 
     it('should generate cluster state correctly on second call', () => {
         const podsJobRunning = cloneDeep<TSPodList>(_podsJobRunning as any);
-        const clusterState = {};
+        const clusterState: ClusterState = {};
 
         gen(podsJobRunning, clusterState);
         gen(podsJobRunning, clusterState);

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8sState-v2-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8sState-v2-spec.ts
@@ -1,4 +1,5 @@
 import { cloneDeep } from '@terascope/utils';
+import { ClusterState } from '@terascope/types';
 import _podsJobRunning from '../files/job-running-v1-k8s-pods.json';
 import { gen } from '../../../../../../../../src/lib/cluster/services/cluster/backends/kubernetesV2/k8sState.js';
 import { TSPodList } from '../../../../../../../../src/lib/cluster/services/cluster/backends/kubernetesV2/interfaces.js';
@@ -6,7 +7,7 @@ import { TSPodList } from '../../../../../../../../src/lib/cluster/services/clus
 describe('k8sState', () => {
     it('should generate cluster state correctly on first call', () => {
         const podsJobRunning = cloneDeep<TSPodList>(_podsJobRunning as any);
-        const clusterState = {};
+        const clusterState: ClusterState = {};
 
         gen(podsJobRunning, clusterState);
         // console.log(`clusterState\n\n${JSON.stringify(clusterState, null, 2)}`);
@@ -39,7 +40,7 @@ describe('k8sState', () => {
 
     it('should generate cluster state correctly on second call', () => {
         const podsJobRunning = cloneDeep<TSPodList>(_podsJobRunning as any);
-        const clusterState = {};
+        const clusterState: ClusterState = {};
 
         gen(podsJobRunning, clusterState);
         gen(podsJobRunning, clusterState);
@@ -72,9 +73,16 @@ describe('k8sState', () => {
 
     it('should remove old host ips', () => {
         const podsJobRunning = cloneDeep<TSPodList>(_podsJobRunning as any);
-        const clusterState = {};
+        const clusterState: ClusterState = {};
         clusterState['2.2.2.2'] = {
+            node_id: '2.2.2.2',
+            hostname: '2.2.2.2',
+            pid: 'N/A',
+            node_version: 'N/A',
+            teraslice_version: 'N/A',
+            total: 'N/A',
             state: 'idk',
+            available: 'N/A',
             active: []
         };
 

--- a/packages/teraslice/test/node_master-spec.ts
+++ b/packages/teraslice/test/node_master-spec.ts
@@ -97,7 +97,7 @@ describe('Node master', () => {
             processCounter += 1;
 
             for (const [key, value] of Object.entries(envConfig)) {
-                this[key] = value;
+                this[key as keyof this] = value;
             }
 
             this.process = {

--- a/packages/teraslice/test/services/messaging-spec.ts
+++ b/packages/teraslice/test/services/messaging-spec.ts
@@ -494,7 +494,7 @@ describe('messaging module', () => {
         const messaging2 = new Messaging(testContext2, logger);
 
         expect(() => messaging1.listen()).not.toThrow();
-        expect(() => messaging2.listen({ server: 45645 })).not.toThrow();
+        expect(() => messaging2.listen({ port: 45645 })).not.toThrow();
 
         await messaging1.shutdown();
         await messaging2.shutdown();

--- a/packages/teraslice/test/services/messaging-spec.ts
+++ b/packages/teraslice/test/services/messaging-spec.ts
@@ -5,7 +5,7 @@ import { Messaging, routing } from '../../src/lib/cluster/services/cluster/backe
 
 describe('messaging module', () => {
     const logger = debugLogger('messaging');
-    let connected = {};
+    let connected: Record<string, { rooms: Record<string, string> }> = {};
 
     const testExId = '7890';
 
@@ -15,7 +15,7 @@ describe('messaging module', () => {
     let clusterFn: any = () => {};
 
     function testMessaging(messaging: Messaging, fn: string) {
-        return (...args: any[]) => messaging[fn](...args);
+        return (...args: any[]) => messaging[fn as keyof Messaging](...args);
     }
 
     class MyCluster extends events.EventEmitter {
@@ -494,7 +494,7 @@ describe('messaging module', () => {
         const messaging2 = new Messaging(testContext2, logger);
 
         expect(() => messaging1.listen()).not.toThrow();
-        expect(() => messaging2.listen({ server: 45645 } as any)).not.toThrow();
+        expect(() => messaging2.listen({ server: 45645 })).not.toThrow();
 
         await messaging1.shutdown();
         await messaging2.shutdown();

--- a/packages/teraslice/test/utils/asset_utils-spec.ts
+++ b/packages/teraslice/test/utils/asset_utils-spec.ts
@@ -49,7 +49,7 @@ describe('Asset Utils', () => {
         });
     });
 
-    const wrongPlatform = {
+    const wrongPlatform: Record<string, NodeJS.Platform> = {
         darwin: 'linux',
         linux: 'darwin',
     };

--- a/packages/teraslice/test/workers/helpers/test-context.ts
+++ b/packages/teraslice/test/workers/helpers/test-context.ts
@@ -55,7 +55,7 @@ export class TestContext {
     assignment: string;
     clusterMaster!: ClusterMaster.Server;
     _stores: TestStoreContainer = {};
-    cleanups = {};
+    cleanups: Record<string, () => Promise<void>> = {};
 
     constructor(options: TestContextArgs = {}) {
         const {

--- a/packages/teraslice/test/workers/worker/slice-spec.ts
+++ b/packages/teraslice/test/workers/worker/slice-spec.ts
@@ -4,7 +4,10 @@ import { SliceExecution } from '../../../src/lib/workers/worker/slice.js';
 import { TestContext } from '../helpers/index.js';
 
 describe('Slice', () => {
-    async function setupSlice(testContext: any, eventMocks = {}): Promise<SliceExecution> {
+    async function setupSlice(
+        testContext: any,
+        eventMocks: Record<string, jest.Mock> = {}
+    ): Promise<SliceExecution> {
         await testContext.initialize();
         await testContext.executionContext.initialize();
 
@@ -44,7 +47,7 @@ describe('Slice', () => {
             let slice: SliceExecution;
             let results: any;
             let testContext: any;
-            const eventMocks = {};
+            const eventMocks: Record<string, jest.Mock> = {};
 
             beforeEach(async () => {
                 testContext = new TestContext({ analytics: true });
@@ -93,7 +96,7 @@ describe('Slice', () => {
             let slice: SliceExecution;
             let results: any;
             let testContext: any;
-            const eventMocks = {};
+            const eventMocks: Record<string, jest.Mock> = {};
 
             beforeEach(async () => {
                 testContext = new TestContext({ analytics: false });
@@ -136,7 +139,7 @@ describe('Slice', () => {
             let slice: SliceExecution;
             let results: any;
             let testContext: any;
-            const eventMocks = {};
+            const eventMocks: Record<string, jest.Mock> = {};
 
             beforeEach(async () => {
                 testContext = new TestContext({
@@ -184,7 +187,7 @@ describe('Slice', () => {
             let slice: SliceExecution;
             let err: Error;
             let testContext: any;
-            const eventMocks = {};
+            const eventMocks: Record<string, jest.Mock> = {};
 
             beforeEach(async () => {
                 testContext = new TestContext({
@@ -238,7 +241,7 @@ describe('Slice', () => {
         describe('when the slice fails', () => {
             let slice: SliceExecution;
             let testContext: any;
-            const eventMocks = {};
+            const eventMocks: Record<string, jest.Mock> = {};
             let err: Error;
 
             beforeEach(async () => {
@@ -290,7 +293,7 @@ describe('Slice', () => {
         describe('when the slice fails with zero retries', () => {
             let slice: SliceExecution;
             let testContext: any;
-            const eventMocks = {};
+            const eventMocks: Record<string, jest.Mock> = {};
             let err: Error;
 
             beforeEach(async () => {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -36,9 +36,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.6.0",
-        "@terascope/types": "~1.3.2",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/data-mate": "~1.7.0",
+        "@terascope/types": "~1.4.0",
+        "@terascope/utils": "~1.7.0",
         "awesome-phonenumber": "~7.2.0",
         "graphlib": "~2.1.8",
         "jexl": "~2.3.0",

--- a/packages/ts-transforms/src/command.ts
+++ b/packages/ts-transforms/src/command.ts
@@ -8,9 +8,9 @@ import {
     DataEntity, debugLogger, parseList,
     AnyObject, get, pMap
 } from '@terascope/utils';
+import { isXLuceneFieldType, xLuceneTypeConfig } from '@terascope/types';
 import { PhaseManager } from './index.js';
 import { PhaseConfig } from './interfaces.js';
-import { xLuceneFieldType } from 'packages/types/dist/src/xlucene-interfaces.js';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -50,7 +50,7 @@ const filePath = command.rules as string;
 const dataPath = command.data as string;
 const streamData = command.f && command.f === 'ldjson' ? command.f : false;
 const ignoreErrors = command.i || false;
-let typesConfig: Record<string, xLuceneFieldType> = {}; // fixme: confirm it's always one of these
+let typesConfig: xLuceneTypeConfig = {};
 const type = command.m ? 'matcher' : 'transform';
 
 interface ESData {
@@ -65,7 +65,11 @@ try {
             if (pieces.length !== 2) {
                 throw new Error(`Expected -t option line #${index} to have key:value pair format, got ${segment}`);
             }
-            typesConfig[pieces[0].trim()] = pieces[1].trim() as xLuceneFieldType;
+            const fieldType = pieces[1].trim();
+            if (!isXLuceneFieldType(fieldType)) {
+                throw new Error(`Expected -t option line #${index} value of ${fieldType} to be of type xLuceneFieldType`);
+            }
+            typesConfig[pieces[0].trim()] = fieldType;
         });
     }
     if (command.T) {

--- a/packages/ts-transforms/src/command.ts
+++ b/packages/ts-transforms/src/command.ts
@@ -10,6 +10,7 @@ import {
 } from '@terascope/utils';
 import { PhaseManager } from './index.js';
 import { PhaseConfig } from './interfaces.js';
+import { xLuceneFieldType } from 'packages/types/dist/src/xlucene-interfaces.js';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -49,7 +50,7 @@ const filePath = command.rules as string;
 const dataPath = command.data as string;
 const streamData = command.f && command.f === 'ldjson' ? command.f : false;
 const ignoreErrors = command.i || false;
-let typesConfig = {};
+let typesConfig: Record<string, xLuceneFieldType> = {}; // fixme: confirm it's always one of these
 const type = command.m ? 'matcher' : 'transform';
 
 interface ESData {
@@ -64,7 +65,7 @@ try {
             if (pieces.length !== 2) {
                 throw new Error(`Expected -t option line #${index} to have key:value pair format, got ${segment}`);
             }
-            typesConfig[pieces[0].trim()] = pieces[1].trim();
+            typesConfig[pieces[0].trim()] = pieces[1].trim() as xLuceneFieldType;
         });
     }
     if (command.T) {
@@ -136,10 +137,10 @@ function toJSON(obj: AnyObject) {
 }
 
 function handleParsedData(
-    data: Record<string, unknown>[] | Record<string, unknown>
+    data: Record<string, unknown>[]
 ): DataEntity<Record<string, unknown>>[] {
     // input from elasticsearch
-    const elasticSearchResults = get(data[0], 'hits.hits', null);
+    const elasticSearchResults = get(data[0], 'hits.hits', null) as ESData[] | null;
     if (elasticSearchResults) {
         return elasticSearchResults.map((doc: ESData) => DataEntity.make(doc._source));
     }

--- a/packages/ts-transforms/src/loader/utils.ts
+++ b/packages/ts-transforms/src/loader/utils.ts
@@ -154,7 +154,7 @@ function findConfigs(
 ): FieldSourceConfigs[] {
     const identifier = config.follow || config.__id;
     const nodeIds: string[] = tagMapping[identifier];
-    const mapping = {};
+    const mapping: Record<string, boolean> = {};
     const results: FieldSourceConfigs[] = [];
 
     configList
@@ -326,7 +326,7 @@ function createResults(list: OperationConfig[]): ValidationResults {
     };
     const { output } = results;
     let currentSelector: undefined | string;
-    const duplicateListing = {};
+    const duplicateListing: Record<string, boolean> = {};
 
     list.forEach((config) => {
         if (duplicateListing[config.__id]) {

--- a/packages/ts-transforms/src/loader/utils.ts
+++ b/packages/ts-transforms/src/loader/utils.ts
@@ -298,7 +298,7 @@ export function isSimplePostProcessConfig(config: Config) {
     return !has(config, 'follow') && hasPostProcess(config);
 }
 
-export function hasExtractions(config: Config) {
+export function hasExtractions(config: Config): boolean {
     return has(config, 'source') || has(config, 'exp');
 }
 

--- a/packages/ts-transforms/src/operations/index.ts
+++ b/packages/ts-transforms/src/operations/index.ts
@@ -80,6 +80,7 @@ class OperationsManager {
 
     constructor(pluginList: PluginList = []) {
         pluginList.push(CorePlugins);
+        // @ts-expect-error FIXME: try to remove this ignore
         pluginList.push(ValidatorPlugins);
         pluginList.push(dataMatePlugin);
 

--- a/packages/ts-transforms/src/operations/index.ts
+++ b/packages/ts-transforms/src/operations/index.ts
@@ -34,7 +34,7 @@ import MacAddress from './lib/validations/mac-address.js';
 import Uuid from './lib/validations/uuid.js';
 import ISDN from './lib/validations/isdn.js';
 import { Validator, ValidatorPlugins } from './plugins/validator/index.js';
-import dataMapePlugin from './plugins/data-mate/index.js';
+import dataMatePlugin from './plugins/data-mate/index.js';
 
 import {
     OperationsDict, PluginClassType, BaseOperationClass, PluginList
@@ -80,9 +80,8 @@ class OperationsManager {
 
     constructor(pluginList: PluginList = []) {
         pluginList.push(CorePlugins);
-        // @ts-expect-error FIXME: try to remove this ignore
         pluginList.push(ValidatorPlugins);
-        pluginList.push(dataMapePlugin);
+        pluginList.push(dataMatePlugin);
 
         const operations = pluginList.reduce((plugins, PluginClass) => {
             const plugin = new PluginClass();

--- a/packages/ts-transforms/src/operations/lib/validations/base.ts
+++ b/packages/ts-transforms/src/operations/lib/validations/base.ts
@@ -2,11 +2,11 @@ import {
     DataEntity, get, isFunction, isNil
 } from '@terascope/utils';
 import OperationBase from '../base.js';
+import { OperationConfig } from '../../../interfaces.js';
 
 export default abstract class ValidationOpBase<T> extends OperationBase {
     private invert: boolean;
-    // @ts-expect-error
-    constructor(config) {
+    constructor(config: OperationConfig) {
         super(config);
         this.invert = this.config.output === false;
     }

--- a/packages/ts-transforms/src/operations/plugins/data-mate/FieldValidator.ts
+++ b/packages/ts-transforms/src/operations/plugins/data-mate/FieldValidator.ts
@@ -75,7 +75,7 @@ class Validator extends OperationBase {
     }
 }
 
-function setup(method: string) {
+function setup(method: keyof typeof FieldValidator) {
     return InjectMethod(Validator, FieldValidator[method], FieldValidator.repository[method]);
 }
 

--- a/packages/ts-transforms/src/operations/plugins/data-mate/RecordTransform.ts
+++ b/packages/ts-transforms/src/operations/plugins/data-mate/RecordTransform.ts
@@ -28,7 +28,7 @@ class Transforms extends TransformsOpBase {
     }
 }
 
-function setup(method: string) {
+function setup(method: keyof typeof RecordTransform) {
     return InjectMethod(Transforms, RecordTransform[method], RecordTransform.repository[method]);
 }
 

--- a/packages/ts-transforms/src/operations/plugins/data-mate/RecordValidator.ts
+++ b/packages/ts-transforms/src/operations/plugins/data-mate/RecordValidator.ts
@@ -37,7 +37,7 @@ class Validator extends OperationBase {
     }
 }
 
-function setup(method: string) {
+function setup(method: keyof typeof RecordValidator) {
     return InjectMethod(Validator, RecordValidator[method], RecordValidator.repository[method]);
 }
 

--- a/packages/ts-transforms/src/operations/plugins/validator/index.ts
+++ b/packages/ts-transforms/src/operations/plugins/validator/index.ts
@@ -1,7 +1,7 @@
 import { deprecate } from 'util';
 import validator from 'validator';
 import ValidationOpBase from '../../lib/validations/base.js';
-import { PostProcessConfig, PluginClassType, InputOutputCardinality, OperationsDict } from '../../../interfaces.js';
+import { PostProcessConfig, PluginClassType, InputOutputCardinality } from '../../../interfaces.js';
 
 export class Validator extends ValidationOpBase<any> {
     private method: keyof typeof validator;
@@ -24,14 +24,7 @@ export class Validator extends ValidationOpBase<any> {
     }
 }
 
-interface ValidatorInterfaceType {
-    new (config: PostProcessConfig): Validator;
-    cardinality: InputOutputCardinality;
-
-}
-
-function setup(method: keyof typeof validator): ValidatorInterfaceType {
-    // @ts-expect-error fixMe: properly type a class returning a different class
+function setup(method: keyof typeof validator) {
     return class ValidatorInterface {
         static cardinality: InputOutputCardinality = 'one-to-one';
 
@@ -42,7 +35,8 @@ function setup(method: keyof typeof validator): ValidatorInterfaceType {
 }
 
 export class ValidatorPlugins implements PluginClassType {
-    init(): OperationsDict {
+    // @ts-expect-error
+    init() {
         return {
             after: deprecate(setup('isAfter'), 'after is being deprecated., please use isAfter instead', 'after'),
             alpha: deprecate(setup('isAlpha'), 'alpha is being deprecated, please use isAlpha instead', 'alpha'),

--- a/packages/ts-transforms/test/loader/rules-validator-spec.ts
+++ b/packages/ts-transforms/test/loader/rules-validator-spec.ts
@@ -377,7 +377,7 @@ describe('rules-validator', () => {
         it('can return an basic extractions formatted correctly', () => {
             const validator = constructValidator(basicExtractionConfig);
             const { extractions } = validator.validate();
-            const results = {};
+            const results: Record<string, OperationConfig[]> = {};
             results['hello:world'] = basicExtractionConfig;
 
             expect(extractions).toEqual(results);
@@ -386,7 +386,7 @@ describe('rules-validator', () => {
         it('can return an expression extractions formatted correctly', () => {
             const validator = constructValidator(basicExpressionConfig);
             const { extractions } = validator.validate();
-            const results = {};
+            const results: Record<string, OperationConfig[]> = {};
             results['hello:world'] = basicExpressionConfig;
 
             expect(extractions).toEqual(results);
@@ -395,7 +395,7 @@ describe('rules-validator', () => {
         it('can multiple extractions', () => {
             const validator = constructValidator(multiSelectorConfig);
             const { extractions } = validator.validate();
-            const results = {};
+            const results: Record<string, OperationConfig[]> = {};
 
             results['hello:world'] = [multiSelectorConfig[0]];
             results['other:things'] = [multiSelectorConfig[1]];
@@ -407,7 +407,7 @@ describe('rules-validator', () => {
         it('can work with newJoinRules', () => {
             const validator = constructValidator(newJoinRules);
             const { extractions } = validator.validate();
-            const results = {};
+            const results: Record<string, OperationConfig[]> = {};
 
             results['hello:world'] = newJoinRules.slice(0, 2);
 

--- a/packages/ts-transforms/test/operations/validations/validator-lib-spec.ts
+++ b/packages/ts-transforms/test/operations/validations/validator-lib-spec.ts
@@ -7,9 +7,9 @@ describe('validator lib', () => {
     const operationsClass = new ValidatorPlugins();
     const operations = operationsClass.init();
 
-    function getValidator(opConfig: PostProcessConfig, method: string): Validator {
+    function getValidator(opConfig: PostProcessConfig, method: keyof typeof operations): Validator {
         const Class = operations[method];
-        return new Class(opConfig);
+        return new Class(opConfig) as Validator;
     }
 
     function encode(str: string, type: string) {

--- a/packages/ts-transforms/tsconfig.json
+++ b/packages/ts-transforms/tsconfig.json
@@ -2,8 +2,7 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": ".",
-        "suppressImplicitAnyIndexErrors": false
+        "rootDir": "."
     },
     "include": ["src", "test"]
 }

--- a/packages/ts-transforms/tsconfig.json
+++ b/packages/ts-transforms/tsconfig.json
@@ -2,7 +2,8 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": "."
+        "rootDir": ".",
+        "suppressImplicitAnyIndexErrors": false
     },
     "include": ["src", "test"]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/types",
     "displayName": "Types",
-    "version": "1.3.2",
+    "version": "1.4.0",
     "description": "A collection of typescript interfaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/types#readme",
     "bugs": {

--- a/packages/types/src/elasticsearch-interfaces.ts
+++ b/packages/types/src/elasticsearch-interfaces.ts
@@ -192,6 +192,7 @@ type BasicESTypeMapping = {
 
 type IgnoredESTypeMapping = {
     enabled: boolean;
+    [prop: string]: any;
 };
 
 type FieldsESTypeMapping = {
@@ -203,6 +204,7 @@ type FieldsESTypeMapping = {
             analyzer?: string;
         };
     };
+    [prop: string]: any;
 };
 
 export type PropertyESTypes = FieldsESTypeMapping | BasicESTypeMapping;

--- a/packages/types/src/teraslice.ts
+++ b/packages/types/src/teraslice.ts
@@ -523,8 +523,8 @@ export interface SysConfig extends BaseSysconfig<TerasliceConfig> {}
 export type Assignment = 'assets_service' | 'cluster_master' | 'node_master' | 'execution_controller' | 'worker';
 
 interface BaseWorkerNode {
-    worker_id: number;
-    pid: number;
+    worker_id: string | number;
+    pid?: number;
 }
 
 export enum ProcessAssignment {
@@ -572,12 +572,12 @@ export type ProcessNode = ClusterNode
 export interface NodeState {
     node_id: string;
     hostname: string;
-    pid: number;
+    pid: number | 'N/A';
     node_version: string;
     teraslice_version: string;
-    total: number;
+    total: number | 'N/A';
     state: string;
-    available: number;
+    available: number | 'N/A';
     active: ProcessNode[];
 }
 

--- a/packages/types/src/xlucene-interfaces.ts
+++ b/packages/types/src/xlucene-interfaces.ts
@@ -14,6 +14,10 @@ export enum xLuceneFieldType {
     Number = 'number',
 }
 
+export function isXLuceneFieldType(value: string): value is xLuceneFieldType {
+    return Object.values(xLuceneFieldType).includes(value as xLuceneFieldType);
+}
+
 export interface xLuceneTypeConfig {
     [field: string]: xLuceneFieldType;
 }

--- a/packages/types/src/xlucene-interfaces.ts
+++ b/packages/types/src/xlucene-interfaces.ts
@@ -14,8 +14,9 @@ export enum xLuceneFieldType {
     Number = 'number',
 }
 
-export function isXLuceneFieldType(value: string): value is xLuceneFieldType {
-    return Object.values(xLuceneFieldType).includes(value as xLuceneFieldType);
+export function isXLuceneFieldType(value: any): value is xLuceneFieldType {
+    const possibleValues = Object.values(xLuceneFieldType);
+    return possibleValues.includes(value);
 }
 
 export interface xLuceneTypeConfig {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@chainsafe/is-ip": "~2.0.2",
-        "@terascope/types": "~1.3.2",
+        "@terascope/types": "~1.4.0",
         "@turf/bbox": "~7.1.0",
         "@turf/bbox-polygon": "~7.1.0",
         "@turf/boolean-contains": "~7.1.0",

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -2,8 +2,7 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": ".",
-        "suppressImplicitAnyIndexErrors": false
+        "rootDir": "."
     },
     "include": ["src", "test"]
 }

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -33,8 +33,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "~1.3.2",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/types": "~1.4.0",
+        "@terascope/utils": "~1.7.0",
         "peggy": "~4.2.0",
         "ts-pegjs": "~4.2.1"
     },

--- a/packages/xlucene-parser/src/parser.ts
+++ b/packages/xlucene-parser/src/parser.ts
@@ -7,7 +7,7 @@ import { parse } from './peg-engine.js';
 import * as i from './interfaces.js';
 import * as utils from './utils.js';
 
-const termTypes = new Set(utils.termTypes.filter((type) => (
+const termTypes = new Set<i.NodeType>(utils.termTypes.filter((type) => (
     type !== i.NodeType.Range && type !== i.NodeType.Function
 )));
 

--- a/packages/xlucene-parser/tsconfig.json
+++ b/packages/xlucene-parser/tsconfig.json
@@ -2,8 +2,7 @@
     "extends": "../../tsconfig",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": ".",
-        "suppressImplicitAnyIndexErrors": false
+        "rootDir": "."
     },
     "include": ["src", "test"]
 }

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -29,10 +29,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/types": "~1.3.2",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/types": "~1.4.0",
+        "@terascope/utils": "~1.7.0",
         "@types/elasticsearch": "~5.0.43",
-        "xlucene-parser": "~1.6.0"
+        "xlucene-parser": "~1.7.0"
     },
     "devDependencies": {
         "elasticsearch": "~15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -24,10 +24,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@terascope/utils": "~1.6.0"
+        "@terascope/utils": "~1.7.0"
     },
     "devDependencies": {
-        "@terascope/types": "~1.3.2"
+        "@terascope/types": "~1.4.0"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
         "esModuleInterop": true,
         "resolveJsonModule": true,
         "forceConsistentCasingInFileNames": true,
-        "suppressImplicitAnyIndexErrors": true,
         "ignoreDeprecations": "5.0",
         "composite": true,
         "declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2206,6 +2206,13 @@
     lz4-asm "~0.4.2"
     node-gzip "~1.1.2"
 
+"@terascope/types@~1.3.1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@terascope/types/-/types-1.3.2.tgz#444006f6e9fbf45fab0e1b45b1894fb06dc48a35"
+  integrity sha512-pt0793isrLAK0D6A5qJJDrj0mgE1wa1c12xCjIb1c5zacgtJFxdK6VArTEvieqjyDn+DAUY5h9fAAnUsVPnpSg==
+  dependencies:
+    prom-client "~15.1.3"
+
 "@terascope/utils@~1.4.0":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-1.4.2.tgz#de4134651094c4028db16dc670335a5ed0cb5ac2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2648,7 +2648,7 @@
     "@types/jsonfile" "*"
     "@types/node" "*"
 
-"@types/gc-stats@^1.4.3":
+"@types/gc-stats@~1.4.3":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@types/gc-stats/-/gc-stats-1.4.3.tgz#2dc35998fdb6032870816b92b704ee12899f1523"
   integrity sha512-Aek/WiRt7EHDKFNI3hDjYVvPNEeSjWGxN/8jxyaFoAawAq/bd8geI04XPMLQlLBO7LneLoWAAAvFv7hedgdi3w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2648,6 +2648,13 @@
     "@types/jsonfile" "*"
     "@types/node" "*"
 
+"@types/gc-stats@^1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@types/gc-stats/-/gc-stats-1.4.3.tgz#2dc35998fdb6032870816b92b704ee12899f1523"
+  integrity sha512-Aek/WiRt7EHDKFNI3hDjYVvPNEeSjWGxN/8jxyaFoAawAq/bd8geI04XPMLQlLBO7LneLoWAAAvFv7hedgdi3w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/geojson@^7946.0.10", "@types/geojson@^7946.0.14", "@types/geojson@~7946.0.15":
   version "7946.0.15"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.15.tgz#f9d55fd5a0aa2de9dc80b1b04e437538b7298868"
@@ -5529,7 +5536,7 @@ functions-have-names@^1.2.3:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
-gc-stats@~1.4.0:
+gc-stats@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/gc-stats/-/gc-stats-1.4.1.tgz#c9142dc54d02af9e93472b0bd972e6bacecc7be5"
   integrity sha512-eAvDBpI6UjVIYwLxshPCJJIkPyfamIrJzBtW/103+ooJWkISS+chVnHNnsZ+ubaw2607rFeiRDNWHkNUA+ioqg==
@@ -8117,7 +8124,7 @@ parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
-patch-package@^8.0.0:
+patch-package@~8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-8.0.0.tgz#d191e2f1b6e06a4624a0116bcb88edd6714ede61"
   integrity sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==
@@ -8298,7 +8305,7 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
   integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
 
-postinstall-postinstall@^2.1.0:
+postinstall-postinstall@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
   integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
@@ -9784,10 +9791,10 @@ typescript-eslint@~8.18.0:
     "@typescript-eslint/parser" "8.18.0"
     "@typescript-eslint/utils" "8.18.0"
 
-typescript@~5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
-  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+typescript@~5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
+  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
 
 typpy@^2.3.1:
   version "2.3.13"


### PR DESCRIPTION
This PR makes the following changes:
- Update `typescript` from v5.2.2 to v5.7.2
- remove `suppressExplicitAnyIndexErrors` rule from all `tsconfig.json` files
- fix all typescript errors associated with removing the above rule
- add missing `@types/gc-stats` v1.4.3 dev dependency
- bump teraslice to v2.11.0

ref: #3772 