### PR TITLE
[data-mate, scripts, teraslice, utils] update mnemonist to 0.40.1

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -45,11 +45,11 @@
         "ms": "~2.1.3"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.10.2",
+        "@terascope/scripts": "~1.10.3",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "bunyan": "~1.8.15",
-        "elasticsearch-store": "~1.8.1",
+        "elasticsearch-store": "~1.8.2",
         "fs-extra": "~11.3.0",
         "jest": "^29.7.0",
         "jest-extended": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@eslint/js": "~9.20.0",
         "@swc/core": "1.10.15",
         "@swc/jest": "~0.2.37",
-        "@terascope/scripts": "~1.10.2",
+        "@terascope/scripts": "~1.10.3",
         "@types/bluebird": "~3.5.42",
         "@types/convict": "~6.1.6",
         "@types/elasticsearch": "~5.0.43",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.12.5",
+    "version": "2.12.6",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -41,7 +41,7 @@
         "ipaddr.js": "~2.2.0",
         "is-cidr": "~5.1.0",
         "jexl": "~2.3.0",
-        "mnemonist": "~0.39.8",
+        "mnemonist": "~0.40.0",
         "uuid": "~11.0.5",
         "valid-url": "~1.0.9",
         "validator": "~13.12.0",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -41,7 +41,7 @@
         "ipaddr.js": "~2.2.0",
         "is-cidr": "~5.1.0",
         "jexl": "~2.3.0",
-        "mnemonist": "~0.40.0",
+        "mnemonist": "~0.40.1",
         "uuid": "~11.0.5",
         "valid-url": "~1.0.9",
         "validator": "~13.12.0",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "1.7.4",
+    "version": "1.7.5",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -30,9 +30,9 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../data-mate --"
     },
     "dependencies": {
-        "@terascope/data-types": "~1.7.3",
+        "@terascope/data-types": "~1.7.4",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "@types/validator": "~13.12.2",
         "awesome-phonenumber": "~7.2.0",
         "date-fns": "~4.1.0",
@@ -45,7 +45,7 @@
         "uuid": "~11.0.5",
         "valid-url": "~1.0.9",
         "validator": "~13.12.0",
-        "xlucene-parser": "~1.7.4"
+        "xlucene-parser": "~1.7.5"
     },
     "devDependencies": {
         "@types/ip6addr": "~0.2.6",

--- a/packages/data-mate/src/core/WritableData.ts
+++ b/packages/data-mate/src/core/WritableData.ts
@@ -1,9 +1,6 @@
 import { getTypeOf, isInteger } from '@terascope/utils';
 import type { Maybe, TypedArrayConstructor } from '@terascope/types';
-import * as dataStructurePkg from 'mnemonist';
-
-// @ts-expect-error
-const { SparseMap } = dataStructurePkg.default;
+import { SparseMap } from 'mnemonist';
 
 /**
  * A generic write-only optimized view of data used for Builders.
@@ -29,7 +26,7 @@ export class WritableData<T> {
     /**
      * The value to indices Map
     */
-    private readonly _values: dataStructurePkg.SparseMap<T>;
+    private readonly _values: SparseMap<T>;
 
     /**
      * The total number of values stored
@@ -42,7 +39,7 @@ export class WritableData<T> {
         }
 
         this._values = Values
-            ? new SparseMap(
+            ? new (SparseMap as any)(
                 Values, size
             )
             : new SparseMap(size);

--- a/packages/data-mate/src/core/WritableData.ts
+++ b/packages/data-mate/src/core/WritableData.ts
@@ -39,7 +39,7 @@ export class WritableData<T> {
         }
 
         this._values = Values
-            ? new (SparseMap as any)(
+            ? new SparseMap(
                 Values, size
             )
             : new SparseMap(size);

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "1.7.3",
+    "version": "1.7.4",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "graphql": "~16.10.0",
         "yargs": "~17.7.2"
     },

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "4.8.1",
+    "version": "4.8.2",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -25,7 +25,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "bluebird": "~3.7.2",
         "setimmediate": "~1.0.5"
     },
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "~1.2.0",
         "@types/elasticsearch": "~5.0.43",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.8.1",
+        "elasticsearch-store": "~1.8.2",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@~7.17.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@~8.15.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,10 +30,10 @@
         "test:watch": "ts-scripts yarn workspace @terascope/scripts test --watch ../elasticsearch-store --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.7.4",
-        "@terascope/data-types": "~1.7.3",
+        "@terascope/data-mate": "~1.7.5",
+        "@terascope/data-types": "~1.7.4",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "ajv": "~8.17.1",
         "ajv-formats": "~3.0.1",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
@@ -43,7 +43,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@~2.12.0",
         "setimmediate": "~1.0.5",
         "uuid": "~11.0.5",
-        "xlucene-translator": "~1.7.4"
+        "xlucene-translator": "~1.7.5"
     },
     "devDependencies": {
         "@types/uuid": "~10.0.0"

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "1.9.4",
+    "version": "1.9.5",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -43,7 +43,7 @@
         "js-yaml": "~4.1.0",
         "kafkajs": "~2.2.4",
         "micromatch": "~4.0.8",
-        "mnemonist": "~0.40.0",
+        "mnemonist": "~0.40.1",
         "ms": "~2.1.3",
         "package-json": "~10.0.1",
         "package-up": "~5.0.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -43,7 +43,7 @@
         "js-yaml": "~4.1.0",
         "kafkajs": "~2.2.4",
         "micromatch": "~4.0.8",
-        "mnemonist": "~0.39.8",
+        "mnemonist": "~0.40.0",
         "ms": "~2.1.3",
         "package-json": "~10.0.1",
         "package-up": "~5.0.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.10.2",
+    "version": "1.10.3",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "codecov": "~3.8.3",
         "execa": "~9.5.2",
         "fs-extra": "~11.3.0",

--- a/packages/scripts/src/helpers/packages.ts
+++ b/packages/scripts/src/helpers/packages.ts
@@ -7,8 +7,7 @@ import {
     uniq, fastCloneDeep, get, trim
 } from '@terascope/utils';
 import toposort from 'toposort';
-// import MultiMap from 'mnemonist/multi-map'
-import mem from 'mnemonist';
+import { MultiMap } from 'mnemonist';
 
 import packageJson, { PackageNotFoundError, VersionNotFoundError } from 'package-json';
 import sortPackageJson from 'sort-package-json';
@@ -17,8 +16,6 @@ import {
     writeIfChanged
 } from './misc.js';
 import * as i from './interfaces.js';
-
-const { MultiMap } = mem;
 
 let _packages: i.PackageInfo[] = [];
 let _e2eDir: string | undefined;

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "1.10.1",
+    "version": "1.10.2",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -30,14 +30,14 @@
     "dependencies": {
         "@terascope/file-asset-apis": "~1.0.3",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "bluebird": "~3.7.2",
         "bunyan": "~1.8.15",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.8.1",
+        "elasticsearch-store": "~1.8.2",
         "express": "~4.21.2",
         "js-yaml": "~4.1.0",
         "nanoid": "~5.0.9",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -44,7 +44,7 @@
     "devDependencies": {
         "@terascope/fetch-github-release": "~2.0.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "@types/decompress": "~4.2.7",
         "@types/diff": "~7.0.1",
         "@types/ejs": "~3.1.5",
@@ -68,7 +68,7 @@
         "pretty-bytes": "~6.1.1",
         "prompts": "~2.4.2",
         "signale": "~1.4.0",
-        "teraslice-client-js": "~1.7.3",
+        "teraslice-client-js": "~1.7.4",
         "tmp": "~0.2.3",
         "tty-table": "~4.2.3",
         "yargs": "~17.7.2"

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "1.7.3",
+    "version": "1.7.4",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "auto-bind": "~5.0.1",
         "got": "~13.0.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "1.10.4",
+    "version": "1.10.5",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "get-port": "~7.1.0",
         "ms": "~2.1.3",
         "nanoid": "~5.0.9",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -24,8 +24,8 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../teraslice-state-storage --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "~4.8.1",
-        "@terascope/utils": "~1.7.3"
+        "@terascope/elasticsearch-api": "~4.8.2",
+        "@terascope/utils": "~1.7.4"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "~11.3.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "~1.9.4"
+        "@terascope/job-components": "~1.9.5"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=1.9.4"
+        "@terascope/job-components": ">=1.9.5"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -39,11 +39,11 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
-        "@terascope/elasticsearch-api": "~4.8.1",
-        "@terascope/job-components": "~1.9.4",
-        "@terascope/teraslice-messaging": "~1.10.4",
+        "@terascope/elasticsearch-api": "~4.8.2",
+        "@terascope/job-components": "~1.9.5",
+        "@terascope/teraslice-messaging": "~1.10.5",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "async-mutex": "~0.5.0",
         "barbe": "~3.0.16",
         "body-parser": "~1.20.3",
@@ -62,7 +62,7 @@
         "semver": "~7.7.1",
         "socket.io": "~1.7.4",
         "socket.io-client": "~1.7.4",
-        "terafoundation": "~1.10.1",
+        "terafoundation": "~1.10.2",
         "uuid": "~11.0.5"
     },
     "devDependencies": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.12.5",
+    "version": "2.12.6",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "1.7.4",
+    "version": "1.7.5",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -36,9 +36,9 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../ts-transforms --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.7.4",
+        "@terascope/data-mate": "~1.7.5",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "awesome-phonenumber": "~7.2.0",
         "graphlib": "~2.1.8",
         "jexl": "~2.3.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -61,7 +61,7 @@
         "kind-of": "~6.0.3",
         "latlon-geohash": "~2.0.0",
         "lodash-es": "~4.17.21",
-        "mnemonist": "~0.40.0",
+        "mnemonist": "~0.40.1",
         "p-map": "~7.0.3",
         "shallow-clone": "~3.0.1",
         "validator": "~13.12.0"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "1.7.3",
+    "version": "1.7.4",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -61,7 +61,7 @@
         "kind-of": "~6.0.3",
         "latlon-geohash": "~2.0.0",
         "lodash-es": "~4.17.21",
-        "mnemonist": "~0.39.8",
+        "mnemonist": "~0.40.0",
         "p-map": "~7.0.3",
         "shallow-clone": "~3.0.1",
         "validator": "~13.12.0"

--- a/packages/utils/src/big-lru-map.ts
+++ b/packages/utils/src/big-lru-map.ts
@@ -1,5 +1,5 @@
 import { TypedArray } from '@terascope/types';
-import dataStructurePkg from 'mnemonist';
+import { LRUMap } from 'mnemonist';
 import { BigMap } from './big-map.js';
 
 /**
@@ -13,7 +13,7 @@ export class FlexibleArray {
     }
 }
 
-export class BigLRUMap<V> extends dataStructurePkg.LRUMap<string | number, V> {
+export class BigLRUMap<V> extends LRUMap<string | number, V> {
     constructor(
         mapSize: number,
         keyArray: FlexibleArray | TypedArray = FlexibleArray,

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "1.7.4",
+    "version": "1.7.5",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "peggy": "~4.2.0",
         "ts-pegjs": "~4.2.1"
     },

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "1.7.4",
+    "version": "1.7.5",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -30,9 +30,9 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.3",
+        "@terascope/utils": "~1.7.4",
         "@types/elasticsearch": "~5.0.43",
-        "xlucene-parser": "~1.7.4"
+        "xlucene-parser": "~1.7.5"
     },
     "devDependencies": {
         "elasticsearch": "~15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "1.7.3",
+    "version": "1.7.4",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../xpressions --"
     },
     "dependencies": {
-        "@terascope/utils": "~1.7.3"
+        "@terascope/utils": "~1.7.4"
     },
     "devDependencies": {
         "@terascope/types": "~1.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2838,13 +2838,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/data-mate@npm:~1.7.4, @terascope/data-mate@workspace:packages/data-mate":
+"@terascope/data-mate@npm:~1.7.5, @terascope/data-mate@workspace:packages/data-mate":
   version: 0.0.0-use.local
   resolution: "@terascope/data-mate@workspace:packages/data-mate"
   dependencies:
-    "@terascope/data-types": "npm:~1.7.3"
+    "@terascope/data-types": "npm:~1.7.4"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     "@types/ip6addr": "npm:~0.2.6"
     "@types/uuid": "npm:~10.0.0"
     "@types/validator": "npm:~13.12.2"
@@ -2857,20 +2857,20 @@ __metadata:
     ipaddr.js: "npm:~2.2.0"
     is-cidr: "npm:~5.1.0"
     jexl: "npm:~2.3.0"
-    mnemonist: "npm:~0.39.8"
+    mnemonist: "npm:~0.40.1"
     uuid: "npm:~11.0.5"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
-    xlucene-parser: "npm:~1.7.4"
+    xlucene-parser: "npm:~1.7.5"
   languageName: unknown
   linkType: soft
 
-"@terascope/data-types@npm:~1.7.3, @terascope/data-types@workspace:packages/data-types":
+"@terascope/data-types@npm:~1.7.4, @terascope/data-types@workspace:packages/data-types":
   version: 0.0.0-use.local
   resolution: "@terascope/data-types@workspace:packages/data-types"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     "@types/yargs": "npm:~17.0.33"
     graphql: "npm:~16.10.0"
     yargs: "npm:~17.7.2"
@@ -2887,17 +2887,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/elasticsearch-api@npm:~4.8.1, @terascope/elasticsearch-api@workspace:packages/elasticsearch-api":
+"@terascope/elasticsearch-api@npm:~4.8.2, @terascope/elasticsearch-api@workspace:packages/elasticsearch-api":
   version: 0.0.0-use.local
   resolution: "@terascope/elasticsearch-api@workspace:packages/elasticsearch-api"
   dependencies:
     "@opensearch-project/opensearch": "npm:~1.2.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     "@types/elasticsearch": "npm:~5.0.43"
     bluebird: "npm:~3.7.2"
     elasticsearch: "npm:~15.4.1"
-    elasticsearch-store: "npm:~1.8.1"
+    elasticsearch-store: "npm:~1.8.2"
     elasticsearch6: "npm:@elastic/elasticsearch@~6.8.0"
     elasticsearch7: "npm:@elastic/elasticsearch@~7.17.0"
     elasticsearch8: "npm:@elastic/elasticsearch@~8.15.0"
@@ -2960,12 +2960,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/job-components@npm:~1.9.4, @terascope/job-components@workspace:packages/job-components":
+"@terascope/job-components@npm:~1.9.5, @terascope/job-components@workspace:packages/job-components":
   version: 0.0.0-use.local
   resolution: "@terascope/job-components@workspace:packages/job-components"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     benchmark: "npm:~2.1.4"
     convict: "npm:~6.2.4"
     convict-format-with-moment: "npm:~6.2.0"
@@ -2980,12 +2980,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/scripts@npm:~1.10.2, @terascope/scripts@workspace:packages/scripts":
+"@terascope/scripts@npm:~1.10.3, @terascope/scripts@workspace:packages/scripts":
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
     "@kubernetes/client-node": "npm:~0.22.3"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     "@types/ip": "npm:~1.1.3"
     "@types/micromatch": "npm:~4.0.9"
     "@types/ms": "npm:~0.7.34"
@@ -3001,7 +3001,7 @@ __metadata:
     js-yaml: "npm:~4.1.0"
     kafkajs: "npm:~2.2.4"
     micromatch: "npm:~4.0.8"
-    mnemonist: "npm:~0.39.8"
+    mnemonist: "npm:~0.40.1"
     ms: "npm:~2.1.3"
     package-json: "npm:~10.0.1"
     package-up: "npm:~5.0.0"
@@ -3023,12 +3023,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/teraslice-messaging@npm:~1.10.4, @terascope/teraslice-messaging@workspace:packages/teraslice-messaging":
+"@terascope/teraslice-messaging@npm:~1.10.5, @terascope/teraslice-messaging@workspace:packages/teraslice-messaging":
   version: 0.0.0-use.local
   resolution: "@terascope/teraslice-messaging@workspace:packages/teraslice-messaging"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     "@types/ms": "npm:~0.7.34"
     "@types/socket.io": "npm:~2.1.13"
     "@types/socket.io-client": "npm:~1.4.35"
@@ -3045,8 +3045,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terascope/teraslice-state-storage@workspace:packages/teraslice-state-storage"
   dependencies:
-    "@terascope/elasticsearch-api": "npm:~4.8.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/elasticsearch-api": "npm:~4.8.2"
+    "@terascope/utils": "npm:~1.7.4"
   languageName: unknown
   linkType: soft
 
@@ -3111,7 +3111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/utils@npm:~1.7.3, @terascope/utils@workspace:packages/utils":
+"@terascope/utils@npm:~1.7.4, @terascope/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@terascope/utils@workspace:packages/utils"
   dependencies:
@@ -3152,7 +3152,7 @@ __metadata:
     kind-of: "npm:~6.0.3"
     latlon-geohash: "npm:~2.0.0"
     lodash-es: "npm:~4.17.21"
-    mnemonist: "npm:~0.39.8"
+    mnemonist: "npm:~0.40.1"
     p-map: "npm:~7.0.3"
     shallow-clone: "npm:~3.0.1"
     validator: "npm:~13.12.0"
@@ -6386,11 +6386,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e@workspace:e2e"
   dependencies:
-    "@terascope/scripts": "npm:~1.10.2"
+    "@terascope/scripts": "npm:~1.10.3"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     bunyan: "npm:~1.8.15"
-    elasticsearch-store: "npm:~1.8.1"
+    elasticsearch-store: "npm:~1.8.2"
     fs-extra: "npm:~11.3.0"
     jest: "npm:^29.7.0"
     jest-extended: "npm:^4.0.2"
@@ -6453,14 +6453,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elasticsearch-store@npm:~1.8.1, elasticsearch-store@workspace:packages/elasticsearch-store":
+"elasticsearch-store@npm:~1.8.2, elasticsearch-store@workspace:packages/elasticsearch-store":
   version: 0.0.0-use.local
   resolution: "elasticsearch-store@workspace:packages/elasticsearch-store"
   dependencies:
-    "@terascope/data-mate": "npm:~1.7.4"
-    "@terascope/data-types": "npm:~1.7.3"
+    "@terascope/data-mate": "npm:~1.7.5"
+    "@terascope/data-types": "npm:~1.7.4"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     "@types/uuid": "npm:~10.0.0"
     ajv: "npm:~8.17.1"
     ajv-formats: "npm:~3.0.1"
@@ -6471,7 +6471,7 @@ __metadata:
     opensearch2: "npm:@opensearch-project/opensearch@~2.12.0"
     setimmediate: "npm:~1.0.5"
     uuid: "npm:~11.0.5"
-    xlucene-translator: "npm:~1.7.4"
+    xlucene-translator: "npm:~1.7.5"
   languageName: unknown
   linkType: soft
 
@@ -10680,6 +10680,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mnemonist@npm:~0.40.1":
+  version: 0.40.2
+  resolution: "mnemonist@npm:0.40.2"
+  dependencies:
+    obliterator: "npm:^2.0.4"
+  checksum: 10c0/0c94a7ac588f1430005fcfaadb4baed25a3b88f5dd06830f4eef6715b79612636ed488332f772d10c8933e568fbc3e00c2b195c22664c4410978ec2f5c3b9325
+  languageName: node
+  linkType: hard
+
 "moment@npm:^2.19.3, moment@npm:^2.22.2, moment@npm:^2.29.1":
   version: 2.30.1
   resolution: "moment@npm:2.30.1"
@@ -11051,7 +11060,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"obliterator@npm:^2.0.1":
+"obliterator@npm:^2.0.1, obliterator@npm:^2.0.4":
   version: 2.0.5
   resolution: "obliterator@npm:2.0.5"
   checksum: 10c0/36e67d88271c51aa6412a7d449d6c60ae6387176f94dbc557eea67456bf6ccedbcbcecdb1e56438aa4f4694f68f531b3bf2be87b019e2f69961b144bec124e70
@@ -13286,13 +13295,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terafoundation@npm:~1.10.1, terafoundation@workspace:packages/terafoundation":
+"terafoundation@npm:~1.10.2, terafoundation@workspace:packages/terafoundation":
   version: 0.0.0-use.local
   resolution: "terafoundation@workspace:packages/terafoundation"
   dependencies:
     "@terascope/file-asset-apis": "npm:~1.0.3"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     "@types/bunyan": "npm:~1.8.11"
     "@types/elasticsearch": "npm:~5.0.43"
     "@types/express": "npm:~4.17.21"
@@ -13303,7 +13312,7 @@ __metadata:
     convict-format-with-moment: "npm:~6.2.0"
     convict-format-with-validator: "npm:~6.2.0"
     elasticsearch: "npm:~15.4.1"
-    elasticsearch-store: "npm:~1.8.1"
+    elasticsearch-store: "npm:~1.8.2"
     express: "npm:~4.21.2"
     got: "npm:~13.0.0"
     js-yaml: "npm:~4.1.0"
@@ -13320,7 +13329,7 @@ __metadata:
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.0.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     "@types/decompress": "npm:~4.2.7"
     "@types/diff": "npm:~7.0.1"
     "@types/ejs": "npm:~3.1.5"
@@ -13345,7 +13354,7 @@ __metadata:
     pretty-bytes: "npm:~6.1.1"
     prompts: "npm:~2.4.2"
     signale: "npm:~1.4.0"
-    teraslice-client-js: "npm:~1.7.3"
+    teraslice-client-js: "npm:~1.7.4"
     tmp: "npm:~0.2.3"
     tty-table: "npm:~4.2.3"
     yargs: "npm:~17.7.2"
@@ -13355,12 +13364,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"teraslice-client-js@npm:~1.7.3, teraslice-client-js@workspace:packages/teraslice-client-js":
+"teraslice-client-js@npm:~1.7.4, teraslice-client-js@workspace:packages/teraslice-client-js":
   version: 0.0.0-use.local
   resolution: "teraslice-client-js@workspace:packages/teraslice-client-js"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     auto-bind: "npm:~5.0.1"
     got: "npm:~13.0.0"
     nock: "npm:~13.5.6"
@@ -13372,11 +13381,11 @@ __metadata:
   resolution: "teraslice-test-harness@workspace:packages/teraslice-test-harness"
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.0.0"
-    "@terascope/job-components": "npm:~1.9.4"
+    "@terascope/job-components": "npm:~1.9.5"
     decompress: "npm:~4.2.1"
     fs-extra: "npm:~11.3.0"
   peerDependencies:
-    "@terascope/job-components": ">=1.9.4"
+    "@terascope/job-components": ">=1.9.5"
   languageName: unknown
   linkType: soft
 
@@ -13387,7 +13396,7 @@ __metadata:
     "@eslint/js": "npm:~9.20.0"
     "@swc/core": "npm:1.10.15"
     "@swc/jest": "npm:~0.2.37"
-    "@terascope/scripts": "npm:~1.10.2"
+    "@terascope/scripts": "npm:~1.10.3"
     "@types/bluebird": "npm:~3.5.42"
     "@types/convict": "npm:~6.1.6"
     "@types/elasticsearch": "npm:~5.0.43"
@@ -13411,11 +13420,11 @@ __metadata:
   resolution: "teraslice@workspace:packages/teraslice"
   dependencies:
     "@kubernetes/client-node": "npm:~0.22.3"
-    "@terascope/elasticsearch-api": "npm:~4.8.1"
-    "@terascope/job-components": "npm:~1.9.4"
-    "@terascope/teraslice-messaging": "npm:~1.10.4"
+    "@terascope/elasticsearch-api": "npm:~4.8.2"
+    "@terascope/job-components": "npm:~1.9.5"
+    "@terascope/teraslice-messaging": "npm:~1.10.5"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     "@types/archiver": "npm:~6.0.3"
     "@types/express": "npm:~4.17.21"
     "@types/gc-stats": "npm:~1.4.3"
@@ -13446,7 +13455,7 @@ __metadata:
     semver: "npm:~7.7.1"
     socket.io: "npm:~1.7.4"
     socket.io-client: "npm:~1.7.4"
-    terafoundation: "npm:~1.10.1"
+    terafoundation: "npm:~1.10.2"
     uuid: "npm:~11.0.5"
   languageName: unknown
   linkType: soft
@@ -13660,9 +13669,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ts-transforms@workspace:packages/ts-transforms"
   dependencies:
-    "@terascope/data-mate": "npm:~1.7.4"
+    "@terascope/data-mate": "npm:~1.7.5"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     "@types/graphlib": "npm:~2.1.12"
     "@types/jexl": "npm:~2.3.4"
     "@types/valid-url": "npm:~1.0.7"
@@ -14412,12 +14421,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xlucene-parser@npm:~1.7.4, xlucene-parser@workspace:packages/xlucene-parser":
+"xlucene-parser@npm:~1.7.5, xlucene-parser@workspace:packages/xlucene-parser":
   version: 0.0.0-use.local
   resolution: "xlucene-parser@workspace:packages/xlucene-parser"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     "@turf/invariant": "npm:~7.2.0"
     "@turf/random": "npm:~7.2.0"
     peggy: "npm:~4.2.0"
@@ -14425,15 +14434,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"xlucene-translator@npm:~1.7.4, xlucene-translator@workspace:packages/xlucene-translator":
+"xlucene-translator@npm:~1.7.5, xlucene-translator@workspace:packages/xlucene-translator":
   version: 0.0.0-use.local
   resolution: "xlucene-translator@workspace:packages/xlucene-translator"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
     "@types/elasticsearch": "npm:~5.0.43"
     elasticsearch: "npm:~15.4.1"
-    xlucene-parser: "npm:~1.7.4"
+    xlucene-parser: "npm:~1.7.5"
   languageName: unknown
   linkType: soft
 
@@ -14449,7 +14458,7 @@ __metadata:
   resolution: "xpressions@workspace:packages/xpressions"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.3"
+    "@terascope/utils": "npm:~1.7.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR makes the following changes:
- update mnemonist from 0.39.8 to 0.40.1
- update imports since ESM is now supported.
- bump package versions
   - bump: (patch) @terascope/data-mate@1.7.5, elasticsearch-store@1.8.2
   - bump: (patch) terafoundation@1.10.2, ts-transforms@1.7.5
   - bump: (patch) @terascope/scripts@1.10.3, @terascope/utils@1.7.4
   - bump: (patch) @terascope/data-types@1.7.4, xlucene-parser@1.7.5
   - bump: (patch) xlucene-translator@1.7.5, @terascope/elasticsearch-api@4.8.2
   - bump: (patch) @terascope/teraslice-state-storage@1.8.2, @terascope/job-components@1.9.5
- [bump teraslice from 2.12.5 to 2.12.6](release: (patch) teraslice@2.12.6)

Needs: #3960 merged first