### PR TITLE
[docs] Helm docs improvements

### DIFF
--- a/helm/helm-repo-site/index.tpl
+++ b/helm/helm-repo-site/index.tpl
@@ -282,7 +282,7 @@ releases:
 			{{range $key, $chartEntry := .Entries }}
         {{ if not (index $chartEntry 0).Deprecated }}
           <div class="chart">
-            <a href="{{ (index (index $chartEntry 0).Urls 0) }}" title="{{ (index (index $chartEntry 0).Urls 0) }}">
+            <a href="https://github.com/terascope/teraslice/pkgs/container/{{ $key }}" title="{{ (index (index $chartEntry 0).Urls 0) }}">
               <div class="icon">
                 <img class="chart-item-logo" alt="{{ $key }}'s logo" src="{{ if eq (index $chartEntry 0).Name "teraslice-chart" }}/teraslice/img/logo.png{{ else }}/teraslice/charts/_images/{{ (index $chartEntry 0).Name }}.png{{ end }}">
               </div>

--- a/helm/helm-repo-site/index.tpl
+++ b/helm/helm-repo-site/index.tpl
@@ -242,7 +242,7 @@ releases:
 
   - name: teraslice
     namespace: ts-dev1
-    version: {{ (index (index .Entries "teraslice") 0).Version }}
+    version: {{ (index (index .Entries "teraslice-chart") 0).Version }}
     chart: terascope/teraslice-chart
     needs:
       - ts-dev1/opensearch1

--- a/helm/helm-repo-site/index.tpl
+++ b/helm/helm-repo-site/index.tpl
@@ -4,6 +4,7 @@
     <title>Helm Charts</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/x-icon" href="/teraslice/img/favicon.png">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/2.10.0/github-markdown.min.css" />
     <style>
       .markdown-body {

--- a/helm/helm-repo-site/index.tpl
+++ b/helm/helm-repo-site/index.tpl
@@ -188,7 +188,7 @@ nodes:
 </code>
       </pre>
 
-    <p>Next run the kind command below to luanch a kind cluster.</p>
+    <p>Next run the kind command below to launch a kind cluster.</p>
 
       <pre class="snippet" lang="no-highlight" style="padding: 0">
         <button class="btn" onclick="copyToClipboard(this)">

--- a/helm/helm-repo-site/index.tpl
+++ b/helm/helm-repo-site/index.tpl
@@ -264,7 +264,7 @@ releases:
           <div class="chart">
             <a href="{{ (index (index $chartEntry 0).Urls 0) }}" title="{{ (index (index $chartEntry 0).Urls 0) }}">
               <div class="icon">
-                <img class="chart-item-logo" alt="{{ $key }}'s logo" src="{{ if eq (index $chartEntry 0).Name "teraslice" }}/teraslice/img/logo.png{{ else }}/teraslice/charts/_images/{{ (index $chartEntry 0).Name }}.png{{ end }}">
+                <img class="chart-item-logo" alt="{{ $key }}'s logo" src="{{ if eq (index $chartEntry 0).Name "teraslice-chart" }}/teraslice/img/logo.png{{ else }}/teraslice/charts/_images/{{ (index $chartEntry 0).Name }}.png{{ end }}">
               </div>
               <div class="body">
                 <p class="info">

--- a/helm/helm-repo-site/index.tpl
+++ b/helm/helm-repo-site/index.tpl
@@ -169,7 +169,27 @@
         </ul>
       </p>
 
-      <p>Create a new file called <code>kindConfig.yaml</code> and paste the following code snippet in it and save. Then run:</p>
+      <p>Create a new file called <code>kindConfig.yaml</code> and paste the following code snippet in it and save.</p>
+
+      <pre class="snippet" lang="no-highlight" style="padding: 0;padding-left: 15px;">
+        <button class="btn" onclick="copyToClipboard(this)">
+          <img class="clippy" src="/teraslice/charts/_images/clippy.svg" alt="Copy to clipboard" width="13">
+        </button>
+<code id="helm-search-command">kind: Cluster
+name: k8s-env
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 30678 # Map internal teraslice api service to host port
+    hostPort: 5678
+  - containerPort: 30921 # Map internal opensearch1 service to host port
+    hostPort: 9200
+</code>
+      </pre>
+
+    <p>Next run the kind command below to luanch a kind cluster.</p>
+
       <pre class="snippet" lang="no-highlight" style="padding: 0">
         <button class="btn" onclick="copyToClipboard(this)">
           <img class="clippy" src="/teraslice/charts/_images/clippy.svg" alt="Copy to clipboard" width="13">

--- a/helm/teraslice/README.md
+++ b/helm/teraslice/README.md
@@ -24,3 +24,81 @@ The easiest way to install teraslice with opensearch is to use the `helmfile` cl
 ## Configuration
 
 View the `values.yaml` for charts configuration settings.
+
+| Parameter                         | Description                                            | Default                   |
+|-----------------------------------|--------------------------------------------------------|---------------------------|
+| `replicaCount`                    | Number of replicas to run                             | `1`                       |
+| `image.repository`                | Image repository for Teraslice                        | `ghcr.io/terascope/teraslice` |
+| `image.pullPolicy`                | Image pull policy                                    | `IfNotPresent`            |
+| `image.nodeVersion`               | Node version used in the image tag                   | `v22.13.0`                |
+| `imagePullSecrets`                | Image pull secrets                                  | `[]`                      |
+| `nameOverride`                    | Override for the chart name                          | `""`                      |
+| `fullnameOverride`                | Override for the full chart name                     | `""`                      |
+| `extraContainers`                 | Additional sidecar containers                        | `[]`                      |
+| `env`                             | Environment variables for Teraslice master           | `{}`                      |
+| `stateConnection`                 | Teraslice Elasticsearch/Opensearch state connection                          | `default`                 |
+| `priorityClass.create`            | Whether to create a priority class                  | `false`                   |
+| `priorityClass.preemptionPolicy`  | Preemption policy for the priority class            | `Never`                   |
+| `priorityClass.value`             | Priority class value                                | `9999`                    |
+| `master.teraslice.assets_directory` | Directory for assets in the master pod              | `/app/assets`             |
+| `master.teraslice.workers`        | Number of worker processes in master pod            | `0`                       |
+| `worker.teraslice.assets_directory` | Directory for assets in the worker pod              | `/app/assets`             |
+| `terafoundation.environment`      | Runtime environment                                 | `production`              |
+| `terafoundation.log_level`        | Logging level                                       | `info`                    |
+| `terafoundation.prom_metrics_enabled` | Enable internal Prometheus metrics                  | `false`                   |
+| `terafoundation.prom_metrics_port` | Prometheus metrics port                            | `3333`                    |
+| `terafoundation.prom_metrics_add_default` | Add default Prometheus metrics                    | `true`                    |
+| `terafoundation.connectors`       | Connector configurations for teraslice. Read docs [here](https://terascope.github.io/teraslice/docs/configuration/overview) for more information  | `{}`                      |
+| `terafoundation.stats`            | Statistics configuration                           | `{}`                      |
+| `serviceAccount.create`           | Whether to create a service account                | `true`                    |
+| `serviceAccount.annotations`      | Annotations for the service account                | `{}`                      |
+| `serviceAccount.name`             | Name of the service account                        | `""`                      |
+| `podSecurityContext`              | Security context for pods                          | `{}`                      |
+| `securityContext`                 | Security context for containers                    | `{}`                      |
+| `strategyType`                    | Deployment strategy type                           | `Recreate`                |
+| `service.type`                    | Service type                                      | `ClusterIP`               |
+| `service.port`                    | Service port                                      | `5678`                    |
+| `service.annotations`             | Annotations for the service                       | `{}`                      |
+| `service.labels`                  | Labels for the service                            | `{}`                      |
+| `service.nodePort`                | Node port (if applicable). Must set `service.type` to `NodePort`       | `null`                    |
+| `ingress.enabled`                 | Enable ingress                                    | `false`                   |
+| `ingress.className`               | Ingress class name                                | `""`                      |
+| `ingress.annotations`             | Ingress annotations                              | `{}`                      |
+| `ingress.hosts[0].host`           | Ingress hostname                                 | `teraslice.local`         |
+| `ingress.hosts[0].paths[0].path`  | Ingress path                                     | `/`                       |
+| `ingress.hosts[0].paths[0].pathType` | Path type                                      | `ImplementationSpecific`  |
+| `ingress.tls`                     | TLS configuration for ingress                    | `[]`                      |
+| `resources`                       | Resource limits and requests                     | `{}`                      |
+| `nodeSelector`                    | Node selector configuration                      | `{}`                      |
+| `tolerations`                     | Tolerations for scheduling                       | `[]`                      |
+| `affinity`                        | Affinity rules for scheduling                    | `{}`                      |
+| `persistence.enabled`             | Enable persistent storage                        | `false`                   |
+| `persistence.size`                | Storage size                                     | `20Gi`                    |
+| `persistence.accessModes`         | Storage access modes                            | `["ReadWriteMany"]`       |
+| `extraVolumes`                    | Additional volumes                              | `[]`                      |
+| `extraVolumeMounts`               | Additional volume mounts                        | `[]`                      |
+| `exporter.enabled`                | Enable external exporter                        | `false`                   |
+| `exporter.image.repository`       | Exporter image repository                       | `terascope/teraslice-exporter` |
+| `exporter.image.tag`              | Exporter image tag. This image is archived as of right now. See repo [here](https://github.com/terascope/teraslice-exporter)                | `v0.4.0`                  |
+| `exporter.image.pullPolicy`       | Exporter image pull policy                      | `IfNotPresent`            |
+| `exporter.env.TERASLICE_URL`      | URL for the Teraslice service                   | `http://localhost:5678`   |
+| `exporter.env.PORT`               | Exporter port                                   | `8080`                    |
+| `serviceMonitor.enabled`          | Enable Prometheus service monitor               | `false`                   |
+| `serviceMonitor.interval`         | Scrape interval                                | `60s`                     |
+| `serviceMonitor.metricRelabelings` | Metric relabeling rules                        | `[]`                      |
+| `serviceMonitor.relabelings`      | Relabeling rules                               | `[]`                      |
+| `serviceMonitor.rules`            | Prometheus alerting rules                      | `null`                    |
+| `podMonitor.enabled`              | Enable Prometheus PodMonitor                    | `false`                   |
+| `podMonitor.labels`               | Labels for PodMonitor                          | `{}`                      |
+| `podMonitor.annotations`          | Annotations for PodMonitor                     | `{}`                      |
+| `podMonitor.jobLabel`             | Job label for PodMonitor                       | `app.kubernetes.io/instance` |
+| `podMonitor.interval`             | Scrape interval for PodMonitor                 | `60s`                     |
+| `podMonitor.podTargetLabels`      | Target labels for PodMonitor                   | Look in [values.yaml](https://github.com/terascope/teraslice/blob/master/helm/teraslice/values.yaml)                   |
+| `podMonitor.matchLabels`          | Match labels for PodMonitor                    | `{}`                      |
+| `podMonitor.metricRelabelings`    | Metric relabeling rules for PodMonitor         | `[]`                      |
+| `podMonitor.relabelings`          | Relabeling rules for PodMonitor                | `[]`                      |
+| `prometheusRule.enabled`          | Enable Prometheus alerts                       | `false`                   |
+| `prometheusRule.rules`            | Prometheus alerting rules                      | `[]`                      |
+| `busybox.repository`              | Busybox image repository                       | `busybox`                 |
+| `busybox.tag`                     | Busybox image tag                              | `latest`                  |
+| `busybox.pullPolicy`              | Busybox image pull policy                      | `IfNotPresent`            |

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -137,6 +137,10 @@ module.exports = {
                             label: 'Github',
                             to: 'https://github.com/terascope/teraslice',
                         },
+                        {
+                            to: 'https://terascope.github.io/teraslice/charts',
+                            label: 'Chart'
+                        },
                     ],
                 },
             ],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -99,6 +99,11 @@ module.exports = {
                     position: 'left'
                 },
                 {
+                    href: 'https://terascope.github.io/teraslice/charts',
+                    label: 'Chart',
+                    position: 'left'
+                },
+                {
                     to: '/help',
                     label: 'Help',
                     position: 'left'


### PR DESCRIPTION
This PR makes the following changes:

- Adds an icon to the teraslice chart web docs page
- Adds chart link in the navigation bar of the teraslice web docs
- Miscellaneous link fixes on the chart web docs
- Add kindConfig copy paste to the helm chart docs.
- Add config docs to the helm chart 

Ref to issue #3920