### PR TITLE
Fix CI issues after yarn 4 update

### DIFF
--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -63,7 +63,7 @@ jobs:
           cache: 'yarn'
 
       - name: Build documentation
-        run: ./scripts/build-documentation.sh  # output in website/build
+        run: yarn && ./scripts/build-documentation.sh  # output in website/build
       - name: Check Output
         run: find ./website/build
       - name: Upload artifact

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -43,7 +43,7 @@
         "ms": "~2.1.3"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.8.1",
+        "@terascope/scripts": "~1.9.0",
         "@terascope/types": "~1.4.1",
         "bunyan": "~1.8.15",
         "elasticsearch-store": "~1.7.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "@eslint/js": "~9.16.0",
         "@swc/core": "1.4.0",
         "@swc/jest": "~0.2.36",
-        "@terascope/scripts": "~1.8.1",
+        "@terascope/scripts": "~1.9.0",
         "@types/bluebird": "~3.5.42",
         "@types/convict": "~6.1.6",
         "@types/elasticsearch": "~5.0.43",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.8.1",
+    "version": "1.9.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -1,5 +1,5 @@
 import {
-    get, concat, pMap,
+    concat, pMap,
     isString, toHumanTime
 } from '@terascope/utils';
 import { PackageInfo } from '../interfaces.js';
@@ -11,7 +11,7 @@ import {
 } from './utils.js';
 import {
     yarnPublish, yarnRun, remoteDockerImageExists,
-    dockerBuild, dockerPush, yarnPublishV2,
+    dockerBuild, dockerPush,
     getNodeVersionFromImage
 } from '../scripts.js';
 import { getRootInfo, getDevDockerImage, formatList } from '../misc.js';
@@ -69,13 +69,7 @@ async function npmPublish(
         return pkgInfo.name;
     }
 
-    const rootInfo = getRootInfo();
-    if (rootInfo.terascope.version === 2) {
-        await yarnPublishV2(pkgInfo, tag);
-    } else {
-        const registry: string | undefined = get(pkgInfo, 'publishConfig.registry');
-        await yarnPublish(pkgInfo, tag, registry);
-    }
+    await yarnPublish(pkgInfo, tag);
     return pkgInfo.name;
 }
 

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -586,9 +586,9 @@ export function mapToArgs(input: ArgsMap): string[] {
 }
 
 /**
- * Yarn publish for version 2
+ * Yarn publish for yarn versions 2, 3, and 4
 */
-export async function yarnPublishV2(
+export async function yarnPublish(
     pkgInfo: PackageInfo,
     tag = 'latest',
 ): Promise<void> {
@@ -597,31 +597,6 @@ export async function yarnPublishV2(
         args: [
             'npm',
             'publish',
-            '--tag',
-            tag
-        ],
-        cwd: pkgInfo.dir,
-        env: {
-            NODE_ENV: 'production'
-        }
-    });
-}
-
-export async function yarnPublish(
-    pkgInfo: PackageInfo,
-    tag = 'latest',
-    registry = config.NPM_DEFAULT_REGISTRY
-): Promise<void> {
-    await fork({
-        cmd: 'yarn',
-        args: [
-            'publish',
-            '--non-interactive',
-            '--new-version',
-            pkgInfo.version,
-            '--no-git-tag-version',
-            '--registry',
-            registry,
             '--tag',
             tag
         ],

--- a/scripts/build-documentation.sh
+++ b/scripts/build-documentation.sh
@@ -28,7 +28,7 @@ main() {
     yarn setup &&
         yarn docs &&
         cd website &&
-        yarn install --prod --no-default-rc &&
+        yarn install  &&
         yarn run build
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2941,7 +2941,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/scripts@npm:~1.8.1, @terascope/scripts@workspace:packages/scripts":
+"@terascope/scripts@npm:~1.9.0, @terascope/scripts@workspace:packages/scripts":
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
@@ -6261,7 +6261,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e@workspace:e2e"
   dependencies:
-    "@terascope/scripts": "npm:~1.8.1"
+    "@terascope/scripts": "npm:~1.9.0"
     "@terascope/types": "npm:~1.4.1"
     bunyan: "npm:~1.8.15"
     elasticsearch-store: "npm:~1.7.1"
@@ -13226,7 +13226,7 @@ __metadata:
     "@eslint/js": "npm:~9.16.0"
     "@swc/core": "npm:1.4.0"
     "@swc/jest": "npm:~0.2.36"
-    "@terascope/scripts": "npm:~1.8.1"
+    "@terascope/scripts": "npm:~1.9.0"
     "@types/bluebird": "npm:~3.5.42"
     "@types/convict": "npm:~6.1.6"
     "@types/elasticsearch": "npm:~5.0.43"


### PR DESCRIPTION
This PR makes the following changes:

- Fixes broken ci piplines that publish npm packages after a merge to master
  - This is caused by scripts using the old yarn 1 sub-command to publish npm packages which yarn 4 doesn't support
- bump: (minor) @terascope/scripts@1.9.0