### PR TITLE
[tests] use scripts bin instead of yarn workspace

### DIFF
--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -25,9 +25,9 @@
         "benchmark": "yarn build && node bench/index.js",
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../data-mate --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../data-mate --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../data-mate --"
+        "test": "node ../scripts/bin/ts-scripts test ../data-mate --",
+        "test:debug": "node ../scripts/bin/ts-scripts --debug ../data-mate --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../data-mate --"
     },
     "dependencies": {
         "@terascope/data-types": "~1.8.3",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -22,9 +22,9 @@
     "scripts": {
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../data-types --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../data-types --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../data-types --"
+        "test": "node ../scripts/bin/ts-scripts test ../data-types --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../data-types --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../data-types --"
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",

--- a/packages/docker-compose-js/package.json
+++ b/packages/docker-compose-js/package.json
@@ -28,9 +28,9 @@
     "scripts": {
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../docker-compose-js --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../docker-compose-js --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../docker-compose-js --"
+        "test": "node ../scripts/bin/ts-scripts test ../docker-compose-js --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../docker-compose-js --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../docker-compose-js --"
     },
     "resolutions": {
         "debug": "~4.4.1"

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -14,14 +14,14 @@
     "main": "index.js",
     "typings": "types/index.d.ts",
     "scripts": {
-        "test": "TEST_RESTRAINED_ELASTICSEARCH='true' yarn workspace @terascope/scripts ts-scripts test ../elasticsearch-api --",
-        "test:debug": "TEST_RESTRAINED_ELASTICSEARCH='true' yarn workspace @terascope/scripts ts-scripts test --debug ../elasticsearch-api --",
-        "test:elasticsearch6": "TEST_RESTRAINED_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='6.8.6' yarn workspace @terascope/scripts ts-scripts test ../elasticsearch-api --",
-        "test:elasticsearch7": "TEST_RESTRAINED_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='7.9.3' yarn workspace @terascope/scripts ts-scripts test ../elasticsearch-api --",
-        "test:elasticsearch8": "TEST_RESTRAINED_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='8.1.2' yarn workspace @terascope/scripts ts-scripts test ../elasticsearch-api --",
-        "test:opensearch1": "TEST_RESTRAINED_OPENSEARCH='true' yarn workspace @terascope/scripts ts-scripts test --debug ../elasticsearch-api --",
-        "test:opensearch2": "TEST_RESTRAINED_OPENSEARCH='true' OPENSEARCH_VERSION='2.15.0' yarn workspace @terascope/scripts ts-scripts test --debug ../elasticsearch-api --",
-        "test:watch": "TEST_RESTRAINED_ELASTICSEARCH='true' yarn workspace @terascope/scripts ts-scripts test --watch ../elasticsearch-api --"
+        "test": "TEST_RESTRAINED_ELASTICSEARCH='true' node ../scripts/bin/ts-scripts test ../elasticsearch-api --",
+        "test:debug": "TEST_RESTRAINED_ELASTICSEARCH='true' node ../scripts/bin/ts-scripts test --debug ../elasticsearch-api --",
+        "test:elasticsearch6": "TEST_RESTRAINED_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='6.8.6' node ../scripts/bin/ts-scripts test ../elasticsearch-api --",
+        "test:elasticsearch7": "TEST_RESTRAINED_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='7.9.3' node ../scripts/bin/ts-scripts test ../elasticsearch-api --",
+        "test:elasticsearch8": "TEST_RESTRAINED_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='8.1.2' node ../scripts/bin/ts-scripts test ../elasticsearch-api --",
+        "test:opensearch1": "TEST_RESTRAINED_OPENSEARCH='true' node ../scripts/bin/ts-scripts test --debug ../elasticsearch-api --",
+        "test:opensearch2": "TEST_RESTRAINED_OPENSEARCH='true' OPENSEARCH_VERSION='2.15.0' node ../scripts/bin/ts-scripts test --debug ../elasticsearch-api --",
+        "test:watch": "TEST_RESTRAINED_ELASTICSEARCH='true' node ../scripts/bin/ts-scripts test --watch ../elasticsearch-api --"
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -20,13 +20,13 @@
     "scripts": {
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "TEST_ELASTICSEARCH='true' yarn workspace @terascope/scripts ts-scripts test ../elasticsearch-store --",
-        "test:debug": "TEST_ELASTICSEARCH='true' yarn workspace @terascope/scripts ts-scripts test --debug ../elasticsearch-store --",
-        "test:elasticsearch6": "TEST_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='6.8.6' yarn workspace @terascope/scripts ts-scripts test ../elasticsearch-store --",
-        "test:elasticsearch7": "TEST_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='7.9.3' yarn workspace @terascope/scripts ts-scripts test ../elasticsearch-store --",
-        "test:elasticsearch8": "TEST_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='8.1.2' yarn workspace @terascope/scripts ts-scripts test ../elasticsearch-store --",
-        "test:opensearch1": "TEST_OPENSEARCH='true' yarn workspace @terascope/scripts ts-scripts test ../elasticsearch-store --",
-        "test:opensearch2": "TEST_OPENSEARCH='true' OPENSEARCH_VERSION='2.15.0' yarn workspace @terascope/scripts ts-scripts test ../elasticsearch-store --",
+        "test": "TEST_ELASTICSEARCH='true' node ../scripts/bin/ts-scripts test ../elasticsearch-store --",
+        "test:debug": "TEST_ELASTICSEARCH='true' node ../scripts/bin/ts-scripts test --debug ../elasticsearch-store --",
+        "test:elasticsearch6": "TEST_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='6.8.6' node ../scripts/bin/ts-scripts test ../elasticsearch-store --",
+        "test:elasticsearch7": "TEST_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='7.9.3' node ../scripts/bin/ts-scripts test ../elasticsearch-store --",
+        "test:elasticsearch8": "TEST_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='8.1.2' node ../scripts/bin/ts-scripts test ../elasticsearch-store --",
+        "test:opensearch1": "TEST_OPENSEARCH='true' node ../scripts/bin/ts-scripts test ../elasticsearch-store --",
+        "test:opensearch2": "TEST_OPENSEARCH='true' OPENSEARCH_VERSION='2.15.0' node ../scripts/bin/ts-scripts test ../elasticsearch-store --",
         "test:watch": "ts-scripts yarn workspace @terascope/scripts test --watch ../elasticsearch-store --"
     },
     "dependencies": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -13,9 +13,9 @@
     "type": "module",
     "main": "index.js",
     "scripts": {
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../eslint-config --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../eslint-config --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../eslint-config --"
+        "test": "node ../scripts/bin/ts-scripts test ../eslint-config --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../eslint-config --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../eslint-config --"
     },
     "dependencies": {
         "@eslint/compat": "~1.2.9",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -27,9 +27,9 @@
         "benchmark": " yarn build && node bench/index.js",
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../job-components --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../job-components --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../job-components --"
+        "test": "node ../scripts/bin/ts-scripts test ../job-components --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../job-components --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../job-components --"
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -23,9 +23,9 @@
     "scripts": {
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../terafoundation --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../terafoundation --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../terafoundation --"
+        "test": "node ../scripts/bin/ts-scripts test ../terafoundation --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../terafoundation --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../terafoundation --"
     },
     "dependencies": {
         "@terascope/file-asset-apis": "~1.0.6",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -34,7 +34,7 @@
         "build": "tsc --build && yarn postbuild",
         "postbuild": "node build.js",
         "build:watch": "tsc --build --watch & node build.js --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../teraslice-cli --",
+        "test": "node ../scripts/bin/ts-scripts test ../teraslice-cli --",
         "test:debug": "yarn workspace @terascope/scripts test --debug ../teraslice-cli --",
         "test:watch": "yarn workspace @terascope/scripts test --watch ../teraslice-cli --"
     },

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -27,9 +27,9 @@
     "scripts": {
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../teraslice-client-js --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../teraslice-client-js --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../teraslice-client-js --"
+        "test": "node ../scripts/bin/ts-scripts test ../teraslice-client-js --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../teraslice-client-js --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../teraslice-client-js --"
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -26,9 +26,9 @@
     "scripts": {
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../teraslice-messaging --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../teraslice-messaging --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../teraslice-messaging --"
+        "test": "node ../scripts/bin/ts-scripts test ../teraslice-messaging --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../teraslice-messaging --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../teraslice-messaging --"
     },
     "resolutions": {
         "debug": "~4.4.1",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -19,9 +19,9 @@
     "scripts": {
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../teraslice-state-storage --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../teraslice-state-storage --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../teraslice-state-storage --"
+        "test": "node ../scripts/bin/ts-scripts test ../teraslice-state-storage --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../teraslice-state-storage --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../teraslice-state-storage --"
     },
     "dependencies": {
         "@terascope/elasticsearch-api": "~4.9.2",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -26,9 +26,9 @@
     "scripts": {
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../teraslice-test-harness --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../teraslice-test-harness --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../teraslice-test-harness --"
+        "test": "node ../scripts/bin/ts-scripts test ../teraslice-test-harness --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../teraslice-test-harness --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../teraslice-test-harness --"
     },
     "dependencies": {
         "@terascope/fetch-github-release": "~2.2.1",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -25,13 +25,13 @@
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
         "start": "node service.js",
-        "test": "TEST_ELASTICSEARCH='true' yarn workspace @terascope/scripts ts-scripts test ../teraslice --",
-        "test:debug": "TEST_ELASTICSEARCH='true' yarn workspace @terascope/scripts ts-scripts test --debug ../teraslice --",
-        "test:elasticsearch6": "TEST_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='6.8.6' yarn workspace @terascope/scripts ts-scripts test ../teraslice --",
-        "test:elasticsearch7": "TEST_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='7.9.3' yarn workspace @terascope/scripts ts-scripts test ../teraslice --",
-        "test:opensearch1": "TEST_OPENSEARCH='true' yarn workspace @terascope/scripts ts-scripts test ../teraslice --",
-        "test:opensearch2": "TEST_OPENSEARCH='true' OPENSEARCH_VERSION='2.15.0' yarn workspace @terascope/scripts ts-scripts test ../teraslice --",
-        "test:watch": "TEST_ELASTICSEARCH='true' yarn workspace @terascope/scripts ts-scripts test --watch ../teraslice --"
+        "test": "TEST_ELASTICSEARCH='true' node ../scripts/bin/ts-scripts test ../teraslice --",
+        "test:debug": "TEST_ELASTICSEARCH='true' node ../scripts/bin/ts-scripts test --debug ../teraslice --",
+        "test:elasticsearch6": "TEST_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='6.8.6' node ../scripts/bin/ts-scripts test ../teraslice --",
+        "test:elasticsearch7": "TEST_ELASTICSEARCH='true' ELASTICSEARCH_VERSION='7.9.3' node ../scripts/bin/ts-scripts test ../teraslice --",
+        "test:opensearch1": "TEST_OPENSEARCH='true' node ../scripts/bin/ts-scripts test ../teraslice --",
+        "test:opensearch2": "TEST_OPENSEARCH='true' OPENSEARCH_VERSION='2.15.0' node ../scripts/bin/ts-scripts test ../teraslice --",
+        "test:watch": "TEST_ELASTICSEARCH='true' node ../scripts/bin/ts-scripts test --watch ../teraslice --"
     },
     "resolutions": {
         "debug": "~4.4.1",

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -31,9 +31,9 @@
     "scripts": {
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../ts-transforms --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../ts-transforms --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../ts-transforms --"
+        "test": "node ../scripts/bin/ts-scripts test ../ts-transforms --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../ts-transforms --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../ts-transforms --"
     },
     "dependencies": {
         "@terascope/data-mate": "~1.8.3",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -20,9 +20,9 @@
     "scripts": {
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../types --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../types --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../types --"
+        "test": "node ../scripts/bin/ts-scripts test ../types --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../types --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../types --"
     },
     "dependencies": {
         "prom-client": "~15.1.3"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,9 +21,9 @@
         "benchmark": "yarn build && node bench/index.js",
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../utils --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../utils --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../utils --"
+        "test": "node ../scripts/bin/ts-scripts test ../utils --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../utils --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../utils --"
     },
     "resolutions": {
         "debug": "~4.4.1"

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -28,9 +28,9 @@
         "build": "yarn prebuild && tsc --build",
         "build:watch": "yarn build --watch",
         "postinstall": "./scripts/fix-deps.js",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../xlucene-parser --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../xlucene-parser --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../xlucene-parser --"
+        "test": "node ../scripts/bin/ts-scripts test ../xlucene-parser --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../xlucene-parser --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../xlucene-parser --"
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -24,9 +24,9 @@
     "scripts": {
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../xlucene-translator --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../xlucene-translator --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../xlucene-translator --"
+        "test": "node ../scripts/bin/ts-scripts test ../xlucene-translator --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../xlucene-translator --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../xlucene-translator --"
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -19,9 +19,9 @@
     "scripts": {
         "build": "tsc --build",
         "build:watch": "yarn build --watch",
-        "test": "yarn workspace @terascope/scripts ts-scripts test ../xpressions --",
-        "test:debug": "yarn workspace @terascope/scripts ts-scripts test --debug ../xpressions --",
-        "test:watch": "yarn workspace @terascope/scripts ts-scripts test --watch ../xpressions --"
+        "test": "node ../scripts/bin/ts-scripts test ../xpressions --",
+        "test:debug": "node ../scripts/bin/ts-scripts test --debug ../xpressions --",
+        "test:watch": "node ../scripts/bin/ts-scripts test --watch ../xpressions --"
     },
     "dependencies": {
         "@terascope/utils": "~1.8.2"


### PR DESCRIPTION
This PR makes the following changes:

- Changes the way ts-scripts is called in all packages in the monorepo
  - This fixes a bug where the developer can't pass `ts-scripts` flags when executing tests

Ref to issue #4043