### PR TITLE
[E2e, utils] Validate service ports when running ci tests

### DIFF
--- a/e2e/k8s/kindConfigTestPorts.yaml
+++ b/e2e/k8s/kindConfigTestPorts.yaml
@@ -8,6 +8,12 @@ nodes:
   # teraslice port mapping needs to be at index 0 in this array
   - containerPort: 30678 # Map internal teraslice service to host port
     hostPort: 45678
+
+  # Leaving this commented out instead if removing. `hostPort` is now dynamic but
+  # `containerPort` is still hardcoded and is useful information to list
+  # These values are dynamically set here:
+  # https://github.com/terascope/teraslice/blob/c83e68c196d926c96bffb37f544c2751ffcc78d3/packages/scripts/src/helpers/kind.ts#L52-L80
+  #
   # - containerPort: 30200 # Map internal elasticsearch service to host port
   #   hostPort: 49200
   # - containerPort: 30210 # Map internal opensearch service to host port
@@ -20,6 +26,7 @@ nodes:
   #   hostPort: 49000
   # - containerPort: 30901 # Map internal minio-ui service to host port
   #   hostPort: 49001
+
   extraMounts:
   - hostPath: ./e2e/autoload
     containerPath: /autoload

--- a/e2e/k8s/kindConfigTestPorts.yaml
+++ b/e2e/k8s/kindConfigTestPorts.yaml
@@ -8,18 +8,18 @@ nodes:
   # teraslice port mapping needs to be at index 0 in this array
   - containerPort: 30678 # Map internal teraslice service to host port
     hostPort: 45678
-  - containerPort: 30200 # Map internal elasticsearch service to host port
-    hostPort: 49200
-  - containerPort: 30210 # Map internal opensearch service to host port
-    hostPort: 49210
-  - containerPort: 30092 # Map internal kafka service to host port
-    hostPort: 49092
-  - containerPort: 30094 # Map external kafka service to host port
-    hostPort: 49094
-  - containerPort: 30900 # Map internal minio service to host port
-    hostPort: 49000
-  - containerPort: 30901 # Map internal minio-ui service to host port
-    hostPort: 49001
+  # - containerPort: 30200 # Map internal elasticsearch service to host port
+  #   hostPort: 49200
+  # - containerPort: 30210 # Map internal opensearch service to host port
+  #   hostPort: 49210
+  # - containerPort: 30092 # Map internal kafka service to host port
+  #   hostPort: 49092
+  # - containerPort: 30094 # Map external kafka service to host port
+  #   hostPort: 49094
+  # - containerPort: 30900 # Map internal minio service to host port
+  #   hostPort: 49000
+  # - containerPort: 30901 # Map internal minio-ui service to host port
+  #   hostPort: 49001
   extraMounts:
   - hostPath: ./e2e/autoload
     containerPath: /autoload

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -47,11 +47,11 @@
         "ms": "~2.1.3"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.14.1",
+        "@terascope/scripts": "~1.15.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "bunyan": "~1.8.15",
-        "elasticsearch-store": "~1.9.2",
+        "elasticsearch-store": "~1.10.0",
         "fs-extra": "~11.3.0",
         "jest": "^29.7.0",
         "jest-extended": "^4.0.2",

--- a/e2e/test/cases/kafka/kafka-spec.ts
+++ b/e2e/test/cases/kafka/kafka-spec.ts
@@ -3,7 +3,8 @@ import { exec } from '@terascope/scripts';
 import { TerasliceHarness } from '../../teraslice-harness.js';
 import signale from '../../signale.js';
 import {
-    CERT_PATH, ENCRYPT_KAFKA, ROOT_CERT_PATH, TEST_PLATFORM
+    CERT_PATH, ENCRYPT_KAFKA, ROOT_CERT_PATH,
+    TEST_PLATFORM, KAFKA_PORT
 } from '../../config.js';
 
 describe('kafka', () => {
@@ -74,7 +75,7 @@ describe('kafka', () => {
             it('should have an encrypted connection', async () => {
                 const result = await exec({
                     cmd: 'sh',
-                    args: ['-c', `printf '\\n' | openssl s_client -connect localhost:49094 -cert ${CERT_PATH}/kafka-keypair.pem -key ${CERT_PATH}/kafka-keypair.pem -CAfile ${ROOT_CERT_PATH}`]
+                    args: ['-c', `printf '\\n' | openssl s_client -connect localhost:${KAFKA_PORT} -cert ${CERT_PATH}/kafka-keypair.pem -key ${CERT_PATH}/kafka-keypair.pem -CAfile ${ROOT_CERT_PATH}`]
                 });
                 // console.log('s_client output: ', result);
                 expect(result).toContain('Verification: OK');

--- a/e2e/test/config.ts
+++ b/e2e/test/config.ts
@@ -48,6 +48,7 @@ const WORKERS_PER_NODE = 8;
 
 const {
     KAFKA_BROKER = 'locahost:9092',
+    KAFKA_PORT = '49094',
     HOST_IP = '127.0.0.1',
     GENERATE_ONLY,
     TEST_OPENSEARCH = false,
@@ -99,6 +100,7 @@ export {
     ELASTICSEARCH_VERSION,
     HOST_IP,
     KAFKA_BROKER,
+    KAFKA_PORT,
     CLUSTER_NAME,
     TEST_INDEX_PREFIX,
     DEFAULT_NODES,

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@eslint/js": "~9.23.0",
         "@swc/core": "1.11.13",
         "@swc/jest": "~0.2.37",
-        "@terascope/scripts": "~1.14.1",
+        "@terascope/scripts": "~1.15.0",
         "@types/bluebird": "~3.5.42",
         "@types/convict": "~6.1.6",
         "@types/elasticsearch": "~5.0.43",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "1.7.9",
+    "version": "1.8.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -30,9 +30,9 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../data-mate --"
     },
     "dependencies": {
-        "@terascope/data-types": "~1.7.8",
+        "@terascope/data-types": "~1.8.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "@types/validator": "~13.12.2",
         "awesome-phonenumber": "~7.4.0",
         "date-fns": "~4.1.0",
@@ -45,7 +45,7 @@
         "uuid": "~11.1.0",
         "valid-url": "~1.0.9",
         "validator": "~13.12.0",
-        "xlucene-parser": "~1.7.9"
+        "xlucene-parser": "~1.8.0"
     },
     "devDependencies": {
         "@types/ip6addr": "~0.2.6",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "1.7.8",
+    "version": "1.8.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "graphql": "~16.10.0",
         "yargs": "~17.7.2"
     },

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "4.8.6",
+    "version": "4.9.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -25,7 +25,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "bluebird": "~3.7.2",
         "setimmediate": "~1.0.5"
     },
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "~1.2.0",
         "@types/elasticsearch": "~5.0.43",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.9.2",
+        "elasticsearch-store": "~1.10.0",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@~7.17.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@~8.15.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "1.9.2",
+    "version": "1.10.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,10 +30,10 @@
         "test:watch": "ts-scripts yarn workspace @terascope/scripts test --watch ../elasticsearch-store --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.7.9",
-        "@terascope/data-types": "~1.7.8",
+        "@terascope/data-mate": "~1.8.0",
+        "@terascope/data-types": "~1.8.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "ajv": "~8.17.1",
         "ajv-formats": "~3.0.1",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
@@ -43,7 +43,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@~2.12.0",
         "setimmediate": "~1.0.5",
         "uuid": "~11.1.0",
-        "xlucene-translator": "~1.7.9"
+        "xlucene-translator": "~1.8.0"
     },
     "devDependencies": {
         "@types/uuid": "~10.0.0"

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "1.9.9",
+    "version": "1.10.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",

--- a/packages/scripts/bin/ts-scripts.js
+++ b/packages/scripts/bin/ts-scripts.js
@@ -2,10 +2,60 @@
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isPortInUse, getAvailablePort, toBoolean } from '@terascope/utils';
+import signale from '../dist/src/helpers/signale.js';
+
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // this path.join is only used for pkg asset injection
 path.join(dirname, '../package.json');
+
+// Validate that all ports aren't in use
+const allPorts = {
+    TEST_ELASTICSEARCH: {
+        ELASTICSEARCH_PORT: process.env.ELASTICSEARCH_PORT || '49200'
+    },
+    TEST_RESTRAINED_ELASTICSEARCH: {
+        RESTRAINED_ELASTICSEARCH_PORT: process.env.RESTRAINED_ELASTICSEARCH_PORT || '49202'
+    },
+    TEST_KAFKA: {
+        KAFKA_PORT: process.env.KAFKA_PORT || '49094',
+        ZOOKEEPER_CLIENT_PORT: process.env.ZOOKEEPER_CLIENT_PORT || '42181',
+    },
+    TEST_MINIO: {
+        MINIO_PORT: process.env.MINIO_PORT || '49000',
+        MINIO_UI_PORT: process.env.MINIO_UI_PORT || '49001'
+    },
+    TEST_RABBITMQ: {
+        RABBITMQ_PORT: process.env.RABBITMQ_PORT || '45672',
+        RABBITMQ_MANAGEMENT_PORT: process.env.RABBITMQ_MANAGEMENT_PORT || '55672',
+    },
+    TEST_OPENSEARCH: {
+        OPENSEARCH_PORT: process.env.OPENSEARCH_PORT || '49210'
+    },
+    TEST_RESTRAINED_OPENSEARCH: {
+        RESTRAINED_OPENSEARCH_PORT: process.env.RESTRAINED_OPENSEARCH_PORT || '49206'
+    }
+};
+
+for (const [testKey, portsObj] of Object.entries(allPorts)) {
+    const serviceEnabled = toBoolean(process.env[testKey]);
+
+    if (serviceEnabled) {
+        for (const [envVarName, port] of Object.entries(portsObj)) {
+            signale.debug(`Checking availability of port ${port}`);
+
+            if (await isPortInUse(Number.parseInt(port))) {
+                signale.warn(`port ${port} is in use. Switching port..`);
+                const newPort = await getAvailablePort();
+                process.env[envVarName] = newPort.toString();
+                signale.warn(`${envVarName} env variable now uses port ${newPort}`);
+            } else {
+                signale.debug(`port ${port} is valid for env variable ${envVarName}`);
+            }
+        }
+    }
+}
 
 import('../dist/src/command.js');

--- a/packages/scripts/bin/ts-scripts.js
+++ b/packages/scripts/bin/ts-scripts.js
@@ -10,7 +10,8 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 // this path.join is only used for pkg asset injection
 path.join(dirname, '../package.json');
 
-// Validate that all ports aren't in use
+// An object that contains all possible port environment variables used in scripts
+// NOTE: The defaults set here override the defaults in the scripts/src/helpers/config.ts file
 const allPorts = {
     TEST_ELASTICSEARCH: {
         ELASTICSEARCH_PORT: process.env.ELASTICSEARCH_PORT || '49200'
@@ -38,7 +39,9 @@ const allPorts = {
     }
 };
 
+// Iterates over the `allports` object to see if any TEST_{SERVICE_NAME} variable is set
 for (const [testKey, portsObj] of Object.entries(allPorts)) {
+    // We only want to check ports for services that are set to 'true'
     const serviceEnabled = toBoolean(process.env[testKey]);
 
     if (serviceEnabled) {
@@ -46,7 +49,7 @@ for (const [testKey, portsObj] of Object.entries(allPorts)) {
             signale.debug(`Checking availability of port ${port}`);
 
             if (await isPortInUse(Number.parseInt(port))) {
-                signale.warn(`port ${port} is in use. Switching port..`);
+                signale.warn(`port ${port} is in use. Switching ${envVarName} to different port..`);
                 const newPort = await getAvailablePort();
                 process.env[envVarName] = newPort.toString();
                 signale.warn(`${envVarName} env variable now uses port ${newPort}`);

--- a/packages/scripts/bin/ts-scripts.js
+++ b/packages/scripts/bin/ts-scripts.js
@@ -5,7 +5,6 @@ import { fileURLToPath } from 'node:url';
 import { isPortInUse, getAvailablePort, toBoolean } from '@terascope/utils';
 import signale from '../dist/src/helpers/signale.js';
 
-
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // this path.join is only used for pkg asset injection

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.14.1",
+    "version": "1.15.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "execa": "~9.5.2",
         "fs-extra": "~11.3.0",
         "globby": "~14.1.0",

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -1,11 +1,60 @@
 import ipPkg from 'ip';
 import {
-    toBoolean, toSafeString, isCI, toIntegerOrThrow
+    toBoolean, toSafeString, isCI,
+    toIntegerOrThrow, isPortInUse, getAvailablePort
 } from '@terascope/utils';
 import { Service } from './interfaces.js';
 import { kafkaVersionMapper } from './mapper.js';
+import signale from './signale.js';
 
 const { address } = ipPkg;
+
+// Validate that all ports aren't in use
+const allPorts = {
+    TEST_ELASTICSEARCH: {
+        ELASTICSEARCH_PORT: process.env.ELASTICSEARCH_PORT || '49200'
+    },
+    TEST_RESTRAINED_ELASTICSEARCH: {
+        RESTRAINED_ELASTICSEARCH_PORT: process.env.RESTRAINED_ELASTICSEARCH_PORT || '49202'
+    },
+    TEST_KAFKA: {
+        KAFKA_PORT: process.env.KAFKA_PORT || '49092',
+        ZOOKEEPER_CLIENT_PORT: process.env.ZOOKEEPER_CLIENT_PORT || '42181',
+    },
+    TEST_MINIO: {
+        MINIO_PORT: process.env.MINIO_PORT || '49000',
+        MINIO_UI_PORT: process.env.MINIO_UI_PORT || '49001'
+    },
+    TEST_RABBITMQ: {
+        RABBITMQ_PORT: process.env.RABBITMQ_PORT || '45672',
+        RABBITMQ_MANAGEMENT_PORT: process.env.RABBITMQ_MANAGEMENT_PORT || '55672',
+    },
+    TEST_OPENSEARCH: {
+        OPENSEARCH_PORT: process.env.OPENSEARCH_PORT || '49210'
+    },
+    TEST_RESTRAINED_OPENSEARCH: {
+        RESTRAINED_OPENSEARCH_PORT: process.env.RESTRAINED_OPENSEARCH_PORT || '49206'
+    }
+}
+
+for (const [testKey, portsObj] of Object.entries(allPorts)) {
+    const serviceEnabled = toBoolean(process.env[testKey]);
+
+    if (serviceEnabled) {
+      for (const [envVarName, port] of Object.entries(portsObj)) {
+        signale.debug(`Checking availability of port ${port}`);
+
+        if (await isPortInUse(Number.parseInt(port))) {
+          signale.warn(`port ${port} is in use. Switching port..`);
+          const newPort = await getAvailablePort();
+          process.env[envVarName] = newPort.toString();
+          signale.warn(`${envVarName} env variable now uses port ${newPort}`);
+        } else {
+          signale.debug(`port ${port} is valid for env variable ${envVarName}`);
+        }
+      }
+    }
+  }
 
 const forceColor = process.env.FORCE_COLOR || '1';
 export const FORCE_COLOR = toBoolean(forceColor)
@@ -220,3 +269,4 @@ export const DOCKER_IMAGE_LIST_PATH = `${DOCKER_IMAGES_PATH}/image-list.txt`;
 export const DOCKER_CACHE_PATH = '/tmp/docker_cache';
 export const SKIP_IMAGE_DELETION = toBoolean(process.env.SKIP_IMAGE_DELETION) || false;
 export const USE_HELMFILE = toBoolean(process.env.USE_HELMFILE) || false;
+

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -35,26 +35,26 @@ const allPorts = {
     TEST_RESTRAINED_OPENSEARCH: {
         RESTRAINED_OPENSEARCH_PORT: process.env.RESTRAINED_OPENSEARCH_PORT || '49206'
     }
-}
+};
 
 for (const [testKey, portsObj] of Object.entries(allPorts)) {
     const serviceEnabled = toBoolean(process.env[testKey]);
 
     if (serviceEnabled) {
-      for (const [envVarName, port] of Object.entries(portsObj)) {
-        signale.debug(`Checking availability of port ${port}`);
+        for (const [envVarName, port] of Object.entries(portsObj)) {
+            signale.debug(`Checking availability of port ${port}`);
 
-        if (await isPortInUse(Number.parseInt(port))) {
-          signale.warn(`port ${port} is in use. Switching port..`);
-          const newPort = await getAvailablePort();
-          process.env[envVarName] = newPort.toString();
-          signale.warn(`${envVarName} env variable now uses port ${newPort}`);
-        } else {
-          signale.debug(`port ${port} is valid for env variable ${envVarName}`);
+            if (await isPortInUse(Number.parseInt(port))) {
+                signale.warn(`port ${port} is in use. Switching port..`);
+                const newPort = await getAvailablePort();
+                process.env[envVarName] = newPort.toString();
+                signale.warn(`${envVarName} env variable now uses port ${newPort}`);
+            } else {
+                signale.debug(`port ${port} is valid for env variable ${envVarName}`);
+            }
         }
-      }
     }
-  }
+}
 
 const forceColor = process.env.FORCE_COLOR || '1';
 export const FORCE_COLOR = toBoolean(forceColor)
@@ -269,4 +269,3 @@ export const DOCKER_IMAGE_LIST_PATH = `${DOCKER_IMAGES_PATH}/image-list.txt`;
 export const DOCKER_CACHE_PATH = '/tmp/docker_cache';
 export const SKIP_IMAGE_DELETION = toBoolean(process.env.SKIP_IMAGE_DELETION) || false;
 export const USE_HELMFILE = toBoolean(process.env.USE_HELMFILE) || false;
-

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -1,60 +1,12 @@
 import ipPkg from 'ip';
 import {
     toBoolean, toSafeString, isCI,
-    toIntegerOrThrow, isPortInUse, getAvailablePort
+    toIntegerOrThrow
 } from '@terascope/utils';
 import { Service } from './interfaces.js';
 import { kafkaVersionMapper } from './mapper.js';
-import signale from './signale.js';
 
 const { address } = ipPkg;
-
-// Validate that all ports aren't in use
-const allPorts = {
-    TEST_ELASTICSEARCH: {
-        ELASTICSEARCH_PORT: process.env.ELASTICSEARCH_PORT || '49200'
-    },
-    TEST_RESTRAINED_ELASTICSEARCH: {
-        RESTRAINED_ELASTICSEARCH_PORT: process.env.RESTRAINED_ELASTICSEARCH_PORT || '49202'
-    },
-    TEST_KAFKA: {
-        KAFKA_PORT: process.env.KAFKA_PORT || '49092',
-        ZOOKEEPER_CLIENT_PORT: process.env.ZOOKEEPER_CLIENT_PORT || '42181',
-    },
-    TEST_MINIO: {
-        MINIO_PORT: process.env.MINIO_PORT || '49000',
-        MINIO_UI_PORT: process.env.MINIO_UI_PORT || '49001'
-    },
-    TEST_RABBITMQ: {
-        RABBITMQ_PORT: process.env.RABBITMQ_PORT || '45672',
-        RABBITMQ_MANAGEMENT_PORT: process.env.RABBITMQ_MANAGEMENT_PORT || '55672',
-    },
-    TEST_OPENSEARCH: {
-        OPENSEARCH_PORT: process.env.OPENSEARCH_PORT || '49210'
-    },
-    TEST_RESTRAINED_OPENSEARCH: {
-        RESTRAINED_OPENSEARCH_PORT: process.env.RESTRAINED_OPENSEARCH_PORT || '49206'
-    }
-};
-
-for (const [testKey, portsObj] of Object.entries(allPorts)) {
-    const serviceEnabled = toBoolean(process.env[testKey]);
-
-    if (serviceEnabled) {
-        for (const [envVarName, port] of Object.entries(portsObj)) {
-            signale.debug(`Checking availability of port ${port}`);
-
-            if (await isPortInUse(Number.parseInt(port))) {
-                signale.warn(`port ${port} is in use. Switching port..`);
-                const newPort = await getAvailablePort();
-                process.env[envVarName] = newPort.toString();
-                signale.warn(`${envVarName} env variable now uses port ${newPort}`);
-            } else {
-                signale.debug(`port ${port} is valid for env variable ${envVarName}`);
-            }
-        }
-    }
-}
 
 const forceColor = process.env.FORCE_COLOR || '1';
 export const FORCE_COLOR = toBoolean(forceColor)
@@ -95,7 +47,7 @@ export const RESTRAINED_ELASTICSEARCH_HOST = `http://${ELASTICSEARCH_HOSTNAME}:$
 
 export const KAFKA_NAME = process.env.KAFKA_NAME || 'kafka';
 export const KAFKA_HOSTNAME = process.env.KAFKA_HOSTNAME || HOST_IP;
-export const KAFKA_PORT = process.env.KAFKA_PORT || '49092';
+export const KAFKA_PORT = process.env.KAFKA_PORT || '49094';
 export const KAFKA_BROKER = `${KAFKA_HOSTNAME}:${KAFKA_PORT}`;
 export const KAFKA_VERSION = process.env.KAFKA_VERSION || '3.7.2';
 export const KAFKA_DOCKER_IMAGE = process.env.KAFKA_DOCKER_IMAGE || 'confluentinc/cp-kafka';

--- a/packages/scripts/src/helpers/kind.ts
+++ b/packages/scripts/src/helpers/kind.ts
@@ -49,7 +49,7 @@ export class Kind {
 
         const configFile = yaml.load(fs.readFileSync(configPath, 'utf8')) as KindCluster;
 
-        // Map ports with the config
+        // Map external ports from kind to the host machine based off of config variables
         for (const service of ENV_SERVICES) {
             if (service === 'elasticsearch') {
                 configFile.nodes[0].extraPortMappings.push({
@@ -71,7 +71,7 @@ export class Kind {
                     hostPort: Number.parseInt(MINIO_UI_PORT)
                 });
             } else if (service === 'kafka') {
-                // This will map only the external port so it can resolve with the host machine
+                // map only the external kafka port so it can resolve with the host machine
                 configFile.nodes[0].extraPortMappings.push({
                     containerPort: 30094,
                     hostPort: Number.parseInt(KAFKA_PORT)

--- a/packages/scripts/src/helpers/kind.ts
+++ b/packages/scripts/src/helpers/kind.ts
@@ -12,7 +12,7 @@ import {
     DOCKER_CACHE_PATH, TERASLICE_PORT, ENV_SERVICES,
     ELASTICSEARCH_PORT, OPENSEARCH_PORT, MINIO_PORT,
     MINIO_UI_PORT, KAFKA_PORT
- } from './config.js';
+} from './config.js';
 
 export class Kind {
     clusterName: string;

--- a/packages/scripts/src/helpers/kind.ts
+++ b/packages/scripts/src/helpers/kind.ts
@@ -71,8 +71,9 @@ export class Kind {
                     hostPort: Number.parseInt(MINIO_UI_PORT)
                 });
             } else if (service === 'kafka') {
+                // This will map only the external port so it can resolve with the host machine
                 configFile.nodes[0].extraPortMappings.push({
-                    containerPort: 30092,
+                    containerPort: 30094,
                     hostPort: Number.parseInt(KAFKA_PORT)
                 });
             }

--- a/packages/scripts/test/service-spec.ts
+++ b/packages/scripts/test/service-spec.ts
@@ -56,6 +56,7 @@ jest.unstable_mockModule('../src/helpers/config.js', () => ({
     MINIO_NAME: '',
     MINIO_HOSTNAME: '',
     MINIO_PORT: '',
+    MINIO_UI_PORT: '',
     ENCRYPT_MINIO: '',
     MINIO_HOST: '',
     MINIO_DOCKER_IMAGE: '',

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "1.11.2",
+    "version": "1.12.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -30,14 +30,14 @@
     "dependencies": {
         "@terascope/file-asset-apis": "~1.0.5",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "bluebird": "~3.7.2",
         "bunyan": "~1.8.15",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.9.2",
+        "elasticsearch-store": "~1.10.0",
         "express": "~5.1.0",
         "js-yaml": "~4.1.0",
         "nanoid": "~5.1.5",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -44,7 +44,7 @@
     "devDependencies": {
         "@terascope/fetch-github-release": "~2.1.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "@types/decompress": "~4.2.7",
         "@types/diff": "~7.0.2",
         "@types/ejs": "~3.1.5",
@@ -68,7 +68,7 @@
         "pretty-bytes": "~6.1.1",
         "prompts": "~2.4.2",
         "signale": "~1.4.0",
-        "teraslice-client-js": "~1.7.8",
+        "teraslice-client-js": "~1.8.0",
         "tmp": "~0.2.3",
         "tty-table": "~4.2.3",
         "yargs": "~17.7.2"

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "1.7.8",
+    "version": "1.8.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "auto-bind": "~5.0.1",
         "got": "~13.0.0"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "1.10.9",
+    "version": "1.11.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "get-port": "~7.1.0",
         "ms": "~2.1.3",
         "nanoid": "~5.1.5",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "1.8.6",
+    "version": "1.9.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -24,8 +24,8 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../teraslice-state-storage --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "~4.8.6",
-        "@terascope/utils": "~1.7.8"
+        "@terascope/elasticsearch-api": "~4.9.0",
+        "@terascope/utils": "~1.8.0"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "~11.3.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "~1.9.9"
+        "@terascope/job-components": "~1.10.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=1.9.9"
+        "@terascope/job-components": ">=1.10.0"
     },
     "engines": {
         "node": ">=18.18.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -39,11 +39,11 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~0.22.3",
-        "@terascope/elasticsearch-api": "~4.8.6",
-        "@terascope/job-components": "~1.9.9",
-        "@terascope/teraslice-messaging": "~1.10.9",
+        "@terascope/elasticsearch-api": "~4.9.0",
+        "@terascope/job-components": "~1.10.0",
+        "@terascope/teraslice-messaging": "~1.11.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "async-mutex": "~0.5.0",
         "barbe": "~3.0.17",
         "body-parser": "~2.2.0",
@@ -62,7 +62,7 @@
         "semver": "~7.7.1",
         "socket.io": "~1.7.4",
         "socket.io-client": "~1.7.4",
-        "terafoundation": "~1.11.2",
+        "terafoundation": "~1.12.0",
         "uuid": "~11.1.0"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "1.7.9",
+    "version": "1.8.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -36,9 +36,9 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../ts-transforms --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.7.9",
+        "@terascope/data-mate": "~1.8.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "awesome-phonenumber": "~7.4.0",
         "graphlib": "~2.1.8",
         "jexl": "~2.3.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "1.7.8",
+    "version": "1.8.0",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/ip.ts
+++ b/packages/utils/src/ip.ts
@@ -402,6 +402,8 @@ export function isPortInUse(port: number): Promise<boolean> {
     return new Promise((resolve) => {
         const testServer = net.createServer()
             .once('error', (err: any) => {
+                // Close the server in all error cases
+                testServer.close();
                 if (err.code === 'EADDRINUSE') {
                     resolve(true);
                 } else {

--- a/packages/utils/src/ip.ts
+++ b/packages/utils/src/ip.ts
@@ -400,20 +400,20 @@ function _expandIPv6Part(part: string) {
  */
 export function isPortInUse(port: number): Promise<boolean> {
     return new Promise((resolve) => {
-      const testServer = net.createServer()
-        .once('error', (err: any) => {
-          if (err.code === 'EADDRINUSE') {
-            resolve(true);
-          } else {
-            resolve(false);
-          }
-        })
-        .once('listening', () => {
-          testServer.close(() => {
-            resolve(false);
-          });
-        })
-        .listen(port);
+        const testServer = net.createServer()
+            .once('error', (err: any) => {
+                if (err.code === 'EADDRINUSE') {
+                    resolve(true);
+                } else {
+                    resolve(false);
+                }
+            })
+            .once('listening', () => {
+                testServer.close(() => {
+                    resolve(false);
+                });
+            })
+            .listen(port);
     });
 }
 
@@ -427,10 +427,10 @@ export function isPortInUse(port: number): Promise<boolean> {
 export async function getAvailablePort(min = 10000, max = 60000): Promise<number> {
     const maxAttempts = 50;
     for (let i = 0; i < maxAttempts; i++) {
-      const port = Math.floor(Math.random() * (max - min + 1)) + min;
-      if (!(await isPortInUse(port))) {
-        return port;
-      }
+        const port = Math.floor(Math.random() * (max - min + 1)) + min;
+        if (!(await isPortInUse(port))) {
+            return port;
+        }
     }
     throw new Error(`No available ports found in range ${min}-${max}`);
 }

--- a/packages/utils/test/ip-spec.ts
+++ b/packages/utils/test/ip-spec.ts
@@ -1,5 +1,6 @@
 import 'jest-extended';
 
+import net from 'node:net';
 import {
     isIP,
     isIPv6,
@@ -22,7 +23,9 @@ import {
     getLastIPInCIDR,
     shortenIPv6Address,
     getFirstUsableIPInCIDR,
-    getLastUsableIPInCIDR
+    getLastUsableIPInCIDR,
+    isPortInUse,
+    getAvailablePort
 } from '../src/ip.js';
 
 describe('IP Utils', () => {
@@ -570,6 +573,68 @@ describe('IP Utils', () => {
             expect(() => {
                 toCIDR('2001:0db8:0123:4567:89ab:cdef:1234:5678', 223);
             }).toThrowError('input must be a valid IP address and suffix must be a value <= 32 for IPv4 or <= 128 for IPv6');
+        });
+    });
+
+    describe('getAvailablePort', () => {
+        let server: net.Server;
+        let takenPort: number;
+
+        beforeAll(async () => {
+            takenPort = await isPortInUse(28333) ? await getAvailablePort() : 28333;
+            server = net.createServer();
+        });
+
+        afterAll(async () => {
+            server.close();
+        });
+
+        it('Should give a valid port', async () => {
+            const minPort = 10000;
+            const maxPort = 30000;
+            const port = await getAvailablePort(minPort, maxPort);
+            expect(port).toBeNumber();
+            expect(port).toBeLessThanOrEqual(maxPort);
+            expect(port).toBeGreaterThanOrEqual(minPort);
+        });
+
+        it('Should throw if no ports are available within a given range', async () => {
+            server.listen(takenPort)
+                .once('listening', async () => {
+                    const expectedError = `No available ports found in range ${takenPort}-${takenPort}`;
+                    await expect(getAvailablePort(takenPort, takenPort))
+                        .rejects.toThrow(expectedError);
+                });
+        });
+    });
+
+    describe('isPortInUse', () => {
+        let server: net.Server;
+        let takenPort: number;
+
+        beforeAll(async () => {
+            takenPort = await isPortInUse(28333) ? await getAvailablePort() : 28333;
+            server = net.createServer();
+        });
+
+        afterAll(async () => {
+            server.close();
+        });
+
+        it('Should be false if port is NOT in use', async () => {
+            const port = await getAvailablePort();
+            const portInUse = await isPortInUse(port);
+
+            expect(portInUse).toBeFalse();
+        });
+
+        it('Should be true if port IS in use', async () => {
+            server.listen(takenPort)
+                .once('listening', async () => {
+                    const portInUse = await isPortInUse(takenPort);
+
+                    expect(portInUse).toBeTrue();
+                });
         });
     });
 });

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "1.7.9",
+    "version": "1.8.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "peggy": "~4.2.0",
         "ts-pegjs": "~4.2.1"
     },

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "1.7.9",
+    "version": "1.8.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -30,9 +30,9 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.7.8",
+        "@terascope/utils": "~1.8.0",
         "@types/elasticsearch": "~5.0.43",
-        "xlucene-parser": "~1.7.9"
+        "xlucene-parser": "~1.8.0"
     },
     "devDependencies": {
         "elasticsearch": "~15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "1.7.8",
+    "version": "1.8.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../xpressions --"
     },
     "dependencies": {
-        "@terascope/utils": "~1.7.8"
+        "@terascope/utils": "~1.8.0"
     },
     "devDependencies": {
         "@terascope/types": "~1.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3012,13 +3012,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/data-mate@npm:~1.7.9, @terascope/data-mate@workspace:packages/data-mate":
+"@terascope/data-mate@npm:~1.8.0, @terascope/data-mate@workspace:packages/data-mate":
   version: 0.0.0-use.local
   resolution: "@terascope/data-mate@workspace:packages/data-mate"
   dependencies:
-    "@terascope/data-types": "npm:~1.7.8"
+    "@terascope/data-types": "npm:~1.8.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     "@types/ip6addr": "npm:~0.2.6"
     "@types/uuid": "npm:~10.0.0"
     "@types/validator": "npm:~13.12.2"
@@ -3035,16 +3035,16 @@ __metadata:
     uuid: "npm:~11.1.0"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
-    xlucene-parser: "npm:~1.7.9"
+    xlucene-parser: "npm:~1.8.0"
   languageName: unknown
   linkType: soft
 
-"@terascope/data-types@npm:~1.7.8, @terascope/data-types@workspace:packages/data-types":
+"@terascope/data-types@npm:~1.8.0, @terascope/data-types@workspace:packages/data-types":
   version: 0.0.0-use.local
   resolution: "@terascope/data-types@workspace:packages/data-types"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     "@types/yargs": "npm:~17.0.33"
     graphql: "npm:~16.10.0"
     yargs: "npm:~17.7.2"
@@ -3061,17 +3061,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/elasticsearch-api@npm:~4.8.6, @terascope/elasticsearch-api@workspace:packages/elasticsearch-api":
+"@terascope/elasticsearch-api@npm:~4.9.0, @terascope/elasticsearch-api@workspace:packages/elasticsearch-api":
   version: 0.0.0-use.local
   resolution: "@terascope/elasticsearch-api@workspace:packages/elasticsearch-api"
   dependencies:
     "@opensearch-project/opensearch": "npm:~1.2.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     "@types/elasticsearch": "npm:~5.0.43"
     bluebird: "npm:~3.7.2"
     elasticsearch: "npm:~15.4.1"
-    elasticsearch-store: "npm:~1.9.2"
+    elasticsearch-store: "npm:~1.10.0"
     elasticsearch6: "npm:@elastic/elasticsearch@~6.8.0"
     elasticsearch7: "npm:@elastic/elasticsearch@~7.17.0"
     elasticsearch8: "npm:@elastic/elasticsearch@~8.15.0"
@@ -3133,12 +3133,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/job-components@npm:~1.9.9, @terascope/job-components@workspace:packages/job-components":
+"@terascope/job-components@npm:~1.10.0, @terascope/job-components@workspace:packages/job-components":
   version: 0.0.0-use.local
   resolution: "@terascope/job-components@workspace:packages/job-components"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     benchmark: "npm:~2.1.4"
     convict: "npm:~6.2.4"
     convict-format-with-moment: "npm:~6.2.0"
@@ -3153,12 +3153,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/scripts@npm:~1.14.1, @terascope/scripts@workspace:packages/scripts":
+"@terascope/scripts@npm:~1.15.0, @terascope/scripts@workspace:packages/scripts":
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
     "@kubernetes/client-node": "npm:~0.22.3"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     "@types/ip": "npm:~1.1.3"
     "@types/micromatch": "npm:~4.0.9"
     "@types/ms": "npm:~0.7.34"
@@ -3195,12 +3195,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/teraslice-messaging@npm:~1.10.9, @terascope/teraslice-messaging@workspace:packages/teraslice-messaging":
+"@terascope/teraslice-messaging@npm:~1.11.0, @terascope/teraslice-messaging@workspace:packages/teraslice-messaging":
   version: 0.0.0-use.local
   resolution: "@terascope/teraslice-messaging@workspace:packages/teraslice-messaging"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     "@types/ms": "npm:~0.7.34"
     "@types/socket.io": "npm:~2.1.13"
     "@types/socket.io-client": "npm:~1.4.36"
@@ -3217,8 +3217,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terascope/teraslice-state-storage@workspace:packages/teraslice-state-storage"
   dependencies:
-    "@terascope/elasticsearch-api": "npm:~4.8.6"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/elasticsearch-api": "npm:~4.9.0"
+    "@terascope/utils": "npm:~1.8.0"
   languageName: unknown
   linkType: soft
 
@@ -3230,7 +3230,51 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/utils@npm:~1.7.7, @terascope/utils@npm:~1.7.8, @terascope/utils@workspace:packages/utils":
+"@terascope/utils@npm:~1.7.7":
+  version: 1.7.8
+  resolution: "@terascope/utils@npm:1.7.8"
+  dependencies:
+    "@chainsafe/is-ip": "npm:~2.1.0"
+    "@terascope/types": "npm:~1.4.1"
+    "@turf/bbox": "npm:~7.2.0"
+    "@turf/bbox-polygon": "npm:~7.2.0"
+    "@turf/boolean-contains": "npm:~7.2.0"
+    "@turf/boolean-disjoint": "npm:~7.2.0"
+    "@turf/boolean-equal": "npm:~7.2.0"
+    "@turf/boolean-intersects": "npm:~7.2.0"
+    "@turf/boolean-point-in-polygon": "npm:~7.2.0"
+    "@turf/boolean-within": "npm:~7.2.0"
+    "@turf/circle": "npm:~7.2.0"
+    "@turf/helpers": "npm:~7.2.0"
+    "@turf/invariant": "npm:~7.2.0"
+    "@turf/line-to-polygon": "npm:~7.2.0"
+    "@types/lodash-es": "npm:~4.17.12"
+    "@types/validator": "npm:~13.12.2"
+    awesome-phonenumber: "npm:~7.4.0"
+    date-fns: "npm:~4.1.0"
+    date-fns-tz: "npm:~3.2.0"
+    datemath-parser: "npm:~1.0.6"
+    debug: "npm:~4.4.0"
+    geo-tz: "npm:~8.1.4"
+    ip-bigint: "npm:~8.2.1"
+    ip-cidr: "npm:~4.0.2"
+    ip6addr: "npm:~0.2.5"
+    ipaddr.js: "npm:~2.2.0"
+    is-cidr: "npm:~5.1.1"
+    is-plain-object: "npm:~5.0.0"
+    js-string-escape: "npm:~1.0.1"
+    kind-of: "npm:~6.0.3"
+    latlon-geohash: "npm:~2.0.0"
+    lodash-es: "npm:~4.17.21"
+    mnemonist: "npm:~0.40.3"
+    p-map: "npm:~7.0.3"
+    shallow-clone: "npm:~3.0.1"
+    validator: "npm:~13.12.0"
+  checksum: 10c0/6a8d2cc63740bcd3a0b102af0d5acc2377e7f00e6021af32cc9da6a010c4e48c7ecece6a6818a3597e0fa232feee0c4013f69929af7eaef124737790bda2c2b9
+  languageName: node
+  linkType: hard
+
+"@terascope/utils@npm:~1.8.0, @terascope/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@terascope/utils@workspace:packages/utils"
   dependencies:
@@ -6275,11 +6319,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e@workspace:e2e"
   dependencies:
-    "@terascope/scripts": "npm:~1.14.1"
+    "@terascope/scripts": "npm:~1.15.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     bunyan: "npm:~1.8.15"
-    elasticsearch-store: "npm:~1.9.2"
+    elasticsearch-store: "npm:~1.10.0"
     fs-extra: "npm:~11.3.0"
     jest: "npm:^29.7.0"
     jest-extended: "npm:^4.0.2"
@@ -6342,14 +6386,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elasticsearch-store@npm:~1.9.2, elasticsearch-store@workspace:packages/elasticsearch-store":
+"elasticsearch-store@npm:~1.10.0, elasticsearch-store@workspace:packages/elasticsearch-store":
   version: 0.0.0-use.local
   resolution: "elasticsearch-store@workspace:packages/elasticsearch-store"
   dependencies:
-    "@terascope/data-mate": "npm:~1.7.9"
-    "@terascope/data-types": "npm:~1.7.8"
+    "@terascope/data-mate": "npm:~1.8.0"
+    "@terascope/data-types": "npm:~1.8.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     "@types/uuid": "npm:~10.0.0"
     ajv: "npm:~8.17.1"
     ajv-formats: "npm:~3.0.1"
@@ -6360,7 +6404,7 @@ __metadata:
     opensearch2: "npm:@opensearch-project/opensearch@~2.12.0"
     setimmediate: "npm:~1.0.5"
     uuid: "npm:~11.1.0"
-    xlucene-translator: "npm:~1.7.9"
+    xlucene-translator: "npm:~1.8.0"
   languageName: unknown
   linkType: soft
 
@@ -13039,13 +13083,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terafoundation@npm:~1.11.2, terafoundation@workspace:packages/terafoundation":
+"terafoundation@npm:~1.12.0, terafoundation@workspace:packages/terafoundation":
   version: 0.0.0-use.local
   resolution: "terafoundation@workspace:packages/terafoundation"
   dependencies:
     "@terascope/file-asset-apis": "npm:~1.0.5"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     "@types/bunyan": "npm:~1.8.11"
     "@types/elasticsearch": "npm:~5.0.43"
     "@types/express": "npm:~5.0.1"
@@ -13056,7 +13100,7 @@ __metadata:
     convict-format-with-moment: "npm:~6.2.0"
     convict-format-with-validator: "npm:~6.2.0"
     elasticsearch: "npm:~15.4.1"
-    elasticsearch-store: "npm:~1.9.2"
+    elasticsearch-store: "npm:~1.10.0"
     express: "npm:~5.1.0"
     got: "npm:~13.0.0"
     js-yaml: "npm:~4.1.0"
@@ -13073,7 +13117,7 @@ __metadata:
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.1.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     "@types/decompress": "npm:~4.2.7"
     "@types/diff": "npm:~7.0.2"
     "@types/ejs": "npm:~3.1.5"
@@ -13098,7 +13142,7 @@ __metadata:
     pretty-bytes: "npm:~6.1.1"
     prompts: "npm:~2.4.2"
     signale: "npm:~1.4.0"
-    teraslice-client-js: "npm:~1.7.8"
+    teraslice-client-js: "npm:~1.8.0"
     tmp: "npm:~0.2.3"
     tty-table: "npm:~4.2.3"
     yargs: "npm:~17.7.2"
@@ -13108,12 +13152,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"teraslice-client-js@npm:~1.7.8, teraslice-client-js@workspace:packages/teraslice-client-js":
+"teraslice-client-js@npm:~1.8.0, teraslice-client-js@workspace:packages/teraslice-client-js":
   version: 0.0.0-use.local
   resolution: "teraslice-client-js@workspace:packages/teraslice-client-js"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     auto-bind: "npm:~5.0.1"
     got: "npm:~13.0.0"
     nock: "npm:~13.5.6"
@@ -13125,11 +13169,11 @@ __metadata:
   resolution: "teraslice-test-harness@workspace:packages/teraslice-test-harness"
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.1.0"
-    "@terascope/job-components": "npm:~1.9.9"
+    "@terascope/job-components": "npm:~1.10.0"
     decompress: "npm:~4.2.1"
     fs-extra: "npm:~11.3.0"
   peerDependencies:
-    "@terascope/job-components": ">=1.9.9"
+    "@terascope/job-components": ">=1.10.0"
   languageName: unknown
   linkType: soft
 
@@ -13140,7 +13184,7 @@ __metadata:
     "@eslint/js": "npm:~9.23.0"
     "@swc/core": "npm:1.11.13"
     "@swc/jest": "npm:~0.2.37"
-    "@terascope/scripts": "npm:~1.14.1"
+    "@terascope/scripts": "npm:~1.15.0"
     "@types/bluebird": "npm:~3.5.42"
     "@types/convict": "npm:~6.1.6"
     "@types/elasticsearch": "npm:~5.0.43"
@@ -13164,11 +13208,11 @@ __metadata:
   resolution: "teraslice@workspace:packages/teraslice"
   dependencies:
     "@kubernetes/client-node": "npm:~0.22.3"
-    "@terascope/elasticsearch-api": "npm:~4.8.6"
-    "@terascope/job-components": "npm:~1.9.9"
-    "@terascope/teraslice-messaging": "npm:~1.10.9"
+    "@terascope/elasticsearch-api": "npm:~4.9.0"
+    "@terascope/job-components": "npm:~1.10.0"
+    "@terascope/teraslice-messaging": "npm:~1.11.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     "@types/archiver": "npm:~6.0.3"
     "@types/express": "npm:~5.0.1"
     "@types/gc-stats": "npm:~1.4.3"
@@ -13199,7 +13243,7 @@ __metadata:
     semver: "npm:~7.7.1"
     socket.io: "npm:~1.7.4"
     socket.io-client: "npm:~1.7.4"
-    terafoundation: "npm:~1.11.2"
+    terafoundation: "npm:~1.12.0"
     uuid: "npm:~11.1.0"
   languageName: unknown
   linkType: soft
@@ -13398,9 +13442,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ts-transforms@workspace:packages/ts-transforms"
   dependencies:
-    "@terascope/data-mate": "npm:~1.7.9"
+    "@terascope/data-mate": "npm:~1.8.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     "@types/graphlib": "npm:~2.1.12"
     "@types/jexl": "npm:~2.3.4"
     "@types/valid-url": "npm:~1.0.7"
@@ -14125,12 +14169,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xlucene-parser@npm:~1.7.9, xlucene-parser@workspace:packages/xlucene-parser":
+"xlucene-parser@npm:~1.8.0, xlucene-parser@workspace:packages/xlucene-parser":
   version: 0.0.0-use.local
   resolution: "xlucene-parser@workspace:packages/xlucene-parser"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     "@turf/invariant": "npm:~7.2.0"
     "@turf/random": "npm:~7.2.0"
     peggy: "npm:~4.2.0"
@@ -14138,15 +14182,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"xlucene-translator@npm:~1.7.9, xlucene-translator@workspace:packages/xlucene-translator":
+"xlucene-translator@npm:~1.8.0, xlucene-translator@workspace:packages/xlucene-translator":
   version: 0.0.0-use.local
   resolution: "xlucene-translator@workspace:packages/xlucene-translator"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
     "@types/elasticsearch": "npm:~5.0.43"
     elasticsearch: "npm:~15.4.1"
-    xlucene-parser: "npm:~1.7.9"
+    xlucene-parser: "npm:~1.8.0"
   languageName: unknown
   linkType: soft
 
@@ -14162,7 +14206,7 @@ __metadata:
   resolution: "xpressions@workspace:packages/xpressions"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.8"
+    "@terascope/utils": "npm:~1.8.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR makes the following changes:

- Adds port validation to all tests that need services
  - If a service port is in use, scripts will now find a random port that isn't in use and assign the new port to said service

Ref to issue #3898