### PR TITLE
[CI] Helm chart workflow fix

### DIFF
--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -204,6 +204,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          ref: master
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -6,6 +6,8 @@ on:
       - master
     types:
       - closed
+    paths-ignore:
+      - 'helm/helm-repo-site/index.yaml'
 
 jobs:
   build-release:

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -110,10 +110,16 @@ jobs:
       contents: write
       packages: write
     steps:
+      - name: Generate a token
+        id: token-generation
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.GH_INDEX_APP_ID }}
+          private-key: ${{ secrets.GH_INDEX_APP_KEY }}
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.token-generation.outputs.token }}
 
       - name: Set Up Helm
         run: |
@@ -174,7 +180,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add ./helm/helm-repo-site/index.yaml
           git commit -m "Update Helm chart index.yaml for version $CHART_VERSION"
-          git push origin master
+          git push -v https://x-access-token:${{ steps.token-generation.outputs.token }}@github.com/terascope/teraslice.git HEAD:master
 
       - name: Publish Helm Chart to GHCR
         if: steps.check-version.outputs.version_exists == 'false'

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -116,8 +116,8 @@ jobs:
         id: token-generation
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ vars.GH_INDEX_APP_ID }}
-          private-key: ${{ secrets.GH_INDEX_APP_KEY }}
+          app-id: ${{ vars.RELEASES_APP_ID }}
+          private-key: ${{ secrets.RELEASES_PRIVATE_KEY }}
       - name: Checkout Code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This PR makes the following changes:

- Adds a GitHub App token to the `build-and-publish-helm-charts` ci job with the correct permissions
  - This fixes an issue where the job would fail because it couldn't push the `index.yaml` into the master branch
- Adds ignore path to the `merge to master` pipeline because Github Apps can trigger other ci pipelines
  - This specifically ignores re-triggering the pipeline in the event `index.yaml` is merged with master
- Makes change to `build-docs` ci job that will checkout the latest changes from the master branch
  - This resolves an issue where in a previous pipeline we push to the master branch and don't receive the expected changes that are necessary for the `build-docs` job