### PR TITLE
run yarn setup at end of bump commands

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -45,7 +45,7 @@
         "ms": "~2.1.3"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.10.0",
+        "@terascope/scripts": "~1.10.1",
         "@terascope/types": "~1.4.1",
         "@terascope/utils": "~1.7.3",
         "bunyan": "~1.8.15",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@eslint/js": "~9.19.0",
         "@swc/core": "1.10.12",
         "@swc/jest": "~0.2.37",
-        "@terascope/scripts": "~1.10.0",
+        "@terascope/scripts": "~1.10.1",
         "@types/bluebird": "~3.5.42",
         "@types/convict": "~6.1.6",
         "@types/elasticsearch": "~5.0.43",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.10.0",
+    "version": "1.10.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/bump/index.ts
+++ b/packages/scripts/src/helpers/bump/index.ts
@@ -66,8 +66,6 @@ export async function bumpAssetOnly(
     const bumpAssetInfo = await bumpAssetVersion(packages, options, isAsset);
     const commitMsgs = getBumpCommitMessages(bumpAssetInfo, options.release);
 
-    await setup();
-
     for (const pkgInfo of packages) {
         await updatePkgJSON(pkgInfo);
     }

--- a/packages/scripts/src/helpers/bump/index.ts
+++ b/packages/scripts/src/helpers/bump/index.ts
@@ -13,6 +13,7 @@ import {
 } from './utils.js';
 import signale from '../signale.js';
 import { syncVersions } from '../sync/utils.js';
+import { setup } from '../scripts.js';
 
 export async function bumpPackages(options: BumpPackageOptions, isAsset: boolean): Promise<void> {
     const rootInfo = getRootInfo();
@@ -43,6 +44,8 @@ export async function bumpPackages(options: BumpPackageOptions, isAsset: boolean
 
     await updatePkgJSON(rootInfo);
 
+    await setup();
+
     signale.success(`
 
 Please commit these changes:
@@ -62,6 +65,8 @@ export async function bumpAssetOnly(
     const packages: PackageInfo[] = [..._packages, rootInfo as any];
     const bumpAssetInfo = await bumpAssetVersion(packages, options, isAsset);
     const commitMsgs = getBumpCommitMessages(bumpAssetInfo, options.release);
+
+    await setup();
 
     for (const pkgInfo of packages) {
         await updatePkgJSON(pkgInfo);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2971,7 +2971,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/scripts@npm:~1.10.0, @terascope/scripts@workspace:packages/scripts":
+"@terascope/scripts@npm:~1.10.1, @terascope/scripts@workspace:packages/scripts":
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
@@ -6377,7 +6377,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e@workspace:e2e"
   dependencies:
-    "@terascope/scripts": "npm:~1.10.0"
+    "@terascope/scripts": "npm:~1.10.1"
     "@terascope/types": "npm:~1.4.1"
     "@terascope/utils": "npm:~1.7.3"
     bunyan: "npm:~1.8.15"
@@ -13371,7 +13371,7 @@ __metadata:
     "@eslint/js": "npm:~9.19.0"
     "@swc/core": "npm:1.10.12"
     "@swc/jest": "npm:~0.2.37"
-    "@terascope/scripts": "npm:~1.10.0"
+    "@terascope/scripts": "npm:~1.10.1"
     "@types/bluebird": "npm:~3.5.42"
     "@types/convict": "npm:~6.1.6"
     "@types/elasticsearch": "npm:~5.0.43"


### PR DESCRIPTION
This PR makes the following changes:
- run `yarn setup` after the `ts-scripts bump` command modifies all `package.json` dependency versions. This ensures that the `yarn.lock` will be synced when the branch is pushed.
- bump scripts from 1.10.0 to 1.10.1