### PR TITLE
[e2e, helm] autoload_directory should be created in e2e helm, not be default in helm chart

### DIFF
--- a/e2e/helm/templates/teraslice.yaml.gotmpl
+++ b/e2e/helm/templates/teraslice.yaml.gotmpl
@@ -192,6 +192,8 @@ master:
         asset_storage_connection_type: {{ .Values | get "teraslice.asset_storage_connection_type" "elasticsearch-next" }}
         asset_storage_connection: {{ .Values | get "teraslice.asset_storage_connection" "default" }}
         name: "ts-dev1"
+        autoload_directory: /app/autoload
+
 
 worker:
     teraslice:
@@ -200,3 +202,4 @@ worker:
         asset_storage_connection_type: {{ .Values | get "teraslice.asset_storage_connection_type" "elasticsearch-next" }}
         asset_storage_connection: {{ .Values | get "teraslice.asset_storage_connection" "default" }}
         name: "ts-dev1"
+        autoload_directory: /app/autoload

--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -1,8 +1,10 @@
 apiVersion: v2
 name: teraslice-chart
 description: Teraslice -  Distributed computing platform for processing JSON data
+home: https://github.com/terascope/teraslice
+icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 2.3.0
+version: 2.3.1
 appVersion: v2.14.1
 sources:
   - https://github.com/terascope/teraslice

--- a/helm/teraslice/values.yaml
+++ b/helm/teraslice/values.yaml
@@ -38,14 +38,12 @@ priorityClass:
 master:
   teraslice:
     assets_directory: /app/assets
-    autoload_directory: /app/autoload
     workers: 0
 
 # Teraslice Worker Config Options
 worker:
   teraslice:
     assets_directory: /app/assets
-    autoload_directory: /app/autoload
 
 # Terafoundation
 # Everything under terafoundation key will used as the master and worker config


### PR DESCRIPTION
This PR fixes a mistake that added `autoload_directory` to the default teraslice helm `values.yaml`. This setting is only needed for e2e, so is now set in `e2e/helm/templates/teraslice.yaml.gotmpl`.

The chart is bumped to version 2.3.1

I also added `icon` and `home` links to the chart.