### PR TITLE
[teraslice] bump version to 2.15.0, build with terafoundation_kafka_connector v1.5.0

### DIFF
--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 2.8.0
-appVersion: v2.14.5
+version: 2.9.0
+appVersion: v2.15.0
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/helm/teraslice/values.yaml
+++ b/helm/teraslice/values.yaml
@@ -11,7 +11,7 @@ image:
   pullPolicy: IfNotPresent
   # node version will be inserted into the image tag (which defaults to the chart version)
   # setting the image tag will ignore this value
-  nodeVersion: v22.14.0
+  nodeVersion: v22.15.0
 
 imagePullSecrets: []
 nameOverride: ""

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.14.5",
+    "version": "2.15.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.14.5",
+    "version": "2.15.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:
- bump teraslice from 2.14.5 to 2.15.0
- this release will build on the teraslice base-docker-image containing:
  - `terafoundation_kafka_connector v1.5.0`
  - `node-rdkafka v3.4.0`
  - `librdkafka v2.10.0`