### PR TITLE
[teraslice 2.12.4-rc0] Revert to base docker image using terafoundation_kafka_connector 1.0.0 and node 22.9.0 for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -473,7 +473,9 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
+        node-version: [22]
+        # temporarily remove node 18, revert after Dockerfile test complete
+        # node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 # NODE_VERSION is set by default in the config.ts, the following value will only
 # be used if you build images by default with docker build
 ARG NODE_VERSION=22
-FROM ghcr.io/terascope/node-base:${NODE_VERSION}
+
+# Pinning node-base image for testing purposes
+# Revert this change when testing is complete
+FROM ghcr.io/terascope/node-base:22.9.0
+# FROM ghcr.io/terascope/node-base:${NODE_VERSION}
 
 ARG TERASLICE_VERSION
 ARG BUILD_TIMESTAMP

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.12.3",
+    "version": "2.12.4-rc.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.12.3",
+    "version": "2.12.4-rc.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:
- bump teraslice from 2.12.3 to 2.12.4-rc0
- pin the base docker image to node-base:22.9.0 in the Dockerfile
  - terafoundation_kafka_connector v1.0.0
  - node-rdkafka v3.1.1
  - librdkafka v2.5.3
  - node v22.9.0
- temporarily disable node 18 e2e tests, as the Dockerfile only creates a node 22 image

** NOTE: ** When testing is finished the Dockerfile and test workflow changes must be reverted 