### PR TITLE
release: (minor) teraslice@2.13.0

### DIFF
--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: teraslice-chart
 description: Teraslice -  Distributed computing platform for processing JSON data
 type: application
-version: 2.0.0
-appVersion: v2.12.2
+version: 2.1.0
+appVersion: v2.13.0
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/helm/teraslice/values.yaml
+++ b/helm/teraslice/values.yaml
@@ -11,7 +11,7 @@ image:
   pullPolicy: IfNotPresent
   # node version will be inserted into the image tag (which defaults to the chart version)
   # setting the image tag will ignore this value
-  nodeVersion: v22.13.0
+  nodeVersion: v22.14.0
 
 imagePullSecrets: []
 nameOverride: ""
@@ -94,8 +94,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-podSecurityContext: {}
-  # fsGroup: 2000
+
+podSecurityContext: {} # fsGroup: 2000
 
 securityContext: {}
   # capabilities:
@@ -207,8 +207,7 @@ serviceMonitor:
 # Pod Monitor used by teraslice job metric api
 podMonitor:
   enabled: false
-  labels: {}
-    #scrape.prometheus.io/instance: prometheus-instance
+  labels: {} #scrape.prometheus.io/instance: prometheus-instance
   annotations: {}
   jobLabel: app.kubernetes.io/instance
   interval: 60s
@@ -234,7 +233,7 @@ prometheusRule:
   #    labels:
   #      severity: warning
 
-# Test images
+  # Test images
 busybox:
   repository: busybox
   tag: latest

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.12.8",
+    "version": "2.13.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.12.8",
+    "version": "2.13.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
This PR bumps teraslice from 2.12.8 to 2.13.0
- This version will be built on `base-docker-image` version 1.4.0
  - terafoundation_kafka_connector v1.4.0
  - node-rdkafka v3.2.1
  - librdkafka v2.8.0