### PR TITLE
release: (patch) teraslice@2.16.4

### DIFF
--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 2.13.0
-appVersion: v2.16.3
+version: 2.14.0
+appVersion: v2.16.4
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.16.3",
+    "version": "2.16.4",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.16.3",
+    "version": "2.16.4",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:
- bump teraslice from 2.16.3 to 2.16.4
- this release will build on the teraslice base-docker-image containing:
  - `terafoundation_kafka_connector v1.5.1`
  - `node-rdkafka v3.4.1`
  - `librdkafka v2.10.1`