### PR TITLE
fix npm auth token for yarn 4

### DIFF
--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -41,7 +41,14 @@ jobs:
       - name: Install and build packages
         run: yarn && yarn setup
 
+      - name: Verify npm authentication within yarn
+        env:
+          CI_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: yarn npm whoami
+
       - name: Publish to npm
+        env:
+          CI_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn ts-scripts publish -t latest npm
 
       - name: Publish to docker

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install and build packages
         run: yarn && yarn setup
 
+      - name: Verify npm authentication within yarn
+        run: CI_NPM_AUTH_TOKEN=${{ secrets.NPM_TOKEN }} yarn npm whoami
+
       - name: Publish to npm
         run: CI_NPM_AUTH_TOKEN=${{ secrets.NPM_TOKEN }} yarn ts-scripts publish -t tag npm
 

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -30,10 +30,14 @@ jobs:
         run: yarn && yarn setup
 
       - name: Verify npm authentication within yarn
-        run: CI_NPM_AUTH_TOKEN=${{ secrets.NPM_TOKEN }} yarn npm whoami
+        env:
+          CI_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: yarn npm whoami
 
       - name: Publish to npm
-        run: CI_NPM_AUTH_TOKEN=${{ secrets.NPM_TOKEN }} yarn ts-scripts publish -t tag npm
+        env:
+          CI_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: yarn ts-scripts publish -t tag npm
 
   docker-build-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -30,7 +30,7 @@ jobs:
         run: yarn && yarn setup
 
       - name: Publish to npm
-        run: yarn ts-scripts publish -t tag npm
+        run: CI_NPM_AUTH_TOKEN=${{ secrets.NPM_TOKEN }} yarn ts-scripts publish -t tag npm
 
   docker-build-publish:
     runs-on: ubuntu-latest

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,6 +8,4 @@ yarnPath: .yarn/releases/yarn-4.6.0.cjs
 
 enableHardenedMode: false
 
-npmScopes:
-  _default:
-    npmAuthToken: "${CI_NPM_AUTH_TOKEN:-placeHolderToken}"
+npmAuthToken: "${CI_NPM_AUTH_TOKEN:-placeHolderToken}"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,3 +7,7 @@ nodeLinker: node-modules
 yarnPath: .yarn/releases/yarn-4.6.0.cjs
 
 enableHardenedMode: false
+
+npmScopes:
+  _default:
+    npmAuthToken: "${CI_NPM_AUTH_TOKEN:-placeHolderToken}"


### PR DESCRIPTION
This PR makes the following changes:

- Fixes issue where yarn wasn't getting an npm auth token when publishing packages.