### PR TITLE
[teraslice-cli] Remove hard-coded restrictions when using --build-target flag

### DIFF
--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "2.10.7",
+    "version": "2.11.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"

--- a/packages/teraslice-cli/src/helpers/yargs-options.ts
+++ b/packages/teraslice-cli/src/helpers/yargs-options.ts
@@ -64,15 +64,11 @@ export default class Options {
             type: 'boolean'
         }),
         'bundle-target': () => ({
-            describe: 'Specify which version of node is used as the target for esbuild.'
-                + ' Defaults to current major node version',
+            describe: 'Specify the ECMAScript target environment for esbuild, such as a specific Node.js version.\n'
+                + 'Defaults to the current major Node.js version in use.'
+                + 'Use the syntax accepted by esbuild, for example: "node20" or "es2020".\n'
+                + 'See full list of valid targets at: https://esbuild.github.io/api/#target',
             default: `node${process.version.split('.', 1)[0].substring(1)}`,
-            choices: [
-                'node16',
-                'node18',
-                'node20',
-                'node22'
-            ],
             // I have disabled this because for some reason this requirement was
             // being enforced even when `bundle-target` wasn't specified.
             // Ideally we'd have a way to warn the user that they need to set

--- a/packages/teraslice-cli/test/helpers/asset-src-spec.ts
+++ b/packages/teraslice-cli/test/helpers/asset-src-spec.ts
@@ -111,7 +111,7 @@ describe('AssetSrc', () => {
         const devMode = false;
         const debug = false;
         const bundle = false;
-        const bundleTarget = 'node18';
+        const bundleTarget = 'node22';
         const overwrite = false;
 
         try {
@@ -124,13 +124,13 @@ describe('AssetSrc', () => {
         }
     });
 
-    it('can build a node 18 bundle', async () => {
+    it('can build a node 22 bundle', async () => {
         expect.hasAssertions();
 
         const devMode = false;
         const debug = false;
         const bundle = true;
-        const bundleTarget = 'node18';
+        const bundleTarget = 'node22';
         const overwrite = false;
 
         const myTestAsset = new AssetSrc(
@@ -141,7 +141,7 @@ describe('AssetSrc', () => {
 
         try {
             resp = await myTestAsset.build();
-            expect(resp.name).toContain('node-18');
+            expect(resp.name).toContain('node-22');
         } finally {
             if (resp) {
                 await fs.remove(resp.name);


### PR DESCRIPTION
This PR makes the following changes:

## Minor changes 

- Removes hardcoded restrictions when using `--build-target` flag in `earl assets build` command
  - We now have esbuild be in charge of errors that occur when an invalid build target is provided
  - This frees us from the burden of having to maintain and update earl every time there is a new node release
- Bump: (minor) teraslice-cli from `v2.10.7` to `v2.11.0`

## Testing 
- Update `teraslice-cli` tests to build test for `node22` instead of `node18`