### PR TITLE
[CI] Add inputs to workflow_dispatch of daily-docker-cache.yml

### DIFF
--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 12 * * 1-5' # Monday - Friday at 5am Arizona Time
   workflow_dispatch:
     inputs:
+      # Represents the reason that this workflow is running. If triggering this
+      # workflow with an api call the reason should be included in the request body.
       reason:
         required: false
         default: "Manually triggered"

--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -4,6 +4,13 @@ on:
   schedule:
     - cron: '0 12 * * 1-5' # Monday - Friday at 5am Arizona Time
   workflow_dispatch:
+    inputs:
+      reason:
+        required: false
+        default: "Manually triggered"
+
+run-name: Daily Docker Cache - ${{ inputs.reason || 'Scheduled Weekly Run' }}
+  
 
 jobs:
   call-refresh-docker-cache-workflow:


### PR DESCRIPTION
This PR makes the following change:
- Add `inputs` to the `workflow_dispatch`. This allows us to have a custom `run-name` for the workflow. If the workflow is triggered by a cron job the run-name will include `Scheduled Weekly Run`, if triggered manually it will include `Manually Triggered`, and if triggered by the `base-docker-image` release workflow it will include `New Base Images Released`.

ref: #3955 