### PR TITLE
[teraslice, scripts] upgrade kubernetes/client-node to v1.1.0

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -47,7 +47,7 @@
         "ms": "~2.1.3"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.13.0",
+        "@terascope/scripts": "~1.14.0",
         "@terascope/types": "~1.4.1",
         "@terascope/utils": "~1.7.7",
         "bunyan": "~1.8.15",

--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: teraslice-chart
 description: Teraslice -  Distributed computing platform for processing JSON data
 type: application
-version: 2.3.0
-appVersion: v2.14.1
+version: 2.4.0
+appVersion: v2.15.0
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.14.1",
+    "version": "2.15.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {
@@ -53,7 +53,7 @@
         "@eslint/js": "~9.22.0",
         "@swc/core": "1.11.8",
         "@swc/jest": "~0.2.37",
-        "@terascope/scripts": "~1.13.0",
+        "@terascope/scripts": "~1.14.0",
         "@types/bluebird": "~3.5.42",
         "@types/convict": "~6.1.6",
         "@types/elasticsearch": "~5.0.43",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.13.0",
+    "version": "1.14.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -32,7 +32,7 @@
         "typescript": "~5.8.2"
     },
     "dependencies": {
-        "@kubernetes/client-node": "~0.22.3",
+        "@kubernetes/client-node": "~1.1.0",
         "@terascope/utils": "~1.7.7",
         "codecov": "~3.8.3",
         "execa": "~9.5.2",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.14.1",
+    "version": "2.15.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -38,7 +38,7 @@
         "ms": "~2.1.3"
     },
     "dependencies": {
-        "@kubernetes/client-node": "~0.22.3",
+        "@kubernetes/client-node": "~1.1.0",
         "@terascope/elasticsearch-api": "~4.8.5",
         "@terascope/job-components": "~1.9.8",
         "@terascope/teraslice-messaging": "~1.10.8",

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/interfaces.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/interfaces.ts
@@ -1,4 +1,3 @@
-import { IncomingMessage } from 'node:http';
 import * as k8s from '@kubernetes/client-node';
 
 export interface KubeConfigOptions {
@@ -141,28 +140,6 @@ export interface TSReplicaSetList extends k8s.V1ReplicaSetList {
 }
 export interface TSServiceList extends k8s.V1ServiceList {
     items: TSService[];
-}
-
-export interface ResourceListApiResponse {
-    response: IncomingMessage;
-    body: K8sResourceList;
-}
-
-export interface ResourceApiResponse {
-    response: IncomingMessage;
-    body: K8sResource;
-}
-
-export interface PatchApiResponse {
-    response: IncomingMessage;
-    body: k8s.V1Deployment;
-}
-
-export type DeleteResponseBody = k8s.V1Pod | k8s.V1Status | k8s.V1Service;
-
-export interface DeleteApiResponse {
-    response: IncomingMessage;
-    body: DeleteResponseBody;
 }
 
 export type ListParams = [

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
@@ -52,7 +52,7 @@ export class K8s {
      * @return {Promise} [description]
      */
     async getNamespaces() {
-        let namespaces;
+        let namespaces: k8s.V1NamespaceList;
         try {
             namespaces = await pRetry(() => this.k8sCoreV1Api.listNamespace(), getRetryConfig());
         } catch (err) {
@@ -61,7 +61,7 @@ export class K8s {
             });
             throw error;
         }
-        return namespaces.body;
+        return namespaces;
     }
 
     /**
@@ -86,11 +86,11 @@ export class K8s {
         const end = now + timeout;
 
         while (true) {
-            const result = await pRetry(() => this.k8sCoreV1Api
-                .listNamespacedPod(namespace, undefined, undefined, undefined, undefined, selector),
+            const podListObj: k8s.V1PodList = await pRetry(() => this.k8sCoreV1Api
+                .listNamespacedPod({ namespace, labelSelector: selector }),
             getRetryConfig());
             // NOTE: This assumes the first pod returned.
-            const pod = get(result, 'body.items[0]');
+            const pod = get(podListObj, 'items[0]');
 
             if (pod && isTSPod(pod)) {
                 if (statusType === 'readiness-probe') {
@@ -133,11 +133,11 @@ export class K8s {
         const end = now + timeout;
 
         while (true) {
-            const result = await pRetry(() => this.k8sCoreV1Api
-                .listNamespacedPod(namespace, undefined, undefined, undefined, undefined, selector),
+            const podListObj: k8s.V1PodList = await pRetry(() => this.k8sCoreV1Api
+                .listNamespacedPod({ namespace, labelSelector: selector }),
             getRetryConfig());
 
-            const podList: k8s.V1Pod[] = get(result, 'body.items');
+            const podList: k8s.V1Pod[] = get(podListObj, 'items');
 
             if (podList.length === number) return podList;
 
@@ -170,41 +170,37 @@ export class K8s {
     async list(selector: string, objType: i.ResourceType, ns?: string): Promise<i.TSResourceList>;
     async list(selector: string, objType: i.ResourceType, ns?: string): Promise<i.TSResourceList> {
         const namespace = ns || this.defaultNamespace;
-        let responseObj: i.ResourceListApiResponse;
+        let resourceListObj: i.K8sResourceList;
 
-        const params: i.ListParams = [
+        const params = {
             namespace,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
             selector
-        ];
+        };
 
         try {
             if (objType === 'deployments') {
-                responseObj = await pRetry(
-                    () => this.k8sAppsV1Api.listNamespacedDeployment(...params),
+                resourceListObj = await pRetry(
+                    () => this.k8sAppsV1Api.listNamespacedDeployment(params),
                     getRetryConfig()
                 );
             } else if (objType === 'jobs') {
-                responseObj = await pRetry(
-                    () => this.k8sBatchV1Api.listNamespacedJob(...params),
+                resourceListObj = await pRetry(
+                    () => this.k8sBatchV1Api.listNamespacedJob(params),
                     getRetryConfig()
                 );
             } else if (objType === 'pods') {
-                responseObj = await pRetry(
-                    () => this.k8sCoreV1Api.listNamespacedPod(...params),
+                resourceListObj = await pRetry(
+                    () => this.k8sCoreV1Api.listNamespacedPod(params),
                     getRetryConfig()
                 );
             } else if (objType === 'replicasets') {
-                responseObj = await pRetry(
-                    () => this.k8sAppsV1Api.listNamespacedReplicaSet(...params),
+                resourceListObj = await pRetry(
+                    () => this.k8sAppsV1Api.listNamespacedReplicaSet(params),
                     getRetryConfig()
                 );
             } else if (objType === 'services') {
-                responseObj = await pRetry(
-                    () => this.k8sCoreV1Api.listNamespacedService(...params),
+                resourceListObj = await pRetry(
+                    () => this.k8sCoreV1Api.listNamespacedService(params),
                     getRetryConfig()
                 );
             } else {
@@ -212,7 +208,7 @@ export class K8s {
                 this.logger.error(error);
                 return Promise.reject(error);
             }
-            return convertToTSResourceList(responseObj.body);
+            return convertToTSResourceList(resourceListObj);
         } catch (e) {
             const err = new Error(`Request k8s.list of ${objType} with selector ${selector} failed: ${e}`);
             this.logger.error(err);
@@ -246,30 +242,31 @@ export class K8s {
     async post(manifest: k8s.V1ReplicaSet): Promise<i.TSReplicaSet>;
     async post(manifest: k8s.V1Service): Promise<i.TSService>;
     async post(manifest: i.K8sResource): Promise<i.TSResource> {
-        let responseObj: i.ResourceApiResponse;
+        let resourceObj: i.K8sResource;
+        const namespace = this.defaultNamespace;
 
         try {
             if (isDeployment(manifest)) {
-                responseObj = await this.k8sAppsV1Api
-                    .createNamespacedDeployment(this.defaultNamespace, manifest);
+                resourceObj = await this.k8sAppsV1Api
+                    .createNamespacedDeployment({ namespace, body: manifest });
             } else if (isJob(manifest)) {
-                responseObj = await this.k8sBatchV1Api
-                    .createNamespacedJob(this.defaultNamespace, manifest);
+                resourceObj = await this.k8sBatchV1Api
+                    .createNamespacedJob({ namespace, body: manifest });
             } else if (isPod(manifest)) {
-                responseObj = await this.k8sCoreV1Api
-                    .createNamespacedPod(this.defaultNamespace, manifest);
+                resourceObj = await this.k8sCoreV1Api
+                    .createNamespacedPod({ namespace, body: manifest });
             } else if (isReplicaSet(manifest)) {
-                responseObj = await this.k8sAppsV1Api
-                    .createNamespacedReplicaSet(this.defaultNamespace, manifest);
+                resourceObj = await this.k8sAppsV1Api
+                    .createNamespacedReplicaSet({ namespace, body: manifest });
             } else if (isService(manifest)) {
-                responseObj = await this.k8sCoreV1Api
-                    .createNamespacedService(this.defaultNamespace, manifest);
+                resourceObj = await this.k8sCoreV1Api
+                    .createNamespacedService({ namespace, body: manifest });
             } else {
                 const error = new Error('Invalid manifest type');
                 return Promise.reject(error);
             }
 
-            return convertToTSResource(responseObj.body);
+            return convertToTSResource(resourceObj);
         } catch (e) {
             const err = new Error(`Request k8s.post of ${manifest.kind} with body ${JSON.stringify(manifest)} failed: ${e}`);
             return Promise.reject(err);
@@ -280,28 +277,21 @@ export class K8s {
      * Patches specified k8s deployment with the provided record
      * @param  {String} record record, like 'app=teraslice'
      * @param  {String} name   Name of the deployment to patch
-     * @return {Object}        body of k8s patch response.
+     * @return {Object}        k8s V1Deployment object.
      */
     // TODO: I renamed this from patchDeployment to just patch because this is
     // the low level k8s api method, I expect to eventually change the interface
     // on this to require `objType` to support patching other things
     async patch(record: Record<string, any>, name: string) {
-        let responseObj: i.PatchApiResponse;
+        let responseObj: k8s.V1Deployment;
         try {
-            const options = { headers: { 'Content-type': k8s.PatchUtils.PATCH_FORMAT_JSON_PATCH } };
-            responseObj = await pRetry(() => this.k8sAppsV1Api
-                .patchNamespacedDeployment(
-                    name,
-                    this.defaultNamespace,
-                    record,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    options,
-                ), getRetryConfig());
-            return responseObj.body;
+            const options = k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.JsonPatch);
+            responseObj = await pRetry(() => this.k8sAppsV1Api.patchNamespacedDeployment({
+                name,
+                namespace: this.defaultNamespace,
+                body: record
+            }, options as k8s.ConfigurationOptions), getRetryConfig());
+            return responseObj;
         } catch (e) {
             const err = new Error(`Request k8s.patch with name: ${name} failed with: ${e}`);
             this.logger.error(err);
@@ -316,7 +306,7 @@ export class K8s {
      *                                 'deployments', 'services', 'jobs', 'pods', 'replicasets'
      * @param  {Boolean}   force       Forcefully delete resource by setting gracePeriodSeconds to 1
      *                                 to be forcefully stopped.
-     * @return {Object}                k8s delete response body.
+     * @return {Object}                k8s service, pod or status object.
      */
     async delete(
         name: string, objType: 'pods', force?: boolean
@@ -329,15 +319,15 @@ export class K8s {
     ): Promise<k8s.V1Service>;
     async delete(
         name: string, objType: i.ResourceType, force?: boolean
-    ): Promise<i.DeleteResponseBody>;
+    ): Promise<k8s.V1Pod | k8s.V1Status | k8s.V1Service>;
     async delete(
         name: string, objType: i.ResourceType, force?: boolean
-    ): Promise<i.DeleteResponseBody> {
+    ): Promise<k8s.V1Pod | k8s.V1Status | k8s.V1Service> {
         if (name === undefined || name.trim() === '') {
             throw new Error(`Name of resource to delete must be specified. Received: "${name}".`);
         }
 
-        let responseObj: i.DeleteApiResponse;
+        let responseObj: k8s.V1Pod | k8s.V1Status | k8s.V1Service;
 
         // To get a Job to remove the associated pods you have to
         // include a body like the one below with the delete request.
@@ -352,20 +342,15 @@ export class K8s {
             deleteOptions.gracePeriodSeconds = 1;
         }
 
-        const params: i.DeleteParams = [
+        const params = {
             name,
-            this.defaultNamespace,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
+            namespace: this.defaultNamespace,
             deleteOptions
-        ];
+        };
 
         const deleteWithErrorHandling = async (
-            deleteFn: () => Promise<i.DeleteApiResponse>
-        ): Promise<i.DeleteApiResponse> => {
+            deleteFn: () => Promise<k8s.V1Pod | k8s.V1Status | k8s.V1Service>
+        ): Promise<k8s.V1Pod | k8s.V1Status | k8s.V1Service> => {
             try {
                 const res = await deleteFn();
                 return res;
@@ -384,24 +369,24 @@ export class K8s {
         try {
             if (objType === 'services') {
                 responseObj = await pRetry(() => deleteWithErrorHandling(() => this.k8sCoreV1Api
-                    .deleteNamespacedService(...params)), getRetryConfig());
+                    .deleteNamespacedService(params)), getRetryConfig());
             } else if (objType === 'deployments') {
                 responseObj = await pRetry(() => deleteWithErrorHandling(() => this.k8sAppsV1Api
-                    .deleteNamespacedDeployment(...params)), getRetryConfig());
+                    .deleteNamespacedDeployment(params)), getRetryConfig());
             } else if (objType === 'jobs') {
                 responseObj = await pRetry(() => deleteWithErrorHandling(() => this.k8sBatchV1Api
-                    .deleteNamespacedJob(...params)), getRetryConfig());
+                    .deleteNamespacedJob(params)), getRetryConfig());
             } else if (objType === 'pods') {
                 responseObj = await pRetry(() => deleteWithErrorHandling(() => this.k8sCoreV1Api
-                    .deleteNamespacedPod(...params)), getRetryConfig());
+                    .deleteNamespacedPod(params)), getRetryConfig());
             } else if (objType === 'replicasets') {
                 responseObj = await pRetry(() => deleteWithErrorHandling(() => this.k8sAppsV1Api
-                    .deleteNamespacedReplicaSet(...params)), getRetryConfig());
+                    .deleteNamespacedReplicaSet(params)), getRetryConfig());
             } else {
                 throw new Error(`Invalid objType: ${objType}`);
             }
 
-            return responseObj.body;
+            return responseObj;
         } catch (e) {
             const err = new Error(`Request k8s.delete with name: ${name} failed with: ${e}`);
             this.logger.error(err);
@@ -458,7 +443,7 @@ export class K8s {
 
     async _deleteObjByExId(
         exId: string, nodeType: i.NodeType, objType: i.ResourceType, force?: boolean
-    ): Promise<i.DeleteResponseBody[] | void> {
+    ): Promise<(k8s.V1Pod | k8s.V1Status | k8s.V1Service)[] | void> {
         let objList: i.TSResourceList;
         const deleteResponses: Array<k8s.V1Pod | k8s.V1Service | k8s.V1Status> = [];
 

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
@@ -309,7 +309,7 @@ export class K8s {
                 },
                 {
                     middleware: [
-                        setHeaderMiddleware('Content-Type', 'MyValue'),
+                        setHeaderMiddleware('Content-Type', k8s.PatchStrategy.MergePatch),
                     ],
                     middlewareMergeStrategy: 'append',
                 }
@@ -553,13 +553,11 @@ export class K8s {
 
         this.logger.info(`New Scale for exId=${exId}: ${newScale}`);
 
-        const scalePatch = [
-            {
-                op: 'replace',
-                path: '/spec/replicas',
-                value: newScale
+        const scalePatch = {
+            spec: {
+                replicas: newScale
             }
-        ];
+        };
 
         const patchResponseBody = await this
             .patch(scalePatch, workerDeployment.metadata.name);

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8s-v2-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8s-v2-spec.ts
@@ -489,13 +489,11 @@ describe('k8s', () => {
 
         it('can set nodes to a deployment to 2', async () => {
             deployment.spec.replicas = 2;
-            scope.patch('/apis/apps/v1/namespaces/default/deployments/dname', [
-                {
-                    op: 'replace',
-                    path: '/spec/replicas',
-                    value: 2
+            scope.patch('/apis/apps/v1/namespaces/default/deployments/dname', {
+                spec: {
+                    replicas: 2
                 }
-            ]).reply(200, deployment);
+            }).reply(200, deployment);
 
             const response = await k8s.scaleExecution('abcde1234', 2, 'set');
             expect(response.spec?.replicas).toEqual(2);
@@ -503,13 +501,11 @@ describe('k8s', () => {
 
         it('can add 2 nodes to a deployment with 5 to get 7', async () => {
             deployment.spec.replicas = 7;
-            scope.patch('/apis/apps/v1/namespaces/default/deployments/dname', [
-                {
-                    op: 'replace',
-                    path: '/spec/replicas',
-                    value: 7
+            scope.patch('/apis/apps/v1/namespaces/default/deployments/dname', {
+                spec: {
+                    replicas: 7
                 }
-            ]).reply(200, deployment);
+            }).reply(200, deployment);
 
             const response = await k8s.scaleExecution('abcde1234', 2, 'add');
             expect(response.spec?.replicas).toEqual(7);
@@ -517,13 +513,11 @@ describe('k8s', () => {
 
         it('can remove 2 nodes from a deployment with 5 to get 3', async () => {
             deployment.spec.replicas = 3;
-            scope.patch('/apis/apps/v1/namespaces/default/deployments/dname', [
-                {
-                    op: 'replace',
-                    path: '/spec/replicas',
-                    value: 3
+            scope.patch('/apis/apps/v1/namespaces/default/deployments/dname', {
+                spec: {
+                    replicas: 3
                 }
-            ]).reply(200, deployment);
+            }).reply(200, deployment);
 
             const response = await k8s.scaleExecution('abcde1234', 2, 'remove');
             expect(response.spec?.replicas).toEqual(3);

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8s-v2-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8s-v2-spec.ts
@@ -1,6 +1,6 @@
 import {
     V1Deployment, V1Job, V1Pod,
-    V1ReplicaSet, V1Service
+    V1ReplicaSet, V1Service, V1Status
 } from '@kubernetes/client-node';
 import nock from 'nock';
 import { debugLogger } from '@terascope/job-components';
@@ -123,6 +123,13 @@ describe('k8s', () => {
         },
         kind: 'Status',
         status: 'Success'
+    };
+
+    const apiException = {
+        'HTTP-Code': 400,
+        Message: 'Unknown API Status Code!',
+        Body: { statusCode: 400 },
+        Headers: { 'content-type': 'application/json' }
     };
 
     beforeEach(async () => {
@@ -326,17 +333,17 @@ describe('k8s', () => {
             expect(response).toEqual({});
         });
 
-        it('will throw on a reponse code >= 400', async () => {
+        it('will throw on a response code >= 400', async () => {
             nock(_url)
                 .patch('/apis/apps/v1/namespaces/default/deployments/bad-response')
-                .replyWithError({ statusCode: 400 })
+                .reply(400, apiException)
                 .patch('/apis/apps/v1/namespaces/default/deployments/bad-response')
-                .replyWithError({ statusCode: 400 })
+                .reply(400, apiException)
                 .patch('/apis/apps/v1/namespaces/default/deployments/bad-response')
-                .replyWithError({ statusCode: 400 });
+                .reply(400, apiException);
 
             await expect(k8s.patch({ name: 'bad-response' }, 'bad-response'))
-                .rejects.toThrow('Request k8s.patch with name: bad-response failed with: TSError: {"statusCode":400}');
+                .rejects.toThrow('HTTP-Code: 400');
         });
     });
 
@@ -396,43 +403,39 @@ describe('k8s', () => {
             expect(response).toEqual({});
         });
 
-        it('will throw on a reponse code >= 400, excluding 404', async () => {
+        it('will throw on a response code >= 400, excluding 404', async () => {
             nock(_url)
                 .delete('/api/v1/namespaces/default/pods/bad-response')
-                .replyWithError({ statusCode: 400 })
+                .reply(400, apiException)
                 .delete('/api/v1/namespaces/default/pods/bad-response')
-                .replyWithError({ statusCode: 400 })
+                .reply(400, apiException)
                 .delete('/api/v1/namespaces/default/pods/bad-response')
-                .replyWithError({ statusCode: 400 });
+                .reply(400, apiException);
 
             await expect(k8s.delete('bad-response', 'pods'))
-                .rejects.toThrow('Request k8s.delete with name: bad-response failed with: TSError: {"statusCode":400}');
+                .rejects.toThrow('HTTP-Code: 400');
         });
 
         it('will succeed on a 404 response code', async () => {
-            const notFoundResponse = {
-                body: {
-                    kind: 'Status',
-                    apiVersion: 'v1',
-                    metadata: {},
-                    status: 'Failure',
-                    message: 'pods "non-existent" not found',
-                    reason: 'NotFound',
-                    details: { name: 'non-existent', kind: 'pods' },
-                    code: 404
-                },
-                statusCode: 404
+            const notFoundResponse: V1Status = {
+                kind: 'Status',
+                apiVersion: 'v1',
+                metadata: {},
+                status: 'Failure',
+                message: 'pods "non-existent" not found',
+                reason: 'NotFound',
+                details: { name: 'non-existent', kind: 'pods' },
+                code: 404
             };
             nock(_url)
                 .delete('/api/v1/namespaces/default/pods/non-existent')
-                .replyWithError(notFoundResponse);
-
+                .reply(404, notFoundResponse);
             const response = await k8s.delete('non-existent', 'pods');
-            expect(response).toEqual(notFoundResponse.body);
+            expect(response).toEqual(notFoundResponse);
         });
     });
 
-    describe('->_deletObjByExId', () => {
+    describe('->_deleteObjByExId', () => {
         it('can delete a single object', async () => {
             nock(_url)
                 .get('/apis/batch/v1/namespaces/default/jobs')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1745,25 +1745,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kubernetes/client-node@npm:~0.22.3":
-  version: 0.22.3
-  resolution: "@kubernetes/client-node@npm:0.22.3"
+"@kubernetes/client-node@npm:~1.1.0":
+  version: 1.1.0
+  resolution: "@kubernetes/client-node@npm:1.1.0"
   dependencies:
-    byline: "npm:^5.0.0"
+    "@types/js-yaml": "npm:^4.0.1"
+    "@types/node": "npm:^22.0.0"
+    "@types/node-fetch": "npm:^2.6.9"
+    "@types/stream-buffers": "npm:^3.0.3"
+    "@types/tar": "npm:^6.1.1"
+    "@types/ws": "npm:^8.5.4"
+    form-data: "npm:^4.0.0"
+    hpagent: "npm:^1.2.0"
     isomorphic-ws: "npm:^5.0.0"
     js-yaml: "npm:^4.1.0"
-    jsonpath-plus: "npm:^10.2.0"
+    jsonpath-plus: "npm:^10.3.0"
+    node-fetch: "npm:^2.6.9"
     openid-client: "npm:^6.1.3"
-    request: "npm:^2.88.0"
     rfc4648: "npm:^1.3.0"
+    socks-proxy-agent: "npm:^8.0.4"
     stream-buffers: "npm:^3.0.2"
     tar: "npm:^7.0.0"
-    tslib: "npm:^2.4.1"
+    tmp-promise: "npm:^3.0.2"
     ws: "npm:^8.18.0"
-  dependenciesMeta:
-    openid-client:
-      optional: true
-  checksum: 10c0/78ce0b81eaa6521a506813e88195692f6b52128427c70b1fe4bc5e277e6cc56ab366617fd1daec4e39da6b8a9c7f4b7b1ad35c598a64b277a150c1b52734f2a4
+  checksum: 10c0/f2dbc9b2f23387a7c0a62748e893c8b34e264def5dd02e51a981fa4c9cf24c7b5da5a4a56f6ecefde18fd00704528a00fb0be7fdd2f64881e1ca983d497ffe09
   languageName: node
   linkType: hard
 
@@ -2895,11 +2900,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/scripts@npm:~1.13.0, @terascope/scripts@workspace:packages/scripts":
+"@terascope/scripts@npm:~1.14.0, @terascope/scripts@workspace:packages/scripts":
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
-    "@kubernetes/client-node": "npm:~0.22.3"
+    "@kubernetes/client-node": "npm:~1.1.0"
     "@terascope/utils": "npm:~1.7.7"
     "@types/ip": "npm:~1.1.3"
     "@types/micromatch": "npm:~4.0.9"
@@ -3631,7 +3636,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/js-yaml@npm:~4.0.9":
+"@types/js-yaml@npm:^4.0.1, @types/js-yaml@npm:~4.0.9":
   version: 4.0.9
   resolution: "@types/js-yaml@npm:4.0.9"
   checksum: 10c0/24de857aa8d61526bbfbbaa383aa538283ad17363fcd5bb5148e2c7f604547db36646440e739d78241ed008702a8920665d1add5618687b6743858fae00da211
@@ -3716,6 +3721,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node-fetch@npm:^2.6.9":
+  version: 2.6.12
+  resolution: "@types/node-fetch@npm:2.6.12"
+  dependencies:
+    "@types/node": "npm:*"
+    form-data: "npm:^4.0.0"
+  checksum: 10c0/7693acad5499b7df2d1727d46cff092a63896dc04645f36b973dd6dd754a59a7faba76fcb777bdaa35d80625c6a9dd7257cca9c401a4bab03b04480cda7fd1af
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*":
   version: 22.13.5
   resolution: "@types/node@npm:22.13.5"
@@ -3729,6 +3744,15 @@ __metadata:
   version: 10.17.60
   resolution: "@types/node@npm:10.17.60"
   checksum: 10c0/0742294912a6e79786cdee9ed77cff6ee8ff007b55d8e21170fc3e5994ad3a8101fea741898091876f8dc32b0a5ae3d64537b7176799e92da56346028d2cbcd2
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^22.0.0":
+  version: 22.13.11
+  resolution: "@types/node@npm:22.13.11"
+  dependencies:
+    undici-types: "npm:~6.20.0"
+  checksum: 10c0/f6ee33d36372242535c38640fe7550a6640d8a775ec19b55bfc11775b521cba072d892ca92a912332ce01b317293d645c1bf767f3f882ec719f2404a3d2a5b96
   languageName: node
   linkType: hard
 
@@ -3866,6 +3890,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/stream-buffers@npm:^3.0.3":
+  version: 3.0.7
+  resolution: "@types/stream-buffers@npm:3.0.7"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/c27f2b698a63aa6c0a4023ac47aad174bd601963d65a419f7422970ec7f946e65ed6920c71540fc8a9c1044642e5da769ea51e370abbc5d614f3ab16ff08529f
+  languageName: node
+  linkType: hard
+
+"@types/tar@npm:^6.1.1":
+  version: 6.1.13
+  resolution: "@types/tar@npm:6.1.13"
+  dependencies:
+    "@types/node": "npm:*"
+    minipass: "npm:^4.0.0"
+  checksum: 10c0/98cc72d444fa622049e86e457a64d859c6effd7c7518d36e7b40b4ab1e7aa9e2412cc868cbef396650485dae07d50d98f662e8a53bb45f4a70eb6c61f80a63c7
+  languageName: node
+  linkType: hard
+
 "@types/tmp@npm:~0.2.6":
   version: 0.2.6
   resolution: "@types/tmp@npm:0.2.6"
@@ -3928,6 +3971,15 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/fa958e64596ca9487c3ed6012834de70b47f25d971f1950cfb8e6a99cb77ff340ae82ac7627744e01b58010674ef8ede07d5a2ac29ca9ad0d67a430fcc69ae14
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.5.4":
+  version: 8.18.0
+  resolution: "@types/ws@npm:8.18.0"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/a56d2e0d1da7411a1f3548ce02b51a50cbe9e23f025677d03df48f87e4a3c72e1342fbf1d12e487d7eafa8dc670c605152b61bbf9165891ec0e9694b0d3ea8d4
   languageName: node
   linkType: hard
 
@@ -5049,13 +5101,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"byline@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "byline@npm:5.0.0"
-  checksum: 10c0/33fb64cd84440b3652a99a68d732c56ef18a748ded495ba38e7756a242fab0d4654b9b8ce269fd0ac14c5f97aa4e3c369613672b280a1f60b559b34223105c85
-  languageName: node
-  linkType: hard
-
 "bytes@npm:3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
@@ -6074,7 +6119,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e@workspace:e2e"
   dependencies:
-    "@terascope/scripts": "npm:~1.13.0"
+    "@terascope/scripts": "npm:~1.14.0"
     "@terascope/types": "npm:~1.4.1"
     "@terascope/utils": "npm:~1.7.7"
     bunyan: "npm:~1.8.15"
@@ -7360,6 +7405,18 @@ __metadata:
     mime-types: "npm:^2.1.35"
     safe-buffer: "npm:^5.2.1"
   checksum: 10c0/48b910745d4fcd403f3d6876e33082a334e712199b8c86c4eb82f6da330a59b859943999d793856758c5ff18ca5261ced4d1062235a14543022d986bd21faa7d
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "form-data@npm:4.0.2"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    mime-types: "npm:^2.1.12"
+  checksum: 10c0/e534b0cf025c831a0929bf4b9bbe1a9a6b03e273a8161f9947286b9b13bf8fb279c6944aae0070c4c311100c6d6dbb815cd955dc217728caf73fad8dc5b8ee9c
   languageName: node
   linkType: hard
 
@@ -9640,7 +9697,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonpath-plus@npm:^10.2.0":
+"jsonpath-plus@npm:^10.3.0":
   version: 10.3.0
   resolution: "jsonpath-plus@npm:10.3.0"
   dependencies:
@@ -10286,6 +10343,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minipass@npm:^4.0.0":
+  version: 4.2.8
+  resolution: "minipass@npm:4.2.8"
+  checksum: 10c0/4ea76b030d97079f4429d6e8a8affd90baf1b6a1898977c8ccce4701c5a2ba2792e033abc6709373f25c2c4d4d95440d9d5e9464b46b7b76ca44d2ce26d939ce
+  languageName: node
+  linkType: hard
+
 "minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2":
   version: 7.1.2
   resolution: "minipass@npm:7.1.2"
@@ -10448,7 +10512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.1":
+"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.9":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -12395,7 +12459,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^8.0.3":
+"socks-proxy-agent@npm:^8.0.3, socks-proxy-agent@npm:^8.0.4":
   version: 8.0.5
   resolution: "socks-proxy-agent@npm:8.0.5"
   dependencies:
@@ -13047,7 +13111,7 @@ __metadata:
     "@eslint/js": "npm:~9.22.0"
     "@swc/core": "npm:1.11.8"
     "@swc/jest": "npm:~0.2.37"
-    "@terascope/scripts": "npm:~1.13.0"
+    "@terascope/scripts": "npm:~1.14.0"
     "@types/bluebird": "npm:~3.5.42"
     "@types/convict": "npm:~6.1.6"
     "@types/elasticsearch": "npm:~5.0.43"
@@ -13070,7 +13134,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "teraslice@workspace:packages/teraslice"
   dependencies:
-    "@kubernetes/client-node": "npm:~0.22.3"
+    "@kubernetes/client-node": "npm:~1.1.0"
     "@terascope/elasticsearch-api": "npm:~4.8.5"
     "@terascope/job-components": "npm:~1.9.8"
     "@terascope/teraslice-messaging": "npm:~1.10.8"
@@ -13162,7 +13226,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:~0.2.3":
+"tmp-promise@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "tmp-promise@npm:3.0.3"
+  dependencies:
+    tmp: "npm:^0.2.0"
+  checksum: 10c0/23b47dcb2e82b14bbd8f61ed7a9d9353cdb6a6f09d7716616cfd27d0087040cd40152965a518e598d7aabe1489b9569bf1eebde0c5fadeaf3ec8098adcebea4e
+  languageName: node
+  linkType: hard
+
+"tmp@npm:^0.2.0, tmp@npm:~0.2.3":
   version: 0.2.3
   resolution: "tmp@npm:0.2.3"
   checksum: 10c0/3e809d9c2f46817475b452725c2aaa5d11985cf18d32a7a970ff25b568438e2c076c2e8609224feef3b7923fa9749b74428e3e634f6b8e520c534eef2fd24125
@@ -13352,7 +13425,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.4.0, tslib@npm:^2.4.1, tslib@npm:^2.6.2, tslib@npm:^2.8.1":
+"tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62


### PR DESCRIPTION
This PR makes the following changes:
- update `kubernetes/client-node` from v0.22.3 to v1.1.0 in teraslice and scripts packages
- modify k8s function calls to use parameter objects
- remove unneeded interfaces/types since API responses no longer use a wrapper object.
- update error handling since some 400 level responses from kubectl now throw an `ApiException` error internally.
- `k8s.patch` fix
  - middleware workaround
    - comment from issue with workaround I used: https://github.com/kubernetes-client/javascript/issues/2160#issuecomment-2726005739
    - PR that should fix this: https://github.com/kubernetes-client/javascript/pull/2316
  - switched from a json patch to a merge patch because json patch didn't work with the above fix. Merge patch seems to have some limitations, but we only use the patch function to scale workers, so it's not an issue. When we remove the patch we should switch this back to json patch.

ref: #3959 