### PR TITLE
Re-enable docker-compose-js and types unit tests

### DIFF
--- a/packages/docker-compose-js/package.json
+++ b/packages/docker-compose-js/package.json
@@ -48,7 +48,7 @@
     },
     "srcMain": "src/index.ts",
     "terascope": {
-        "testSuite": "disabled",
+        "testSuite": "unit",
         "enableTypedoc": true
     }
 }

--- a/packages/docker-compose-js/package.json
+++ b/packages/docker-compose-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/docker-compose-js",
     "displayName": "Docker Compose Js",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "description": "Node.js driver for controlling docker-compose testing environments.",
     "keywords": [
         "docker",

--- a/packages/docker-compose-js/src/index.ts
+++ b/packages/docker-compose-js/src/index.ts
@@ -96,15 +96,10 @@ export class Compose {
                         error.stdout = stdout;
                         reject(error);
                     } else {
-                        // sometimes a command is successful (no error), but prints a failure
-                        // of some kind to stderr. It may also print to stdout, so return both.
-                        if (stderr && stdout) {
-                            resolve(`stdout: ${stdout}, stderr: ${stderr}`);
-                        }
-                        if (stderr) {
-                            resolve(stderr);
-                        }
-                        resolve(stdout);
+                        // sometimes a command is successful (no error), but prints a failure of
+                        // some kind to stderr. If no stdout, return stderr instead.
+                        const msg = stdout !== '' ? stdout : stderr;
+                        resolve(msg);
                     }
                 });
             }

--- a/packages/docker-compose-js/test/docker-compose-spec.ts
+++ b/packages/docker-compose-js/test/docker-compose-spec.ts
@@ -1,4 +1,5 @@
 import 'jest-extended';
+import { jest } from '@jest/globals';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Compose } from '../src/index.js';
@@ -25,14 +26,16 @@ describe('compose', () => {
     it('should be able to call compose.version()', async () => {
         const result = await compose.version();
         expect(result).not.toBeNil();
-        expect(result).toContain('docker-compose version');
+        expect(result).toContain('Docker Compose version');
     });
 
     describe('when the cluster is up', () => {
-        beforeAll(() => compose.up({
-            timeout: 1,
-            'force-recreate': ''
-        }));
+        beforeAll(async () => {
+            await compose.up({
+                timeout: 1,
+                'force-recreate': ''
+            });
+        });
 
         afterAll(() => compose.down({
             timeout: 1,
@@ -40,22 +43,25 @@ describe('compose', () => {
             '--remove-orphans': ''
         }));
 
-        it('should be able to call rm on the service', () => {
-            expect(() => compose.rm('test')).not.toThrow();
+        it('should be able to call rm on the service', async () => {
+            const result = await compose.rm('test');
+            expect(result).toContain('No stopped containers');
         });
 
-        it('should be able to call port', () => {
+        it('should be able to call port on the service', () => {
             expect(() => compose.port('test', '40230')).not.toThrow();
         });
 
-        it('should be able to call pause and unpause the service', async () => {
-            await expect(async () => {
-                await compose.pause('test');
-                await compose.unpause('test');
-            }).resolves.not.toThrow();
+        it('should be able to call pause and unpause on the service', async () => {
+            await expect(
+                (async () => {
+                    await compose.pause('test');
+                    await compose.unpause('test');
+                })()
+            ).resolves.not.toThrow();
         });
 
-        it('should be able to call start, ps and stop the service', async () => {
+        it('should be able to call start, ps and stop on the service', async () => {
             await compose.start('test');
 
             const result = await compose.ps();
@@ -67,11 +73,13 @@ describe('compose', () => {
             });
         });
 
-        it('should be able to call restart and kill the service', async () => {
-            await expect(async () => {
-                await compose.restart('test', { '--timeout': 1 });
-                await compose.kill('test');
-            }).resolves.not.toThrow();
+        it('should be able to call restart and kill on the service', async () => {
+            await expect(
+                (async () => {
+                    await compose.restart('test', { '--timeout': 1 });
+                    await compose.kill('test');
+                })()
+            ).resolves.not.toThrow();
         });
 
         it('should return a rejection when passing in incorrect options', async () => {
@@ -80,7 +88,7 @@ describe('compose', () => {
                 await compose.start('something wrong');
             } catch (err) {
                 expect(err.message).toContain('Command exited: 1');
-                expect(err.message).toContain('No such service: something wrong');
+                expect(err.message).toContain('no such service: something wrong');
                 expect(err.stdout).toBeDefined();
             }
         });

--- a/packages/docker-compose-js/test/fixtures/example.yaml
+++ b/packages/docker-compose-js/test/fixtures/example.yaml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   test:
     image: 'bash:3.2.57'

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -37,7 +37,7 @@
     },
     "srcMain": "src/index.ts",
     "terascope": {
-        "testSuite": "disabled",
+        "testSuite": "unit",
         "enableTypedoc": true
     }
 }


### PR DESCRIPTION
This PR makes the following changes:
- bump docker-compose-js from v1.4.2 to v1.4.3
- re-enable unit tests for docker-compose-js and types packages
- update docker-compose-js tests to account for changes to package since the tests were disabled