### PR TITLE
[teraslice, scripts] update @kubernetes/client-node to v1.1.1

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -47,7 +47,7 @@
         "ms": "~2.1.3"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.15.1",
+        "@terascope/scripts": "~1.15.2",
         "@terascope/types": "~1.4.1",
         "@terascope/utils": "~1.8.0",
         "bunyan": "~1.8.15",

--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 2.6.0
-appVersion: v2.14.3
+version: 2.7.0
+appVersion: v2.14.4
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.14.3",
+    "version": "2.14.4",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {
@@ -53,7 +53,7 @@
         "@eslint/js": "~9.23.0",
         "@swc/core": "1.11.13",
         "@swc/jest": "~0.2.37",
-        "@terascope/scripts": "~1.15.1",
+        "@terascope/scripts": "~1.15.2",
         "@types/bluebird": "~3.5.42",
         "@types/convict": "~6.1.6",
         "@types/elasticsearch": "~5.0.43",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.15.1",
+    "version": "1.15.2",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -32,7 +32,7 @@
         "typescript": "~5.8.2"
     },
     "dependencies": {
-        "@kubernetes/client-node": "~0.22.3",
+        "@kubernetes/client-node": "~1.1.1",
         "@terascope/utils": "~1.8.0",
         "execa": "~9.5.2",
         "fs-extra": "~11.3.0",

--- a/packages/scripts/src/helpers/k8s-env/k8s.ts
+++ b/packages/scripts/src/helpers/k8s-env/k8s.ts
@@ -333,10 +333,10 @@ export class K8s {
      */
     async createKubernetesSecret(namespace: string, secret: k8sClient.V1Secret): Promise<void> {
         try {
-            await this.k8sCoreV1Api.createNamespacedSecret(
+            await this.k8sCoreV1Api.createNamespacedSecret({
                 namespace,
-                secret
-            );
+                body: secret
+            });
         } catch (err) {
             throw new TSError(`Unable to make kubernetes secret. \n ${err}`);
         }

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.14.3",
+    "version": "2.14.4",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -38,7 +38,7 @@
         "ms": "~2.1.3"
     },
     "dependencies": {
-        "@kubernetes/client-node": "~0.22.3",
+        "@kubernetes/client-node": "~1.1.1",
         "@terascope/elasticsearch-api": "~4.9.0",
         "@terascope/job-components": "~1.10.0",
         "@terascope/teraslice-messaging": "~1.11.0",

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/interfaces.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/interfaces.ts
@@ -1,4 +1,3 @@
-import { IncomingMessage } from 'node:http';
 import * as k8s from '@kubernetes/client-node';
 
 export interface KubeConfigOptions {
@@ -141,28 +140,6 @@ export interface TSReplicaSetList extends k8s.V1ReplicaSetList {
 }
 export interface TSServiceList extends k8s.V1ServiceList {
     items: TSService[];
-}
-
-export interface ResourceListApiResponse {
-    response: IncomingMessage;
-    body: K8sResourceList;
-}
-
-export interface ResourceApiResponse {
-    response: IncomingMessage;
-    body: K8sResource;
-}
-
-export interface PatchApiResponse {
-    response: IncomingMessage;
-    body: k8s.V1Deployment;
-}
-
-export type DeleteResponseBody = k8s.V1Pod | k8s.V1Status | k8s.V1Service;
-
-export interface DeleteApiResponse {
-    response: IncomingMessage;
-    body: DeleteResponseBody;
 }
 
 export type ListParams = [

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
@@ -52,7 +52,7 @@ export class K8s {
      * @return {Promise} [description]
      */
     async getNamespaces() {
-        let namespaces;
+        let namespaces: k8s.V1NamespaceList;
         try {
             namespaces = await pRetry(() => this.k8sCoreV1Api.listNamespace(), getRetryConfig());
         } catch (err) {
@@ -61,7 +61,7 @@ export class K8s {
             });
             throw error;
         }
-        return namespaces.body;
+        return namespaces;
     }
 
     /**
@@ -86,11 +86,11 @@ export class K8s {
         const end = now + timeout;
 
         while (true) {
-            const result = await pRetry(() => this.k8sCoreV1Api
-                .listNamespacedPod(namespace, undefined, undefined, undefined, undefined, selector),
+            const podListObj: k8s.V1PodList = await pRetry(() => this.k8sCoreV1Api
+                .listNamespacedPod({ namespace, labelSelector: selector }),
             getRetryConfig());
             // NOTE: This assumes the first pod returned.
-            const pod = get(result, 'body.items[0]');
+            const pod = get(podListObj, 'items[0]');
 
             if (pod && isTSPod(pod)) {
                 if (statusType === 'readiness-probe') {
@@ -133,11 +133,11 @@ export class K8s {
         const end = now + timeout;
 
         while (true) {
-            const result = await pRetry(() => this.k8sCoreV1Api
-                .listNamespacedPod(namespace, undefined, undefined, undefined, undefined, selector),
+            const podListObj: k8s.V1PodList = await pRetry(() => this.k8sCoreV1Api
+                .listNamespacedPod({ namespace, labelSelector: selector }),
             getRetryConfig());
 
-            const podList: k8s.V1Pod[] = get(result, 'body.items');
+            const podList: k8s.V1Pod[] = get(podListObj, 'items');
 
             if (podList.length === number) return podList;
 
@@ -170,41 +170,37 @@ export class K8s {
     async list(selector: string, objType: i.ResourceType, ns?: string): Promise<i.TSResourceList>;
     async list(selector: string, objType: i.ResourceType, ns?: string): Promise<i.TSResourceList> {
         const namespace = ns || this.defaultNamespace;
-        let responseObj: i.ResourceListApiResponse;
+        let resourceListObj: i.K8sResourceList;
 
-        const params: i.ListParams = [
+        const params = {
             namespace,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
             selector
-        ];
+        };
 
         try {
             if (objType === 'deployments') {
-                responseObj = await pRetry(
-                    () => this.k8sAppsV1Api.listNamespacedDeployment(...params),
+                resourceListObj = await pRetry(
+                    () => this.k8sAppsV1Api.listNamespacedDeployment(params),
                     getRetryConfig()
                 );
             } else if (objType === 'jobs') {
-                responseObj = await pRetry(
-                    () => this.k8sBatchV1Api.listNamespacedJob(...params),
+                resourceListObj = await pRetry(
+                    () => this.k8sBatchV1Api.listNamespacedJob(params),
                     getRetryConfig()
                 );
             } else if (objType === 'pods') {
-                responseObj = await pRetry(
-                    () => this.k8sCoreV1Api.listNamespacedPod(...params),
+                resourceListObj = await pRetry(
+                    () => this.k8sCoreV1Api.listNamespacedPod(params),
                     getRetryConfig()
                 );
             } else if (objType === 'replicasets') {
-                responseObj = await pRetry(
-                    () => this.k8sAppsV1Api.listNamespacedReplicaSet(...params),
+                resourceListObj = await pRetry(
+                    () => this.k8sAppsV1Api.listNamespacedReplicaSet(params),
                     getRetryConfig()
                 );
             } else if (objType === 'services') {
-                responseObj = await pRetry(
-                    () => this.k8sCoreV1Api.listNamespacedService(...params),
+                resourceListObj = await pRetry(
+                    () => this.k8sCoreV1Api.listNamespacedService(params),
                     getRetryConfig()
                 );
             } else {
@@ -212,7 +208,7 @@ export class K8s {
                 this.logger.error(error);
                 return Promise.reject(error);
             }
-            return convertToTSResourceList(responseObj.body);
+            return convertToTSResourceList(resourceListObj);
         } catch (e) {
             const err = new Error(`Request k8s.list of ${objType} with selector ${selector} failed: ${e}`);
             this.logger.error(err);
@@ -246,30 +242,31 @@ export class K8s {
     async post(manifest: k8s.V1ReplicaSet): Promise<i.TSReplicaSet>;
     async post(manifest: k8s.V1Service): Promise<i.TSService>;
     async post(manifest: i.K8sResource): Promise<i.TSResource> {
-        let responseObj: i.ResourceApiResponse;
+        let resourceObj: i.K8sResource;
+        const namespace = this.defaultNamespace;
 
         try {
             if (isDeployment(manifest)) {
-                responseObj = await this.k8sAppsV1Api
-                    .createNamespacedDeployment(this.defaultNamespace, manifest);
+                resourceObj = await this.k8sAppsV1Api
+                    .createNamespacedDeployment({ namespace, body: manifest });
             } else if (isJob(manifest)) {
-                responseObj = await this.k8sBatchV1Api
-                    .createNamespacedJob(this.defaultNamespace, manifest);
+                resourceObj = await this.k8sBatchV1Api
+                    .createNamespacedJob({ namespace, body: manifest });
             } else if (isPod(manifest)) {
-                responseObj = await this.k8sCoreV1Api
-                    .createNamespacedPod(this.defaultNamespace, manifest);
+                resourceObj = await this.k8sCoreV1Api
+                    .createNamespacedPod({ namespace, body: manifest });
             } else if (isReplicaSet(manifest)) {
-                responseObj = await this.k8sAppsV1Api
-                    .createNamespacedReplicaSet(this.defaultNamespace, manifest);
+                resourceObj = await this.k8sAppsV1Api
+                    .createNamespacedReplicaSet({ namespace, body: manifest });
             } else if (isService(manifest)) {
-                responseObj = await this.k8sCoreV1Api
-                    .createNamespacedService(this.defaultNamespace, manifest);
+                resourceObj = await this.k8sCoreV1Api
+                    .createNamespacedService({ namespace, body: manifest });
             } else {
                 const error = new Error('Invalid manifest type');
                 return Promise.reject(error);
             }
 
-            return convertToTSResource(responseObj.body);
+            return convertToTSResource(resourceObj);
         } catch (e) {
             const err = new Error(`Request k8s.post of ${manifest.kind} with body ${JSON.stringify(manifest)} failed: ${e}`);
             return Promise.reject(err);
@@ -280,28 +277,21 @@ export class K8s {
      * Patches specified k8s deployment with the provided record
      * @param  {String} record record, like 'app=teraslice'
      * @param  {String} name   Name of the deployment to patch
-     * @return {Object}        body of k8s patch response.
+     * @return {Object}        k8s V1Deployment object.
      */
     // TODO: I renamed this from patchDeployment to just patch because this is
     // the low level k8s api method, I expect to eventually change the interface
     // on this to require `objType` to support patching other things
     async patch(record: Record<string, any>, name: string) {
-        let responseObj: i.PatchApiResponse;
+        let responseObj: k8s.V1Deployment;
         try {
-            const options = { headers: { 'Content-type': k8s.PatchUtils.PATCH_FORMAT_JSON_PATCH } };
-            responseObj = await pRetry(() => this.k8sAppsV1Api
-                .patchNamespacedDeployment(
-                    name,
-                    this.defaultNamespace,
-                    record,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    options,
-                ), getRetryConfig());
-            return responseObj.body;
+            const options = k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.JsonPatch);
+            responseObj = await pRetry(() => this.k8sAppsV1Api.patchNamespacedDeployment({
+                name,
+                namespace: this.defaultNamespace,
+                body: record
+            }, options as k8s.ConfigurationOptions), getRetryConfig());
+            return responseObj;
         } catch (e) {
             const err = new Error(`Request k8s.patch with name: ${name} failed with: ${e}`);
             this.logger.error(err);
@@ -316,7 +306,7 @@ export class K8s {
      *                                 'deployments', 'services', 'jobs', 'pods', 'replicasets'
      * @param  {Boolean}   force       Forcefully delete resource by setting gracePeriodSeconds to 1
      *                                 to be forcefully stopped.
-     * @return {Object}                k8s delete response body.
+     * @return {Object}                k8s service, pod or status object.
      */
     async delete(
         name: string, objType: 'pods', force?: boolean
@@ -329,15 +319,15 @@ export class K8s {
     ): Promise<k8s.V1Service>;
     async delete(
         name: string, objType: i.ResourceType, force?: boolean
-    ): Promise<i.DeleteResponseBody>;
+    ): Promise<k8s.V1Pod | k8s.V1Status | k8s.V1Service>;
     async delete(
         name: string, objType: i.ResourceType, force?: boolean
-    ): Promise<i.DeleteResponseBody> {
+    ): Promise<k8s.V1Pod | k8s.V1Status | k8s.V1Service> {
         if (name === undefined || name.trim() === '') {
             throw new Error(`Name of resource to delete must be specified. Received: "${name}".`);
         }
 
-        let responseObj: i.DeleteApiResponse;
+        let responseObj: k8s.V1Pod | k8s.V1Status | k8s.V1Service;
 
         // To get a Job to remove the associated pods you have to
         // include a body like the one below with the delete request.
@@ -352,20 +342,15 @@ export class K8s {
             deleteOptions.gracePeriodSeconds = 1;
         }
 
-        const params: i.DeleteParams = [
+        const params = {
             name,
-            this.defaultNamespace,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
+            namespace: this.defaultNamespace,
             deleteOptions
-        ];
+        };
 
         const deleteWithErrorHandling = async (
-            deleteFn: () => Promise<i.DeleteApiResponse>
-        ): Promise<i.DeleteApiResponse> => {
+            deleteFn: () => Promise<k8s.V1Pod | k8s.V1Status | k8s.V1Service>
+        ): Promise<k8s.V1Pod | k8s.V1Status | k8s.V1Service> => {
             try {
                 const res = await deleteFn();
                 return res;
@@ -384,24 +369,24 @@ export class K8s {
         try {
             if (objType === 'services') {
                 responseObj = await pRetry(() => deleteWithErrorHandling(() => this.k8sCoreV1Api
-                    .deleteNamespacedService(...params)), getRetryConfig());
+                    .deleteNamespacedService(params)), getRetryConfig());
             } else if (objType === 'deployments') {
                 responseObj = await pRetry(() => deleteWithErrorHandling(() => this.k8sAppsV1Api
-                    .deleteNamespacedDeployment(...params)), getRetryConfig());
+                    .deleteNamespacedDeployment(params)), getRetryConfig());
             } else if (objType === 'jobs') {
                 responseObj = await pRetry(() => deleteWithErrorHandling(() => this.k8sBatchV1Api
-                    .deleteNamespacedJob(...params)), getRetryConfig());
+                    .deleteNamespacedJob(params)), getRetryConfig());
             } else if (objType === 'pods') {
                 responseObj = await pRetry(() => deleteWithErrorHandling(() => this.k8sCoreV1Api
-                    .deleteNamespacedPod(...params)), getRetryConfig());
+                    .deleteNamespacedPod(params)), getRetryConfig());
             } else if (objType === 'replicasets') {
                 responseObj = await pRetry(() => deleteWithErrorHandling(() => this.k8sAppsV1Api
-                    .deleteNamespacedReplicaSet(...params)), getRetryConfig());
+                    .deleteNamespacedReplicaSet(params)), getRetryConfig());
             } else {
                 throw new Error(`Invalid objType: ${objType}`);
             }
 
-            return responseObj.body;
+            return responseObj;
         } catch (e) {
             const err = new Error(`Request k8s.delete with name: ${name} failed with: ${e}`);
             this.logger.error(err);
@@ -458,7 +443,7 @@ export class K8s {
 
     async _deleteObjByExId(
         exId: string, nodeType: i.NodeType, objType: i.ResourceType, force?: boolean
-    ): Promise<i.DeleteResponseBody[] | void> {
+    ): Promise<(k8s.V1Pod | k8s.V1Status | k8s.V1Service)[] | void> {
         let objList: i.TSResourceList;
         const deleteResponses: Array<k8s.V1Pod | k8s.V1Service | k8s.V1Status> = [];
 

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8s.ts
@@ -174,7 +174,7 @@ export class K8s {
 
         const params = {
             namespace,
-            selector
+            labelSelector: selector
         };
 
         try {
@@ -290,7 +290,7 @@ export class K8s {
                 name,
                 namespace: this.defaultNamespace,
                 body: record
-            }, options as k8s.ConfigurationOptions), getRetryConfig());
+            }, options), getRetryConfig());
             return responseObj;
         } catch (e) {
             const err = new Error(`Request k8s.patch with name: ${name} failed with: ${e}`);
@@ -345,7 +345,7 @@ export class K8s {
         const params = {
             name,
             namespace: this.defaultNamespace,
-            deleteOptions
+            body: deleteOptions
         };
 
         const deleteWithErrorHandling = async (
@@ -355,11 +355,12 @@ export class K8s {
                 const res = await deleteFn();
                 return res;
             } catch (e) {
-                if (e.statusCode) {
+                if (e.body) {
+                    const bodyObj = JSON.parse(e.body);
                     // 404 should be an acceptable response to a delete request, not an error
-                    if (e.statusCode === 404) {
+                    if (bodyObj.code === 404) {
                         this.logger.info(`No ${objType} with name ${name} found while attempting to delete.`);
-                        return e;
+                        return bodyObj;
                     }
                 }
                 throw e;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1745,25 +1745,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kubernetes/client-node@npm:~0.22.3":
-  version: 0.22.3
-  resolution: "@kubernetes/client-node@npm:0.22.3"
+"@kubernetes/client-node@npm:~1.1.1":
+  version: 1.1.1
+  resolution: "@kubernetes/client-node@npm:1.1.1"
   dependencies:
-    byline: "npm:^5.0.0"
+    "@types/js-yaml": "npm:^4.0.1"
+    "@types/node": "npm:^22.0.0"
+    "@types/node-fetch": "npm:^2.6.9"
+    "@types/stream-buffers": "npm:^3.0.3"
+    "@types/tar": "npm:^6.1.1"
+    "@types/ws": "npm:^8.5.4"
+    form-data: "npm:^4.0.0"
+    hpagent: "npm:^1.2.0"
     isomorphic-ws: "npm:^5.0.0"
     js-yaml: "npm:^4.1.0"
-    jsonpath-plus: "npm:^10.2.0"
+    jsonpath-plus: "npm:^10.3.0"
+    node-fetch: "npm:^2.6.9"
     openid-client: "npm:^6.1.3"
-    request: "npm:^2.88.0"
     rfc4648: "npm:^1.3.0"
+    socks-proxy-agent: "npm:^8.0.4"
     stream-buffers: "npm:^3.0.2"
     tar: "npm:^7.0.0"
-    tslib: "npm:^2.4.1"
+    tmp-promise: "npm:^3.0.2"
     ws: "npm:^8.18.0"
-  dependenciesMeta:
-    openid-client:
-      optional: true
-  checksum: 10c0/78ce0b81eaa6521a506813e88195692f6b52128427c70b1fe4bc5e277e6cc56ab366617fd1daec4e39da6b8a9c7f4b7b1ad35c598a64b277a150c1b52734f2a4
+  checksum: 10c0/8f61e1be823957ae77d45c8ec4feea5bf4c40f8b015cf082b3a76061c9f424ac6fefcf2168a33459bfe78dc98f79a4c2edc3e609856ae31f9a66bd9b79584545
   languageName: node
   linkType: hard
 
@@ -3157,7 +3162,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
-    "@kubernetes/client-node": "npm:~0.22.3"
+    "@kubernetes/client-node": "npm:~1.1.1"
     "@terascope/utils": "npm:~1.8.0"
     "@types/ip": "npm:~1.1.3"
     "@types/micromatch": "npm:~4.0.9"
@@ -3925,7 +3930,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/js-yaml@npm:~4.0.9":
+"@types/js-yaml@npm:^4.0.1, @types/js-yaml@npm:~4.0.9":
   version: 4.0.9
   resolution: "@types/js-yaml@npm:4.0.9"
   checksum: 10c0/24de857aa8d61526bbfbbaa383aa538283ad17363fcd5bb5148e2c7f604547db36646440e739d78241ed008702a8920665d1add5618687b6743858fae00da211
@@ -4010,6 +4015,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node-fetch@npm:^2.6.9":
+  version: 2.6.12
+  resolution: "@types/node-fetch@npm:2.6.12"
+  dependencies:
+    "@types/node": "npm:*"
+    form-data: "npm:^4.0.0"
+  checksum: 10c0/7693acad5499b7df2d1727d46cff092a63896dc04645f36b973dd6dd754a59a7faba76fcb777bdaa35d80625c6a9dd7257cca9c401a4bab03b04480cda7fd1af
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*":
   version: 22.13.5
   resolution: "@types/node@npm:22.13.5"
@@ -4023,6 +4038,15 @@ __metadata:
   version: 10.17.60
   resolution: "@types/node@npm:10.17.60"
   checksum: 10c0/0742294912a6e79786cdee9ed77cff6ee8ff007b55d8e21170fc3e5994ad3a8101fea741898091876f8dc32b0a5ae3d64537b7176799e92da56346028d2cbcd2
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^22.0.0":
+  version: 22.14.0
+  resolution: "@types/node@npm:22.14.0"
+  dependencies:
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/9d79f3fa1af9c2c869514f419c4a4905b34c10e12915582fd1784868ac4e74c6d306cf5eb47ef889b6750ab85a31be96618227b86739c4a3e0b1c15063f384c6
   languageName: node
   linkType: hard
 
@@ -4160,6 +4184,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/stream-buffers@npm:^3.0.3":
+  version: 3.0.7
+  resolution: "@types/stream-buffers@npm:3.0.7"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/c27f2b698a63aa6c0a4023ac47aad174bd601963d65a419f7422970ec7f946e65ed6920c71540fc8a9c1044642e5da769ea51e370abbc5d614f3ab16ff08529f
+  languageName: node
+  linkType: hard
+
+"@types/tar@npm:^6.1.1":
+  version: 6.1.13
+  resolution: "@types/tar@npm:6.1.13"
+  dependencies:
+    "@types/node": "npm:*"
+    minipass: "npm:^4.0.0"
+  checksum: 10c0/98cc72d444fa622049e86e457a64d859c6effd7c7518d36e7b40b4ab1e7aa9e2412cc868cbef396650485dae07d50d98f662e8a53bb45f4a70eb6c61f80a63c7
+  languageName: node
+  linkType: hard
+
 "@types/tmp@npm:~0.2.6":
   version: 0.2.6
   resolution: "@types/tmp@npm:0.2.6"
@@ -4222,6 +4265,15 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/fa958e64596ca9487c3ed6012834de70b47f25d971f1950cfb8e6a99cb77ff340ae82ac7627744e01b58010674ef8ede07d5a2ac29ca9ad0d67a430fcc69ae14
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.5.4":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/61aff1129143fcc4312f083bc9e9e168aa3026b7dd6e70796276dcfb2c8211c4292603f9c4864fae702f2ed86e4abd4d38aa421831c2fd7f856c931a481afbab
   languageName: node
   linkType: hard
 
@@ -5314,13 +5366,6 @@ __metadata:
   bin:
     bunyan: bin/bunyan
   checksum: 10c0/c7b3adc07a4db3256f857dcba42b97dd6c35ab054cb26766643aae2b90e1b614795cdf231774ddaf374572d952f52ef4f4205047e15414e155e478aa0672e041
-  languageName: node
-  linkType: hard
-
-"byline@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "byline@npm:5.0.0"
-  checksum: 10c0/33fb64cd84440b3652a99a68d732c56ef18a748ded495ba38e7756a242fab0d4654b9b8ce269fd0ac14c5f97aa4e3c369613672b280a1f60b559b34223105c85
   languageName: node
   linkType: hard
 
@@ -7588,6 +7633,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"form-data@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "form-data@npm:4.0.2"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    mime-types: "npm:^2.1.12"
+  checksum: 10c0/e534b0cf025c831a0929bf4b9bbe1a9a6b03e273a8161f9947286b9b13bf8fb279c6944aae0070c4c311100c6d6dbb815cd955dc217728caf73fad8dc5b8ee9c
+  languageName: node
+  linkType: hard
+
 "form-data@npm:~2.3.2":
   version: 2.3.3
   resolution: "form-data@npm:2.3.3"
@@ -9833,7 +9890,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonpath-plus@npm:^10.2.0":
+"jsonpath-plus@npm:^10.3.0":
   version: 10.3.0
   resolution: "jsonpath-plus@npm:10.3.0"
   dependencies:
@@ -10479,6 +10536,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minipass@npm:^4.0.0":
+  version: 4.2.8
+  resolution: "minipass@npm:4.2.8"
+  checksum: 10c0/4ea76b030d97079f4429d6e8a8affd90baf1b6a1898977c8ccce4701c5a2ba2792e033abc6709373f25c2c4d4d95440d9d5e9464b46b7b76ca44d2ce26d939ce
+  languageName: node
+  linkType: hard
+
 "minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2":
   version: 7.1.2
   resolution: "minipass@npm:7.1.2"
@@ -10631,6 +10695,20 @@ __metadata:
     json-stringify-safe: "npm:^5.0.1"
     propagate: "npm:^2.0.0"
   checksum: 10c0/94249a294176a6e521bbb763c214de4aa6b6ab63dff1e299aaaf455886a465d38906891d7f24570d94a43b1e376c239c54d89ff7697124bc57ef188006acc25e
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.9":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
   languageName: node
   linkType: hard
 
@@ -12562,7 +12640,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^8.0.3":
+"socks-proxy-agent@npm:^8.0.3, socks-proxy-agent@npm:^8.0.4":
   version: 8.0.5
   resolution: "socks-proxy-agent@npm:8.0.5"
   dependencies:
@@ -13208,7 +13286,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "teraslice@workspace:packages/teraslice"
   dependencies:
-    "@kubernetes/client-node": "npm:~0.22.3"
+    "@kubernetes/client-node": "npm:~1.1.1"
     "@terascope/elasticsearch-api": "npm:~4.9.0"
     "@terascope/job-components": "npm:~1.10.0"
     "@terascope/teraslice-messaging": "npm:~1.11.0"
@@ -13300,7 +13378,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:~0.2.3":
+"tmp-promise@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "tmp-promise@npm:3.0.3"
+  dependencies:
+    tmp: "npm:^0.2.0"
+  checksum: 10c0/23b47dcb2e82b14bbd8f61ed7a9d9353cdb6a6f09d7716616cfd27d0087040cd40152965a518e598d7aabe1489b9569bf1eebde0c5fadeaf3ec8098adcebea4e
+  languageName: node
+  linkType: hard
+
+"tmp@npm:^0.2.0, tmp@npm:~0.2.3":
   version: 0.2.3
   resolution: "tmp@npm:0.2.3"
   checksum: 10c0/3e809d9c2f46817475b452725c2aaa5d11985cf18d32a7a970ff25b568438e2c076c2e8609224feef3b7923fa9749b74428e3e634f6b8e520c534eef2fd24125
@@ -13365,6 +13452,13 @@ __metadata:
     psl: "npm:^1.1.28"
     punycode: "npm:^2.1.1"
   checksum: 10c0/e1cadfb24d40d64ca16de05fa8192bc097b66aeeb2704199b055ff12f450e4f30c927ce250f53d01f39baad18e1c11d66f65e545c5c6269de4c366fafa4c0543
+  languageName: node
+  linkType: hard
+
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
   languageName: node
   linkType: hard
 
@@ -13484,7 +13578,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.4.0, tslib@npm:^2.4.1, tslib@npm:^2.6.2, tslib@npm:^2.8.1":
+"tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
@@ -13753,6 +13847,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
+  languageName: node
+  linkType: hard
+
 "undici@npm:^6.21.1":
   version: 6.21.1
   resolution: "undici@npm:6.21.1"
@@ -13946,6 +14047,23 @@ __metadata:
   dependencies:
     defaults: "npm:^1.0.3"
   checksum: 10c0/5b61ca583a95e2dd85d7078400190efd452e05751a64accb8c06ce4db65d7e0b0cde9917d705e826a2e05cc2548f61efde115ffa374c3e436d04be45c889e5b4
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: "npm:~0.0.3"
+    webidl-conversions: "npm:^3.0.0"
+  checksum: 10c0/1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3158,7 +3158,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/scripts@npm:~1.15.1, @terascope/scripts@workspace:packages/scripts":
+"@terascope/scripts@npm:~1.15.2, @terascope/scripts@workspace:packages/scripts":
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
@@ -6365,7 +6365,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e@workspace:e2e"
   dependencies:
-    "@terascope/scripts": "npm:~1.15.1"
+    "@terascope/scripts": "npm:~1.15.2"
     "@terascope/types": "npm:~1.4.1"
     "@terascope/utils": "npm:~1.8.0"
     bunyan: "npm:~1.8.15"
@@ -13263,7 +13263,7 @@ __metadata:
     "@eslint/js": "npm:~9.23.0"
     "@swc/core": "npm:1.11.13"
     "@swc/jest": "npm:~0.2.37"
-    "@terascope/scripts": "npm:~1.15.1"
+    "@terascope/scripts": "npm:~1.15.2"
     "@types/bluebird": "npm:~3.5.42"
     "@types/convict": "npm:~6.1.6"
     "@types/elasticsearch": "npm:~5.0.43"


### PR DESCRIPTION
This PR makes the following changes:
- Update @kubernetes/client-node from v0.22.3 to v1.1.1
- fix API breaking changes
- bump teraslice to v2.14.4
- bump @terascope/scripts to v1.15.2
- bump teraslice helm chart to v2.7.0