### PR TITLE
[CI] trigger helm-charts update-gh-pages workflow when teraslice chart updates

### DIFF
--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -106,11 +106,14 @@ jobs:
 
 
   build-and-publish-helm-charts:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     needs: build-release
     permissions:
       contents: write
       packages: write
+    outputs:
+       version_exists: ${{ steps.check-version.outputs.version_exists }}
     steps:
       - name: Generate a token
         id: token-generation
@@ -244,3 +247,25 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  trigger-terascope-helm-charts-update-gh-pages-workflow:
+    if: github.event.pull_request.merged == true && needs.build-and-publish-helm-charts.outputs.version_exists == false
+    needs: [build-and-publish-helm-charts]
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.GH_CROSS_REPO_ACTIONS_APP_ID }}
+          private-key: ${{ secrets.GH_CROSS_REPO_ACTIONS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: helm-charts
+      - 
+        name: Send workflow dispatch event to terascope/helm-charts
+        run: |
+          curl -X POST -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ steps.generate-token.outputs.token }}" \
+                https://api.github.com/repos/terascope/helm-charts/actions/workflows/update-gh-pages.yaml/dispatches \
+                -d '{"ref":"main","inputs":{"reason":"Teraslice chart release"}}'

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -113,7 +113,7 @@ jobs:
       contents: write
       packages: write
     outputs:
-       version_exists: ${{ steps.check-version.outputs.version_exists }}
+       helm_chart_updated: ${{ !steps.check-version.outputs.version_exists }}
     steps:
       - name: Generate a token
         id: token-generation
@@ -249,7 +249,7 @@ jobs:
         uses: actions/deploy-pages@v4
 
   trigger-terascope-helm-charts-update-gh-pages-workflow:
-    if: github.event.pull_request.merged == true && needs.build-and-publish-helm-charts.outputs.version_exists == 'false'
+    if: github.event.pull_request.merged == true && needs.build-and-publish-helm-charts.outputs.helm_chart_updated == 'true'
     needs: [build-and-publish-helm-charts]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -249,7 +249,7 @@ jobs:
         uses: actions/deploy-pages@v4
 
   trigger-terascope-helm-charts-update-gh-pages-workflow:
-    if: github.event.pull_request.merged == true && needs.build-and-publish-helm-charts.outputs.version_exists == false
+    if: github.event.pull_request.merged == true && needs.build-and-publish-helm-charts.outputs.version_exists == 'false'
     needs: [build-and-publish-helm-charts]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds a new job to the `publish-master` workflow. It will run only if the teraslice helm-chart has been updated. The job triggers the `update-gh-pages` workflow in the `terascope/helm-charts` repository, which will merge the new teraslice-chart [index.yaml](https://terascope.github.io/teraslice/charts/index.yaml) with the helm-charts [index.yaml](https://terascope.github.io/helm-charts/index.yaml), allowing all public terascope charts to be accessible using `helm repo add terascope https://terascope.github.io/helm-charts.

ref: #3999