### PR TITLE
[teraslice-cli] clean up 'jobs export' command to run serially without pMap

### DIFF
--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "2.10.1",
+    "version": "2.10.2",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -822,11 +822,9 @@ export default class Jobs {
 
         reply.yellow(`Saving jobFile(s) for ${jobIds.join(', ')} on ${this.config.args.clusterAlias}`);
 
-        await pMap(
-            this.jobs,
-            (job) => this.exportOne(job.config),
-            { concurrency: 1 }
-        );
+        for (const job of this.jobs) {
+            await this.exportOne(job.config);
+        }
 
         reply.green(`Saved jobFile(s) to ${this.config.outdir}`);
     }


### PR DESCRIPTION
When running `teraslice-cli jobs export`, remove the pMap wrapper from the call to `exportOne()` as it is useless if we set concurrency to 1.

Bump teraslice-cli from `2.10.1` to `2.10.2`

ref: #3844 