### PR TITLE
[workspace] add workflow job to automate Teraslice releases

### DIFF
--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -62,15 +62,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version:  22
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'yarn'
-
       - name: Install semver-compare-cli
-        run: yarn add semver-compare-cli
+        run: yarn && yarn add semver-compare-cli
 
       - name: Check for teraslice version update
         id: version_check

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -94,7 +94,7 @@ jobs:
           name: ${{ steps.version_check.outputs.tag }}
           generate_release_notes: true
 
-      - name: Post text to a Slack channel
+      - name: Announce release in Slack releases channel
         if: steps.version_check.outputs.version_updated == 'true'
         uses: slackapi/slack-github-action@v2.0.0
         with:

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -77,7 +77,7 @@ jobs:
           if ./node_modules/.bin/semver-compare $CURRENT_VERSION gt $NPM_VERSION; then
             echo "Teraslice version updated from $NPM_VERSION to $CURRENT_VERSION, creating release"
             echo "version_updated=true" >> $GITHUB_OUTPUT
-            echo "tag=v$CURRENT_VERSION"
+            echo "tag: v$CURRENT_VERSION"
             echo "tag=v$CURRENT_VERSION" >> $GITHUB_OUTPUT
           else
             echo "Teraslice version not updated, will not release"

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -1,4 +1,4 @@
-name: Publish Teraslice NPM Packages, Documents and Docker Image
+name: Publish Teraslice NPM Packages, Documents and Docker Image, Create Release
 
 on:
   pull_request:
@@ -53,6 +53,59 @@ jobs:
 
       - name: Publish to docker
         run: yarn ts-scripts publish -t dev docker
+
+  create-release-on-teraslice-bump:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    needs: build-release
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version:  22
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+
+      - name: Install semver-compare-cli
+        run: yarn add semver-compare-cli
+
+      - name: Check for teraslice version update
+        id: version_check
+        run: |
+          # HEAD is the merge commit
+          # HEAD^ is the previous commit (final commit of the PR)
+          # BASE_COMMIT is the common ancestor (previous HEAD of master branch)
+          BASE_COMMIT=$(git merge-base HEAD HEAD^)
+          echo "base commit:" $BASE_COMMIT
+
+          BASE_VERSION=$(git show $BASE_COMMIT:package.json | jq -r .version)
+          echo "base version:" $BASE_VERSION
+
+          CURRENT_VERSION=$(jq -r .version package.json)
+          echo "current version:" $CURRENT_VERSION
+
+          if ./node_modules/.bin/semver-compare $CURRENT_VERSION gt $BASE_VERSION; then
+            echo "Teraslice version updated, creating release"
+            echo "version_updated=true" >> $GITHUB_OUTPUT
+            echo "tag=v$CURRENT_VERSION"
+            echo "tag=v$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "Teraslice version not updated, will not release"
+            echo "version_updated=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        if: steps.version_check.outputs.version_updated == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          tag_name: ${{ steps.version_check.outputs.tag }}
+          name: ${{ steps.version_check.outputs.tag }}
+          generate_release_notes: true
 
   build-docs:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -94,6 +94,19 @@ jobs:
           name: ${{ steps.version_check.outputs.tag }}
           generate_release_notes: true
 
+      - name: Post text to a Slack channel
+        if: steps.version_check.outputs.version_updated == 'true'
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ vars.SLACK_RELEASES_CHANNEL_ID }}
+            text: |
+              "Teraslice version ${{ steps.version_check.outputs.tag }} has been released.
+              Please review and revise the automated release notes:
+              https://github.com/terascope/teraslice/releases/tag/${{ steps.version_check.outputs.tag }}"
+
   build-docs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -75,20 +75,14 @@ jobs:
       - name: Check for teraslice version update
         id: version_check
         run: |
-          # HEAD is the merge commit
-          # HEAD^ is the previous commit (final commit of the PR)
-          # BASE_COMMIT is the common ancestor (previous HEAD of master branch)
-          BASE_COMMIT=$(git merge-base HEAD HEAD^)
-          echo "base commit:" $BASE_COMMIT
-
-          BASE_VERSION=$(git show $BASE_COMMIT:package.json | jq -r .version)
-          echo "base version:" $BASE_VERSION
-
           CURRENT_VERSION=$(jq -r .version package.json)
           echo "current version:" $CURRENT_VERSION
 
-          if ./node_modules/.bin/semver-compare $CURRENT_VERSION gt $BASE_VERSION; then
-            echo "Teraslice version updated, creating release"
+          NPM_VERSION=$(yarn npm info teraslice --json | jq -r '.["dist-tags"].latest')
+          echo "npm version:" $NPM_VERSION
+
+          if ./node_modules/.bin/semver-compare $CURRENT_VERSION gt $NPM_VERSION; then
+            echo "Teraslice version updated from $NPM_VERSION to $CURRENT_VERSION, creating release"
             echo "version_updated=true" >> $GITHUB_OUTPUT
             echo "tag=v$CURRENT_VERSION"
             echo "tag=v$CURRENT_VERSION" >> $GITHUB_OUTPUT

--- a/e2e/test/cases/validation/version-sync-spec.ts
+++ b/e2e/test/cases/validation/version-sync-spec.ts
@@ -1,0 +1,14 @@
+import path from 'node:path';
+import semver from 'semver';
+import fse from 'fs-extra';
+import { getRootInfo } from '@terascope/scripts';
+
+describe('Ensure teraslice and root versions are in sync', () => {
+    it('Versions are equal', () => {
+        const pathToTeraslicePkgJson = path.join(process.cwd(), '../packages/teraslice/package.json');
+        const terasliceVersion = fse.readJSONSync(pathToTeraslicePkgJson).version;
+        const rootVersion = getRootInfo().version;
+
+        expect(semver.eq(terasliceVersion, rootVersion)).toBe(true);
+    });
+});

--- a/packages/scripts/src/helpers/bump/index.ts
+++ b/packages/scripts/src/helpers/bump/index.ts
@@ -30,7 +30,7 @@ export async function bumpPackages(options: BumpPackageOptions, isAsset: boolean
     const bumpedMain = mainInfo ? packagesToBump[mainInfo.name] : false;
 
     if (bumpedMain) {
-        signale.note(`IMPORTANT: make sure create release of v${mainInfo!.version} after merging`);
+        signale.note(`IMPORTANT: make sure to update release notes for automated release of v${mainInfo!.version} after merging`);
     }
 
     if (rootInfo.terascope.version !== 2) {


### PR DESCRIPTION
This PR makes the following changes:
- Add a new job to the `publish-master.yml` workflow called `create-release-on-teraslice-bump`. It first uses `semver-compare-cli` to check if the version of Teraslice in the root `package.json` is greater than it was in the previous master branch. If it has then the `softprops/action-gh-release@v2` action creates a release. As with a manual release, the publish-tag.yml workflow will automatically run when the release is created.
- Add a test to ensure the teraslice version and root package.json version stay in sync. 

TODO: Should we bump teraslice just to make the new workflow job run?

ref: #1502 
