### PR TITLE
[development] Update example helm environment

### DIFF
--- a/examples/helm/README.md
+++ b/examples/helm/README.md
@@ -28,13 +28,20 @@ cd ./examples/helm
 
 Quickly build an launch teraslice with `opensearch2` as the state cluster, minio, utility pod, and kafka with the script below:
 
+**NOTE:** _Ensure the directory at `teraslice/e2e/helm/utility/data` doesn't have large files in it or else the utility pod will fail to deploy running the script below. It's okay to move large files in the directory after the command below completes. More info about the [utility pod](#utility-pod-usage) is discussed below_
+
 ```bash
 kind create cluster --config kindConfig.yaml
+#### If these images already exist they can be skipped to stand up teraslice faster
 docker build -t terascope/teraslice:dev ../../.
 docker build -t teraslice-utility:0.0.1 ../../e2e/helm/utility/.
+# If instead you'd rather pull a teraslice image you can pull it and retag it like below
+# docker pull ghcr.io/terascope/teraslice:v2.16.4-nodev22.16.0
+# docker tag ghcr.io/terascope/teraslice:v2.16.4-nodev22.16.0 terascope/teraslice:dev
 kind load docker-image --name k8s-env terascope/teraslice:dev teraslice-utility:0.0.1
 helmfile sync
 ```
+
 Once completed, verify that teraslice is running by hitting the api:
 
 ```bash
@@ -54,6 +61,8 @@ Ensure minio is running correctly logging into the the [Minio UI](http://localho
 **Password:** _minioadmin_
 
 Kafka also has a UI by default, in the browser go to the [Kafka UI](http://localhost:8084) and ensure the `kafka-dev` cluster is present.
+
+### Utility pod usage
 
 The utility pod has useful tools to interact and load data into services. Services include:
 

--- a/examples/helm/README.md
+++ b/examples/helm/README.md
@@ -18,6 +18,62 @@ The following dependencies are required to successfully deploy a basic instance 
 - [teraslice-cli](https://www.npmjs.com/package/teraslice-cli) - A CLI tool for managing Teraslice
     - `npm install -g teraslice-cli`
 
+## Quick Start
+
+Start with being in the correct directory. Starting in the top level of the teraslice directory run:
+
+```bash
+cd ./examples/helm
+```
+
+Quickly build an launch teraslice with `opensearch2` as the state cluster, minio, utility pod, and kafka with the script below:
+
+```bash
+kind create cluster --config kindConfig.yaml
+docker build -t terascope/teraslice:dev ../../.
+docker build -t teraslice-utility:0.0.1 ../../e2e/helm/utility/.
+kind load docker-image --name k8s-env terascope/teraslice:dev teraslice-utility:0.0.1
+helmfile sync
+```
+Once completed, verify that teraslice is running by hitting the api:
+
+```bash
+curl localhost:5678
+```
+
+Also confirm that opensearch2 has all the teraslice state indices by running:
+
+```bash
+curl localhost:9200/_cat/indices
+```
+
+Ensure minio is running correctly logging into the the [Minio UI](http://localhost:9001) with the following username and password:
+
+**Username:** _minioadmin_
+
+**Password:** _minioadmin_
+
+Kafka also has a UI by default, in the browser go to the [Kafka UI](http://localhost:8084) and ensure the `kafka-dev` cluster is present.
+
+The utility pod has useful tools to interact and load data into services. Services include:
+
+- **kcat** a cli tool used to read, write, and interact with kafka
+- **jq** a command-line tool for processing JSON data
+- **fake_stream.sh** script, used for trickling data slowly in to a kafka topic to mimic streams of data
+- **curl** a command-line tool for transferring data with URLs
+
+We can open a bash shell into the utility container to use these tools with the command below:
+
+```bash
+kubectl -n services-dev1 exec -it $(kubectl -n services-dev1 get pod -l app=teraslice-utility -o jsonpath="{.items[0].metadata.name}") -- bash
+```
+
+The utility pod has a shared volume on the host machine to make moving files into the kind cluster easier. For example, a large ldjson file can be moved into the directory `teraslice/e2e/helm/utility/data` on the host machine. Then opening a shell with the command above and going to the `/app/data` directory, the file will now exist in the pod. If we wanted to quickly write this ldjson file into a kafka topic called `test-v1`, we could run:
+
+```bash
+kcat -b kafka-headless.services-dev1.svc.cluster.local:9092 -t test-v1 -P -l /app/data/<ldjson file name>
+```
+
 ### Initial Setup
 
 First you're going to want to be in the correct directory. Starting in the top level of the teraslice directory:

--- a/examples/helm/helmfile.yaml.gotmpl
+++ b/examples/helm/helmfile.yaml.gotmpl
@@ -14,6 +14,10 @@ repositories:
     url: https://charts.min.io/
   - name: chaos-mesh
     url: https://charts.chaos-mesh.org
+  - name: terascope
+    url: https://terascope.github.io/helm-charts/
+  - name: kafka-ui
+    url: https://provectus.github.io/kafka-ui-charts/
 
 helmDefaults:
   wait: true
@@ -73,10 +77,34 @@ releases:
 
   - name: kafka
     namespace: services-dev1
-    chart: ../../e2e/helm/kafka/cp-helm-charts-0.6.1.tgz
-    installed: {{ .Values | get "kafka.enabled" false }}
+    chart: terascope/kafka
+    version: 1.2.0
+    installed: {{ .Values | get "kafka.enabled" true }}
     values:
       - ../../e2e/helm/templates/kafka.yaml.gotmpl
+
+  - name: kafka-ui
+    namespace: services-dev1
+    chart: kafka-ui/kafka-ui
+    needs:
+      - services-dev1/kafka
+    version: 0.7.6
+    installed: {{ .Values | get "kafka.enabled" true }}
+    values:
+      - yamlApplicationConfig:
+          kafka:
+            clusters:
+              - name: kafka-dev
+                bootstrapServers: "PLAINTEXT://kafka-headless.services-dev1.svc.cluster.local:9092"
+          auth:
+            type: disabled
+          management:
+            health:
+              ldap:
+                enabled: false
+        service:
+          type: NodePort
+          nodePort: 30084
 
   - name: teraslice
     namespace: ts-dev1
@@ -87,3 +115,11 @@ releases:
       - ../../e2e/helm/templates/teraslice.yaml.gotmpl
     labels:
       app: teraslice
+
+  - name: utility
+    namespace: services-dev1
+    chart: ../../e2e/helm/utility
+    version: 0.0.1
+    installed: {{ .Values | get "utility.enabled" true }}
+    values:
+      - ../../e2e/helm/templates/utility.yaml.gotmpl

--- a/examples/helm/kindConfig.yaml
+++ b/examples/helm/kindConfig.yaml
@@ -19,6 +19,8 @@ nodes:
     hostPort: 9092
   - containerPort: 30094 # Map external kafka service to host port
     hostPort: 9094
+  - containerPort: 30084 # Map external kafka-ui service to host port
+    hostPort: 8084
   - containerPort: 30900 # Map internal minio service to host port
     hostPort: 9000
   - containerPort: 30901 # Map internal minio-ui service to host port
@@ -26,8 +28,10 @@ nodes:
   - containerPort: 30333 # Map internal chaos-mesh-ui service to host port
     hostPort: 2333
   extraMounts:
-  - hostPath: ./e2e/autoload
+  - hostPath: ../../e2e/autoload
     containerPath: /autoload
+  - hostPath: ../../e2e/helm/utility/data
+    containerPath: /data
 
 ###
 # Uncomment the code below for a multi-node kind cluster

--- a/examples/helm/values.yaml
+++ b/examples/helm/values.yaml
@@ -49,7 +49,7 @@ elasticsearch7:
 
 minio:
   # If false, minio will be excluded on helmfile sync
-  enabled: false
+  enabled: true
   version: RELEASE.2024-08-29T01-40-52Z
   instances: 1
   rootUser: minioadmin
@@ -64,8 +64,19 @@ minio:
 
 kafka:
   # If false, kafka will be excluded on helmfile sync
-  enabled: false
-  version: 7.7.1
+  enabled: true
+
+  # If true, "caCert" needs to be set
+  ssl:
+    enabled: false
+
+    # CA certificate in a single-line string format with "\" as line breaks
+    # Use the following command to convert a rootCA PEM file to the correct format:
+    # awk '{printf "%s\", $0}' <path-to-pem-file> | pbcopy
+    # This is so teraslice can get the rootCA for it's client validation
+    caCert: null
+  image: apache/kafka
+  version: 3.7.2
   brokers: 1
   offsets:
     topic:
@@ -84,6 +95,11 @@ teraslice:
     # Overrides the image tag whose default is the chart appVersion.
     tag: dev
   stateCluster: opensearch2
+  asset_storage_connection_type: elasticsearch-next
+  asset_storage_connection: default
+  env: {}
+  extraVolumes: []
+  extraVolumeMounts: []
 
 chaos-mesh:
   # When enabled, the choas-mesh dashboard will be available in browser
@@ -91,3 +107,12 @@ chaos-mesh:
   # Documentation on how to create "experiments":
   # https://chaos-mesh.org/docs/run-a-chaos-experiment/
   enabled: false
+
+utility:
+  # If false, utility will be excluded on helmfile sync
+  enabled: true
+  image:
+    repository: teraslice-utility
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: 0.0.1
+  instances: 1


### PR DESCRIPTION
This PR makes the following changes:

- Fixes configuration error within example helm that breaks teraslice
- Adds kafka-ui and teraslice utility pod to the example helm environment 
- Adds quick start guide to example helm docs with links and docs to exposed services