### PR TITLE
[xlucene-parser] Fix xlucene-parser postinstall permissions for npm

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -46,7 +46,7 @@
         "@terascope/scripts": "~1.9.0",
         "@terascope/types": "~1.4.1",
         "bunyan": "~1.8.15",
-        "elasticsearch-store": "~1.7.1",
+        "elasticsearch-store": "~1.7.2",
         "fs-extra": "~11.2.0",
         "jest": "^29.7.0",
         "jest-extended": "^4.0.2",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -45,7 +45,7 @@
         "uuid": "~11.0.3",
         "valid-url": "~1.0.9",
         "validator": "~13.12.0",
-        "xlucene-parser": "~1.7.1"
+        "xlucene-parser": "~1.7.2"
     },
     "devDependencies": {
         "@types/ip6addr": "~0.2.6",

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "~1.2.0",
         "@types/elasticsearch": "~5.0.43",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.7.1",
+        "elasticsearch-store": "~1.7.2",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@~7.17.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@~8.15.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,7 +30,7 @@
         "test:watch": "ts-scripts yarn workspace @terascope/scripts test --watch ../elasticsearch-store --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.7.1",
+        "@terascope/data-mate": "~1.7.2",
         "@terascope/data-types": "~1.7.1",
         "@terascope/types": "~1.4.1",
         "@terascope/utils": "~1.7.1",
@@ -43,7 +43,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@~2.12.0",
         "setimmediate": "~1.0.5",
         "uuid": "~11.0.3",
-        "xlucene-translator": "~1.7.1"
+        "xlucene-translator": "~1.7.2"
     },
     "devDependencies": {
         "@types/uuid": "~10.0.0"

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "1.9.1",
+    "version": "1.9.2",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -37,7 +37,7 @@
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.7.1",
+        "elasticsearch-store": "~1.7.2",
         "express": "~4.21.2",
         "js-yaml": "~4.1.0",
         "nanoid": "~5.0.9",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -62,7 +62,7 @@
         "semver": "~7.6.3",
         "socket.io": "~1.7.4",
         "socket.io-client": "~1.7.4",
-        "terafoundation": "~1.9.1",
+        "terafoundation": "~1.9.2",
         "uuid": "~11.0.3"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -36,7 +36,7 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../ts-transforms --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.7.1",
+        "@terascope/data-mate": "~1.7.2",
         "@terascope/types": "~1.4.1",
         "@terascope/utils": "~1.7.1",
         "awesome-phonenumber": "~7.2.0",

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -25,7 +25,7 @@
     "scripts": {
         "benchmark": "yarn build && node bench/index.js",
         "prebuild": "./scripts/generate-engine.js",
-        "build": "tsc --build",
+        "build": "yarn prebuild && tsc --build",
         "build:watch": "yarn build --watch",
         "postinstall": "./scripts/fix-deps.js",
         "test": "yarn workspace @terascope/scripts ts-scripts test ../xlucene-parser --",
@@ -48,7 +48,10 @@
     },
     "publishConfig": {
         "access": "public",
-        "registry": "https://registry.npmjs.org/"
+        "registry": "https://registry.npmjs.org/",
+        "executableFiles": [
+            "./scripts/fix-deps.js"
+        ]
     },
     "srcMain": "src/index.ts",
     "terascope": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -48,10 +48,10 @@
     },
     "publishConfig": {
         "access": "public",
-        "registry": "https://registry.npmjs.org/",
         "executableFiles": [
             "./scripts/fix-deps.js"
-        ]
+        ],
+        "registry": "https://registry.npmjs.org/"
     },
     "srcMain": "src/index.ts",
     "terascope": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -32,7 +32,7 @@
         "@terascope/types": "~1.4.1",
         "@terascope/utils": "~1.7.1",
         "@types/elasticsearch": "~5.0.43",
-        "xlucene-parser": "~1.7.1"
+        "xlucene-parser": "~1.7.2"
     },
     "devDependencies": {
         "elasticsearch": "~15.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2799,7 +2799,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/data-mate@npm:~1.7.1, @terascope/data-mate@workspace:packages/data-mate":
+"@terascope/data-mate@npm:~1.7.2, @terascope/data-mate@workspace:packages/data-mate":
   version: 0.0.0-use.local
   resolution: "@terascope/data-mate@workspace:packages/data-mate"
   dependencies:
@@ -2822,7 +2822,7 @@ __metadata:
     uuid: "npm:~11.0.3"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
-    xlucene-parser: "npm:~1.7.1"
+    xlucene-parser: "npm:~1.7.2"
   languageName: unknown
   linkType: soft
 
@@ -2858,7 +2858,7 @@ __metadata:
     "@types/elasticsearch": "npm:~5.0.43"
     bluebird: "npm:~3.7.2"
     elasticsearch: "npm:~15.4.1"
-    elasticsearch-store: "npm:~1.7.1"
+    elasticsearch-store: "npm:~1.7.2"
     elasticsearch6: "npm:@elastic/elasticsearch@~6.8.0"
     elasticsearch7: "npm:@elastic/elasticsearch@~7.17.0"
     elasticsearch8: "npm:@elastic/elasticsearch@~8.15.0"
@@ -6264,7 +6264,7 @@ __metadata:
     "@terascope/scripts": "npm:~1.9.0"
     "@terascope/types": "npm:~1.4.1"
     bunyan: "npm:~1.8.15"
-    elasticsearch-store: "npm:~1.7.1"
+    elasticsearch-store: "npm:~1.7.2"
     fs-extra: "npm:~11.2.0"
     jest: "npm:^29.7.0"
     jest-extended: "npm:^4.0.2"
@@ -6327,11 +6327,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elasticsearch-store@npm:~1.7.1, elasticsearch-store@workspace:packages/elasticsearch-store":
+"elasticsearch-store@npm:~1.7.2, elasticsearch-store@workspace:packages/elasticsearch-store":
   version: 0.0.0-use.local
   resolution: "elasticsearch-store@workspace:packages/elasticsearch-store"
   dependencies:
-    "@terascope/data-mate": "npm:~1.7.1"
+    "@terascope/data-mate": "npm:~1.7.2"
     "@terascope/data-types": "npm:~1.7.1"
     "@terascope/types": "npm:~1.4.1"
     "@terascope/utils": "npm:~1.7.1"
@@ -6345,7 +6345,7 @@ __metadata:
     opensearch2: "npm:@opensearch-project/opensearch@~2.12.0"
     setimmediate: "npm:~1.0.5"
     uuid: "npm:~11.0.3"
-    xlucene-translator: "npm:~1.7.1"
+    xlucene-translator: "npm:~1.7.2"
   languageName: unknown
   linkType: soft
 
@@ -13125,7 +13125,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terafoundation@npm:~1.9.1, terafoundation@workspace:packages/terafoundation":
+"terafoundation@npm:~1.9.2, terafoundation@workspace:packages/terafoundation":
   version: 0.0.0-use.local
   resolution: "terafoundation@workspace:packages/terafoundation"
   dependencies:
@@ -13142,7 +13142,7 @@ __metadata:
     convict-format-with-moment: "npm:~6.2.0"
     convict-format-with-validator: "npm:~6.2.0"
     elasticsearch: "npm:~15.4.1"
-    elasticsearch-store: "npm:~1.7.1"
+    elasticsearch-store: "npm:~1.7.2"
     express: "npm:~4.21.2"
     got: "npm:~13.0.0"
     js-yaml: "npm:~4.1.0"
@@ -13285,7 +13285,7 @@ __metadata:
     semver: "npm:~7.6.3"
     socket.io: "npm:~1.7.4"
     socket.io-client: "npm:~1.7.4"
-    terafoundation: "npm:~1.9.1"
+    terafoundation: "npm:~1.9.2"
     uuid: "npm:~11.0.3"
   languageName: unknown
   linkType: soft
@@ -13499,7 +13499,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ts-transforms@workspace:packages/ts-transforms"
   dependencies:
-    "@terascope/data-mate": "npm:~1.7.1"
+    "@terascope/data-mate": "npm:~1.7.2"
     "@terascope/types": "npm:~1.4.1"
     "@terascope/utils": "npm:~1.7.1"
     "@types/graphlib": "npm:~2.1.12"
@@ -14264,7 +14264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xlucene-parser@npm:~1.7.1, xlucene-parser@workspace:packages/xlucene-parser":
+"xlucene-parser@npm:~1.7.2, xlucene-parser@workspace:packages/xlucene-parser":
   version: 0.0.0-use.local
   resolution: "xlucene-parser@workspace:packages/xlucene-parser"
   dependencies:
@@ -14277,7 +14277,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"xlucene-translator@npm:~1.7.1, xlucene-translator@workspace:packages/xlucene-translator":
+"xlucene-translator@npm:~1.7.2, xlucene-translator@workspace:packages/xlucene-translator":
   version: 0.0.0-use.local
   resolution: "xlucene-translator@workspace:packages/xlucene-translator"
   dependencies:
@@ -14285,7 +14285,7 @@ __metadata:
     "@terascope/utils": "npm:~1.7.1"
     "@types/elasticsearch": "npm:~5.0.43"
     elasticsearch: "npm:~15.4.1"
-    xlucene-parser: "npm:~1.7.1"
+    xlucene-parser: "npm:~1.7.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR makes the following changes:

- Fixes the package.json in `xlucene-parser` to specify the post install script to be executable when packaged for npm
- bump: (patch) **xlucene-parser**@1.7.2, 
- bump: (patch) **@terascope/data-mate**@1.7.2
- bump: (patch) **elasticsearch-store**@1.7.2, 
- bump: (patch) **terafoundation**@1.9.2
- bump: (patch) **ts-transforms**@1.7.2, 
- bump: (patch) **xlucene-translator**@1.7.2

Ref to issue #3900