### PR TITLE
bundled dependency updates for 2025-3-10

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -46,11 +46,11 @@
         "ms": "~2.1.3"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.12.0",
+        "@terascope/scripts": "~1.12.1",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "bunyan": "~1.8.15",
-        "elasticsearch-store": "~1.9.0",
+        "elasticsearch-store": "~1.9.1",
         "fs-extra": "~11.3.0",
         "jest": "^29.7.0",
         "jest-extended": "^4.0.2",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -56,7 +56,7 @@
         "jest-extended": "^4.0.2",
         "jest-watch-typeahead": "^2.2.2",
         "ms": "~2.1.3",
-        "nanoid": "~5.1.2",
+        "nanoid": "~5.1.3",
         "semver": "~7.7.1",
         "signale": "~1.4.0",
         "ts-jest": "~29.2.6",

--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: teraslice-chart
 description: Teraslice -  Distributed computing platform for processing JSON data
 type: application
-version: 2.2.0
-appVersion: v2.14.0
+version: 2.3.0
+appVersion: v2.14.1
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
         "nan": "~2.22.0"
     },
     "devDependencies": {
-        "@eslint/js": "~9.21.0",
-        "@swc/core": "1.11.5",
+        "@eslint/js": "~9.22.0",
+        "@swc/core": "1.11.8",
         "@swc/jest": "~0.2.37",
         "@terascope/scripts": "~1.12.0",
         "@types/bluebird": "~3.5.42",
@@ -60,9 +60,9 @@
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~29.5.14",
         "@types/lodash": "~4.17.16",
-        "@types/node": "~22.13.8",
+        "@types/node": "~22.13.10",
         "@types/uuid": "~10.0.0",
-        "eslint": "~9.21.0",
+        "eslint": "~9.22.0",
         "jest": "~29.7.0",
         "jest-extended": "~4.0.2",
         "jest-watch-typeahead": "~2.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.14.0",
+    "version": "2.14.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {
@@ -53,7 +53,7 @@
         "@eslint/js": "~9.22.0",
         "@swc/core": "1.11.8",
         "@swc/jest": "~0.2.37",
-        "@terascope/scripts": "~1.12.0",
+        "@terascope/scripts": "~1.12.1",
         "@types/bluebird": "~3.5.42",
         "@types/convict": "~6.1.6",
         "@types/elasticsearch": "~5.0.43",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "1.7.7",
+    "version": "1.7.8",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -30,9 +30,9 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../data-mate --"
     },
     "dependencies": {
-        "@terascope/data-types": "~1.7.6",
+        "@terascope/data-types": "~1.7.7",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "@types/validator": "~13.12.2",
         "awesome-phonenumber": "~7.4.0",
         "date-fns": "~4.1.0",
@@ -45,7 +45,7 @@
         "uuid": "~11.1.0",
         "valid-url": "~1.0.9",
         "validator": "~13.12.0",
-        "xlucene-parser": "~1.7.7"
+        "xlucene-parser": "~1.7.8"
     },
     "devDependencies": {
         "@types/ip6addr": "~0.2.6",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -34,7 +34,7 @@
         "@terascope/types": "~1.4.1",
         "@terascope/utils": "~1.7.6",
         "@types/validator": "~13.12.2",
-        "awesome-phonenumber": "~7.3.0",
+        "awesome-phonenumber": "~7.4.0",
         "date-fns": "~4.1.0",
         "ip-bigint": "~8.2.1",
         "ip6addr": "~0.2.5",

--- a/packages/data-mate/src/column/Column.ts
+++ b/packages/data-mate/src/column/Column.ts
@@ -85,7 +85,7 @@ export class Column<T = unknown, N extends NameType = string> {
      * And may not be compatible with the JSON spec.
     */
     * [Symbol.iterator](): IterableIterator<Maybe<T>> {
-        yield * this.vector;
+        yield* this.vector;
     }
 
     /**

--- a/packages/data-mate/src/data-frame/DataFrame.ts
+++ b/packages/data-mate/src/data-frame/DataFrame.ts
@@ -187,7 +187,7 @@ export class DataFrame<
      * Iterate over each row, this returns the JSON compatible values.
     */
     * [Symbol.iterator](): IterableIterator<DataEntity<T>> {
-        yield * this.rows(true);
+        yield* this.rows(true);
     }
 
     /**
@@ -219,7 +219,7 @@ export class DataFrame<
         if (options?.skipDuplicateObjects) {
             // cast the type of json to true since typescript
             // can't detect what the return type should be here
-            yield * this.rowsWithoutDuplicates(json as true, options);
+            yield* this.rowsWithoutDuplicates(json as true, options);
             return;
         }
 

--- a/packages/data-mate/src/vector/Vector.ts
+++ b/packages/data-mate/src/vector/Vector.ts
@@ -176,7 +176,7 @@ export abstract class Vector<T = unknown> {
 
     * [Symbol.iterator](): IterableIterator<Maybe<T>> {
         for (const data of this.data) {
-            yield * data;
+            yield* data;
         }
     }
 

--- a/packages/data-mate/test/function-configs/function-configs-spec.ts
+++ b/packages/data-mate/test/function-configs/function-configs-spec.ts
@@ -18,7 +18,7 @@ describe('function configs', () => {
             for (const fnDef of Object.values(functionConfigRepository)) {
                 yield fnDef.name.toLowerCase();
 
-                if (fnDef.aliases) yield * fnDef.aliases.map((s: string) => s.toLowerCase());
+                if (fnDef.aliases) yield* fnDef.aliases.map((s: string) => s.toLowerCase());
             }
         }
         const names = Array.from(allFnNames());

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "1.7.6",
+    "version": "1.7.7",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "graphql": "~16.10.0",
         "yargs": "~17.7.2"
     },

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "4.8.4",
+    "version": "4.8.5",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -25,7 +25,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "bluebird": "~3.7.2",
         "setimmediate": "~1.0.5"
     },
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "~1.2.0",
         "@types/elasticsearch": "~5.0.43",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.9.0",
+        "elasticsearch-store": "~1.9.1",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@~7.17.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@~8.15.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "1.9.0",
+    "version": "1.9.1",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,10 +30,10 @@
         "test:watch": "ts-scripts yarn workspace @terascope/scripts test --watch ../elasticsearch-store --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.7.7",
-        "@terascope/data-types": "~1.7.6",
+        "@terascope/data-mate": "~1.7.8",
+        "@terascope/data-types": "~1.7.7",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "ajv": "~8.17.1",
         "ajv-formats": "~3.0.1",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
@@ -43,7 +43,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@~2.12.0",
         "setimmediate": "~1.0.5",
         "uuid": "~11.1.0",
-        "xlucene-translator": "~1.7.7"
+        "xlucene-translator": "~1.7.8"
     },
     "devDependencies": {
         "@types/uuid": "~10.0.0"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -19,11 +19,11 @@
     },
     "dependencies": {
         "@eslint/compat": "~1.2.7",
-        "@eslint/js": "~9.21.0",
-        "@stylistic/eslint-plugin": "~4.0.1",
-        "@typescript-eslint/eslint-plugin": "~8.25.0",
-        "@typescript-eslint/parser": "~8.25.0",
-        "eslint": "~9.21.0",
+        "@eslint/js": "~9.22.0",
+        "@stylistic/eslint-plugin": "~4.2.0",
+        "@typescript-eslint/eslint-plugin": "~8.26.0",
+        "@typescript-eslint/parser": "~8.26.0",
+        "eslint": "~9.22.0",
         "eslint-plugin-import": "~2.31.0",
         "eslint-plugin-jest": "~28.11.0",
         "eslint-plugin-jest-dom": "~5.5.0",
@@ -33,7 +33,7 @@
         "eslint-plugin-testing-library": "~7.1.1",
         "globals": "~16.0.0",
         "typescript": "~5.8.2",
-        "typescript-eslint": "~8.25.0"
+        "typescript-eslint": "~8.26.0"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/eslint-config",
     "displayName": "Terascope ESLint Config",
-    "version": "1.1.9",
+    "version": "1.1.10",
     "description": "A shared eslint config based on eslint-config-airbnb",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/eslint-config#readme",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "1.9.7",
+    "version": "1.9.8",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.12.0",
+    "version": "1.12.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "codecov": "~3.8.3",
         "execa": "~9.5.2",
         "fs-extra": "~11.3.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -30,14 +30,14 @@
     "dependencies": {
         "@terascope/file-asset-apis": "~1.0.4",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "bluebird": "~3.7.2",
         "bunyan": "~1.8.15",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.9.0",
+        "elasticsearch-store": "~1.9.1",
         "express": "~4.21.2",
         "js-yaml": "~4.1.0",
         "nanoid": "~5.1.3",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -40,7 +40,7 @@
         "elasticsearch-store": "~1.9.0",
         "express": "~4.21.2",
         "js-yaml": "~4.1.0",
-        "nanoid": "~5.1.2",
+        "nanoid": "~5.1.3",
         "node-webhdfs": "~1.0.2",
         "prom-client": "~15.1.3",
         "yargs": "~17.7.2"

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -39,7 +39,7 @@
         "test:watch": "yarn workspace @terascope/scripts test --watch ../teraslice-cli --"
     },
     "dependencies": {
-        "esbuild": "~0.25.0"
+        "esbuild": "~0.25.1"
     },
     "devDependencies": {
         "@terascope/fetch-github-release": "~2.0.0",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "2.10.3",
+    "version": "2.10.4",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"
@@ -44,7 +44,7 @@
     "devDependencies": {
         "@terascope/fetch-github-release": "~2.0.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "@types/decompress": "~4.2.7",
         "@types/diff": "~7.0.1",
         "@types/ejs": "~3.1.5",
@@ -68,7 +68,7 @@
         "pretty-bytes": "~6.1.1",
         "prompts": "~2.4.2",
         "signale": "~1.4.0",
-        "teraslice-client-js": "~1.7.6",
+        "teraslice-client-js": "~1.7.7",
         "tmp": "~0.2.3",
         "tty-table": "~4.2.3",
         "yargs": "~17.7.2"

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "1.7.6",
+    "version": "1.7.7",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "auto-bind": "~5.0.1",
         "got": "~13.0.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -39,7 +39,7 @@
         "@terascope/utils": "~1.7.6",
         "get-port": "~7.1.0",
         "ms": "~2.1.3",
-        "nanoid": "~5.1.2",
+        "nanoid": "~5.1.3",
         "p-event": "~6.0.1",
         "socket.io": "~1.7.4",
         "socket.io-client": "~1.7.4"

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "1.10.7",
+    "version": "1.10.8",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "get-port": "~7.1.0",
         "ms": "~2.1.3",
         "nanoid": "~5.1.3",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "1.8.4",
+    "version": "1.8.5",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -24,8 +24,8 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../teraslice-state-storage --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "~4.8.4",
-        "@terascope/utils": "~1.7.6"
+        "@terascope/elasticsearch-api": "~4.8.5",
+        "@terascope/utils": "~1.7.7"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "~11.3.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "~1.9.7"
+        "@terascope/job-components": "~1.9.8"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=1.9.7"
+        "@terascope/job-components": ">=1.9.8"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -58,7 +58,7 @@
         "ip": "~2.0.1",
         "kubernetes-client": "~9.0.0",
         "ms": "~2.1.3",
-        "nanoid": "~5.1.2",
+        "nanoid": "~5.1.3",
         "semver": "~7.7.1",
         "socket.io": "~1.7.4",
         "socket.io-client": "~1.7.4",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.14.0",
+    "version": "2.14.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {
@@ -39,11 +39,11 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
-        "@terascope/elasticsearch-api": "~4.8.4",
-        "@terascope/job-components": "~1.9.7",
-        "@terascope/teraslice-messaging": "~1.10.7",
+        "@terascope/elasticsearch-api": "~4.8.5",
+        "@terascope/job-components": "~1.9.8",
+        "@terascope/teraslice-messaging": "~1.10.8",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "async-mutex": "~0.5.0",
         "barbe": "~3.0.17",
         "body-parser": "~1.20.3",
@@ -62,7 +62,7 @@
         "semver": "~7.7.1",
         "socket.io": "~1.7.4",
         "socket.io-client": "~1.7.4",
-        "terafoundation": "~1.11.0",
+        "terafoundation": "~1.11.1",
         "uuid": "~11.1.0"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "1.7.7",
+    "version": "1.7.8",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -36,9 +36,9 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../ts-transforms --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.7.7",
+        "@terascope/data-mate": "~1.7.8",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "awesome-phonenumber": "~7.4.0",
         "graphlib": "~2.1.8",
         "jexl": "~2.3.0",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -39,10 +39,10 @@
         "@terascope/data-mate": "~1.7.7",
         "@terascope/types": "~1.4.1",
         "@terascope/utils": "~1.7.6",
-        "awesome-phonenumber": "~7.3.0",
+        "awesome-phonenumber": "~7.4.0",
         "graphlib": "~2.1.8",
         "jexl": "~2.3.0",
-        "nanoid": "~5.1.2",
+        "nanoid": "~5.1.3",
         "valid-url": "~1.0.9",
         "validator": "~13.12.0",
         "yargs": "~17.7.2"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "1.7.6",
+    "version": "1.7.7",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -45,7 +45,7 @@
         "@turf/line-to-polygon": "~7.2.0",
         "@types/lodash-es": "~4.17.12",
         "@types/validator": "~13.12.2",
-        "awesome-phonenumber": "~7.3.0",
+        "awesome-phonenumber": "~7.4.0",
         "date-fns": "~4.1.0",
         "date-fns-tz": "~3.2.0",
         "datemath-parser": "~1.0.6",

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -137,7 +137,7 @@ export function* chunkIter<T>(dataArray: Iterable<T>, size: number): Iterable<T[
         throw new RangeError(`Expected chunk size to be >0, got ${size}`);
     }
     if (isArrayLike(dataArray)) {
-        yield * _chunkArrayIterator(dataArray, size);
+        yield* _chunkArrayIterator(dataArray, size);
         return;
     }
 

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "1.7.7",
+    "version": "1.7.8",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "peggy": "~4.2.0",
         "ts-pegjs": "~4.2.1"
     },

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "1.7.7",
+    "version": "1.7.8",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -30,9 +30,9 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/utils": "~1.7.7",
         "@types/elasticsearch": "~5.0.43",
-        "xlucene-parser": "~1.7.7"
+        "xlucene-parser": "~1.7.8"
     },
     "devDependencies": {
         "elasticsearch": "~15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "1.7.6",
+    "version": "1.7.7",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../xpressions --"
     },
     "dependencies": {
-        "@terascope/utils": "~1.7.6"
+        "@terascope/utils": "~1.7.7"
     },
     "devDependencies": {
         "@terascope/types": "~1.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2754,13 +2754,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/data-mate@npm:~1.7.7, @terascope/data-mate@workspace:packages/data-mate":
+"@terascope/data-mate@npm:~1.7.8, @terascope/data-mate@workspace:packages/data-mate":
   version: 0.0.0-use.local
   resolution: "@terascope/data-mate@workspace:packages/data-mate"
   dependencies:
-    "@terascope/data-types": "npm:~1.7.6"
+    "@terascope/data-types": "npm:~1.7.7"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     "@types/ip6addr": "npm:~0.2.6"
     "@types/uuid": "npm:~10.0.0"
     "@types/validator": "npm:~13.12.2"
@@ -2777,16 +2777,16 @@ __metadata:
     uuid: "npm:~11.1.0"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
-    xlucene-parser: "npm:~1.7.7"
+    xlucene-parser: "npm:~1.7.8"
   languageName: unknown
   linkType: soft
 
-"@terascope/data-types@npm:~1.7.6, @terascope/data-types@workspace:packages/data-types":
+"@terascope/data-types@npm:~1.7.7, @terascope/data-types@workspace:packages/data-types":
   version: 0.0.0-use.local
   resolution: "@terascope/data-types@workspace:packages/data-types"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     "@types/yargs": "npm:~17.0.33"
     graphql: "npm:~16.10.0"
     yargs: "npm:~17.7.2"
@@ -2803,17 +2803,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/elasticsearch-api@npm:~4.8.4, @terascope/elasticsearch-api@workspace:packages/elasticsearch-api":
+"@terascope/elasticsearch-api@npm:~4.8.5, @terascope/elasticsearch-api@workspace:packages/elasticsearch-api":
   version: 0.0.0-use.local
   resolution: "@terascope/elasticsearch-api@workspace:packages/elasticsearch-api"
   dependencies:
     "@opensearch-project/opensearch": "npm:~1.2.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     "@types/elasticsearch": "npm:~5.0.43"
     bluebird: "npm:~3.7.2"
     elasticsearch: "npm:~15.4.1"
-    elasticsearch-store: "npm:~1.9.0"
+    elasticsearch-store: "npm:~1.9.1"
     elasticsearch6: "npm:@elastic/elasticsearch@~6.8.0"
     elasticsearch7: "npm:@elastic/elasticsearch@~7.17.0"
     elasticsearch8: "npm:@elastic/elasticsearch@~8.15.0"
@@ -2875,12 +2875,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/job-components@npm:~1.9.7, @terascope/job-components@workspace:packages/job-components":
+"@terascope/job-components@npm:~1.9.8, @terascope/job-components@workspace:packages/job-components":
   version: 0.0.0-use.local
   resolution: "@terascope/job-components@workspace:packages/job-components"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     benchmark: "npm:~2.1.4"
     convict: "npm:~6.2.4"
     convict-format-with-moment: "npm:~6.2.0"
@@ -2895,12 +2895,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/scripts@npm:~1.12.0, @terascope/scripts@workspace:packages/scripts":
+"@terascope/scripts@npm:~1.12.1, @terascope/scripts@workspace:packages/scripts":
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
     "@kubernetes/client-node": "npm:~0.22.3"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     "@types/ip": "npm:~1.1.3"
     "@types/micromatch": "npm:~4.0.9"
     "@types/ms": "npm:~0.7.34"
@@ -2938,12 +2938,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/teraslice-messaging@npm:~1.10.7, @terascope/teraslice-messaging@workspace:packages/teraslice-messaging":
+"@terascope/teraslice-messaging@npm:~1.10.8, @terascope/teraslice-messaging@workspace:packages/teraslice-messaging":
   version: 0.0.0-use.local
   resolution: "@terascope/teraslice-messaging@workspace:packages/teraslice-messaging"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     "@types/ms": "npm:~0.7.34"
     "@types/socket.io": "npm:~2.1.13"
     "@types/socket.io-client": "npm:~1.4.36"
@@ -2960,8 +2960,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terascope/teraslice-state-storage@workspace:packages/teraslice-state-storage"
   dependencies:
-    "@terascope/elasticsearch-api": "npm:~4.8.4"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/elasticsearch-api": "npm:~4.8.5"
+    "@terascope/utils": "npm:~1.7.7"
   languageName: unknown
   linkType: soft
 
@@ -2973,7 +2973,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/utils@npm:~1.7.4, @terascope/utils@npm:~1.7.6, @terascope/utils@workspace:packages/utils":
+"@terascope/utils@npm:~1.7.4, @terascope/utils@npm:~1.7.7, @terascope/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@terascope/utils@workspace:packages/utils"
   dependencies:
@@ -6074,11 +6074,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e@workspace:e2e"
   dependencies:
-    "@terascope/scripts": "npm:~1.12.0"
+    "@terascope/scripts": "npm:~1.12.1"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     bunyan: "npm:~1.8.15"
-    elasticsearch-store: "npm:~1.9.0"
+    elasticsearch-store: "npm:~1.9.1"
     fs-extra: "npm:~11.3.0"
     jest: "npm:^29.7.0"
     jest-extended: "npm:^4.0.2"
@@ -6141,14 +6141,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elasticsearch-store@npm:~1.9.0, elasticsearch-store@workspace:packages/elasticsearch-store":
+"elasticsearch-store@npm:~1.9.1, elasticsearch-store@workspace:packages/elasticsearch-store":
   version: 0.0.0-use.local
   resolution: "elasticsearch-store@workspace:packages/elasticsearch-store"
   dependencies:
-    "@terascope/data-mate": "npm:~1.7.7"
-    "@terascope/data-types": "npm:~1.7.6"
+    "@terascope/data-mate": "npm:~1.7.8"
+    "@terascope/data-types": "npm:~1.7.7"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     "@types/uuid": "npm:~10.0.0"
     ajv: "npm:~8.17.1"
     ajv-formats: "npm:~3.0.1"
@@ -6159,7 +6159,7 @@ __metadata:
     opensearch2: "npm:@opensearch-project/opensearch@~2.12.0"
     setimmediate: "npm:~1.0.5"
     uuid: "npm:~11.1.0"
-    xlucene-translator: "npm:~1.7.7"
+    xlucene-translator: "npm:~1.7.8"
   languageName: unknown
   linkType: soft
 
@@ -12946,13 +12946,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terafoundation@npm:~1.11.0, terafoundation@workspace:packages/terafoundation":
+"terafoundation@npm:~1.11.1, terafoundation@workspace:packages/terafoundation":
   version: 0.0.0-use.local
   resolution: "terafoundation@workspace:packages/terafoundation"
   dependencies:
     "@terascope/file-asset-apis": "npm:~1.0.4"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     "@types/bunyan": "npm:~1.8.11"
     "@types/elasticsearch": "npm:~5.0.43"
     "@types/express": "npm:~4.17.21"
@@ -12963,7 +12963,7 @@ __metadata:
     convict-format-with-moment: "npm:~6.2.0"
     convict-format-with-validator: "npm:~6.2.0"
     elasticsearch: "npm:~15.4.1"
-    elasticsearch-store: "npm:~1.9.0"
+    elasticsearch-store: "npm:~1.9.1"
     express: "npm:~4.21.2"
     got: "npm:~13.0.0"
     js-yaml: "npm:~4.1.0"
@@ -12980,7 +12980,7 @@ __metadata:
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.0.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     "@types/decompress": "npm:~4.2.7"
     "@types/diff": "npm:~7.0.1"
     "@types/ejs": "npm:~3.1.5"
@@ -13005,7 +13005,7 @@ __metadata:
     pretty-bytes: "npm:~6.1.1"
     prompts: "npm:~2.4.2"
     signale: "npm:~1.4.0"
-    teraslice-client-js: "npm:~1.7.6"
+    teraslice-client-js: "npm:~1.7.7"
     tmp: "npm:~0.2.3"
     tty-table: "npm:~4.2.3"
     yargs: "npm:~17.7.2"
@@ -13015,12 +13015,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"teraslice-client-js@npm:~1.7.6, teraslice-client-js@workspace:packages/teraslice-client-js":
+"teraslice-client-js@npm:~1.7.7, teraslice-client-js@workspace:packages/teraslice-client-js":
   version: 0.0.0-use.local
   resolution: "teraslice-client-js@workspace:packages/teraslice-client-js"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     auto-bind: "npm:~5.0.1"
     got: "npm:~13.0.0"
     nock: "npm:~13.5.6"
@@ -13032,11 +13032,11 @@ __metadata:
   resolution: "teraslice-test-harness@workspace:packages/teraslice-test-harness"
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.0.0"
-    "@terascope/job-components": "npm:~1.9.7"
+    "@terascope/job-components": "npm:~1.9.8"
     decompress: "npm:~4.2.1"
     fs-extra: "npm:~11.3.0"
   peerDependencies:
-    "@terascope/job-components": ">=1.9.7"
+    "@terascope/job-components": ">=1.9.8"
   languageName: unknown
   linkType: soft
 
@@ -13047,7 +13047,7 @@ __metadata:
     "@eslint/js": "npm:~9.22.0"
     "@swc/core": "npm:1.11.8"
     "@swc/jest": "npm:~0.2.37"
-    "@terascope/scripts": "npm:~1.12.0"
+    "@terascope/scripts": "npm:~1.12.1"
     "@types/bluebird": "npm:~3.5.42"
     "@types/convict": "npm:~6.1.6"
     "@types/elasticsearch": "npm:~5.0.43"
@@ -13071,11 +13071,11 @@ __metadata:
   resolution: "teraslice@workspace:packages/teraslice"
   dependencies:
     "@kubernetes/client-node": "npm:~0.22.3"
-    "@terascope/elasticsearch-api": "npm:~4.8.4"
-    "@terascope/job-components": "npm:~1.9.7"
-    "@terascope/teraslice-messaging": "npm:~1.10.7"
+    "@terascope/elasticsearch-api": "npm:~4.8.5"
+    "@terascope/job-components": "npm:~1.9.8"
+    "@terascope/teraslice-messaging": "npm:~1.10.8"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     "@types/archiver": "npm:~6.0.3"
     "@types/express": "npm:~4.17.21"
     "@types/gc-stats": "npm:~1.4.3"
@@ -13106,7 +13106,7 @@ __metadata:
     semver: "npm:~7.7.1"
     socket.io: "npm:~1.7.4"
     socket.io-client: "npm:~1.7.4"
-    terafoundation: "npm:~1.11.0"
+    terafoundation: "npm:~1.11.1"
     uuid: "npm:~11.1.0"
   languageName: unknown
   linkType: soft
@@ -13311,9 +13311,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ts-transforms@workspace:packages/ts-transforms"
   dependencies:
-    "@terascope/data-mate": "npm:~1.7.7"
+    "@terascope/data-mate": "npm:~1.7.8"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     "@types/graphlib": "npm:~2.1.12"
     "@types/jexl": "npm:~2.3.4"
     "@types/valid-url": "npm:~1.0.7"
@@ -14063,12 +14063,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xlucene-parser@npm:~1.7.7, xlucene-parser@workspace:packages/xlucene-parser":
+"xlucene-parser@npm:~1.7.8, xlucene-parser@workspace:packages/xlucene-parser":
   version: 0.0.0-use.local
   resolution: "xlucene-parser@workspace:packages/xlucene-parser"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     "@turf/invariant": "npm:~7.2.0"
     "@turf/random": "npm:~7.2.0"
     peggy: "npm:~4.2.0"
@@ -14076,15 +14076,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"xlucene-translator@npm:~1.7.7, xlucene-translator@workspace:packages/xlucene-translator":
+"xlucene-translator@npm:~1.7.8, xlucene-translator@workspace:packages/xlucene-translator":
   version: 0.0.0-use.local
   resolution: "xlucene-translator@workspace:packages/xlucene-translator"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     "@types/elasticsearch": "npm:~5.0.43"
     elasticsearch: "npm:~15.4.1"
-    xlucene-parser: "npm:~1.7.7"
+    xlucene-parser: "npm:~1.7.8"
   languageName: unknown
   linkType: soft
 
@@ -14100,7 +14100,7 @@ __metadata:
   resolution: "xpressions@workspace:packages/xpressions"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1059,177 +1059,177 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/aix-ppc64@npm:0.25.0"
+"@esbuild/aix-ppc64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/aix-ppc64@npm:0.25.1"
   conditions: os=aix & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/android-arm64@npm:0.25.0"
+"@esbuild/android-arm64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/android-arm64@npm:0.25.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/android-arm@npm:0.25.0"
+"@esbuild/android-arm@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/android-arm@npm:0.25.1"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/android-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/android-x64@npm:0.25.0"
+"@esbuild/android-x64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/android-x64@npm:0.25.1"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/darwin-arm64@npm:0.25.0"
+"@esbuild/darwin-arm64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/darwin-arm64@npm:0.25.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/darwin-x64@npm:0.25.0"
+"@esbuild/darwin-x64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/darwin-x64@npm:0.25.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/freebsd-arm64@npm:0.25.0"
+"@esbuild/freebsd-arm64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/freebsd-arm64@npm:0.25.1"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/freebsd-x64@npm:0.25.0"
+"@esbuild/freebsd-x64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/freebsd-x64@npm:0.25.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-arm64@npm:0.25.0"
+"@esbuild/linux-arm64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/linux-arm64@npm:0.25.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-arm@npm:0.25.0"
+"@esbuild/linux-arm@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/linux-arm@npm:0.25.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-ia32@npm:0.25.0"
+"@esbuild/linux-ia32@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/linux-ia32@npm:0.25.1"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-loong64@npm:0.25.0"
+"@esbuild/linux-loong64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/linux-loong64@npm:0.25.1"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-mips64el@npm:0.25.0"
+"@esbuild/linux-mips64el@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/linux-mips64el@npm:0.25.1"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ppc64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-ppc64@npm:0.25.0"
+"@esbuild/linux-ppc64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/linux-ppc64@npm:0.25.1"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-riscv64@npm:0.25.0"
+"@esbuild/linux-riscv64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/linux-riscv64@npm:0.25.1"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-s390x@npm:0.25.0"
+"@esbuild/linux-s390x@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/linux-s390x@npm:0.25.1"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-x64@npm:0.25.0"
+"@esbuild/linux-x64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/linux-x64@npm:0.25.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-arm64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/netbsd-arm64@npm:0.25.0"
+"@esbuild/netbsd-arm64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/netbsd-arm64@npm:0.25.1"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/netbsd-x64@npm:0.25.0"
+"@esbuild/netbsd-x64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/netbsd-x64@npm:0.25.1"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-arm64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/openbsd-arm64@npm:0.25.0"
+"@esbuild/openbsd-arm64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/openbsd-arm64@npm:0.25.1"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/openbsd-x64@npm:0.25.0"
+"@esbuild/openbsd-x64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/openbsd-x64@npm:0.25.1"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/sunos-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/sunos-x64@npm:0.25.0"
+"@esbuild/sunos-x64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/sunos-x64@npm:0.25.1"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/win32-arm64@npm:0.25.0"
+"@esbuild/win32-arm64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/win32-arm64@npm:0.25.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/win32-ia32@npm:0.25.0"
+"@esbuild/win32-ia32@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/win32-ia32@npm:0.25.1"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/win32-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/win32-x64@npm:0.25.0"
+"@esbuild/win32-x64@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@esbuild/win32-x64@npm:0.25.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1275,6 +1275,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/config-helpers@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@eslint/config-helpers@npm:0.1.0"
+  checksum: 10c0/3562b5325f42740fc83b0b92b7d13a61b383f8db064915143eec36184f09a09fad73eca6c2955ab6c248b0d04fa03c140f9af2f2c4c06770781a6b79f300a01e
+  languageName: node
+  linkType: hard
+
 "@eslint/core@npm:^0.12.0":
   version: 0.12.0
   resolution: "@eslint/core@npm:0.12.0"
@@ -1301,10 +1308,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.21.0, @eslint/js@npm:~9.21.0":
-  version: 9.21.0
-  resolution: "@eslint/js@npm:9.21.0"
-  checksum: 10c0/86c24a2668808995037e3f40c758335df2ae277c553ac0cf84381a1a8698f3099d8a22dd9c388947e6b7f93fcc1142f62406072faaa2b83c43ca79993fc01bb3
+"@eslint/js@npm:9.22.0, @eslint/js@npm:~9.22.0":
+  version: 9.22.0
+  resolution: "@eslint/js@npm:9.22.0"
+  checksum: 10c0/5bcd009bb579dc6c6ed760703bdd741e08a48cd9decd677aa2cf67fe66236658cb09a00185a0369f3904e5cffba9e6e0f2ff4d9ba4fdf598fcd81d34c49213a5
   languageName: node
   linkType: hard
 
@@ -2569,9 +2576,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stylistic/eslint-plugin@npm:~4.0.1":
-  version: 4.0.1
-  resolution: "@stylistic/eslint-plugin@npm:4.0.1"
+"@stylistic/eslint-plugin@npm:~4.2.0":
+  version: 4.2.0
+  resolution: "@stylistic/eslint-plugin@npm:4.2.0"
   dependencies:
     "@typescript-eslint/utils": "npm:^8.23.0"
     eslint-visitor-keys: "npm:^4.2.0"
@@ -2580,94 +2587,94 @@ __metadata:
     picomatch: "npm:^4.0.2"
   peerDependencies:
     eslint: ">=9.0.0"
-  checksum: 10c0/a1a875eaa43a494ce34d490f93f1e61e1b1dfb4d6fafaef54f1ad6db768a8758714e1e826946bd0e8d403af13d0d63820a50f089383f868199a44cd57bddc137
+  checksum: 10c0/d9b2b08635dc4a98ceb59b3768e58e31ecd65f3e727ca8ed2e3538027d9d3d649d43d62631688cda9087f39b3893950b2a11557ccae11cf55b783b20d3f19e4e
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-arm64@npm:1.11.5":
-  version: 1.11.5
-  resolution: "@swc/core-darwin-arm64@npm:1.11.5"
+"@swc/core-darwin-arm64@npm:1.11.8":
+  version: 1.11.8
+  resolution: "@swc/core-darwin-arm64@npm:1.11.8"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-x64@npm:1.11.5":
-  version: 1.11.5
-  resolution: "@swc/core-darwin-x64@npm:1.11.5"
+"@swc/core-darwin-x64@npm:1.11.8":
+  version: 1.11.8
+  resolution: "@swc/core-darwin-x64@npm:1.11.8"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm-gnueabihf@npm:1.11.5":
-  version: 1.11.5
-  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.11.5"
+"@swc/core-linux-arm-gnueabihf@npm:1.11.8":
+  version: 1.11.8
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.11.8"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-gnu@npm:1.11.5":
-  version: 1.11.5
-  resolution: "@swc/core-linux-arm64-gnu@npm:1.11.5"
+"@swc/core-linux-arm64-gnu@npm:1.11.8":
+  version: 1.11.8
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.11.8"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-musl@npm:1.11.5":
-  version: 1.11.5
-  resolution: "@swc/core-linux-arm64-musl@npm:1.11.5"
+"@swc/core-linux-arm64-musl@npm:1.11.8":
+  version: 1.11.8
+  resolution: "@swc/core-linux-arm64-musl@npm:1.11.8"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-gnu@npm:1.11.5":
-  version: 1.11.5
-  resolution: "@swc/core-linux-x64-gnu@npm:1.11.5"
+"@swc/core-linux-x64-gnu@npm:1.11.8":
+  version: 1.11.8
+  resolution: "@swc/core-linux-x64-gnu@npm:1.11.8"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-musl@npm:1.11.5":
-  version: 1.11.5
-  resolution: "@swc/core-linux-x64-musl@npm:1.11.5"
+"@swc/core-linux-x64-musl@npm:1.11.8":
+  version: 1.11.8
+  resolution: "@swc/core-linux-x64-musl@npm:1.11.8"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-win32-arm64-msvc@npm:1.11.5":
-  version: 1.11.5
-  resolution: "@swc/core-win32-arm64-msvc@npm:1.11.5"
+"@swc/core-win32-arm64-msvc@npm:1.11.8":
+  version: 1.11.8
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.11.8"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@swc/core-win32-ia32-msvc@npm:1.11.5":
-  version: 1.11.5
-  resolution: "@swc/core-win32-ia32-msvc@npm:1.11.5"
+"@swc/core-win32-ia32-msvc@npm:1.11.8":
+  version: 1.11.8
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.11.8"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@swc/core-win32-x64-msvc@npm:1.11.5":
-  version: 1.11.5
-  resolution: "@swc/core-win32-x64-msvc@npm:1.11.5"
+"@swc/core-win32-x64-msvc@npm:1.11.8":
+  version: 1.11.8
+  resolution: "@swc/core-win32-x64-msvc@npm:1.11.8"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@swc/core@npm:1.11.5":
-  version: 1.11.5
-  resolution: "@swc/core@npm:1.11.5"
+"@swc/core@npm:1.11.8":
+  version: 1.11.8
+  resolution: "@swc/core@npm:1.11.8"
   dependencies:
-    "@swc/core-darwin-arm64": "npm:1.11.5"
-    "@swc/core-darwin-x64": "npm:1.11.5"
-    "@swc/core-linux-arm-gnueabihf": "npm:1.11.5"
-    "@swc/core-linux-arm64-gnu": "npm:1.11.5"
-    "@swc/core-linux-arm64-musl": "npm:1.11.5"
-    "@swc/core-linux-x64-gnu": "npm:1.11.5"
-    "@swc/core-linux-x64-musl": "npm:1.11.5"
-    "@swc/core-win32-arm64-msvc": "npm:1.11.5"
-    "@swc/core-win32-ia32-msvc": "npm:1.11.5"
-    "@swc/core-win32-x64-msvc": "npm:1.11.5"
+    "@swc/core-darwin-arm64": "npm:1.11.8"
+    "@swc/core-darwin-x64": "npm:1.11.8"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.11.8"
+    "@swc/core-linux-arm64-gnu": "npm:1.11.8"
+    "@swc/core-linux-arm64-musl": "npm:1.11.8"
+    "@swc/core-linux-x64-gnu": "npm:1.11.8"
+    "@swc/core-linux-x64-musl": "npm:1.11.8"
+    "@swc/core-win32-arm64-msvc": "npm:1.11.8"
+    "@swc/core-win32-ia32-msvc": "npm:1.11.8"
+    "@swc/core-win32-x64-msvc": "npm:1.11.8"
     "@swc/counter": "npm:^0.1.3"
     "@swc/types": "npm:^0.1.19"
   peerDependencies:
@@ -2696,7 +2703,7 @@ __metadata:
   peerDependenciesMeta:
     "@swc/helpers":
       optional: true
-  checksum: 10c0/bc809c7f76a315e435a29b2cabbebfcb65a77f9d98e32d68d4d85422f17514b7b9af85e8369270580e749121567adf857820118ce1a5f14c9eea299bb6f7b020
+  checksum: 10c0/2bd5787f81333b11212022fb90318cdc3911e8408b34f3324cd76ce43c48ffd2b9f91295ecbeda11b43dcd86a59404fab70d00e67c5dd26f71c6311ea1a3c1b1
   languageName: node
   linkType: hard
 
@@ -2757,7 +2764,7 @@ __metadata:
     "@types/ip6addr": "npm:~0.2.6"
     "@types/uuid": "npm:~10.0.0"
     "@types/validator": "npm:~13.12.2"
-    awesome-phonenumber: "npm:~7.3.0"
+    awesome-phonenumber: "npm:~7.4.0"
     benchmark: "npm:~2.1.4"
     chance: "npm:~1.1.12"
     date-fns: "npm:~4.1.0"
@@ -2819,11 +2826,11 @@ __metadata:
   resolution: "@terascope/eslint-config@workspace:packages/eslint-config"
   dependencies:
     "@eslint/compat": "npm:~1.2.7"
-    "@eslint/js": "npm:~9.21.0"
-    "@stylistic/eslint-plugin": "npm:~4.0.1"
-    "@typescript-eslint/eslint-plugin": "npm:~8.25.0"
-    "@typescript-eslint/parser": "npm:~8.25.0"
-    eslint: "npm:~9.21.0"
+    "@eslint/js": "npm:~9.22.0"
+    "@stylistic/eslint-plugin": "npm:~4.2.0"
+    "@typescript-eslint/eslint-plugin": "npm:~8.26.0"
+    "@typescript-eslint/parser": "npm:~8.26.0"
+    eslint: "npm:~9.22.0"
     eslint-plugin-import: "npm:~2.31.0"
     eslint-plugin-jest: "npm:~28.11.0"
     eslint-plugin-jest-dom: "npm:~5.5.0"
@@ -2833,7 +2840,7 @@ __metadata:
     eslint-plugin-testing-library: "npm:~7.1.1"
     globals: "npm:~16.0.0"
     typescript: "npm:~5.8.2"
-    typescript-eslint: "npm:~8.25.0"
+    typescript-eslint: "npm:~8.26.0"
   languageName: unknown
   linkType: soft
 
@@ -2942,7 +2949,7 @@ __metadata:
     "@types/socket.io-client": "npm:~1.4.36"
     get-port: "npm:~7.1.0"
     ms: "npm:~2.1.3"
-    nanoid: "npm:~5.1.2"
+    nanoid: "npm:~5.1.3"
     p-event: "npm:~6.0.1"
     socket.io: "npm:~1.7.4"
     socket.io-client: "npm:~1.7.4"
@@ -2990,7 +2997,7 @@ __metadata:
     "@types/js-string-escape": "npm:~1.0.3"
     "@types/lodash-es": "npm:~4.17.12"
     "@types/validator": "npm:~13.12.2"
-    awesome-phonenumber: "npm:~7.3.0"
+    awesome-phonenumber: "npm:~7.4.0"
     benchmark: "npm:~2.1.4"
     date-fns: "npm:~4.1.0"
     date-fns-tz: "npm:~3.2.0"
@@ -3725,12 +3732,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~22.13.8":
-  version: 22.13.8
-  resolution: "@types/node@npm:22.13.8"
+"@types/node@npm:~22.13.10":
+  version: 22.13.10
+  resolution: "@types/node@npm:22.13.10"
   dependencies:
     undici-types: "npm:~6.20.0"
-  checksum: 10c0/bfc92b734a9dce6ac5daee0a52feccdf5dcb3804d895e4bc5384e2f4644612b8801725cd03c8c3c0888fb5eeb16b875877ac44b77641e0196dc1a837b1c2a366
+  checksum: 10c0/a3865f9503d6f718002374f7b87efaadfae62faa499c1a33b12c527cfb9fd86f733e1a1b026b80c5a0e4a965701174bc3305595a7d36078aa1abcf09daa5dee9
   languageName: node
   linkType: hard
 
@@ -3949,15 +3956,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.25.0, @typescript-eslint/eslint-plugin@npm:~8.25.0":
-  version: 8.25.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.25.0"
+"@typescript-eslint/eslint-plugin@npm:8.26.0, @typescript-eslint/eslint-plugin@npm:~8.26.0":
+  version: 8.26.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.26.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.25.0"
-    "@typescript-eslint/type-utils": "npm:8.25.0"
-    "@typescript-eslint/utils": "npm:8.25.0"
-    "@typescript-eslint/visitor-keys": "npm:8.25.0"
+    "@typescript-eslint/scope-manager": "npm:8.26.0"
+    "@typescript-eslint/type-utils": "npm:8.26.0"
+    "@typescript-eslint/utils": "npm:8.26.0"
+    "@typescript-eslint/visitor-keys": "npm:8.26.0"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -3965,24 +3972,24 @@ __metadata:
   peerDependencies:
     "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
     eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/11d63850f5f03b29cd31166f8da111788dc74e46877c2e16a5c488d6c4aa4b6c68c0857b9a396ad920aa7f0f3e7166f4faecbb194c19cd2bb9d3f687c5d2b292
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/b270467672c5cb7fb9085ae063364252af2910a424899f2a9f54cfbe84aba6ce80dbbf5027f1f33f17cc587da9883de212a4b3dc969f22ded30076889b499dd8
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.25.0, @typescript-eslint/parser@npm:~8.25.0":
-  version: 8.25.0
-  resolution: "@typescript-eslint/parser@npm:8.25.0"
+"@typescript-eslint/parser@npm:8.26.0, @typescript-eslint/parser@npm:~8.26.0":
+  version: 8.26.0
+  resolution: "@typescript-eslint/parser@npm:8.26.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.25.0"
-    "@typescript-eslint/types": "npm:8.25.0"
-    "@typescript-eslint/typescript-estree": "npm:8.25.0"
-    "@typescript-eslint/visitor-keys": "npm:8.25.0"
+    "@typescript-eslint/scope-manager": "npm:8.26.0"
+    "@typescript-eslint/types": "npm:8.26.0"
+    "@typescript-eslint/typescript-estree": "npm:8.26.0"
+    "@typescript-eslint/visitor-keys": "npm:8.26.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/9a54539ba297791f23093ff42a885cc57d36b26205d7a390e114d1f01cc584ce91ac6ead01819daa46b48f873cac6c829fcf399a436610bdbfa98e5cd78148a2
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/b937a80aeca4e508a67cbf2e42dfd268316336de265aaf836d04e49008a6ff4d754e73ad30075c183d98756677d1f54061c34e618c97d5fb61a04903c65d4851
   languageName: node
   linkType: hard
 
@@ -3996,18 +4003,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.25.0":
-  version: 8.25.0
-  resolution: "@typescript-eslint/type-utils@npm:8.25.0"
+"@typescript-eslint/scope-manager@npm:8.26.0":
+  version: 8.26.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.26.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.25.0"
-    "@typescript-eslint/utils": "npm:8.25.0"
+    "@typescript-eslint/types": "npm:8.26.0"
+    "@typescript-eslint/visitor-keys": "npm:8.26.0"
+  checksum: 10c0/f93b12daf6a4df3050ca3fc6db1f534b5c521861509ee09a45a8a17d97f2fbb20c2d34975f07291481d69998aac9f2975f8facad0d47f533db56ec8f70f533a0
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:8.26.0":
+  version: 8.26.0
+  resolution: "@typescript-eslint/type-utils@npm:8.26.0"
+  dependencies:
+    "@typescript-eslint/typescript-estree": "npm:8.26.0"
+    "@typescript-eslint/utils": "npm:8.26.0"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.0.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/b7477a2d239cfd337f7d28641666763cf680a43a8d377a09dc42415f715670d35fbb4e772e103dfe8cd620c377e66bce740106bb3983ee65a739c28fab7325d1
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/840b7551dcea7304632564612a2460f869c5330c50661cf21ac5992359aba7539f1466ac7dbde6f2d0bd56f6f769c9f3fed8564045c82d4914a88745da846870
   languageName: node
   linkType: hard
 
@@ -4015,6 +4032,13 @@ __metadata:
   version: 8.25.0
   resolution: "@typescript-eslint/types@npm:8.25.0"
   checksum: 10c0/b39addbee4be4d66e3089c2d01f9f1d69cedc13bff20e4fa9ed0ca5a0e7591d7c6e41ab3763c8c35404f971bc0fbf9f7867dbc2832740e5b63ee0049d60289f5
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.26.0":
+  version: 8.26.0
+  resolution: "@typescript-eslint/types@npm:8.26.0"
+  checksum: 10c0/b16c0f67d12092c204a5935b430854b3a41c80934b386a5a4526acc9c8a829d8ee4f78732e71587e605de7845fa9a801b59fff015471dab7bf33676ee68c0100
   languageName: node
   linkType: hard
 
@@ -4036,7 +4060,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.25.0, @typescript-eslint/utils@npm:^6.0.0 || ^7.0.0 || ^8.0.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.23.0":
+"@typescript-eslint/typescript-estree@npm:8.26.0":
+  version: 8.26.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.26.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.26.0"
+    "@typescript-eslint/visitor-keys": "npm:8.26.0"
+    debug: "npm:^4.3.4"
+    fast-glob: "npm:^3.3.2"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^2.0.1"
+  peerDependencies:
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/898bf7ec8ee1f3454d0e38a0bb3d7bd3cbd39f530857c9b1851650ec1647bcb6997622e86d24332d81848afd9b65ce4c080437ab1c3c023b23915a745dd0b363
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:8.26.0":
+  version: 8.26.0
+  resolution: "@typescript-eslint/utils@npm:8.26.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@typescript-eslint/scope-manager": "npm:8.26.0"
+    "@typescript-eslint/types": "npm:8.26.0"
+    "@typescript-eslint/typescript-estree": "npm:8.26.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/594838a865d385ad5206c8b948678d4cb4010d0c9b826913968ce9e8af4d1c58b1f044de49f91d8dc36cda2ddb121ee7d2c5b53822a05f3e55002b10a42b3bfb
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^6.0.0 || ^7.0.0 || ^8.0.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.23.0":
   version: 8.25.0
   resolution: "@typescript-eslint/utils@npm:8.25.0"
   dependencies:
@@ -4058,6 +4115,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.25.0"
     eslint-visitor-keys: "npm:^4.2.0"
   checksum: 10c0/7eb84c5899a25b1eb89d3c3f4be3ff18171f934669c57e2530b6dfa5fdd6eaae60629f3c89d06f4c8075fd1c701de76c0b9194e2922895c661ab6091e48f7db9
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.26.0":
+  version: 8.26.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.26.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.26.0"
+    eslint-visitor-keys: "npm:^4.2.0"
+  checksum: 10c0/6428c1ba199d962060d43f06ba8a98b874ba6fe875a23b10e8f01550838d8be8ee689ae4da3e8b045d4c7bb01e38385e6a8ae17a9d566cf7cd21f7090b573f61
   languageName: node
   linkType: hard
 
@@ -4549,10 +4616,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"awesome-phonenumber@npm:~7.3.0":
-  version: 7.3.0
-  resolution: "awesome-phonenumber@npm:7.3.0"
-  checksum: 10c0/b64366168e56ae106d7c89363f1a6a013dc6456ed62eea507a2ecdec2d0e9fd305700c6fa6d6842b82e38aa9bec13a84ed1093cc5b12c65edfef9361aab60b9a
+"awesome-phonenumber@npm:~7.4.0":
+  version: 7.4.0
+  resolution: "awesome-phonenumber@npm:7.4.0"
+  checksum: 10c0/294fe6c291799198ecd30f386da6702e61b804b68635bccc762f41a6f7da6b84bda3ba8722b164b3aa3e255c746554f705d2f8b300e4436041dddf613f9aa2f0
   languageName: node
   linkType: hard
 
@@ -6017,7 +6084,7 @@ __metadata:
     jest-extended: "npm:^4.0.2"
     jest-watch-typeahead: "npm:^2.2.2"
     ms: "npm:~2.1.3"
-    nanoid: "npm:~5.1.2"
+    nanoid: "npm:~5.1.3"
     semver: "npm:~7.7.1"
     signale: "npm:~1.4.0"
     ts-jest: "npm:~29.2.6"
@@ -6420,35 +6487,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:~0.25.0":
-  version: 0.25.0
-  resolution: "esbuild@npm:0.25.0"
+"esbuild@npm:~0.25.1":
+  version: 0.25.1
+  resolution: "esbuild@npm:0.25.1"
   dependencies:
-    "@esbuild/aix-ppc64": "npm:0.25.0"
-    "@esbuild/android-arm": "npm:0.25.0"
-    "@esbuild/android-arm64": "npm:0.25.0"
-    "@esbuild/android-x64": "npm:0.25.0"
-    "@esbuild/darwin-arm64": "npm:0.25.0"
-    "@esbuild/darwin-x64": "npm:0.25.0"
-    "@esbuild/freebsd-arm64": "npm:0.25.0"
-    "@esbuild/freebsd-x64": "npm:0.25.0"
-    "@esbuild/linux-arm": "npm:0.25.0"
-    "@esbuild/linux-arm64": "npm:0.25.0"
-    "@esbuild/linux-ia32": "npm:0.25.0"
-    "@esbuild/linux-loong64": "npm:0.25.0"
-    "@esbuild/linux-mips64el": "npm:0.25.0"
-    "@esbuild/linux-ppc64": "npm:0.25.0"
-    "@esbuild/linux-riscv64": "npm:0.25.0"
-    "@esbuild/linux-s390x": "npm:0.25.0"
-    "@esbuild/linux-x64": "npm:0.25.0"
-    "@esbuild/netbsd-arm64": "npm:0.25.0"
-    "@esbuild/netbsd-x64": "npm:0.25.0"
-    "@esbuild/openbsd-arm64": "npm:0.25.0"
-    "@esbuild/openbsd-x64": "npm:0.25.0"
-    "@esbuild/sunos-x64": "npm:0.25.0"
-    "@esbuild/win32-arm64": "npm:0.25.0"
-    "@esbuild/win32-ia32": "npm:0.25.0"
-    "@esbuild/win32-x64": "npm:0.25.0"
+    "@esbuild/aix-ppc64": "npm:0.25.1"
+    "@esbuild/android-arm": "npm:0.25.1"
+    "@esbuild/android-arm64": "npm:0.25.1"
+    "@esbuild/android-x64": "npm:0.25.1"
+    "@esbuild/darwin-arm64": "npm:0.25.1"
+    "@esbuild/darwin-x64": "npm:0.25.1"
+    "@esbuild/freebsd-arm64": "npm:0.25.1"
+    "@esbuild/freebsd-x64": "npm:0.25.1"
+    "@esbuild/linux-arm": "npm:0.25.1"
+    "@esbuild/linux-arm64": "npm:0.25.1"
+    "@esbuild/linux-ia32": "npm:0.25.1"
+    "@esbuild/linux-loong64": "npm:0.25.1"
+    "@esbuild/linux-mips64el": "npm:0.25.1"
+    "@esbuild/linux-ppc64": "npm:0.25.1"
+    "@esbuild/linux-riscv64": "npm:0.25.1"
+    "@esbuild/linux-s390x": "npm:0.25.1"
+    "@esbuild/linux-x64": "npm:0.25.1"
+    "@esbuild/netbsd-arm64": "npm:0.25.1"
+    "@esbuild/netbsd-x64": "npm:0.25.1"
+    "@esbuild/openbsd-arm64": "npm:0.25.1"
+    "@esbuild/openbsd-x64": "npm:0.25.1"
+    "@esbuild/sunos-x64": "npm:0.25.1"
+    "@esbuild/win32-arm64": "npm:0.25.1"
+    "@esbuild/win32-ia32": "npm:0.25.1"
+    "@esbuild/win32-x64": "npm:0.25.1"
   dependenciesMeta:
     "@esbuild/aix-ppc64":
       optional: true
@@ -6502,7 +6569,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 10c0/5767b72da46da3cfec51661647ec850ddbf8a8d0662771139f10ef0692a8831396a0004b2be7966cecdb08264fb16bdc16290dcecd92396fac5f12d722fa013d
+  checksum: 10c0/80fca30dd0f21aec23fdfab34f0a8d5f55df5097dd7f475f2ab561d45662c32ee306f5649071cd1a0ba0614b164c48ca3dc3ee1551a4daf204b8af90e4d893f5
   languageName: node
   linkType: hard
 
@@ -6701,13 +6768,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "eslint-scope@npm:8.2.0"
+"eslint-scope@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "eslint-scope@npm:8.3.0"
   dependencies:
     esrecurse: "npm:^4.3.0"
     estraverse: "npm:^5.2.0"
-  checksum: 10c0/8d2d58e2136d548ac7e0099b1a90d9fab56f990d86eb518de1247a7066d38c908be2f3df477a79cf60d70b30ba18735d6c6e70e9914dca2ee515a729975d70d6
+  checksum: 10c0/23bf54345573201fdf06d29efa345ab508b355492f6c6cc9e2b9f6d02b896f369b6dd5315205be94b8853809776c4d13353b85c6b531997b164ff6c3328ecf5b
   languageName: node
   linkType: hard
 
@@ -6725,16 +6792,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:~9.21.0":
-  version: 9.21.0
-  resolution: "eslint@npm:9.21.0"
+"eslint@npm:~9.22.0":
+  version: 9.22.0
+  resolution: "eslint@npm:9.22.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.12.1"
     "@eslint/config-array": "npm:^0.19.2"
+    "@eslint/config-helpers": "npm:^0.1.0"
     "@eslint/core": "npm:^0.12.0"
     "@eslint/eslintrc": "npm:^3.3.0"
-    "@eslint/js": "npm:9.21.0"
+    "@eslint/js": "npm:9.22.0"
     "@eslint/plugin-kit": "npm:^0.2.7"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
@@ -6746,7 +6814,7 @@ __metadata:
     cross-spawn: "npm:^7.0.6"
     debug: "npm:^4.3.2"
     escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.2.0"
+    eslint-scope: "npm:^8.3.0"
     eslint-visitor-keys: "npm:^4.2.0"
     espree: "npm:^10.3.0"
     esquery: "npm:^1.5.0"
@@ -6770,7 +6838,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/558edb25b440cd51825d66fed3e84f1081bd6f4cb2cf994e60ece4c5978fa0583e88b75faf187c1fc21688c4ff7072f12bf5f6d1be1e09a4d6af78cff39dc520
+  checksum: 10c0/7b5ab6f2365971c16efe97349565f75d8343347562fb23f12734c6ab2cd5e35301373a0d51e194789ddcfdfca21db7b62ff481b03d524b8169896c305b65ff48
   languageName: node
   linkType: hard
 
@@ -10323,12 +10391,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:~5.1.2":
-  version: 5.1.2
-  resolution: "nanoid@npm:5.1.2"
+"nanoid@npm:~5.1.3":
+  version: 5.1.3
+  resolution: "nanoid@npm:5.1.3"
   bin:
     nanoid: bin/nanoid.js
-  checksum: 10c0/60b3d30d1629704f4b156f79e53a454d10440a38f4ab14cda1c9aa08091389212d03afb35fbc09c11f4619f83bcf5076abc4719295e3b79c57abad0e40297177
+  checksum: 10c0/632ab0e758f8cdd3d14835b2c094e7320cdb92c2404e4bc6cd864765d8fab76647e73ee664a7d11b1a5b5c7e04b8c030d6719d2b61f8b1295a5fb64a9d779a8b
   languageName: node
   linkType: hard
 
@@ -12899,7 +12967,7 @@ __metadata:
     express: "npm:~4.21.2"
     got: "npm:~13.0.0"
     js-yaml: "npm:~4.1.0"
-    nanoid: "npm:~5.1.2"
+    nanoid: "npm:~5.1.3"
     node-webhdfs: "npm:~1.0.2"
     prom-client: "npm:~15.1.3"
     yargs: "npm:~17.7.2"
@@ -12927,7 +12995,7 @@ __metadata:
     diff: "npm:~7.0.0"
     easy-table: "npm:~1.2.0"
     ejs: "npm:~3.1.10"
-    esbuild: "npm:~0.25.0"
+    esbuild: "npm:~0.25.1"
     execa: "npm:~9.5.2"
     fs-extra: "npm:~11.3.0"
     globby: "npm:~14.1.0"
@@ -12976,8 +13044,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "teraslice-workspace@workspace:."
   dependencies:
-    "@eslint/js": "npm:~9.21.0"
-    "@swc/core": "npm:1.11.5"
+    "@eslint/js": "npm:~9.22.0"
+    "@swc/core": "npm:1.11.8"
     "@swc/jest": "npm:~0.2.37"
     "@terascope/scripts": "npm:~1.12.0"
     "@types/bluebird": "npm:~3.5.42"
@@ -12986,9 +13054,9 @@ __metadata:
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~29.5.14"
     "@types/lodash": "npm:~4.17.16"
-    "@types/node": "npm:~22.13.8"
+    "@types/node": "npm:~22.13.10"
     "@types/uuid": "npm:~10.0.0"
-    eslint: "npm:~9.21.0"
+    eslint: "npm:~9.22.0"
     jest: "npm:~29.7.0"
     jest-extended: "npm:~4.0.2"
     jest-watch-typeahead: "npm:~2.2.2"
@@ -13033,7 +13101,7 @@ __metadata:
     js-yaml: "npm:~4.1.0"
     kubernetes-client: "npm:~9.0.0"
     ms: "npm:~2.1.3"
-    nanoid: "npm:~5.1.2"
+    nanoid: "npm:~5.1.3"
     nock: "npm:~13.5.6"
     semver: "npm:~7.7.1"
     socket.io: "npm:~1.7.4"
@@ -13251,11 +13319,11 @@ __metadata:
     "@types/valid-url": "npm:~1.0.7"
     "@types/validator": "npm:~13.12.2"
     "@types/yargs": "npm:~17.0.33"
-    awesome-phonenumber: "npm:~7.3.0"
+    awesome-phonenumber: "npm:~7.4.0"
     execa: "npm:~9.5.2"
     graphlib: "npm:~2.1.8"
     jexl: "npm:~2.3.0"
-    nanoid: "npm:~5.1.2"
+    nanoid: "npm:~5.1.3"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
     yargs: "npm:~17.7.2"
@@ -13452,17 +13520,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:~8.25.0":
-  version: 8.25.0
-  resolution: "typescript-eslint@npm:8.25.0"
+"typescript-eslint@npm:~8.26.0":
+  version: 8.26.0
+  resolution: "typescript-eslint@npm:8.26.0"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.25.0"
-    "@typescript-eslint/parser": "npm:8.25.0"
-    "@typescript-eslint/utils": "npm:8.25.0"
+    "@typescript-eslint/eslint-plugin": "npm:8.26.0"
+    "@typescript-eslint/parser": "npm:8.26.0"
+    "@typescript-eslint/utils": "npm:8.26.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/bdc1165be1bc60311045ca69aa1bff4bbb7feac906c6b7885c4bc859693d8ca1b88840a1ba10b226ca2343c4bd7388b7a36e5c787b0d7f1bab5ababb80e783cc
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/7bf055ac2839c96d72c3c4213b5bef82ca71aba73a02922b8ba9e3bd91bb845127f32f8cb1c7b7ef6201803a7ffcf0cc6be18318b46d84296e1b1e2adbd27643
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR makes the following changes:
- update the terascope chart
  - version from 2.2.0 to 2.3.0
  - appVersion from 2.14.0 to 2.14.1 
- updates the following dependencies:
# e2e
  - devDependencies
    - @terascope/scripts from 1.12.0 to 1.12.1
    - @terascope/utils from 1.7.6 to 1.7.7
    - elasticsearch-store from 1.9.0 to 1.9.1
    - nanoid from 5.1.2 to 5.1.3
# teraslice-workspace
  - devDependencies
    - @eslint/js from 9.21.0 to 9.22.0
    - @swc/core from 1.11.5 to 1.11.8
    - @terascope/scripts from 1.12.0 to 1.12.1
    - @types/node from 22.13.8 to 22.13.10
    - eslint from 9.21.0 to 9.22.0
# @terascope/data-mate
  - dependencies
    - @terascope/data-types from 1.7.6 to 1.7.7
    - @terascope/utils from 1.7.6 to 1.7.7
    - awesome-phonenumber from 7.3.0 to 7.4.0
    - xlucene-parser from 1.7.7 to 1.7.8
# @terascope/data-types
  - dependencies
    - @terascope/utils from 1.7.6 to 1.7.7
# @terascope/elasticsearch-api
  - dependencies
    - @terascope/utils from 1.7.6 to 1.7.7
    - elasticsearch-store from 1.9.0 to 1.9.1
# elasticsearch-store
  - dependencies
    - @terascope/data-mate from 1.7.7 to 1.7.8
    - @terascope/data-types from 1.7.6 to 1.7.7
    - @terascope/utils from 1.7.6 to 1.7.7
    - xlucene-translator from 1.7.7 to 1.7.8
# @terascope/eslint-config
  - dependencies
    - @eslint/js from 9.21.0 to 9.22.0
    - @stylistic/eslint-plugin from 4.0.1 to 4.2.0
    - @typescript-eslint/eslint-plugin from 8.25.0 to 8.26.0
    - @typescript-eslint/parser from 8.25.0 to 8.26.0
    - eslint from 9.21.0 to 9.22.0
    - typescript-eslint from 8.25.0 to 8.26.0
# @terascope/job-components
  - dependencies
    - @terascope/utils from 1.7.6 to 1.7.7
# @terascope/scripts
  - dependencies
    - @terascope/utils from 1.7.6 to 1.7.7
# terafoundation
  - dependencies
    - @terascope/utils from 1.7.6 to 1.7.7
    - elasticsearch-store from 1.9.0 to 1.9.1
    - nanoid from 5.1.2 to 5.1.3
# teraslice-cli
  - dependencies
    - esbuild from 0.25.0 to 0.25.1
  - devDependencies
    - @terascope/utils from 1.7.6 to 1.7.7
    - teraslice-client-js from 1.7.6 to 1.7.7
# teraslice-client-js
  - dependencies
    - @terascope/utils from 1.7.6 to 1.7.7
# @terascope/teraslice-messaging
  - dependencies
    - @terascope/utils from 1.7.6 to 1.7.7
    - nanoid from 5.1.2 to 5.1.3
# @terascope/teraslice-state-storage
  - dependencies
    - @terascope/elasticsearch-api from 4.8.4 to 4.8.5
    - @terascope/utils from 1.7.6 to 1.7.7
# teraslice-test-harness
  - devDependencies
    - @terascope/job-components from 1.9.7 to 1.9.8
# teraslice
  - dependencies
    - @terascope/elasticsearch-api from 4.8.4 to 4.8.5
    - @terascope/job-components from 1.9.7 to 1.9.8
    - @terascope/teraslice-messaging from 1.10.7 to 1.10.8
    - @terascope/utils from 1.7.6 to 1.7.7
    - nanoid from 5.1.2 to 5.1.3
    - terafoundation from 1.11.0 to 1.11.1
# ts-transforms
  - dependencies
    - @terascope/data-mate from 1.7.7 to 1.7.8
    - @terascope/utils from 1.7.6 to 1.7.7
    - awesome-phonenumber from 7.3.0 to 7.4.0
    - nanoid from 5.1.2 to 5.1.3
# @terascope/utils
  - dependencies
    - awesome-phonenumber from 7.3.0 to 7.4.0
# xlucene-parser
  - dependencies
    - @terascope/utils from 1.7.6 to 1.7.7
# xlucene-translator
  - dependencies
    - @terascope/utils from 1.7.6 to 1.7.7
    - xlucene-parser from 1.7.7 to 1.7.8
# xpressions
  - dependencies
    - @terascope/utils from 1.7.6 to 1.7.7  - devDependencies