### PR TITLE
[teraslice, workspace] Update typescript to 5.7.3, body-parser to 1.20.3

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -56,7 +56,7 @@
         "semver": "~7.6.3",
         "signale": "~1.4.0",
         "ts-jest": "^29.2.5",
-        "typescript": "~5.7.2",
+        "typescript": "~5.7.3",
         "uuid": "~11.0.3"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "jest-watch-typeahead": "~2.2.2",
         "node-notifier": "~10.0.1",
         "ts-jest": "~29.2.5",
-        "typescript": "~5.7.2"
+        "typescript": "~5.7.3"
     },
     "packageManager": "yarn@4.6.0",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -33,7 +33,7 @@
         "eslint-plugin-react-hooks": "~5.1.0",
         "eslint-plugin-testing-library": "~7.1.1",
         "globals": "~15.13.0",
-        "typescript": "~5.7.2",
+        "typescript": "~5.7.3",
         "typescript-eslint": "~8.18.0"
     },
     "engines": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -29,7 +29,7 @@
     },
     "resolutions": {
         "ms": "~2.1.3",
-        "typescript": "~5.7.2"
+        "typescript": "~5.7.3"
     },
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
@@ -64,7 +64,7 @@
         "@types/toposort": "~2.0.7"
     },
     "peerDependencies": {
-        "typescript": "~5.7.2"
+        "typescript": "~5.7.3"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -46,7 +46,7 @@
         "@terascope/utils": "~1.7.1",
         "async-mutex": "~0.5.0",
         "barbe": "~3.0.16",
-        "body-parser": "~1.20.2",
+        "body-parser": "~1.20.3",
         "decompress": "~4.2.1",
         "easy-table": "~1.2.0",
         "event-loop-stats": "~1.4.1",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2885,7 +2885,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:~5.1.0"
     eslint-plugin-testing-library: "npm:~7.1.1"
     globals: "npm:~15.13.0"
-    typescript: "npm:~5.7.2"
+    typescript: "npm:~5.7.3"
     typescript-eslint: "npm:~8.18.0"
   languageName: unknown
   linkType: soft
@@ -5014,7 +5014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:1.20.3, body-parser@npm:~1.20.2":
+"body-parser@npm:1.20.3, body-parser@npm:~1.20.3":
   version: 1.20.3
   resolution: "body-parser@npm:1.20.3"
   dependencies:
@@ -6274,7 +6274,7 @@ __metadata:
     semver: "npm:~7.6.3"
     signale: "npm:~1.4.0"
     ts-jest: "npm:^29.2.5"
-    typescript: "npm:~5.7.2"
+    typescript: "npm:~5.7.3"
     uuid: "npm:~11.0.3"
   languageName: unknown
   linkType: soft
@@ -13241,7 +13241,7 @@ __metadata:
     jest-watch-typeahead: "npm:~2.2.2"
     node-notifier: "npm:~10.0.1"
     ts-jest: "npm:~29.2.5"
-    typescript: "npm:~5.7.2"
+    typescript: "npm:~5.7.3"
   languageName: unknown
   linkType: soft
 
@@ -13261,7 +13261,7 @@ __metadata:
     archiver: "npm:~7.0.1"
     async-mutex: "npm:~0.5.0"
     barbe: "npm:~3.0.16"
-    body-parser: "npm:~1.20.2"
+    body-parser: "npm:~1.20.3"
     bufferstreams: "npm:~3.0.0"
     chance: "npm:~1.1.12"
     convict: "npm:~6.2.4"
@@ -13721,23 +13721,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.7.2":
-  version: 5.7.2
-  resolution: "typescript@npm:5.7.2"
+"typescript@npm:~5.7.3":
+  version: 5.7.3
+  resolution: "typescript@npm:5.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/a873118b5201b2ef332127ef5c63fb9d9c155e6fdbe211cbd9d8e65877283797cca76546bad742eea36ed7efbe3424a30376818f79c7318512064e8625d61622
+  checksum: 10c0/b7580d716cf1824736cc6e628ab4cd8b51877408ba2be0869d2866da35ef8366dd6ae9eb9d0851470a39be17cbd61df1126f9e211d8799d764ea7431d5435afa
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.7.2#optional!builtin<compat/typescript>":
-  version: 5.7.2
-  resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=5786d5"
+"typescript@patch:typescript@npm%3A~5.7.3#optional!builtin<compat/typescript>":
+  version: 5.7.3
+  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/f3b8082c9d1d1629a215245c9087df56cb784f9fb6f27b5d55577a20e68afe2a889c040aacff6d27e35be165ecf9dca66e694c42eb9a50b3b2c451b36b5675cb
+  checksum: 10c0/6fd7e0ed3bf23a81246878c613423730c40e8bdbfec4c6e4d7bf1b847cbb39076e56ad5f50aa9d7ebd89877999abaee216002d3f2818885e41c907caaa192cc4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2974,7 +2974,7 @@ __metadata:
     typedoc-plugin-markdown: "npm:~4.0.3"
     yargs: "npm:~17.7.2"
   peerDependencies:
-    typescript: ~5.7.2
+    typescript: ~5.7.3
   peerDependenciesMeta:
     typescript:
       optional: true


### PR DESCRIPTION
This PR updates the following dependencies:
- typescript from 5.7.2 to 5.7.3
- body-parser from 1.20.2 to 1.20.3
  - The default depth of a body object is now limited to 32 by default
- bump teraslice from 2.12.0 to 2.12.1