### PR TITLE
[Chart] Set prom_metrics_display_url automatically

### DIFF
--- a/helm/teraslice/templates/_helpers.tpl
+++ b/helm/teraslice/templates/_helpers.tpl
@@ -129,8 +129,12 @@ terafoundation:
   {{- toYaml $filtered | nindent 2 }}
   {{- if hasKey . "prom_metrics_display_url" }}
   prom_metrics_display_url: {{ .prom_metrics_display_url }}
-  {{- else if and ($.Values.ingress.enabled) (not (empty $.Values.ingress.hosts)) }}
-  prom_metrics_display_url: {{ (index $.Values.ingress.hosts 0).host }}
+  {{- else if and (hasKey $.Values "ingress") ($.Values.ingress.enabled | default false) (not (empty $.Values.ingress.hosts)) }}
+  {{- $protocol := "http://" }}
+  {{- if and (hasKey $.Values.ingress "tls") (not (empty $.Values.ingress.tls)) }}
+    {{- $protocol = "https://" }}
+  {{- end }}
+  prom_metrics_display_url: {{ printf "%s%s" $protocol (index $.Values.ingress.hosts 0).host }}
   {{- end }}
 {{- end }}
 
@@ -179,8 +183,12 @@ terafoundation:
   {{- toYaml $filtered | nindent 2 }}
   {{- if hasKey . "prom_metrics_display_url" }}
   prom_metrics_display_url: {{ .prom_metrics_display_url }}
-  {{- else if and ($.Values.ingress.enabled) (not (empty $.Values.ingress.hosts)) }}
-  prom_metrics_display_url: {{ (index $.Values.ingress.hosts 0).host }}
+  {{- else if and (hasKey $.Values "ingress") ($.Values.ingress.enabled | default false) (not (empty $.Values.ingress.hosts)) }}
+  {{- $protocol := "http://" }}
+  {{- if and (hasKey $.Values.ingress "tls") (not (empty $.Values.ingress.tls)) }}
+    {{- $protocol = "https://" }}
+  {{- end }}
+  prom_metrics_display_url: {{ printf "%s%s" $protocol (index $.Values.ingress.hosts 0).host }}
   {{- end }}
 {{- end }}
 

--- a/helm/teraslice/templates/_helpers.tpl
+++ b/helm/teraslice/templates/_helpers.tpl
@@ -175,7 +175,13 @@ Create teraslice worker base config
 {{- define "teraslice.workerConfig" -}}
 {{- with .Values.terafoundation }}
 terafoundation:
-  {{- toYaml . | nindent 2 }}
+  {{- $filtered := omit . "prom_metrics_display_url" }}
+  {{- toYaml $filtered | nindent 2 }}
+  {{- if hasKey . "prom_metrics_display_url" }}
+  prom_metrics_display_url: {{ .prom_metrics_display_url }}
+  {{- else if and ($.Values.ingress.enabled) (not (empty $.Values.ingress.hosts)) }}
+  prom_metrics_display_url: {{ (index $.Values.ingress.hosts 0).host }}
+  {{- end }}
 {{- end }}
 
 {{- with .Values.stats }}

--- a/helm/teraslice/templates/_helpers.tpl
+++ b/helm/teraslice/templates/_helpers.tpl
@@ -128,13 +128,15 @@ terafoundation:
   {{- $filtered := omit . "prom_metrics_display_url" }}
   {{- toYaml $filtered | nindent 2 }}
   {{- if hasKey . "prom_metrics_display_url" }}
-  prom_metrics_display_url: {{ .prom_metrics_display_url }}
+  {{- $url := .prom_metrics_display_url }}
+  prom_metrics_display_url: {{ printf "%s/" (trimSuffix "/" $url) }}
   {{- else if and (hasKey $.Values "ingress") ($.Values.ingress.enabled | default false) (not (empty $.Values.ingress.hosts)) }}
   {{- $protocol := "http://" }}
   {{- if and (hasKey $.Values.ingress "tls") (not (empty $.Values.ingress.tls)) }}
     {{- $protocol = "https://" }}
   {{- end }}
-  prom_metrics_display_url: {{ printf "%s%s" $protocol (index $.Values.ingress.hosts 0).host }}
+  {{- $baseUrl := printf "%s%s" $protocol (index $.Values.ingress.hosts 0).host }}
+  prom_metrics_display_url: {{ printf "%s/" (trimSuffix "/" $baseUrl) }}
   {{- end }}
 {{- end }}
 
@@ -182,13 +184,15 @@ terafoundation:
   {{- $filtered := omit . "prom_metrics_display_url" }}
   {{- toYaml $filtered | nindent 2 }}
   {{- if hasKey . "prom_metrics_display_url" }}
-  prom_metrics_display_url: {{ .prom_metrics_display_url }}
+  {{- $url := .prom_metrics_display_url }}
+  prom_metrics_display_url: {{ printf "%s/" (trimSuffix "/" $url) }}
   {{- else if and (hasKey $.Values "ingress") ($.Values.ingress.enabled | default false) (not (empty $.Values.ingress.hosts)) }}
   {{- $protocol := "http://" }}
   {{- if and (hasKey $.Values.ingress "tls") (not (empty $.Values.ingress.tls)) }}
     {{- $protocol = "https://" }}
   {{- end }}
-  prom_metrics_display_url: {{ printf "%s%s" $protocol (index $.Values.ingress.hosts 0).host }}
+  {{- $baseUrl := printf "%s%s" $protocol (index $.Values.ingress.hosts 0).host }}
+  prom_metrics_display_url: {{ printf "%s/" (trimSuffix "/" $baseUrl) }}
   {{- end }}
 {{- end }}
 

--- a/helm/teraslice/templates/_helpers.tpl
+++ b/helm/teraslice/templates/_helpers.tpl
@@ -125,8 +125,15 @@ Create teraslice master base config
 {{- define "teraslice.masterConfig" -}}
 {{- with .Values.terafoundation }}
 terafoundation:
-  {{- toYaml . | nindent 2 }}
+  {{- $filtered := omit . "prom_metrics_display_url" }}
+  {{- toYaml $filtered | nindent 2 }}
+  {{- if hasKey . "prom_metrics_display_url" }}
+  prom_metrics_display_url: {{ .prom_metrics_display_url }}
+  {{- else if and ($.Values.ingress.enabled) (not (empty $.Values.ingress.hosts)) }}
+  prom_metrics_display_url: {{ (index $.Values.ingress.hosts 0).host }}
+  {{- end }}
 {{- end }}
+
 
 {{- with .Values.stats }}
 stats:


### PR DESCRIPTION
This PR makes the following changes:

- Adds feature to helm chart template to support dynamic configuration of `prom_metrics_display_url`
  - If the user explicitly sets `prom_metrics_display_url` in the terafoundation config, the provided value is used without modification (except making sure a trailing slash is appended if missing). Ex: `http://teraslice.local` will end up as `http://teraslice.local/` in the configmap.
  - When `prom_metrics_display_url` is not set, the URL is dynamically constructed based on if the `ingress.enabled` configuration is `true` or `false`
    - If `true`, it will make a url based off of the value in `.Values.ingress.hosts`.
      - It will also add a `https://` prefix if `ingress.tls` is defined and non-empty. Otherwise will use `http://` prefix
    - If `false` it will leave `prom_metrics_display_url` unset

Ref to issue #3852