### PR TITLE
[CI, scripts] Reintroduce code coverage metrics

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: off
+    patch: off

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,11 @@ jobs:
       - name: Test
         env:
           REPORT_COVERAGE: true
-        run: yarn test --suite unit -d --
+          # Only run one test per batch for now because jest will only create code
+          # coverage for the first package in the batch
+          # https://github.com/jestjs/jest/issues/4255
+          MAX_PROJECTS_PER_BATCH: 1
+        run: yarn test --suite unit --
 
       - name: Upload Node ${{ matrix.node-version }} unit test coverage
         uses: codecov/codecov-action@v5
@@ -456,74 +460,96 @@ jobs:
   #       run: yarn test:${{ matrix.search-version }}
   #       working-directory: ./packages/teraslice
 
-  # elasticsearch-store-tests:
-  #   runs-on: ubuntu-latest
-  #   needs: [compute-node-version-vars, verify-build, cache-docker-images]
-  #   strategy:
-  #     # opensearch is finiky, keep testing others if it fails
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
-  #       search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+        # - name: Upload teraslice node-${{ matrix.node-version }} ${{ matrix.search-version }} test coverage
+        #   uses: codecov/codecov-action@v5
+        #   with:
+        #     fail_ci_if_error: false
+        #     # files: ./coverage1.xml,./coverage2.xml # optional
+        #     flags: teraslice-integration
+        #     name: teraslice-${{ matrix.search-version }}-node-${{ matrix.node-version }}-tests
+        #     token: ${{ secrets.CODECOV_TOKEN }}
+        #     verbose: true # optional (default = false)
 
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
+  elasticsearch-store-tests:
+    runs-on: ubuntu-latest
+    needs: [compute-node-version-vars, verify-build, cache-docker-images]
+    strategy:
+      # opensearch is finiky, keep testing others if it fails
+      fail-fast: false
+      matrix:
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
+        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     # we login to docker to avoid docker pull limit rates
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
-  #     - name: Install and build packages
-  #       run: yarn && yarn setup
+      # we login to docker to avoid docker pull limit rates
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-  #     - name: Create Docker Image List
-  #       run: |
-  #         yarn docker:listImages
-  #         cat ./images/image-list.txt
+      - name: Install and build packages
+        run: yarn && yarn setup
 
-  #     - name: Restore Docker image cache
-  #       id: docker-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/docker_cache
-  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
 
-  #     - name: Test ${{ matrix.search-version }}
-  #       run: yarn test:${{ matrix.search-version }}
-  #       working-directory: ./packages/elasticsearch-store
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-  # lint-and-sync:
-  #   runs-on: ubuntu-latest
-  #   needs: [compute-node-version-vars, verify-build, cache-docker-images]
-  #   # will remove the checkout, build and setup when the artifact is made to just
-  #   # test the linting and syncing of the codebase
-  #   steps:
-  #   - name: Check out code
-  #     uses: actions/checkout@v4
+      - name: Test ${{ matrix.search-version }}
+        env:
+          REPORT_COVERAGE: true
+        run: yarn test:${{ matrix.search-version }}
+        working-directory: ./packages/elasticsearch-store
 
-  #   - name: Setup Node
-  #     uses: actions/setup-node@v4
-  #     with:
-  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSION_MAIN) }}
-  #       cache: 'yarn'
+      - name: Upload elasticsearch-store node-${{ matrix.node-version }} ${{ matrix.search-version }} test coverage
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: false
+          # files: ./coverage1.xml,./coverage2.xml # optional
+          flags: es-store-integration
+          name: es-store-${{ matrix.search-version }}-node-${{ matrix.node-version }}-tests
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true # optional (default = false)
 
-  #   - name: Install and build packages
-  #     run: yarn && yarn setup
+  lint-and-sync:
+    runs-on: ubuntu-latest
+    needs: [compute-node-version-vars, verify-build, cache-docker-images]
+    # will remove the checkout, build and setup when the artifact is made to just
+    # test the linting and syncing of the codebase
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
 
-  #   - name: Lint codebase
-  #     run: yarn lint
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSION_MAIN) }}
+        cache: 'yarn'
 
-  #   - name: Sync codebase
-  #     run: yarn sync --verify
+    - name: Install and build packages
+      run: yarn && yarn setup
+
+    - name: Lint codebase
+      run: yarn lint
+
+    - name: Sync codebase
+      run: yarn sync --verify
 
   # elasticsearch-api-tests:
   #   runs-on: ubuntu-latest
@@ -634,30 +660,30 @@ jobs:
   #       run: NODE_VERSION=${{ matrix.node-version }} yarn test:${{ matrix.search-version }}
   #       working-directory: ./e2e
 
-  # check-docker-limit-after:
-  #   needs: [
-  #     e2e-k8s-v2-encrypted-tests,
-  #     e2e-external-storage-tests,
-  #     e2e-k8s-v2-tests,
-  #     e2e-k8s-tests,
-  #     e2e-tests,
-  #     elasticsearch-api-tests,
-  #     elasticsearch-store-tests,
-  #     teraslice-elasticsearch-tests
-  #   ]
-  #   uses: terascope/workflows/.github/workflows/check-docker-limit.yml@a30c5cb5151ee231edc8ff0ac22d7a29d66540f2
-  #   secrets: inherit
+  check-docker-limit-after:
+    needs: [
+      # e2e-k8s-v2-encrypted-tests,
+      # e2e-external-storage-tests,
+      # e2e-k8s-v2-tests,
+      # e2e-k8s-tests,
+      # e2e-tests,
+      # elasticsearch-api-tests,
+      elasticsearch-store-tests,
+      # teraslice-elasticsearch-tests
+    ]
+    uses: terascope/workflows/.github/workflows/check-docker-limit.yml@a30c5cb5151ee231edc8ff0ac22d7a29d66540f2
+    secrets: inherit
 
-  # check-github-api-limit-after:
-  #   needs: [
-  #     e2e-k8s-v2-encrypted-tests,
-  #     e2e-external-storage-tests,
-  #     e2e-k8s-v2-tests,
-  #     e2e-k8s-tests,
-  #     e2e-tests,
-  #     elasticsearch-api-tests,
-  #     elasticsearch-store-tests,
-  #     teraslice-elasticsearch-tests
-  #   ]
-  #   uses: terascope/workflows/.github/workflows/check-github-api-limit.yml@a30c5cb5151ee231edc8ff0ac22d7a29d66540f2
-  #   secrets: inherit
+  check-github-api-limit-after:
+    needs: [
+      # e2e-k8s-v2-encrypted-tests,
+      # e2e-external-storage-tests,
+      # e2e-k8s-v2-tests,
+      # e2e-k8s-tests,
+      # e2e-tests,
+      # elasticsearch-api-tests,
+      elasticsearch-store-tests,
+      # teraslice-elasticsearch-tests
+    ]
+    uses: terascope/workflows/.github/workflows/check-github-api-limit.yml@a30c5cb5151ee231edc8ff0ac22d7a29d66540f2
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -415,60 +415,62 @@ jobs:
   #       run: NODE_VERSION=${{ matrix.node-version }} yarn test:s3AssetStorage
   #       working-directory: ./e2e
 
-  # teraslice-elasticsearch-tests:
-  #   runs-on: ubuntu-latest
-  #   needs: [compute-node-version-vars, verify-build, cache-docker-images]
-  #   strategy:
-  #     # opensearch is finiky, keep testing others if it fails
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
-  #       search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  teraslice-elasticsearch-tests:
+    runs-on: ubuntu-latest
+    needs: [compute-node-version-vars, verify-build, cache-docker-images]
+    strategy:
+      # opensearch is finiky, keep testing others if it fails
+      fail-fast: false
+      matrix:
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
+        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
-  #     # we login to docker to avoid docker pull limit rates
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
+      # we login to docker to avoid docker pull limit rates
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-  #     - name: Install and build packages
-  #       run: yarn && yarn setup
+      - name: Install and build packages
+        run: yarn && yarn setup
 
-  #     - name: Create Docker Image List
-  #       run: |
-  #         yarn docker:listImages
-  #         cat ./images/image-list.txt
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
 
-  #     - name: Restore Docker image cache
-  #       id: docker-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/docker_cache
-  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-  #     - name: Test ${{ matrix.search-version }}
-  #       run: yarn test:${{ matrix.search-version }}
-  #       working-directory: ./packages/teraslice
+      - name: Test ${{ matrix.search-version }}
+        env:
+          REPORT_COVERAGE: true
+        run: yarn test:${{ matrix.search-version }}
+        working-directory: ./packages/teraslice
 
-        # - name: Upload teraslice node-${{ matrix.node-version }} ${{ matrix.search-version }} test coverage
-        #   uses: codecov/codecov-action@v5
-        #   with:
-        #     fail_ci_if_error: false
-        #     # files: ./coverage1.xml,./coverage2.xml # optional
-        #     flags: teraslice-integration
-        #     name: teraslice-${{ matrix.search-version }}-node-${{ matrix.node-version }}-tests
-        #     token: ${{ secrets.CODECOV_TOKEN }}
-        #     verbose: true # optional (default = false)
+      - name: Upload teraslice node-${{ matrix.node-version }} ${{ matrix.search-version }} test coverage
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: false
+          # files: ./coverage1.xml,./coverage2.xml # optional
+          flags: teraslice-integration
+          name: teraslice-${{ matrix.search-version }}-node-${{ matrix.node-version }}-tests
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true # optional (default = false)
 
   elasticsearch-store-tests:
     runs-on: ubuntu-latest
@@ -669,7 +671,7 @@ jobs:
       # e2e-tests,
       # elasticsearch-api-tests,
       elasticsearch-store-tests,
-      # teraslice-elasticsearch-tests
+      teraslice-elasticsearch-tests
     ]
     uses: terascope/workflows/.github/workflows/check-docker-limit.yml@a30c5cb5151ee231edc8ff0ac22d7a29d66540f2
     secrets: inherit
@@ -683,7 +685,7 @@ jobs:
       # e2e-tests,
       # elasticsearch-api-tests,
       elasticsearch-store-tests,
-      # teraslice-elasticsearch-tests
+      teraslice-elasticsearch-tests
     ]
     uses: terascope/workflows/.github/workflows/check-github-api-limit.yml@a30c5cb5151ee231edc8ff0ac22d7a29d66540f2
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,8 @@ jobs:
         run: yarn && yarn setup
 
       - name: Test
+        env:
+          REPORT_COVERAGE: true
         run: yarn test --suite unit --
 
       - name: Upload Node ${{ matrix.node-version }} unit test coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Test
         env:
           REPORT_COVERAGE: true
-        run: yarn test --suite unit --
+        run: yarn test --suite unit -d --
 
       - name: Upload Node ${{ matrix.node-version }} unit test coverage
         uses: codecov/codecov-action@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,17 @@ jobs:
       - name: Test
         run: yarn test --suite unit --
 
+      - name: Upload Node ${{ matrix.node-version }} unit test coverage
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: false
+          # files: ./coverage1.xml,./coverage2.xml # optional
+          flags: unit
+          name: node-${{ matrix.node-version }}-unit-tests
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true # optional (default = false)
+
+
   e2e-k8s-tests:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,568 +96,568 @@ jobs:
           verbose: true # optional (default = false)
 
 
-  e2e-k8s-tests:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
-    strategy:
-      # opensearch is finiky, keep testing others if it fails
-      fail-fast: false
-      matrix:
-        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_K8S) }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-
-      # we login to docker to avoid docker pull limit rates
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Install and build packages
-        run: yarn && yarn setup
-
-      - name: Create Docker Image List
-        run: |
-          yarn docker:listImages
-          cat ./images/image-list.txt
-
-      - name: Restore Docker image cache
-        id: docker-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker_cache
-          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
-
-      - name: Compile e2e code
-        run: yarn build
-        working-directory: ./e2e
-
-      - name: Get Asset Bundle List From Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: asset-bundle-txt-file-list
-          path: ${{ github.workspace }}/e2e/scripts
-
-      - name: Restore asset bundle cache
-        id: asset-bundle-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/teraslice_assets
-          key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
-
-      - name: Install Kind and Kubectl
-        uses: helm/kind-action@v1.10.0
-        with:
-          install_only: "true"
-
-      - name: Test k8s elasticsearch7
-        run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8s
-        working-directory: ./e2e
-
-  e2e-k8s-v2-tests:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
-    strategy:
-      # opensearch is finiky, keep testing others if it fails
-      fail-fast: false
-      matrix:
-        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_K8S) }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-
-      # we login to docker to avoid docker pull limit rates
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Install and build packages
-        run: yarn && yarn setup
-
-      - name: Create Docker Image List
-        run: |
-          yarn docker:listImages
-          cat ./images/image-list.txt
-
-      - name: Restore Docker image cache
-        id: docker-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker_cache
-          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
-
-      - name: Compile e2e code
-        run: yarn build
-        working-directory: ./e2e
-
-      - name: Get Asset Bundle List From Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: asset-bundle-txt-file-list
-          path: ${{ github.workspace }}/e2e/scripts
-
-      - name: Restore asset bundle cache
-        id: asset-bundle-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/teraslice_assets
-          key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
-
-      - name: Install Kind and Kubectl
-        uses: helm/kind-action@v1.10.0
-        with:
-          install_only: "true"
-
-      - name: Install Helmfile
-        run: |
-          VERSION=$(curl -s https://api.github.com/repos/helmfile/helmfile/releases/latest | jq -r '.tag_name')
-          VERSION_NO_V=${VERSION#v}
-          curl -L "https://github.com/helmfile/helmfile/releases/download/${VERSION}/helmfile_${VERSION_NO_V}_linux_amd64.tar.gz" -o helmfile.tgz
-          tar -xzf helmfile.tgz
-          chmod +x helmfile
-          mv helmfile /usr/local/bin/helmfile
-          helm plugin install https://github.com/databus23/helm-diff
-          helmfile version
-          helm version
-
-      - name: Test CLI Commands
-        run: |
-          command -v kind
-          command -v kubectl
-          command -v helm
-          command -v helmfile
-
-      - name: Test k8s V2 opensearch2
-        run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8sV2Helmfile
-        working-directory: ./e2e
-
-  e2e-k8s-v2-encrypted-tests:
-    runs-on: ubuntu-latest
-    needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
-    strategy:
-      # opensearch is finiky, keep testing others if it fails
-      fail-fast: false
-      matrix:
-        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_STORAGE) }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-
-      # we login to docker to avoid docker pull limit rates
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Install and build packages
-        run: yarn && yarn setup
-
-      - name: Create Docker Image List
-        run: |
-          yarn docker:listImages
-          cat ./images/image-list.txt
-
-      - name: Restore Docker image cache
-        id: docker-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker_cache
-          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
-
-      - name: Install mkcert
-        run: curl -Ss -JLO "https://dl.filippo.io/mkcert/v1.4.4?for=linux/amd64" && sudo chmod 777 mkcert-v1.4.4-linux-amd64 && sudo cp mkcert-v1.4.4-linux-amd64 /usr/local/bin/mkcert
-
-      - name: Install grep
-        run: sudo apt update && sudo apt install grep
-
-      - name: Check mkcert
-        run: command -v mkcert
-
-      - name: Check grep
-        run: command -v grep
-
-      - name: Compile e2e code
-        run: yarn build
-        working-directory: ./e2e
-
-      - name: Get Asset Bundle List From Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: asset-bundle-txt-file-list
-          path: ${{ github.workspace }}/e2e/scripts
-
-      - name: Restore asset bundle cache
-        id: asset-bundle-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/teraslice_assets
-          key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
-
-      - name: Install Kind and Kubectl
-        uses: helm/kind-action@v1.10.0
-        with:
-          install_only: "true"
-
-      - name: Install Helmfile
-        run: |
-          VERSION=$(curl -s https://api.github.com/repos/helmfile/helmfile/releases/latest | jq -r '.tag_name')
-          VERSION_NO_V=${VERSION#v}
-          curl -L "https://github.com/helmfile/helmfile/releases/download/${VERSION}/helmfile_${VERSION_NO_V}_linux_amd64.tar.gz" -o helmfile.tgz
-          tar -xzf helmfile.tgz
-          chmod +x helmfile
-          mv helmfile /usr/local/bin/helmfile
-          helm plugin install https://github.com/databus23/helm-diff
-          helmfile version
-          helm version
-
-      - name: Test CLI Commands
-        run: |
-          command -v kind
-          command -v kubectl
-          command -v helm
-          command -v helmfile
-
-      - name: Test k8s V2 opensearch2
-        run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8sV2HelmfileEncrypted
-        working-directory: ./e2e
-
-  e2e-external-storage-tests:
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: ubuntu-latest
-    needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
-    strategy:
-      # opensearch is finiky, keep testing others if it fails
-      fail-fast: false
-      matrix:
-        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_STORAGE) }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-
-      # we login to docker to avoid docker pull limit rates
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Install and build packages
-        run: yarn && yarn setup
-
-      - name: Create Docker Image List
-        run: |
-          yarn docker:listImages
-          cat ./images/image-list.txt
-
-      - name: Restore Docker image cache
-        id: docker-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker_cache
-          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
-
-      - name: Compile e2e code
-        run: yarn build
-        working-directory: ./e2e
-
-      - name: Get Asset Bundle List From Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: asset-bundle-txt-file-list
-          path: ${{ github.workspace }}/e2e/scripts
-
-      - name: Restore asset bundle cache
-        id: asset-bundle-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/teraslice_assets
-          key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
-
-      - name: Test external Asset Storage opensearch1
-        run: NODE_VERSION=${{ matrix.node-version }} yarn test:s3AssetStorage
-        working-directory: ./e2e
-
-  teraslice-elasticsearch-tests:
-    runs-on: ubuntu-latest
-    needs: [compute-node-version-vars, verify-build, cache-docker-images]
-    strategy:
-      # opensearch is finiky, keep testing others if it fails
-      fail-fast: false
-      matrix:
-        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
-        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-
-      # we login to docker to avoid docker pull limit rates
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Install and build packages
-        run: yarn && yarn setup
-
-      - name: Create Docker Image List
-        run: |
-          yarn docker:listImages
-          cat ./images/image-list.txt
-
-      - name: Restore Docker image cache
-        id: docker-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker_cache
-          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
-
-      - name: Test ${{ matrix.search-version }}
-        run: yarn test:${{ matrix.search-version }}
-        working-directory: ./packages/teraslice
-
-  elasticsearch-store-tests:
-    runs-on: ubuntu-latest
-    needs: [compute-node-version-vars, verify-build, cache-docker-images]
-    strategy:
-      # opensearch is finiky, keep testing others if it fails
-      fail-fast: false
-      matrix:
-        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
-        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-
-      # we login to docker to avoid docker pull limit rates
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Install and build packages
-        run: yarn && yarn setup
-
-      - name: Create Docker Image List
-        run: |
-          yarn docker:listImages
-          cat ./images/image-list.txt
-
-      - name: Restore Docker image cache
-        id: docker-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker_cache
-          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
-
-      - name: Test ${{ matrix.search-version }}
-        run: yarn test:${{ matrix.search-version }}
-        working-directory: ./packages/elasticsearch-store
-
-  lint-and-sync:
-    runs-on: ubuntu-latest
-    needs: [compute-node-version-vars, verify-build, cache-docker-images]
-    # will remove the checkout, build and setup when the artifact is made to just
-    # test the linting and syncing of the codebase
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v4
-
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSION_MAIN) }}
-        cache: 'yarn'
-
-    - name: Install and build packages
-      run: yarn && yarn setup
-
-    - name: Lint codebase
-      run: yarn lint
-
-    - name: Sync codebase
-      run: yarn sync --verify
-
-  elasticsearch-api-tests:
-    runs-on: ubuntu-latest
-    needs: [compute-node-version-vars, verify-build, cache-docker-images]
-    strategy:
-      # opensearch is finiky, keep testing others if it fails
-      fail-fast: false
-      matrix:
-        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
-        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-
-      # we login to docker to avoid docker pull limit rates
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Install and build packages
-        run: yarn && yarn setup
-
-      - name: Create Docker Image List
-        run: |
-          yarn docker:listImages
-          cat ./images/image-list.txt
-
-      - name: Restore Docker image cache
-        id: docker-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker_cache
-          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
-
-      - name: Test ${{ matrix.search-version }}
-        run: yarn test:${{ matrix.search-version }}
-        working-directory: ./packages/elasticsearch-api
-
-  e2e-tests:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
-    strategy:
-      # opensearch is finiky, keep testing others if it fails
-      fail-fast: false
-      matrix:
-        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
-        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-
-      # we login to docker to avoid docker pull limit rates
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Install and build packages
-        run: yarn && yarn setup
-
-      - name: Create Docker Image List
-        run: |
-          yarn docker:listImages
-          cat ./images/image-list.txt
-
-      - name: Restore Docker image cache
-        id: docker-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker_cache
-          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
-
-      - name: Compile e2e code
-        run: yarn build
-        working-directory: ./e2e
-
-      - name: Get Asset Bundle List From Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: asset-bundle-txt-file-list
-          path: ${{ github.workspace }}/e2e/scripts
-
-      - name: Restore asset bundle cache
-        id: asset-bundle-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/teraslice_assets
-          key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
-
-      - name: Test ${{ matrix.search-version }}
-        run: NODE_VERSION=${{ matrix.node-version }} yarn test:${{ matrix.search-version }}
-        working-directory: ./e2e
-
-  check-docker-limit-after:
-    needs: [
-      e2e-k8s-v2-encrypted-tests,
-      e2e-external-storage-tests,
-      e2e-k8s-v2-tests,
-      e2e-k8s-tests,
-      e2e-tests,
-      elasticsearch-api-tests,
-      elasticsearch-store-tests,
-      teraslice-elasticsearch-tests
-    ]
-    uses: terascope/workflows/.github/workflows/check-docker-limit.yml@a30c5cb5151ee231edc8ff0ac22d7a29d66540f2
-    secrets: inherit
-
-  check-github-api-limit-after:
-    needs: [
-      e2e-k8s-v2-encrypted-tests,
-      e2e-external-storage-tests,
-      e2e-k8s-v2-tests,
-      e2e-k8s-tests,
-      e2e-tests,
-      elasticsearch-api-tests,
-      elasticsearch-store-tests,
-      teraslice-elasticsearch-tests
-    ]
-    uses: terascope/workflows/.github/workflows/check-github-api-limit.yml@a30c5cb5151ee231edc8ff0ac22d7a29d66540f2
-    secrets: inherit
+  # e2e-k8s-tests:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
+  #   strategy:
+  #     # opensearch is finiky, keep testing others if it fails
+  #     fail-fast: false
+  #     matrix:
+  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_K8S) }}
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
+
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
+
+  #     # we login to docker to avoid docker pull limit rates
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+
+  #     - name: Install and build packages
+  #       run: yarn && yarn setup
+
+  #     - name: Create Docker Image List
+  #       run: |
+  #         yarn docker:listImages
+  #         cat ./images/image-list.txt
+
+  #     - name: Restore Docker image cache
+  #       id: docker-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/docker_cache
+  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+
+  #     - name: Compile e2e code
+  #       run: yarn build
+  #       working-directory: ./e2e
+
+  #     - name: Get Asset Bundle List From Artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: asset-bundle-txt-file-list
+  #         path: ${{ github.workspace }}/e2e/scripts
+
+  #     - name: Restore asset bundle cache
+  #       id: asset-bundle-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/teraslice_assets
+  #         key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
+
+  #     - name: Install Kind and Kubectl
+  #       uses: helm/kind-action@v1.10.0
+  #       with:
+  #         install_only: "true"
+
+  #     - name: Test k8s elasticsearch7
+  #       run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8s
+  #       working-directory: ./e2e
+
+  # e2e-k8s-v2-tests:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
+  #   strategy:
+  #     # opensearch is finiky, keep testing others if it fails
+  #     fail-fast: false
+  #     matrix:
+  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_K8S) }}
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
+
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
+
+  #     # we login to docker to avoid docker pull limit rates
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+
+  #     - name: Install and build packages
+  #       run: yarn && yarn setup
+
+  #     - name: Create Docker Image List
+  #       run: |
+  #         yarn docker:listImages
+  #         cat ./images/image-list.txt
+
+  #     - name: Restore Docker image cache
+  #       id: docker-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/docker_cache
+  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+
+  #     - name: Compile e2e code
+  #       run: yarn build
+  #       working-directory: ./e2e
+
+  #     - name: Get Asset Bundle List From Artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: asset-bundle-txt-file-list
+  #         path: ${{ github.workspace }}/e2e/scripts
+
+  #     - name: Restore asset bundle cache
+  #       id: asset-bundle-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/teraslice_assets
+  #         key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
+
+  #     - name: Install Kind and Kubectl
+  #       uses: helm/kind-action@v1.10.0
+  #       with:
+  #         install_only: "true"
+
+  #     - name: Install Helmfile
+  #       run: |
+  #         VERSION=$(curl -s https://api.github.com/repos/helmfile/helmfile/releases/latest | jq -r '.tag_name')
+  #         VERSION_NO_V=${VERSION#v}
+  #         curl -L "https://github.com/helmfile/helmfile/releases/download/${VERSION}/helmfile_${VERSION_NO_V}_linux_amd64.tar.gz" -o helmfile.tgz
+  #         tar -xzf helmfile.tgz
+  #         chmod +x helmfile
+  #         mv helmfile /usr/local/bin/helmfile
+  #         helm plugin install https://github.com/databus23/helm-diff
+  #         helmfile version
+  #         helm version
+
+  #     - name: Test CLI Commands
+  #       run: |
+  #         command -v kind
+  #         command -v kubectl
+  #         command -v helm
+  #         command -v helmfile
+
+  #     - name: Test k8s V2 opensearch2
+  #       run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8sV2Helmfile
+  #       working-directory: ./e2e
+
+  # e2e-k8s-v2-encrypted-tests:
+  #   runs-on: ubuntu-latest
+  #   needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
+  #   strategy:
+  #     # opensearch is finiky, keep testing others if it fails
+  #     fail-fast: false
+  #     matrix:
+  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_STORAGE) }}
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
+
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
+
+  #     # we login to docker to avoid docker pull limit rates
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+
+  #     - name: Install and build packages
+  #       run: yarn && yarn setup
+
+  #     - name: Create Docker Image List
+  #       run: |
+  #         yarn docker:listImages
+  #         cat ./images/image-list.txt
+
+  #     - name: Restore Docker image cache
+  #       id: docker-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/docker_cache
+  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+
+  #     - name: Install mkcert
+  #       run: curl -Ss -JLO "https://dl.filippo.io/mkcert/v1.4.4?for=linux/amd64" && sudo chmod 777 mkcert-v1.4.4-linux-amd64 && sudo cp mkcert-v1.4.4-linux-amd64 /usr/local/bin/mkcert
+
+  #     - name: Install grep
+  #       run: sudo apt update && sudo apt install grep
+
+  #     - name: Check mkcert
+  #       run: command -v mkcert
+
+  #     - name: Check grep
+  #       run: command -v grep
+
+  #     - name: Compile e2e code
+  #       run: yarn build
+  #       working-directory: ./e2e
+
+  #     - name: Get Asset Bundle List From Artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: asset-bundle-txt-file-list
+  #         path: ${{ github.workspace }}/e2e/scripts
+
+  #     - name: Restore asset bundle cache
+  #       id: asset-bundle-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/teraslice_assets
+  #         key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
+
+  #     - name: Install Kind and Kubectl
+  #       uses: helm/kind-action@v1.10.0
+  #       with:
+  #         install_only: "true"
+
+  #     - name: Install Helmfile
+  #       run: |
+  #         VERSION=$(curl -s https://api.github.com/repos/helmfile/helmfile/releases/latest | jq -r '.tag_name')
+  #         VERSION_NO_V=${VERSION#v}
+  #         curl -L "https://github.com/helmfile/helmfile/releases/download/${VERSION}/helmfile_${VERSION_NO_V}_linux_amd64.tar.gz" -o helmfile.tgz
+  #         tar -xzf helmfile.tgz
+  #         chmod +x helmfile
+  #         mv helmfile /usr/local/bin/helmfile
+  #         helm plugin install https://github.com/databus23/helm-diff
+  #         helmfile version
+  #         helm version
+
+  #     - name: Test CLI Commands
+  #       run: |
+  #         command -v kind
+  #         command -v kubectl
+  #         command -v helm
+  #         command -v helmfile
+
+  #     - name: Test k8s V2 opensearch2
+  #       run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8sV2HelmfileEncrypted
+  #       working-directory: ./e2e
+
+  # e2e-external-storage-tests:
+  #   env:
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   runs-on: ubuntu-latest
+  #   needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
+  #   strategy:
+  #     # opensearch is finiky, keep testing others if it fails
+  #     fail-fast: false
+  #     matrix:
+  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_STORAGE) }}
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
+
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
+
+  #     # we login to docker to avoid docker pull limit rates
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+
+  #     - name: Install and build packages
+  #       run: yarn && yarn setup
+
+  #     - name: Create Docker Image List
+  #       run: |
+  #         yarn docker:listImages
+  #         cat ./images/image-list.txt
+
+  #     - name: Restore Docker image cache
+  #       id: docker-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/docker_cache
+  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+
+  #     - name: Compile e2e code
+  #       run: yarn build
+  #       working-directory: ./e2e
+
+  #     - name: Get Asset Bundle List From Artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: asset-bundle-txt-file-list
+  #         path: ${{ github.workspace }}/e2e/scripts
+
+  #     - name: Restore asset bundle cache
+  #       id: asset-bundle-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/teraslice_assets
+  #         key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
+
+  #     - name: Test external Asset Storage opensearch1
+  #       run: NODE_VERSION=${{ matrix.node-version }} yarn test:s3AssetStorage
+  #       working-directory: ./e2e
+
+  # teraslice-elasticsearch-tests:
+  #   runs-on: ubuntu-latest
+  #   needs: [compute-node-version-vars, verify-build, cache-docker-images]
+  #   strategy:
+  #     # opensearch is finiky, keep testing others if it fails
+  #     fail-fast: false
+  #     matrix:
+  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
+  #       search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
+
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
+
+  #     # we login to docker to avoid docker pull limit rates
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+
+  #     - name: Install and build packages
+  #       run: yarn && yarn setup
+
+  #     - name: Create Docker Image List
+  #       run: |
+  #         yarn docker:listImages
+  #         cat ./images/image-list.txt
+
+  #     - name: Restore Docker image cache
+  #       id: docker-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/docker_cache
+  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+
+  #     - name: Test ${{ matrix.search-version }}
+  #       run: yarn test:${{ matrix.search-version }}
+  #       working-directory: ./packages/teraslice
+
+  # elasticsearch-store-tests:
+  #   runs-on: ubuntu-latest
+  #   needs: [compute-node-version-vars, verify-build, cache-docker-images]
+  #   strategy:
+  #     # opensearch is finiky, keep testing others if it fails
+  #     fail-fast: false
+  #     matrix:
+  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
+  #       search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
+
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
+
+  #     # we login to docker to avoid docker pull limit rates
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+
+  #     - name: Install and build packages
+  #       run: yarn && yarn setup
+
+  #     - name: Create Docker Image List
+  #       run: |
+  #         yarn docker:listImages
+  #         cat ./images/image-list.txt
+
+  #     - name: Restore Docker image cache
+  #       id: docker-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/docker_cache
+  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+
+  #     - name: Test ${{ matrix.search-version }}
+  #       run: yarn test:${{ matrix.search-version }}
+  #       working-directory: ./packages/elasticsearch-store
+
+  # lint-and-sync:
+  #   runs-on: ubuntu-latest
+  #   needs: [compute-node-version-vars, verify-build, cache-docker-images]
+  #   # will remove the checkout, build and setup when the artifact is made to just
+  #   # test the linting and syncing of the codebase
+  #   steps:
+  #   - name: Check out code
+  #     uses: actions/checkout@v4
+
+  #   - name: Setup Node
+  #     uses: actions/setup-node@v4
+  #     with:
+  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSION_MAIN) }}
+  #       cache: 'yarn'
+
+  #   - name: Install and build packages
+  #     run: yarn && yarn setup
+
+  #   - name: Lint codebase
+  #     run: yarn lint
+
+  #   - name: Sync codebase
+  #     run: yarn sync --verify
+
+  # elasticsearch-api-tests:
+  #   runs-on: ubuntu-latest
+  #   needs: [compute-node-version-vars, verify-build, cache-docker-images]
+  #   strategy:
+  #     # opensearch is finiky, keep testing others if it fails
+  #     fail-fast: false
+  #     matrix:
+  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
+  #       search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
+
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
+
+  #     # we login to docker to avoid docker pull limit rates
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+
+  #     - name: Install and build packages
+  #       run: yarn && yarn setup
+
+  #     - name: Create Docker Image List
+  #       run: |
+  #         yarn docker:listImages
+  #         cat ./images/image-list.txt
+
+  #     - name: Restore Docker image cache
+  #       id: docker-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/docker_cache
+  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+
+  #     - name: Test ${{ matrix.search-version }}
+  #       run: yarn test:${{ matrix.search-version }}
+  #       working-directory: ./packages/elasticsearch-api
+
+  # e2e-tests:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
+  #   strategy:
+  #     # opensearch is finiky, keep testing others if it fails
+  #     fail-fast: false
+  #     matrix:
+  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
+  #       search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
+
+  #     - name: Setup Node ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'yarn'
+
+  #     # we login to docker to avoid docker pull limit rates
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+
+  #     - name: Install and build packages
+  #       run: yarn && yarn setup
+
+  #     - name: Create Docker Image List
+  #       run: |
+  #         yarn docker:listImages
+  #         cat ./images/image-list.txt
+
+  #     - name: Restore Docker image cache
+  #       id: docker-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/docker_cache
+  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+
+  #     - name: Compile e2e code
+  #       run: yarn build
+  #       working-directory: ./e2e
+
+  #     - name: Get Asset Bundle List From Artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: asset-bundle-txt-file-list
+  #         path: ${{ github.workspace }}/e2e/scripts
+
+  #     - name: Restore asset bundle cache
+  #       id: asset-bundle-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: /tmp/teraslice_assets
+  #         key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
+
+  #     - name: Test ${{ matrix.search-version }}
+  #       run: NODE_VERSION=${{ matrix.node-version }} yarn test:${{ matrix.search-version }}
+  #       working-directory: ./e2e
+
+  # check-docker-limit-after:
+  #   needs: [
+  #     e2e-k8s-v2-encrypted-tests,
+  #     e2e-external-storage-tests,
+  #     e2e-k8s-v2-tests,
+  #     e2e-k8s-tests,
+  #     e2e-tests,
+  #     elasticsearch-api-tests,
+  #     elasticsearch-store-tests,
+  #     teraslice-elasticsearch-tests
+  #   ]
+  #   uses: terascope/workflows/.github/workflows/check-docker-limit.yml@a30c5cb5151ee231edc8ff0ac22d7a29d66540f2
+  #   secrets: inherit
+
+  # check-github-api-limit-after:
+  #   needs: [
+  #     e2e-k8s-v2-encrypted-tests,
+  #     e2e-external-storage-tests,
+  #     e2e-k8s-v2-tests,
+  #     e2e-k8s-tests,
+  #     e2e-tests,
+  #     elasticsearch-api-tests,
+  #     elasticsearch-store-tests,
+  #     teraslice-elasticsearch-tests
+  #   ]
+  #   uses: terascope/workflows/.github/workflows/check-github-api-limit.yml@a30c5cb5151ee231edc8ff0ac22d7a29d66540f2
+  #   secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false
+          codecov_yml_path: ./.github/codecov.yaml
           # files: ./coverage1.xml,./coverage2.xml # optional
           flags: unit
           name: node-${{ matrix.node-version }}-unit-tests
@@ -466,6 +467,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false
+          codecov_yml_path: ./.github/codecov.yaml
           flags: teraslice-integration,integration
           name: teraslice-${{ matrix.search-version }}-node-${{ matrix.node-version }}-tests
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -522,7 +524,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false
-          # files: ./coverage1.xml,./coverage2.xml # optional
+          codecov_yml_path: ./.github/codecov.yaml
           flags: es-store-integration,integration
           name: es-store-${{ matrix.search-version }}-node-${{ matrix.node-version }}-tests
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -603,6 +605,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false
+          codecov_yml_path: ./.github/codecov.yaml
           flags: es-api-integration,integration
           name: es-api-${{ matrix.search-version }}-node-${{ matrix.node-version }}-tests
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -466,8 +466,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false
-          # files: ./coverage1.xml,./coverage2.xml # optional
-          flags: teraslice-integration
+          flags: teraslice-integration,integration
           name: teraslice-${{ matrix.search-version }}-node-${{ matrix.node-version }}-tests
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true # optional (default = false)
@@ -524,7 +523,7 @@ jobs:
         with:
           fail_ci_if_error: false
           # files: ./coverage1.xml,./coverage2.xml # optional
-          flags: es-store-integration
+          flags: es-store-integration,integration
           name: es-store-${{ matrix.search-version }}-node-${{ matrix.node-version }}-tests
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true # optional (default = false)
@@ -553,50 +552,61 @@ jobs:
     - name: Sync codebase
       run: yarn sync --verify
 
-  # elasticsearch-api-tests:
-  #   runs-on: ubuntu-latest
-  #   needs: [compute-node-version-vars, verify-build, cache-docker-images]
-  #   strategy:
-  #     # opensearch is finiky, keep testing others if it fails
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
-  #       search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  elasticsearch-api-tests:
+    runs-on: ubuntu-latest
+    needs: [compute-node-version-vars, verify-build, cache-docker-images]
+    strategy:
+      # opensearch is finiky, keep testing others if it fails
+      fail-fast: false
+      matrix:
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
+        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
-  #     # we login to docker to avoid docker pull limit rates
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
+      # we login to docker to avoid docker pull limit rates
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-  #     - name: Install and build packages
-  #       run: yarn && yarn setup
+      - name: Install and build packages
+        run: yarn && yarn setup
 
-  #     - name: Create Docker Image List
-  #       run: |
-  #         yarn docker:listImages
-  #         cat ./images/image-list.txt
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
 
-  #     - name: Restore Docker image cache
-  #       id: docker-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/docker_cache
-  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-  #     - name: Test ${{ matrix.search-version }}
-  #       run: yarn test:${{ matrix.search-version }}
-  #       working-directory: ./packages/elasticsearch-api
+      - name: Test ${{ matrix.search-version }}
+        env:
+          REPORT_COVERAGE: true
+        run: yarn test:${{ matrix.search-version }}
+        working-directory: ./packages/elasticsearch-api
+
+      - name: Upload es-api node-${{ matrix.node-version }} ${{ matrix.search-version }} test coverage
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: false
+          flags: es-api-integration,integration
+          name: es-api-${{ matrix.search-version }}-node-${{ matrix.node-version }}-tests
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true # optional (default = false)
 
   # e2e-tests:
   #   runs-on: ubuntu-latest
@@ -669,7 +679,7 @@ jobs:
       # e2e-k8s-v2-tests,
       # e2e-k8s-tests,
       # e2e-tests,
-      # elasticsearch-api-tests,
+      elasticsearch-api-tests,
       elasticsearch-store-tests,
       teraslice-elasticsearch-tests
     ]
@@ -683,7 +693,7 @@ jobs:
       # e2e-k8s-v2-tests,
       # e2e-k8s-tests,
       # e2e-tests,
-      # elasticsearch-api-tests,
+      elasticsearch-api-tests,
       elasticsearch-store-tests,
       teraslice-elasticsearch-tests
     ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,320 +100,320 @@ jobs:
           verbose: true # optional (default = false)
 
 
-  # e2e-k8s-tests:
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
-  #   strategy:
-  #     # opensearch is finiky, keep testing others if it fails
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_K8S) }}
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  e2e-k8s-tests:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
+    strategy:
+      # opensearch is finiky, keep testing others if it fails
+      fail-fast: false
+      matrix:
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_K8S) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
-  #     # we login to docker to avoid docker pull limit rates
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
+      # we login to docker to avoid docker pull limit rates
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-  #     - name: Install and build packages
-  #       run: yarn && yarn setup
+      - name: Install and build packages
+        run: yarn && yarn setup
 
-  #     - name: Create Docker Image List
-  #       run: |
-  #         yarn docker:listImages
-  #         cat ./images/image-list.txt
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
 
-  #     - name: Restore Docker image cache
-  #       id: docker-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/docker_cache
-  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-  #     - name: Compile e2e code
-  #       run: yarn build
-  #       working-directory: ./e2e
+      - name: Compile e2e code
+        run: yarn build
+        working-directory: ./e2e
 
-  #     - name: Get Asset Bundle List From Artifact
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: asset-bundle-txt-file-list
-  #         path: ${{ github.workspace }}/e2e/scripts
+      - name: Get Asset Bundle List From Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: asset-bundle-txt-file-list
+          path: ${{ github.workspace }}/e2e/scripts
 
-  #     - name: Restore asset bundle cache
-  #       id: asset-bundle-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/teraslice_assets
-  #         key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
+      - name: Restore asset bundle cache
+        id: asset-bundle-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/teraslice_assets
+          key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
 
-  #     - name: Install Kind and Kubectl
-  #       uses: helm/kind-action@v1.10.0
-  #       with:
-  #         install_only: "true"
+      - name: Install Kind and Kubectl
+        uses: helm/kind-action@v1.10.0
+        with:
+          install_only: "true"
 
-  #     - name: Test k8s elasticsearch7
-  #       run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8s
-  #       working-directory: ./e2e
+      - name: Test k8s elasticsearch7
+        run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8s
+        working-directory: ./e2e
 
-  # e2e-k8s-v2-tests:
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
-  #   strategy:
-  #     # opensearch is finiky, keep testing others if it fails
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_K8S) }}
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  e2e-k8s-v2-tests:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
+    strategy:
+      # opensearch is finiky, keep testing others if it fails
+      fail-fast: false
+      matrix:
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_K8S) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
-  #     # we login to docker to avoid docker pull limit rates
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
+      # we login to docker to avoid docker pull limit rates
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-  #     - name: Install and build packages
-  #       run: yarn && yarn setup
+      - name: Install and build packages
+        run: yarn && yarn setup
 
-  #     - name: Create Docker Image List
-  #       run: |
-  #         yarn docker:listImages
-  #         cat ./images/image-list.txt
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
 
-  #     - name: Restore Docker image cache
-  #       id: docker-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/docker_cache
-  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-  #     - name: Compile e2e code
-  #       run: yarn build
-  #       working-directory: ./e2e
+      - name: Compile e2e code
+        run: yarn build
+        working-directory: ./e2e
 
-  #     - name: Get Asset Bundle List From Artifact
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: asset-bundle-txt-file-list
-  #         path: ${{ github.workspace }}/e2e/scripts
+      - name: Get Asset Bundle List From Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: asset-bundle-txt-file-list
+          path: ${{ github.workspace }}/e2e/scripts
 
-  #     - name: Restore asset bundle cache
-  #       id: asset-bundle-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/teraslice_assets
-  #         key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
+      - name: Restore asset bundle cache
+        id: asset-bundle-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/teraslice_assets
+          key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
 
-  #     - name: Install Kind and Kubectl
-  #       uses: helm/kind-action@v1.10.0
-  #       with:
-  #         install_only: "true"
+      - name: Install Kind and Kubectl
+        uses: helm/kind-action@v1.10.0
+        with:
+          install_only: "true"
 
-  #     - name: Install Helmfile
-  #       run: |
-  #         VERSION=$(curl -s https://api.github.com/repos/helmfile/helmfile/releases/latest | jq -r '.tag_name')
-  #         VERSION_NO_V=${VERSION#v}
-  #         curl -L "https://github.com/helmfile/helmfile/releases/download/${VERSION}/helmfile_${VERSION_NO_V}_linux_amd64.tar.gz" -o helmfile.tgz
-  #         tar -xzf helmfile.tgz
-  #         chmod +x helmfile
-  #         mv helmfile /usr/local/bin/helmfile
-  #         helm plugin install https://github.com/databus23/helm-diff
-  #         helmfile version
-  #         helm version
+      - name: Install Helmfile
+        run: |
+          VERSION=$(curl -s https://api.github.com/repos/helmfile/helmfile/releases/latest | jq -r '.tag_name')
+          VERSION_NO_V=${VERSION#v}
+          curl -L "https://github.com/helmfile/helmfile/releases/download/${VERSION}/helmfile_${VERSION_NO_V}_linux_amd64.tar.gz" -o helmfile.tgz
+          tar -xzf helmfile.tgz
+          chmod +x helmfile
+          mv helmfile /usr/local/bin/helmfile
+          helm plugin install https://github.com/databus23/helm-diff
+          helmfile version
+          helm version
 
-  #     - name: Test CLI Commands
-  #       run: |
-  #         command -v kind
-  #         command -v kubectl
-  #         command -v helm
-  #         command -v helmfile
+      - name: Test CLI Commands
+        run: |
+          command -v kind
+          command -v kubectl
+          command -v helm
+          command -v helmfile
 
-  #     - name: Test k8s V2 opensearch2
-  #       run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8sV2Helmfile
-  #       working-directory: ./e2e
+      - name: Test k8s V2 opensearch2
+        run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8sV2Helmfile
+        working-directory: ./e2e
 
-  # e2e-k8s-v2-encrypted-tests:
-  #   runs-on: ubuntu-latest
-  #   needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
-  #   strategy:
-  #     # opensearch is finiky, keep testing others if it fails
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_STORAGE) }}
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  e2e-k8s-v2-encrypted-tests:
+    runs-on: ubuntu-latest
+    needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
+    strategy:
+      # opensearch is finiky, keep testing others if it fails
+      fail-fast: false
+      matrix:
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_STORAGE) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
-  #     # we login to docker to avoid docker pull limit rates
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
+      # we login to docker to avoid docker pull limit rates
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-  #     - name: Install and build packages
-  #       run: yarn && yarn setup
+      - name: Install and build packages
+        run: yarn && yarn setup
 
-  #     - name: Create Docker Image List
-  #       run: |
-  #         yarn docker:listImages
-  #         cat ./images/image-list.txt
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
 
-  #     - name: Restore Docker image cache
-  #       id: docker-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/docker_cache
-  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-  #     - name: Install mkcert
-  #       run: curl -Ss -JLO "https://dl.filippo.io/mkcert/v1.4.4?for=linux/amd64" && sudo chmod 777 mkcert-v1.4.4-linux-amd64 && sudo cp mkcert-v1.4.4-linux-amd64 /usr/local/bin/mkcert
+      - name: Install mkcert
+        run: curl -Ss -JLO "https://dl.filippo.io/mkcert/v1.4.4?for=linux/amd64" && sudo chmod 777 mkcert-v1.4.4-linux-amd64 && sudo cp mkcert-v1.4.4-linux-amd64 /usr/local/bin/mkcert
 
-  #     - name: Install grep
-  #       run: sudo apt update && sudo apt install grep
+      - name: Install grep
+        run: sudo apt update && sudo apt install grep
 
-  #     - name: Check mkcert
-  #       run: command -v mkcert
+      - name: Check mkcert
+        run: command -v mkcert
 
-  #     - name: Check grep
-  #       run: command -v grep
+      - name: Check grep
+        run: command -v grep
 
-  #     - name: Compile e2e code
-  #       run: yarn build
-  #       working-directory: ./e2e
+      - name: Compile e2e code
+        run: yarn build
+        working-directory: ./e2e
 
-  #     - name: Get Asset Bundle List From Artifact
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: asset-bundle-txt-file-list
-  #         path: ${{ github.workspace }}/e2e/scripts
+      - name: Get Asset Bundle List From Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: asset-bundle-txt-file-list
+          path: ${{ github.workspace }}/e2e/scripts
 
-  #     - name: Restore asset bundle cache
-  #       id: asset-bundle-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/teraslice_assets
-  #         key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
+      - name: Restore asset bundle cache
+        id: asset-bundle-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/teraslice_assets
+          key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
 
-  #     - name: Install Kind and Kubectl
-  #       uses: helm/kind-action@v1.10.0
-  #       with:
-  #         install_only: "true"
+      - name: Install Kind and Kubectl
+        uses: helm/kind-action@v1.10.0
+        with:
+          install_only: "true"
 
-  #     - name: Install Helmfile
-  #       run: |
-  #         VERSION=$(curl -s https://api.github.com/repos/helmfile/helmfile/releases/latest | jq -r '.tag_name')
-  #         VERSION_NO_V=${VERSION#v}
-  #         curl -L "https://github.com/helmfile/helmfile/releases/download/${VERSION}/helmfile_${VERSION_NO_V}_linux_amd64.tar.gz" -o helmfile.tgz
-  #         tar -xzf helmfile.tgz
-  #         chmod +x helmfile
-  #         mv helmfile /usr/local/bin/helmfile
-  #         helm plugin install https://github.com/databus23/helm-diff
-  #         helmfile version
-  #         helm version
+      - name: Install Helmfile
+        run: |
+          VERSION=$(curl -s https://api.github.com/repos/helmfile/helmfile/releases/latest | jq -r '.tag_name')
+          VERSION_NO_V=${VERSION#v}
+          curl -L "https://github.com/helmfile/helmfile/releases/download/${VERSION}/helmfile_${VERSION_NO_V}_linux_amd64.tar.gz" -o helmfile.tgz
+          tar -xzf helmfile.tgz
+          chmod +x helmfile
+          mv helmfile /usr/local/bin/helmfile
+          helm plugin install https://github.com/databus23/helm-diff
+          helmfile version
+          helm version
 
-  #     - name: Test CLI Commands
-  #       run: |
-  #         command -v kind
-  #         command -v kubectl
-  #         command -v helm
-  #         command -v helmfile
+      - name: Test CLI Commands
+        run: |
+          command -v kind
+          command -v kubectl
+          command -v helm
+          command -v helmfile
 
-  #     - name: Test k8s V2 opensearch2
-  #       run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8sV2HelmfileEncrypted
-  #       working-directory: ./e2e
+      - name: Test k8s V2 opensearch2
+        run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8sV2HelmfileEncrypted
+        working-directory: ./e2e
 
-  # e2e-external-storage-tests:
-  #   env:
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   runs-on: ubuntu-latest
-  #   needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
-  #   strategy:
-  #     # opensearch is finiky, keep testing others if it fails
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_STORAGE) }}
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  e2e-external-storage-tests:
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: ubuntu-latest
+    needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
+    strategy:
+      # opensearch is finiky, keep testing others if it fails
+      fail-fast: false
+      matrix:
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_STORAGE) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
-  #     # we login to docker to avoid docker pull limit rates
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
+      # we login to docker to avoid docker pull limit rates
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-  #     - name: Install and build packages
-  #       run: yarn && yarn setup
+      - name: Install and build packages
+        run: yarn && yarn setup
 
-  #     - name: Create Docker Image List
-  #       run: |
-  #         yarn docker:listImages
-  #         cat ./images/image-list.txt
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
 
-  #     - name: Restore Docker image cache
-  #       id: docker-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/docker_cache
-  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-  #     - name: Compile e2e code
-  #       run: yarn build
-  #       working-directory: ./e2e
+      - name: Compile e2e code
+        run: yarn build
+        working-directory: ./e2e
 
-  #     - name: Get Asset Bundle List From Artifact
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: asset-bundle-txt-file-list
-  #         path: ${{ github.workspace }}/e2e/scripts
+      - name: Get Asset Bundle List From Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: asset-bundle-txt-file-list
+          path: ${{ github.workspace }}/e2e/scripts
 
-  #     - name: Restore asset bundle cache
-  #       id: asset-bundle-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/teraslice_assets
-  #         key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
+      - name: Restore asset bundle cache
+        id: asset-bundle-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/teraslice_assets
+          key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
 
-  #     - name: Test external Asset Storage opensearch1
-  #       run: NODE_VERSION=${{ matrix.node-version }} yarn test:s3AssetStorage
-  #       working-directory: ./e2e
+      - name: Test external Asset Storage opensearch1
+        run: NODE_VERSION=${{ matrix.node-version }} yarn test:s3AssetStorage
+        working-directory: ./e2e
 
   teraslice-elasticsearch-tests:
     runs-on: ubuntu-latest
@@ -608,77 +608,77 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true # optional (default = false)
 
-  # e2e-tests:
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
-  #   strategy:
-  #     # opensearch is finiky, keep testing others if it fails
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
-  #       search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
+  e2e-tests:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    needs: [compute-node-version-vars, verify-build, cache-docker-images, cache-asset-bundles]
+    strategy:
+      # opensearch is finiky, keep testing others if it fails
+      fail-fast: false
+      matrix:
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS) }}
+        search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
-  #     - name: Setup Node ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'yarn'
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
-  #     # we login to docker to avoid docker pull limit rates
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
+      # we login to docker to avoid docker pull limit rates
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-  #     - name: Install and build packages
-  #       run: yarn && yarn setup
+      - name: Install and build packages
+        run: yarn && yarn setup
 
-  #     - name: Create Docker Image List
-  #       run: |
-  #         yarn docker:listImages
-  #         cat ./images/image-list.txt
+      - name: Create Docker Image List
+        run: |
+          yarn docker:listImages
+          cat ./images/image-list.txt
 
-  #     - name: Restore Docker image cache
-  #       id: docker-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/docker_cache
-  #         key: docker-images-${{ hashFiles('./images/image-list.txt') }}
+      - name: Restore Docker image cache
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker_cache
+          key: docker-images-${{ hashFiles('./images/image-list.txt') }}
 
-  #     - name: Compile e2e code
-  #       run: yarn build
-  #       working-directory: ./e2e
+      - name: Compile e2e code
+        run: yarn build
+        working-directory: ./e2e
 
-  #     - name: Get Asset Bundle List From Artifact
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: asset-bundle-txt-file-list
-  #         path: ${{ github.workspace }}/e2e/scripts
+      - name: Get Asset Bundle List From Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: asset-bundle-txt-file-list
+          path: ${{ github.workspace }}/e2e/scripts
 
-  #     - name: Restore asset bundle cache
-  #       id: asset-bundle-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: /tmp/teraslice_assets
-  #         key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
+      - name: Restore asset bundle cache
+        id: asset-bundle-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/teraslice_assets
+          key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
 
-  #     - name: Test ${{ matrix.search-version }}
-  #       run: NODE_VERSION=${{ matrix.node-version }} yarn test:${{ matrix.search-version }}
-  #       working-directory: ./e2e
+      - name: Test ${{ matrix.search-version }}
+        run: NODE_VERSION=${{ matrix.node-version }} yarn test:${{ matrix.search-version }}
+        working-directory: ./e2e
 
   check-docker-limit-after:
     needs: [
-      # e2e-k8s-v2-encrypted-tests,
-      # e2e-external-storage-tests,
-      # e2e-k8s-v2-tests,
-      # e2e-k8s-tests,
-      # e2e-tests,
+      e2e-k8s-v2-encrypted-tests,
+      e2e-external-storage-tests,
+      e2e-k8s-v2-tests,
+      e2e-k8s-tests,
+      e2e-tests,
       elasticsearch-api-tests,
       elasticsearch-store-tests,
       teraslice-elasticsearch-tests
@@ -688,11 +688,11 @@ jobs:
 
   check-github-api-limit-after:
     needs: [
-      # e2e-k8s-v2-encrypted-tests,
-      # e2e-external-storage-tests,
-      # e2e-k8s-v2-tests,
-      # e2e-k8s-tests,
-      # e2e-tests,
+      e2e-k8s-v2-encrypted-tests,
+      e2e-external-storage-tests,
+      e2e-k8s-v2-tests,
+      e2e-k8s-tests,
+      e2e-tests,
       elasticsearch-api-tests,
       elasticsearch-store-tests,
       teraslice-elasticsearch-tests

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -92,7 +92,7 @@ export default (projectDir) => {
         },
         roots: [`${packageRoot}/test`],
         collectCoverage: true,
-        coverageReporters: ['lcov', coverageReporters]
+        coverageReporters: coverageReporters
     };
 
     if (fs.existsSync(path.join(projectDir, 'test/global.setup.js'))) {

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -83,7 +83,9 @@ export default (projectDir) => {
                     }
                 }]
         },
-        roots: [`${packageRoot}/test`]
+        roots: [`${packageRoot}/test`],
+        collectCoverage: true,
+        coverageReporters: ['lcov', 'text-summary']
     };
 
     if (fs.existsSync(path.join(projectDir, 'test/global.setup.js'))) {

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCI } from '@terascope/utils';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -28,6 +29,12 @@ export default (projectDir) => {
         workspaceName = `packages/${name}`;
         packageRoot = `<rootDir>/${workspaceName}`;
         rootDir = '../../';
+    }
+
+    const coverageReporters = ['lcov'];
+
+    if (!isCI) {
+        coverageReporters.push('text-summary');
     }
 
     const config = {
@@ -85,7 +92,7 @@ export default (projectDir) => {
         },
         roots: [`${packageRoot}/test`],
         collectCoverage: true,
-        coverageReporters: ['lcov', 'text-summary']
+        coverageReporters: ['lcov', coverageReporters]
     };
 
     if (fs.existsSync(path.join(projectDir, 'test/global.setup.js'))) {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-// import { isCI } from '@terascope/utils';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -26,12 +25,6 @@ const projects = fs
     })
     .map((pkgName) => `<rootDir>/packages/${pkgName}`);
 
-// const coverageReporters = ['lcov', 'html'];
-
-// if (!isCI) {
-//     coverageReporters.push('text-summary');
-// }
-
 export default {
     rootDir: '.',
     verbose: true,
@@ -54,22 +47,6 @@ export default {
         '<rootDir>/packages/*/dist',
         '<rootDir>/packages/teraslice-cli/test/fixtures/'
     ],
-    // collectCoverage: true,
-    // collectCoverageFrom: [
-    //     '<rootDir>/packages/*/index.js',
-    //     '<rootDir>/packages/*/lib/*.js',
-    //     '<rootDir>/packages/*/lib/**/*.js',
-    //     '<rootDir>/packages/*/cmds/*.js',
-    //     '<rootDir>/packages/*/cmds/**/*.js',
-    //     '<rootDir>/packages/*/src/**/*.ts',
-    //     '<rootDir>/packages/*/src/*.ts',
-    //     '!<rootDir>/packages/**/*.json',
-    //     '!<rootDir>/packages/**/*.d.ts',
-    //     '!<rootDir>/packages/**/dist/**',
-    //     '!<rootDir>/packages/**/coverage/**'
-    // ],
-    // coverageReporters,
-    // coverageDirectory: '<rootDir>/coverage',
     moduleNameMapper: {
         '^(\\.{1,2}/.*)\\.js$': '$1',
     },

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { isCI } from '@terascope/utils';
+// import { isCI } from '@terascope/utils';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -26,11 +26,11 @@ const projects = fs
     })
     .map((pkgName) => `<rootDir>/packages/${pkgName}`);
 
-const coverageReporters = ['lcov', 'html'];
+// const coverageReporters = ['lcov', 'html'];
 
-if (!isCI) {
-    coverageReporters.push('text-summary');
-}
+// if (!isCI) {
+//     coverageReporters.push('text-summary');
+// }
 
 export default {
     rootDir: '.',
@@ -54,22 +54,22 @@ export default {
         '<rootDir>/packages/*/dist',
         '<rootDir>/packages/teraslice-cli/test/fixtures/'
     ],
-    collectCoverage: true,
-    collectCoverageFrom: [
-        '<rootDir>/packages/*/index.js',
-        '<rootDir>/packages/*/lib/*.js',
-        '<rootDir>/packages/*/lib/**/*.js',
-        '<rootDir>/packages/*/cmds/*.js',
-        '<rootDir>/packages/*/cmds/**/*.js',
-        '<rootDir>/packages/*/src/**/*.ts',
-        '<rootDir>/packages/*/src/*.ts',
-        '!<rootDir>/packages/**/*.json',
-        '!<rootDir>/packages/**/*.d.ts',
-        '!<rootDir>/packages/**/dist/**',
-        '!<rootDir>/packages/**/coverage/**'
-    ],
-    coverageReporters,
-    coverageDirectory: '<rootDir>/coverage',
+    // collectCoverage: true,
+    // collectCoverageFrom: [
+    //     '<rootDir>/packages/*/index.js',
+    //     '<rootDir>/packages/*/lib/*.js',
+    //     '<rootDir>/packages/*/lib/**/*.js',
+    //     '<rootDir>/packages/*/cmds/*.js',
+    //     '<rootDir>/packages/*/cmds/**/*.js',
+    //     '<rootDir>/packages/*/src/**/*.ts',
+    //     '<rootDir>/packages/*/src/*.ts',
+    //     '!<rootDir>/packages/**/*.json',
+    //     '!<rootDir>/packages/**/*.d.ts',
+    //     '!<rootDir>/packages/**/dist/**',
+    //     '!<rootDir>/packages/**/coverage/**'
+    // ],
+    // coverageReporters,
+    // coverageDirectory: '<rootDir>/coverage',
     moduleNameMapper: {
         '^(\\.{1,2}/.*)\\.js$': '$1',
     },

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -34,7 +34,6 @@
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
         "@terascope/utils": "~1.7.7",
-        "codecov": "~3.8.3",
         "execa": "~9.5.2",
         "fs-extra": "~11.3.0",
         "globby": "~14.1.0",

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -19,7 +19,7 @@ import {
 } from '../scripts.js';
 import { Kind } from '../kind.js';
 import {
-    getArgs, filterBySuite, reportCoverage,
+    getArgs, filterBySuite,
     logE2E, getEnv, groupBySuite,
     generateTestCaCerts, createMinioSecret
 } from './utils.js';
@@ -141,10 +141,7 @@ async function runTestSuite(
 
     const env = printAndGetEnv(suite, options);
 
-    let chunkIndex = -1;
     for (const pkgs of chunked) {
-        chunkIndex++;
-
         if (!pkgs.length) continue;
         if (pkgs.length === 1) {
             writePkgHeader('Running test', pkgs, false);

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -175,10 +175,6 @@ async function runTestSuite(
                 signale.error('Bailing out of tests due to error');
                 break;
             }
-        } finally {
-            if (options.reportCoverage) {
-                // await reportCoverage(suite, chunkIndex);
-            }
         }
     }
 

--- a/packages/scripts/src/helpers/test-runner/index.ts
+++ b/packages/scripts/src/helpers/test-runner/index.ts
@@ -180,7 +180,7 @@ async function runTestSuite(
             }
         } finally {
             if (options.reportCoverage) {
-                await reportCoverage(suite, chunkIndex);
+                // await reportCoverage(suite, chunkIndex);
             }
         }
     }

--- a/packages/scripts/src/helpers/test-runner/utils.ts
+++ b/packages/scripts/src/helpers/test-runner/utils.ts
@@ -34,7 +34,6 @@ export function getArgs(options: TestOptions): ArgsMap {
 
     if (options.debug || options.trace) {
         args.detectOpenHandles = options.trace ? 'true' : 'false';
-        args.coverage = 'false';
         args.runInBand = '';
     } else {
         args.silent = '';

--- a/packages/scripts/src/helpers/test-runner/utils.ts
+++ b/packages/scripts/src/helpers/test-runner/utils.ts
@@ -6,8 +6,7 @@ import {
     isCI, toString, TSError
 } from '@terascope/utils';
 import {
-    ArgsMap, ExecEnv, exec,
-    fork,
+    ArgsMap, ExecEnv, exec
 } from '../scripts.js';
 import { TestOptions, GroupedPackages } from './interfaces.js';
 import { PackageInfo, Service } from '../interfaces.js';
@@ -274,22 +273,6 @@ export async function logE2E(dir: string, failed: boolean): Promise<void> {
         FORCE_COLOR: isCI ? '0' : '1',
     });
     process.stderr.write(`${errLogs}\n`);
-}
-
-const abc = 'abcdefghijklmnopqrstuvwxyz';
-
-export async function reportCoverage(suite: string, chunkIndex: number): Promise<void> {
-    const id = abc[chunkIndex] || 'any';
-
-    signale.info('* reporting coverage');
-    try {
-        await fork({
-            cmd: 'codecov',
-            args: ['--clear', '--flags', `${suite}-${id}`],
-        });
-    } catch (err) {
-        signale.error(err);
-    }
 }
 
 /**

--- a/packages/teraslice/test/storage/s3_store-spec.ts
+++ b/packages/teraslice/test/storage/s3_store-spec.ts
@@ -36,18 +36,18 @@ describe('S3 backend test', () => {
             }
         }
     };
-    // describe('->S3Store', () => {
-    //     it('should throw when given an invalid bucket name', async () => {
-    //         s3Backend = new S3Store({
-    //             context,
-    //             terafoundation: context.sysconfig.terafoundation,
-    //             connection: 'default',
-    //             bucket: 'Invalid-Bucket-Name@'
-    //         });
+    describe('->S3Store', () => {
+        it('should throw when given an invalid bucket name', async () => {
+            s3Backend = new S3Store({
+                context,
+                terafoundation: context.sysconfig.terafoundation,
+                connection: 'default',
+                bucket: 'Invalid-Bucket-Name@'
+            });
 
-    //         await expect(s3Backend.initialize()).rejects.toThrow('Bucket name does not follow S3 naming rules: The specified bucket is not valid.');
-    //     });
-    // });
+            await expect(s3Backend.initialize()).rejects.toThrow('Bucket name does not follow S3 naming rules: The specified bucket is not valid.');
+        });
+    });
 
     describe('->verifyClient', () => {
         beforeEach(async () => {

--- a/packages/teraslice/test/storage/s3_store-spec.ts
+++ b/packages/teraslice/test/storage/s3_store-spec.ts
@@ -36,6 +36,18 @@ describe('S3 backend test', () => {
             }
         }
     };
+    describe('->S3Store', () => {
+        it('should throw when given an invalid bucket name', async () => {
+            s3Backend = new S3Store({
+                context,
+                terafoundation: context.sysconfig.terafoundation,
+                connection: 'default',
+                bucket: 'Invalid-Bucket-Name@'
+            });
+
+            await expect(s3Backend.initialize()).rejects.toThrow('Bucket name does not follow S3 naming rules: The specified bucket is not valid.');
+        });
+    });
 
     describe('->verifyClient', () => {
         beforeEach(async () => {

--- a/packages/teraslice/test/storage/s3_store-spec.ts
+++ b/packages/teraslice/test/storage/s3_store-spec.ts
@@ -36,18 +36,18 @@ describe('S3 backend test', () => {
             }
         }
     };
-    describe('->S3Store', () => {
-        it('should throw when given an invalid bucket name', async () => {
-            s3Backend = new S3Store({
-                context,
-                terafoundation: context.sysconfig.terafoundation,
-                connection: 'default',
-                bucket: 'Invalid-Bucket-Name@'
-            });
+    // describe('->S3Store', () => {
+    //     it('should throw when given an invalid bucket name', async () => {
+    //         s3Backend = new S3Store({
+    //             context,
+    //             terafoundation: context.sysconfig.terafoundation,
+    //             connection: 'default',
+    //             bucket: 'Invalid-Bucket-Name@'
+    //         });
 
-            await expect(s3Backend.initialize()).rejects.toThrow('Bucket name does not follow S3 naming rules: The specified bucket is not valid.');
-        });
-    });
+    //         await expect(s3Backend.initialize()).rejects.toThrow('Bucket name does not follow S3 naming rules: The specified bucket is not valid.');
+    //     });
+    // });
 
     describe('->verifyClient', () => {
         beforeEach(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,7 +2907,6 @@ __metadata:
     "@types/semver": "npm:~7.5.8"
     "@types/signale": "npm:~1.4.7"
     "@types/toposort": "npm:~2.0.7"
-    codecov: "npm:~3.8.3"
     execa: "npm:~9.5.2"
     fs-extra: "npm:~11.3.0"
     globby: "npm:~14.1.0"
@@ -3020,13 +3019,6 @@ __metadata:
     validator: "npm:~13.12.0"
   languageName: unknown
   linkType: soft
-
-"@tootallnate/once@npm:1":
-  version: 1.1.2
-  resolution: "@tootallnate/once@npm:1.1.2"
-  checksum: 10c0/8fe4d006e90422883a4fa9339dd05a83ff626806262e1710cee5758d493e8cbddf2db81c0e4690636dc840b02c9fda62877866ea774ebd07c1777ed5fafbdec6
-  languageName: node
-  linkType: hard
 
 "@ts-morph/common@npm:~0.19.0":
   version: 0.19.0
@@ -4189,15 +4181,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:6":
-  version: 6.0.2
-  resolution: "agent-base@npm:6.0.2"
-  dependencies:
-    debug: "npm:4"
-  checksum: 10c0/dc4f757e40b5f3e3d674bc9beb4f1048f4ee83af189bae39be99f57bf1f48dde166a8b0a5342a84b5944ee8e6ed1e5a9d801858f4ad44764e84957122fe46261
-  languageName: node
-  linkType: hard
-
 "agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
   version: 7.1.3
   resolution: "agent-base@npm:7.1.3"
@@ -4398,13 +4381,6 @@ __metadata:
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
   checksum: 10c0/c5640c2d89045371c7cedd6a70212a04e360fd34d6edeae32f6952c63949e3525ea77dbec0289d8213a99bbaeab5abfa860b5c12cf88a2e6cf8106e90dd27a7e
-  languageName: node
-  linkType: hard
-
-"argv@npm:0.0.2":
-  version: 0.0.2
-  resolution: "argv@npm:0.0.2"
-  checksum: 10c0/13b7a94bf690b8cf04dcaac0c70b631df10de8a1eeb701f31c85abe46a60db449c1e3330e92ef00ffe2a709a5b35baf815e52cc4b8cbe495829c90ceb3e3e30f
   languageName: node
   linkType: hard
 
@@ -5380,21 +5356,6 @@ __metadata:
   version: 1.1.0
   resolution: "code-point-at@npm:1.1.0"
   checksum: 10c0/33f6b234084e46e6e369b6f0b07949392651b4dde70fc6a592a8d3dafa08d5bb32e3981a02f31f6fc323a26bc03a4c063a9d56834848695bda7611c2417ea2e6
-  languageName: node
-  linkType: hard
-
-"codecov@npm:~3.8.3":
-  version: 3.8.3
-  resolution: "codecov@npm:3.8.3"
-  dependencies:
-    argv: "npm:0.0.2"
-    ignore-walk: "npm:3.0.4"
-    js-yaml: "npm:3.14.1"
-    teeny-request: "npm:7.1.1"
-    urlgrey: "npm:1.0.0"
-  bin:
-    codecov: bin/codecov
-  checksum: 10c0/bf51f421eb91cc6b1f88ad418620516adf187712555967cf23ca5bc734f2ab73743006ee5b2ec45bdc5b5b4db0d67656a5bb4c959fe9df89b009823bd611f789
   languageName: node
   linkType: hard
 
@@ -7115,15 +7076,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-url-parser@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "fast-url-parser@npm:1.1.3"
-  dependencies:
-    punycode: "npm:^1.3.2"
-  checksum: 10c0/d85c5c409cf0215417380f98a2d29c23a95004d93ff0d8bdf1af5f1a9d1fc608ac89ac6ffe863783d2c73efb3850dd35390feb1de3296f49877bfee0392eb5d3
-  languageName: node
-  linkType: hard
-
 "fast-xml-parser@npm:4.4.1":
   version: 4.4.1
   resolution: "fast-xml-parser@npm:4.4.1"
@@ -8030,17 +7982,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "http-proxy-agent@npm:4.0.1"
-  dependencies:
-    "@tootallnate/once": "npm:1"
-    agent-base: "npm:6"
-    debug: "npm:4"
-  checksum: 10c0/4fa4774d65b5331814b74ac05cefea56854fc0d5989c80b13432c1b0d42a14c9f4342ca3ad9f0359a52e78da12b1744c9f8a28e50042136ea9171675d972a5fd
-  languageName: node
-  linkType: hard
-
 "http-proxy-agent@npm:^7.0.0":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
@@ -8069,16 +8010,6 @@ __metadata:
     quick-lru: "npm:^5.1.1"
     resolve-alpn: "npm:^1.2.0"
   checksum: 10c0/7207201d3c6e53e72e510c9b8912e4f3e468d3ecc0cf3bf52682f2aac9cd99358b896d1da4467380adc151cf97c412bedc59dc13dae90c523f42053a7449eedb
-  languageName: node
-  linkType: hard
-
-"https-proxy-agent@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "https-proxy-agent@npm:5.0.1"
-  dependencies:
-    agent-base: "npm:6"
-    debug: "npm:4"
-  checksum: 10c0/6dd639f03434003577c62b27cafdb864784ef19b2de430d8ae2a1d45e31c4fd60719e5637b44db1a88a046934307da7089e03d6089ec3ddacc1189d8de8897d1
   languageName: node
   linkType: hard
 
@@ -8137,15 +8068,6 @@ __metadata:
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 10c0/b0782ef5e0935b9f12883a2e2aa37baa75da6e66ce6515c168697b42160807d9330de9a32ec1ed73149aea02e0d822e572bca6f1e22bdcbd2149e13b050b17bb
-  languageName: node
-  linkType: hard
-
-"ignore-walk@npm:3.0.4":
-  version: 3.0.4
-  resolution: "ignore-walk@npm:3.0.4"
-  dependencies:
-    minimatch: "npm:^3.0.4"
-  checksum: 10c0/690372b433887796fa3badd25babab7daf60a1882259dcc130ec78eea79745c2416322e10d1a96b367071204471c532647d20b11cd7ab70bd9b49879e461f956
   languageName: node
   linkType: hard
 
@@ -9422,7 +9344,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:3.14.1, js-yaml@npm:^3.13.1":
+"js-yaml@npm:^3.13.1":
   version: 3.14.1
   resolution: "js-yaml@npm:3.14.1"
   dependencies:
@@ -10448,20 +10370,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.1":
-  version: 2.7.0
-  resolution: "node-fetch@npm:2.7.0"
-  dependencies:
-    whatwg-url: "npm:^5.0.0"
-  peerDependencies:
-    encoding: ^0.1.0
-  peerDependenciesMeta:
-    encoding:
-      optional: true
-  checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
-  languageName: node
-  linkType: hard
-
 "node-gyp-build@npm:^4.8.0":
   version: 4.8.4
   resolution: "node-gyp-build@npm:4.8.4"
@@ -11476,13 +11384,6 @@ __metadata:
   version: 2.3.1
   resolution: "punycode.js@npm:2.3.1"
   checksum: 10c0/1d12c1c0e06127fa5db56bd7fdf698daf9a78104456a6b67326877afc21feaa821257b171539caedd2f0524027fa38e67b13dd094159c8d70b6d26d2bea4dfdb
-  languageName: node
-  linkType: hard
-
-"punycode@npm:^1.3.2":
-  version: 1.4.1
-  resolution: "punycode@npm:1.4.1"
-  checksum: 10c0/354b743320518aef36f77013be6e15da4db24c2b4f62c5f1eb0529a6ed02fbaf1cb52925785f6ab85a962f2b590d9cd5ad730b70da72b5f180e2556b8bd3ca08
   languageName: node
   linkType: hard
 
@@ -12532,15 +12433,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stream-events@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "stream-events@npm:1.0.5"
-  dependencies:
-    stubs: "npm:^3.0.0"
-  checksum: 10c0/5d235a5799a483e94ea8829526fe9d95d76460032d5e78555fe4f801949ac6a27ea2212e4e0827c55f78726b3242701768adf2d33789465f51b31ed8ebd6b086
-  languageName: node
-  linkType: hard
-
 "stream-source@npm:0.3":
   version: 0.3.5
   resolution: "stream-source@npm:0.3.5"
@@ -12816,13 +12708,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stubs@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "stubs@npm:3.0.0"
-  checksum: 10c0/841a4ab8c76795d34aefe129185763b55fbf2e4693208215627caea4dd62e1299423dcd96f708d3128e3dfa0e669bae2cb912e6e906d7d81eaf6493196570923
-  languageName: node
-  linkType: hard
-
 "supports-color@npm:^2.0.0":
   version: 2.0.0
   resolution: "supports-color@npm:2.0.0"
@@ -12930,19 +12815,6 @@ __metadata:
   dependencies:
     bintrees: "npm:1.0.2"
   checksum: 10c0/10187b8144b112fcdfd3a5e4e9068efa42c990b1e30cd0d4f35ee8f58f16d1b41bc587e668fa7a6f6ca31308961cbd06cd5d4a4ae1dc388335902ae04f7d57df
-  languageName: node
-  linkType: hard
-
-"teeny-request@npm:7.1.1":
-  version: 7.1.1
-  resolution: "teeny-request@npm:7.1.1"
-  dependencies:
-    http-proxy-agent: "npm:^4.0.0"
-    https-proxy-agent: "npm:^5.0.0"
-    node-fetch: "npm:^2.6.1"
-    stream-events: "npm:^1.0.5"
-    uuid: "npm:^8.0.0"
-  checksum: 10c0/edbcd2f90429b66574d38ba8ffc5fe530659b7693c5f95ea5e6cea70bf4c640ca36c7100e24931a4b16b35488173ed172d7679877464613ad1c50ce38ed5b2a2
   languageName: node
   linkType: hard
 
@@ -13227,13 +13099,6 @@ __metadata:
     psl: "npm:^1.1.28"
     punycode: "npm:^2.1.1"
   checksum: 10c0/e1cadfb24d40d64ca16de05fa8192bc097b66aeeb2704199b055ff12f450e4f30c927ce250f53d01f39baad18e1c11d66f65e545c5c6269de4c366fafa4c0543
-  languageName: node
-  linkType: hard
-
-"tr46@npm:~0.0.3":
-  version: 0.0.3
-  resolution: "tr46@npm:0.0.3"
-  checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
   languageName: node
   linkType: hard
 
@@ -13705,15 +13570,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"urlgrey@npm:1.0.0":
-  version: 1.0.0
-  resolution: "urlgrey@npm:1.0.0"
-  dependencies:
-    fast-url-parser: "npm:^1.1.3"
-  checksum: 10c0/6fe2bfa0510fa395d489a73841f8c7e8eeb78331589a12f05b1e8f22d235d6999524579f17458f2b7856efd39f4b8347ef446acbf35c08d8b548d6d95f3b842f
-  languageName: node
-  linkType: hard
-
 "util-deprecate@npm:^1.0.1, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
@@ -13737,7 +13593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.0.0, uuid@npm:^8.3.2":
+"uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:
@@ -13822,23 +13678,6 @@ __metadata:
   dependencies:
     defaults: "npm:^1.0.3"
   checksum: 10c0/5b61ca583a95e2dd85d7078400190efd452e05751a64accb8c06ce4db65d7e0b0cde9917d705e826a2e05cc2548f61efde115ffa374c3e436d04be45c889e5b4
-  languageName: node
-  linkType: hard
-
-"webidl-conversions@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "webidl-conversions@npm:3.0.1"
-  checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
-  languageName: node
-  linkType: hard
-
-"whatwg-url@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "whatwg-url@npm:5.0.0"
-  dependencies:
-    tr46: "npm:~0.0.3"
-    webidl-conversions: "npm:^3.0.0"
-  checksum: 10c0/1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR makes the following changes:

- Adds code coverage and uploads coverage to `codecov` 
  - Coverage targets all `unit`, `elasticsearch-store-integration`, `teraslice-integration`, and `elasticsearch-api-integration` tests
  - Excludes `e2e` test coverage for now 
    - #4011
- Adds more tests to `s3Store` class in teraslice
- Removes deprecated [codecov](https://www.npmjs.com/package/codecov) npm package in favor of using the `codecov` Github action for uploading coverage data
  - Removes related `codecov` upload functionality out of scripts

NOTE: Unit tests no longer run in parallel because jest will miss significant code coverage
https://github.com/jestjs/jest/issues/4255

Ref to issue #4004