### PR TITLE
[e2e] update kind Configs used in k8s-env to put teraslice port mapping first.

### DIFF
--- a/e2e/k8s/kindConfigDefaultPorts.yaml
+++ b/e2e/k8s/kindConfigDefaultPorts.yaml
@@ -5,10 +5,11 @@ nodes:
 - role: control-plane
   image: kindest/node:v1.28.12@sha256:fa0e48b1e83bb8688a5724aa7eebffbd6337abd7909ad089a2700bf08c30c6ea
   extraPortMappings:
-  - containerPort: 30200 # Map internal elasticsearch service to host port
-    hostPort: 9200
+  # teraslice port mapping needs to be at index 0 in this array
   - containerPort: 30678 # Map internal teraslice service to host port
     hostPort: 5678
+  - containerPort: 30200 # Map internal elasticsearch service to host port
+    hostPort: 9200
   - containerPort: 30092 # Map internal kafka service to host port
     hostPort: 9092
   - containerPort: 30094 # Map external kafka service to host port

--- a/e2e/k8s/kindConfigDefaultPortsDev.yaml
+++ b/e2e/k8s/kindConfigDefaultPortsDev.yaml
@@ -9,10 +9,11 @@ nodes:
 - role: control-plane
   image: kindest/node:v1.28.12@sha256:fa0e48b1e83bb8688a5724aa7eebffbd6337abd7909ad089a2700bf08c30c6ea
   extraPortMappings:
-  - containerPort: 30200 # Map internal elasticsearch service to host port
-    hostPort: 9200
+  # teraslice port mapping needs to be at index 0 in this array
   - containerPort: 30678 # Map internal teraslice service to host port
     hostPort: 5678
+  - containerPort: 30200 # Map internal elasticsearch service to host port
+    hostPort: 9200
   - containerPort: 30092 # Map internal kafka service to host port
     hostPort: 9092
   - containerPort: 30094 # Map external kafka service to host port


### PR DESCRIPTION
A change in #3929 required a change in the kind configs for the `k8s-env` command, but I forgot to make that change.