### PR TITLE
Bump teraslice to v2.12.7

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -45,11 +45,11 @@
         "ms": "~2.1.3"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.10.3",
+        "@terascope/scripts": "~1.10.4",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "bunyan": "~1.8.15",
-        "elasticsearch-store": "~1.8.2",
+        "elasticsearch-store": "~1.8.3",
         "fs-extra": "~11.3.0",
         "jest": "^29.7.0",
         "jest-extended": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.12.6",
+    "version": "2.12.7",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {
@@ -53,7 +53,7 @@
         "@eslint/js": "~9.20.0",
         "@swc/core": "1.10.15",
         "@swc/jest": "~0.2.37",
-        "@terascope/scripts": "~1.10.3",
+        "@terascope/scripts": "~1.10.4",
         "@types/bluebird": "~3.5.42",
         "@types/convict": "~6.1.6",
         "@types/elasticsearch": "~5.0.43",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "1.7.5",
+    "version": "1.7.6",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -30,9 +30,9 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../data-mate --"
     },
     "dependencies": {
-        "@terascope/data-types": "~1.7.4",
+        "@terascope/data-types": "~1.7.5",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "@types/validator": "~13.12.2",
         "awesome-phonenumber": "~7.3.0",
         "date-fns": "~4.1.0",
@@ -45,7 +45,7 @@
         "uuid": "~11.0.5",
         "valid-url": "~1.0.9",
         "validator": "~13.12.0",
-        "xlucene-parser": "~1.7.5"
+        "xlucene-parser": "~1.7.6"
     },
     "devDependencies": {
         "@types/ip6addr": "~0.2.6",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "1.7.4",
+    "version": "1.7.5",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "graphql": "~16.10.0",
         "yargs": "~17.7.2"
     },

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "4.8.2",
+    "version": "4.8.3",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -25,7 +25,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "bluebird": "~3.7.2",
         "setimmediate": "~1.0.5"
     },
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "~1.2.0",
         "@types/elasticsearch": "~5.0.43",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.8.2",
+        "elasticsearch-store": "~1.8.3",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@~7.17.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@~8.15.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "1.8.2",
+    "version": "1.8.3",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,10 +30,10 @@
         "test:watch": "ts-scripts yarn workspace @terascope/scripts test --watch ../elasticsearch-store --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.7.5",
-        "@terascope/data-types": "~1.7.4",
+        "@terascope/data-mate": "~1.7.6",
+        "@terascope/data-types": "~1.7.5",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "ajv": "~8.17.1",
         "ajv-formats": "~3.0.1",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
@@ -43,7 +43,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@~2.12.0",
         "setimmediate": "~1.0.5",
         "uuid": "~11.0.5",
-        "xlucene-translator": "~1.7.5"
+        "xlucene-translator": "~1.7.6"
     },
     "devDependencies": {
         "@types/uuid": "~10.0.0"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/eslint-config",
     "displayName": "Terascope ESLint Config",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "description": "A shared eslint config based on eslint-config-airbnb",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/eslint-config#readme",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "1.9.5",
+    "version": "1.9.6",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.10.3",
+    "version": "1.10.4",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "codecov": "~3.8.3",
         "execa": "~9.5.2",
         "fs-extra": "~11.3.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "1.10.2",
+    "version": "1.10.3",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -30,14 +30,14 @@
     "dependencies": {
         "@terascope/file-asset-apis": "~1.0.3",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "bluebird": "~3.7.2",
         "bunyan": "~1.8.15",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.8.2",
+        "elasticsearch-store": "~1.8.3",
         "express": "~4.21.2",
         "js-yaml": "~4.1.0",
         "nanoid": "~5.1.0",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "2.10.2",
+    "version": "2.10.3",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -44,7 +44,7 @@
     "devDependencies": {
         "@terascope/fetch-github-release": "~2.0.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "@types/decompress": "~4.2.7",
         "@types/diff": "~7.0.1",
         "@types/ejs": "~3.1.5",
@@ -68,7 +68,7 @@
         "pretty-bytes": "~6.1.1",
         "prompts": "~2.4.2",
         "signale": "~1.4.0",
-        "teraslice-client-js": "~1.7.4",
+        "teraslice-client-js": "~1.7.5",
         "tmp": "~0.2.3",
         "tty-table": "~4.2.3",
         "yargs": "~17.7.2"

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "1.7.4",
+    "version": "1.7.5",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "auto-bind": "~5.0.1",
         "got": "~13.0.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "1.10.5",
+    "version": "1.10.6",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "get-port": "~7.1.0",
         "ms": "~2.1.3",
         "nanoid": "~5.1.0",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "1.8.2",
+    "version": "1.8.3",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -24,8 +24,8 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../teraslice-state-storage --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "~4.8.2",
-        "@terascope/utils": "~1.7.4"
+        "@terascope/elasticsearch-api": "~4.8.3",
+        "@terascope/utils": "~1.7.5"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "~11.3.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "~1.9.5"
+        "@terascope/job-components": "~1.9.6"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=1.9.5"
+        "@terascope/job-components": ">=1.9.6"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.12.6",
+    "version": "2.12.7",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -39,11 +39,11 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
-        "@terascope/elasticsearch-api": "~4.8.2",
-        "@terascope/job-components": "~1.9.5",
-        "@terascope/teraslice-messaging": "~1.10.5",
+        "@terascope/elasticsearch-api": "~4.8.3",
+        "@terascope/job-components": "~1.9.6",
+        "@terascope/teraslice-messaging": "~1.10.6",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "async-mutex": "~0.5.0",
         "barbe": "~3.0.17",
         "body-parser": "~1.20.3",
@@ -62,7 +62,7 @@
         "semver": "~7.7.1",
         "socket.io": "~1.7.4",
         "socket.io-client": "~1.7.4",
-        "terafoundation": "~1.10.2",
+        "terafoundation": "~1.10.3",
         "uuid": "~11.0.5"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "1.7.5",
+    "version": "1.7.6",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -36,9 +36,9 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../ts-transforms --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.7.5",
+        "@terascope/data-mate": "~1.7.6",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "awesome-phonenumber": "~7.3.0",
         "graphlib": "~2.1.8",
         "jexl": "~2.3.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "1.7.4",
+    "version": "1.7.5",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "1.7.5",
+    "version": "1.7.6",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "peggy": "~4.2.0",
         "ts-pegjs": "~4.2.1"
     },

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "1.7.5",
+    "version": "1.7.6",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -30,9 +30,9 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.4",
+        "@terascope/utils": "~1.7.5",
         "@types/elasticsearch": "~5.0.43",
-        "xlucene-parser": "~1.7.5"
+        "xlucene-parser": "~1.7.6"
     },
     "devDependencies": {
         "elasticsearch": "~15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "1.7.4",
+    "version": "1.7.5",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../xpressions --"
     },
     "dependencies": {
-        "@terascope/utils": "~1.7.4"
+        "@terascope/utils": "~1.7.5"
     },
     "devDependencies": {
         "@terascope/types": "~1.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2838,13 +2838,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/data-mate@npm:~1.7.5, @terascope/data-mate@workspace:packages/data-mate":
+"@terascope/data-mate@npm:~1.7.6, @terascope/data-mate@workspace:packages/data-mate":
   version: 0.0.0-use.local
   resolution: "@terascope/data-mate@workspace:packages/data-mate"
   dependencies:
-    "@terascope/data-types": "npm:~1.7.4"
+    "@terascope/data-types": "npm:~1.7.5"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     "@types/ip6addr": "npm:~0.2.6"
     "@types/uuid": "npm:~10.0.0"
     "@types/validator": "npm:~13.12.2"
@@ -2861,16 +2861,16 @@ __metadata:
     uuid: "npm:~11.0.5"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
-    xlucene-parser: "npm:~1.7.5"
+    xlucene-parser: "npm:~1.7.6"
   languageName: unknown
   linkType: soft
 
-"@terascope/data-types@npm:~1.7.4, @terascope/data-types@workspace:packages/data-types":
+"@terascope/data-types@npm:~1.7.5, @terascope/data-types@workspace:packages/data-types":
   version: 0.0.0-use.local
   resolution: "@terascope/data-types@workspace:packages/data-types"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     "@types/yargs": "npm:~17.0.33"
     graphql: "npm:~16.10.0"
     yargs: "npm:~17.7.2"
@@ -2887,17 +2887,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/elasticsearch-api@npm:~4.8.2, @terascope/elasticsearch-api@workspace:packages/elasticsearch-api":
+"@terascope/elasticsearch-api@npm:~4.8.3, @terascope/elasticsearch-api@workspace:packages/elasticsearch-api":
   version: 0.0.0-use.local
   resolution: "@terascope/elasticsearch-api@workspace:packages/elasticsearch-api"
   dependencies:
     "@opensearch-project/opensearch": "npm:~1.2.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     "@types/elasticsearch": "npm:~5.0.43"
     bluebird: "npm:~3.7.2"
     elasticsearch: "npm:~15.4.1"
-    elasticsearch-store: "npm:~1.8.2"
+    elasticsearch-store: "npm:~1.8.3"
     elasticsearch6: "npm:@elastic/elasticsearch@~6.8.0"
     elasticsearch7: "npm:@elastic/elasticsearch@~7.17.0"
     elasticsearch8: "npm:@elastic/elasticsearch@~8.15.0"
@@ -2960,12 +2960,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/job-components@npm:~1.9.5, @terascope/job-components@workspace:packages/job-components":
+"@terascope/job-components@npm:~1.9.6, @terascope/job-components@workspace:packages/job-components":
   version: 0.0.0-use.local
   resolution: "@terascope/job-components@workspace:packages/job-components"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     benchmark: "npm:~2.1.4"
     convict: "npm:~6.2.4"
     convict-format-with-moment: "npm:~6.2.0"
@@ -2980,12 +2980,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/scripts@npm:~1.10.3, @terascope/scripts@workspace:packages/scripts":
+"@terascope/scripts@npm:~1.10.4, @terascope/scripts@workspace:packages/scripts":
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
     "@kubernetes/client-node": "npm:~0.22.3"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     "@types/ip": "npm:~1.1.3"
     "@types/micromatch": "npm:~4.0.9"
     "@types/ms": "npm:~0.7.34"
@@ -3023,12 +3023,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/teraslice-messaging@npm:~1.10.5, @terascope/teraslice-messaging@workspace:packages/teraslice-messaging":
+"@terascope/teraslice-messaging@npm:~1.10.6, @terascope/teraslice-messaging@workspace:packages/teraslice-messaging":
   version: 0.0.0-use.local
   resolution: "@terascope/teraslice-messaging@workspace:packages/teraslice-messaging"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     "@types/ms": "npm:~0.7.34"
     "@types/socket.io": "npm:~2.1.13"
     "@types/socket.io-client": "npm:~1.4.36"
@@ -3045,8 +3045,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terascope/teraslice-state-storage@workspace:packages/teraslice-state-storage"
   dependencies:
-    "@terascope/elasticsearch-api": "npm:~4.8.2"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/elasticsearch-api": "npm:~4.8.3"
+    "@terascope/utils": "npm:~1.7.5"
   languageName: unknown
   linkType: soft
 
@@ -3111,7 +3111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/utils@npm:~1.7.4, @terascope/utils@workspace:packages/utils":
+"@terascope/utils@npm:~1.7.5, @terascope/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@terascope/utils@workspace:packages/utils"
   dependencies:
@@ -6393,11 +6393,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e@workspace:e2e"
   dependencies:
-    "@terascope/scripts": "npm:~1.10.3"
+    "@terascope/scripts": "npm:~1.10.4"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     bunyan: "npm:~1.8.15"
-    elasticsearch-store: "npm:~1.8.2"
+    elasticsearch-store: "npm:~1.8.3"
     fs-extra: "npm:~11.3.0"
     jest: "npm:^29.7.0"
     jest-extended: "npm:^4.0.2"
@@ -6460,14 +6460,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elasticsearch-store@npm:~1.8.2, elasticsearch-store@workspace:packages/elasticsearch-store":
+"elasticsearch-store@npm:~1.8.3, elasticsearch-store@workspace:packages/elasticsearch-store":
   version: 0.0.0-use.local
   resolution: "elasticsearch-store@workspace:packages/elasticsearch-store"
   dependencies:
-    "@terascope/data-mate": "npm:~1.7.5"
-    "@terascope/data-types": "npm:~1.7.4"
+    "@terascope/data-mate": "npm:~1.7.6"
+    "@terascope/data-types": "npm:~1.7.5"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     "@types/uuid": "npm:~10.0.0"
     ajv: "npm:~8.17.1"
     ajv-formats: "npm:~3.0.1"
@@ -6478,7 +6478,7 @@ __metadata:
     opensearch2: "npm:@opensearch-project/opensearch@~2.12.0"
     setimmediate: "npm:~1.0.5"
     uuid: "npm:~11.0.5"
-    xlucene-translator: "npm:~1.7.5"
+    xlucene-translator: "npm:~1.7.6"
   languageName: unknown
   linkType: soft
 
@@ -13318,13 +13318,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terafoundation@npm:~1.10.2, terafoundation@workspace:packages/terafoundation":
+"terafoundation@npm:~1.10.3, terafoundation@workspace:packages/terafoundation":
   version: 0.0.0-use.local
   resolution: "terafoundation@workspace:packages/terafoundation"
   dependencies:
     "@terascope/file-asset-apis": "npm:~1.0.3"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     "@types/bunyan": "npm:~1.8.11"
     "@types/elasticsearch": "npm:~5.0.43"
     "@types/express": "npm:~4.17.21"
@@ -13335,7 +13335,7 @@ __metadata:
     convict-format-with-moment: "npm:~6.2.0"
     convict-format-with-validator: "npm:~6.2.0"
     elasticsearch: "npm:~15.4.1"
-    elasticsearch-store: "npm:~1.8.2"
+    elasticsearch-store: "npm:~1.8.3"
     express: "npm:~4.21.2"
     got: "npm:~13.0.0"
     js-yaml: "npm:~4.1.0"
@@ -13352,7 +13352,7 @@ __metadata:
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.0.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     "@types/decompress": "npm:~4.2.7"
     "@types/diff": "npm:~7.0.1"
     "@types/ejs": "npm:~3.1.5"
@@ -13377,7 +13377,7 @@ __metadata:
     pretty-bytes: "npm:~6.1.1"
     prompts: "npm:~2.4.2"
     signale: "npm:~1.4.0"
-    teraslice-client-js: "npm:~1.7.4"
+    teraslice-client-js: "npm:~1.7.5"
     tmp: "npm:~0.2.3"
     tty-table: "npm:~4.2.3"
     yargs: "npm:~17.7.2"
@@ -13387,12 +13387,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"teraslice-client-js@npm:~1.7.4, teraslice-client-js@workspace:packages/teraslice-client-js":
+"teraslice-client-js@npm:~1.7.5, teraslice-client-js@workspace:packages/teraslice-client-js":
   version: 0.0.0-use.local
   resolution: "teraslice-client-js@workspace:packages/teraslice-client-js"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     auto-bind: "npm:~5.0.1"
     got: "npm:~13.0.0"
     nock: "npm:~13.5.6"
@@ -13404,11 +13404,11 @@ __metadata:
   resolution: "teraslice-test-harness@workspace:packages/teraslice-test-harness"
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.0.0"
-    "@terascope/job-components": "npm:~1.9.5"
+    "@terascope/job-components": "npm:~1.9.6"
     decompress: "npm:~4.2.1"
     fs-extra: "npm:~11.3.0"
   peerDependencies:
-    "@terascope/job-components": ">=1.9.5"
+    "@terascope/job-components": ">=1.9.6"
   languageName: unknown
   linkType: soft
 
@@ -13419,7 +13419,7 @@ __metadata:
     "@eslint/js": "npm:~9.20.0"
     "@swc/core": "npm:1.10.15"
     "@swc/jest": "npm:~0.2.37"
-    "@terascope/scripts": "npm:~1.10.3"
+    "@terascope/scripts": "npm:~1.10.4"
     "@types/bluebird": "npm:~3.5.42"
     "@types/convict": "npm:~6.1.6"
     "@types/elasticsearch": "npm:~5.0.43"
@@ -13443,11 +13443,11 @@ __metadata:
   resolution: "teraslice@workspace:packages/teraslice"
   dependencies:
     "@kubernetes/client-node": "npm:~0.22.3"
-    "@terascope/elasticsearch-api": "npm:~4.8.2"
-    "@terascope/job-components": "npm:~1.9.5"
-    "@terascope/teraslice-messaging": "npm:~1.10.5"
+    "@terascope/elasticsearch-api": "npm:~4.8.3"
+    "@terascope/job-components": "npm:~1.9.6"
+    "@terascope/teraslice-messaging": "npm:~1.10.6"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     "@types/archiver": "npm:~6.0.3"
     "@types/express": "npm:~4.17.21"
     "@types/gc-stats": "npm:~1.4.3"
@@ -13478,7 +13478,7 @@ __metadata:
     semver: "npm:~7.7.1"
     socket.io: "npm:~1.7.4"
     socket.io-client: "npm:~1.7.4"
-    terafoundation: "npm:~1.10.2"
+    terafoundation: "npm:~1.10.3"
     uuid: "npm:~11.0.5"
   languageName: unknown
   linkType: soft
@@ -13692,9 +13692,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ts-transforms@workspace:packages/ts-transforms"
   dependencies:
-    "@terascope/data-mate": "npm:~1.7.5"
+    "@terascope/data-mate": "npm:~1.7.6"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     "@types/graphlib": "npm:~2.1.12"
     "@types/jexl": "npm:~2.3.4"
     "@types/valid-url": "npm:~1.0.7"
@@ -14444,12 +14444,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xlucene-parser@npm:~1.7.5, xlucene-parser@workspace:packages/xlucene-parser":
+"xlucene-parser@npm:~1.7.6, xlucene-parser@workspace:packages/xlucene-parser":
   version: 0.0.0-use.local
   resolution: "xlucene-parser@workspace:packages/xlucene-parser"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     "@turf/invariant": "npm:~7.2.0"
     "@turf/random": "npm:~7.2.0"
     peggy: "npm:~4.2.0"
@@ -14457,15 +14457,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"xlucene-translator@npm:~1.7.5, xlucene-translator@workspace:packages/xlucene-translator":
+"xlucene-translator@npm:~1.7.6, xlucene-translator@workspace:packages/xlucene-translator":
   version: 0.0.0-use.local
   resolution: "xlucene-translator@workspace:packages/xlucene-translator"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
     "@types/elasticsearch": "npm:~5.0.43"
     elasticsearch: "npm:~15.4.1"
-    xlucene-parser: "npm:~1.7.5"
+    xlucene-parser: "npm:~1.7.6"
   languageName: unknown
   linkType: soft
 
@@ -14481,7 +14481,7 @@ __metadata:
   resolution: "xpressions@workspace:packages/xpressions"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.4"
+    "@terascope/utils": "npm:~1.7.5"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR bumps the following packages:

- release: (patch) teraslice@2.12.7
- bump: (patch) @terascope/data-mate@1.7.6, elasticsearch-store@1.8.3
- bump: (patch) terafoundation@1.10.3, ts-transforms@1.7.6
- bump: (patch) @terascope/eslint-config@1.1.7, @terascope/scripts@1.10.4
- bump: (patch) teraslice-cli@2.10.3, @terascope/teraslice-messaging@1.10.6
- bump: (patch) @terascope/utils@1.7.5, @terascope/data-types@1.7.5
- bump: (patch) xlucene-parser@1.7.6, xlucene-translator@1.7.6

PR that bumps deps #3970