### PR TITLE
[e2e, scripts, helm, dockerfile] Small fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,7 +441,7 @@ jobs:
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Install mkcert
-        run: curl -Ss -JLO "https://dl.filippo.io/mkcert/v1.4.4?for=linux/amd64" && sudo chmod 777 mkcert-v1.4.4.-linux-amd64 && sudo cp mkcert-v1.4.4-linux-amd64 /usr/local/bin/mkcert
+        run: curl -Ss -JLO "https://dl.filippo.io/mkcert/v1.4.4?for=linux/amd64" && sudo chmod 777 mkcert-v1.4.4-linux-amd64 && sudo cp mkcert-v1.4.4-linux-amd64 /usr/local/bin/mkcert
 
       - name: Install grep
         run: sudo apt update && sudo apt install grep

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,7 +441,7 @@ jobs:
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Install mkcert
-        run: curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" && sudo chmod 777 mkcert-v*-linux-amd64 && sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
+        run: curl -Ss -JLO "https://dl.filippo.io/mkcert/v1.4.4?for=linux/amd64" && sudo chmod 777 mkcert-v1.4.4.-linux-amd64 && sudo cp mkcert-v1.4.4-linux-amd64 /usr/local/bin/mkcert
 
       - name: Install grep
         run: sudo apt update && sudo apt install grep

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,7 +279,7 @@ jobs:
           key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
       - name: Install mkcert
-        run: curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" && sudo chmod 777 mkcert-v*-linux-amd64 && sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
+        run: curl -Ss -JLO "https://dl.filippo.io/mkcert/v1.4.4?for=linux/amd64" && sudo chmod 777 mkcert-v1.4.4-linux-amd64 && sudo cp mkcert-v1.4.4-linux-amd64 /usr/local/bin/mkcert
 
       - name: Install grep
         run: sudo apt update && sudo apt install grep

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG TERASLICE_VERSION
 ARG BUILD_TIMESTAMP
 ARG GITHUB_SHA
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 COPY package.json yarn.lock tsconfig.json .yarnrc.yml /app/source/
 COPY .yarnclean.ci /app/source/.yarnclean
@@ -38,7 +38,7 @@ EXPOSE 5678
 
 # set up the volumes
 VOLUME /app/config /app/logs /app/assets
-ENV TERAFOUNDATION_CONFIG /app/config/teraslice.yaml
+ENV TERAFOUNDATION_CONFIG=/app/config/teraslice.yaml
 
 LABEL org.opencontainers.image.version="$TERASLICE_VERSION" \
   org.opencontainers.image.created="$BUILD_TIMESTAMP" \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,7 +3,7 @@
 ARG NODE_VERSION=22
 FROM ghcr.io/terascope/node-base:${NODE_VERSION}
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 # Check to see if distutils is installed because python 3.12 removed it
 RUN python3 -c "import distutils" || (apk update && apk add py3-setuptools)
@@ -15,6 +15,6 @@ EXPOSE 5678
 
 # set up the volumes
 VOLUME /app/config /app/logs /app/assets
-ENV TERAFOUNDATION_CONFIG /app/config/teraslice.yaml
+ENV TERAFOUNDATION_CONFIG=/app/config/teraslice.yaml
 
 CMD ["nodemon", "--exitcrash", "service.js"]

--- a/e2e/test/cases/kafka/kafka-spec.ts
+++ b/e2e/test/cases/kafka/kafka-spec.ts
@@ -69,8 +69,8 @@ describe('kafka', () => {
         expect(count).toBe(total);
     });
 
-    describe('encrypted kafka', () => {
-        if (ENCRYPT_KAFKA === 'true') {
+    if (ENCRYPT_KAFKA === 'true') {
+        describe('encrypted kafka', () => {
             it('should have an encrypted connection', async () => {
                 const result = await exec({
                     cmd: 'sh',
@@ -79,6 +79,6 @@ describe('kafka', () => {
                 // console.log('s_client output: ', result);
                 expect(result).toContain('Verification: OK');
             });
-        }
-    });
+        });
+    }
 });

--- a/helm/helm-repo-site/index.tpl
+++ b/helm/helm-repo-site/index.tpl
@@ -305,8 +305,5 @@ releases:
       </div>
     </section>
 		<time datetime="{{ .Generated.Format "2006-01-02T15:04:05" }}" pubdate id="generated">{{ .Generated.Format "Mon Jan 2 2006 03:04:05PM MST-07:00" }}</time>
-
-    <script src="https://unpkg.com/clipboard@2/dist/clipboard.min.js"></script>
-    <script>new ClipboardJS('.btn');</script>
   </body>
 </html>

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -244,7 +244,7 @@ export async function getContainerInfo(name: string): Promise<any> {
 export async function dockerNetworkExists(name: string): Promise<boolean> {
     const subprocess = await execaCommand(
         `docker network ls --format='{{json .Name}}' | grep '"${name}"'`,
-        { reject: false }
+        { reject: false, shell: true }
     );
     return subprocess.exitCode ? subprocess.exitCode > 0 : false;
 }


### PR DESCRIPTION
This PR makes the following updates:
- Remove unneeded `unpkg/clipboardJS` import from helm repo `index.html`
- fix order of checks for the `kafka-spec` encryption test
- fix dockerfile warnings when declaring ENVs
- `dockerNetworkExists()` function was using `execaCommand()` with a `|`, so it needs to set the `shell` option to true
- pin mkcert version within test.yaml