### PR TITLE
[teraslice-messaging] fix memory leak caused by abortController

### DIFF
--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "1.10.3",
+    "version": "1.10.4",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {

--- a/packages/teraslice-messaging/src/execution-controller/client.ts
+++ b/packages/teraslice-messaging/src/execution-controller/client.ts
@@ -7,7 +7,6 @@ const ONE_MIN = 60 * 1000;
 
 export class Client extends core.Client {
     public workerId: string;
-    private abortController: AbortController;
 
     constructor(opts: i.ClientOptions) {
         const {
@@ -48,7 +47,6 @@ export class Client extends core.Client {
 
         this.workerId = workerId;
         this.available = false;
-        this.abortController = new AbortController();
     }
 
     async start() {
@@ -77,13 +75,6 @@ export class Client extends core.Client {
                 payload: msg.payload,
             });
         });
-
-        this.on('server:shutdown', () => {
-            // this will send an abort signal to the Core.onceWithTimeout pEvent
-            // allowing the worker to shutdown without receiving a response to
-            // a sendSliceComplete() message
-            this.abortController.abort();
-        });
     }
 
     onExecutionFinished(fn: () => void) {
@@ -94,7 +85,7 @@ export class Client extends core.Client {
         return this.send('worker:slice:complete', withoutNil(payload), {
             response: true,
             volatile: false,
-            signal: this.abortController.signal
+            sendAbortSignal: true
         });
     }
 

--- a/packages/teraslice-messaging/src/messenger/client.ts
+++ b/packages/teraslice-messaging/src/messenger/client.ts
@@ -278,7 +278,7 @@ export class Client extends Core {
             respondBy,
         };
 
-        const responseMsg = this.handleSendResponse(message, options.signal);
+        const responseMsg = this.handleSendResponse(message, options.sendAbortSignal);
         this.socket.emit(eventName, message);
         return responseMsg;
     }

--- a/packages/teraslice-messaging/src/messenger/interfaces.ts
+++ b/packages/teraslice-messaging/src/messenger/interfaces.ts
@@ -57,7 +57,7 @@ export interface SendOptions {
     volatile?: boolean;
     response?: boolean;
     timeout?: number;
-    signal?: AbortSignal;
+    sendAbortSignal?: boolean;
 }
 
 export interface ConnectedClient {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -41,7 +41,7 @@
         "@kubernetes/client-node": "~0.22.3",
         "@terascope/elasticsearch-api": "~4.8.1",
         "@terascope/job-components": "~1.9.3",
-        "@terascope/teraslice-messaging": "~1.10.3",
+        "@terascope/teraslice-messaging": "~1.10.4",
         "@terascope/types": "~1.4.1",
         "@terascope/utils": "~1.7.3",
         "async-mutex": "~0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3014,7 +3014,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/teraslice-messaging@npm:~1.10.3, @terascope/teraslice-messaging@workspace:packages/teraslice-messaging":
+"@terascope/teraslice-messaging@npm:~1.10.4, @terascope/teraslice-messaging@workspace:packages/teraslice-messaging":
   version: 0.0.0-use.local
   resolution: "@terascope/teraslice-messaging@workspace:packages/teraslice-messaging"
   dependencies:
@@ -13397,7 +13397,7 @@ __metadata:
     "@kubernetes/client-node": "npm:~0.22.3"
     "@terascope/elasticsearch-api": "npm:~4.8.1"
     "@terascope/job-components": "npm:~1.9.3"
-    "@terascope/teraslice-messaging": "npm:~1.10.3"
+    "@terascope/teraslice-messaging": "npm:~1.10.4"
     "@terascope/types": "npm:~1.4.1"
     "@terascope/utils": "npm:~1.7.3"
     "@types/archiver": "npm:~6.0.3"


### PR DESCRIPTION
This PR makes the following changes:
-bump teraslice-messaging from 1.10.3 to 1.10.4
- Remove the `abortController` from the execution-controller client
- Create an `abortController` in the core client `handleSendResponse` function if `sendAbortSignal` is set to true. This is only the case for when the execution-controller client sends the `worker:slice:complete` event. On a `server:shutdown` event the `abortController` will abort awaiting a server response so it can shutdown properly.  

ref: #3945