### PR TITLE
[teraslice, scripts] Update @kubernetes/client-node to v1.3.0

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -47,7 +47,7 @@
         "ms": "~2.1.3"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.17.1",
+        "@terascope/scripts": "~1.17.2",
         "@terascope/types": "~1.4.1",
         "@terascope/utils": "~1.8.2",
         "bunyan": "~1.8.15",

--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 2.11.0
-appVersion: v2.16.1
+version: 2.12.0
+appVersion: v2.16.2
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.16.1",
+    "version": "2.16.2",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {
@@ -54,7 +54,7 @@
         "@eslint/js": "~9.27.0",
         "@swc/core": "1.11.29",
         "@swc/jest": "~0.2.38",
-        "@terascope/scripts": "~1.17.1",
+        "@terascope/scripts": "~1.17.2",
         "@types/bluebird": "~3.5.42",
         "@types/convict": "~6.1.6",
         "@types/elasticsearch": "~5.0.43",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.17.1",
+    "version": "1.17.2",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.16.1",
+    "version": "2.16.2",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2983,7 +2983,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/scripts@npm:~1.17.1, @terascope/scripts@workspace:packages/scripts":
+"@terascope/scripts@npm:~1.17.2, @terascope/scripts@workspace:packages/scripts":
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
@@ -6201,7 +6201,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e@workspace:e2e"
   dependencies:
-    "@terascope/scripts": "npm:~1.17.1"
+    "@terascope/scripts": "npm:~1.17.2"
     "@terascope/types": "npm:~1.4.1"
     "@terascope/utils": "npm:~1.8.2"
     bunyan: "npm:~1.8.15"
@@ -13124,7 +13124,7 @@ __metadata:
     "@eslint/js": "npm:~9.27.0"
     "@swc/core": "npm:1.11.29"
     "@swc/jest": "npm:~0.2.38"
-    "@terascope/scripts": "npm:~1.17.1"
+    "@terascope/scripts": "npm:~1.17.2"
     "@types/bluebird": "npm:~3.5.42"
     "@types/convict": "npm:~6.1.6"
     "@types/elasticsearch": "npm:~5.0.43"


### PR DESCRIPTION
This PR makes the following changes:
- update `@kubernetes/client-node` from v1.2.0 to v1.3.0
  - This version includes the `ws` dependency that was removed in version 1.2.0, breaking `ts-scripts images list`
- bump scripts from v1.17.1 to v1.17.2
- bump teraslice from v2.16.1 to v2.16.2
- bump helm chart from v2.11.0 to 2.12.0