### PR TITLE
[Teraslice 2.12.4-rc.1] Build teraslice docker image from base image with node 22.12.0 and terafoundation_kafka_connector 1.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -473,9 +473,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: [22]
-        # temporarily remove node 18, revert after Dockerfile test complete
-        # node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - name: Check out code

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,7 @@
 # be used if you build images by default with docker build
 ARG NODE_VERSION=22
 
-# Pinning node-base image for testing purposes
-# Revert this change when testing is complete
-FROM ghcr.io/terascope/node-base:22.9.0
-# FROM ghcr.io/terascope/node-base:${NODE_VERSION}
+FROM ghcr.io/terascope/node-base:${NODE_VERSION}
 
 ARG TERASLICE_VERSION
 ARG BUILD_TIMESTAMP

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.12.4-rc.0",
+    "version": "2.12.4-rc.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.12.4-rc.0",
+    "version": "2.12.4-rc.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:
- bump version to 2.12.4-rc.1
- Build a teralice image off base docker image v1.0.0-test release
- Revert changes to `Dockerfile` and `test.yml` needed to create teraslice 2.12.4-rc.0 

** NOTE: ** This version of teraslice is for testing only. The base docker image needs to be reverted when testing is complete.