### PR TITLE
[utils] Add formatAggregateError helper function

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -47,11 +47,11 @@
         "ms": "~2.1.3"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.18.1",
+        "@terascope/scripts": "~1.19.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "bunyan": "~1.8.15",
-        "elasticsearch-store": "~1.10.6",
+        "elasticsearch-store": "~1.11.0",
         "fs-extra": "~11.3.0",
         "jest": "~30.0.0",
         "jest-extended": "~6.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@eslint/js": "~9.29.0",
         "@swc/core": "1.12.1",
         "@swc/jest": "~0.2.38",
-        "@terascope/scripts": "~1.18.1",
+        "@terascope/scripts": "~1.19.0",
         "@types/bluebird": "~3.5.42",
         "@types/convict": "~6.1.6",
         "@types/elasticsearch": "~5.0.43",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "1.8.4",
+    "version": "1.9.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -30,9 +30,9 @@
         "test:watch": "node ../scripts/bin/ts-scripts test --watch ../data-mate --"
     },
     "dependencies": {
-        "@terascope/data-types": "~1.8.4",
+        "@terascope/data-types": "~1.9.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "@types/validator": "~13.12.3",
         "awesome-phonenumber": "~7.5.0",
         "date-fns": "~4.1.0",
@@ -45,7 +45,7 @@
         "uuid": "~11.1.0",
         "valid-url": "~1.0.9",
         "validator": "~13.12.0",
-        "xlucene-parser": "~1.8.3"
+        "xlucene-parser": "~1.9.0"
     },
     "devDependencies": {
         "@types/ip6addr": "~0.2.6",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "1.8.4",
+    "version": "1.9.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "graphql": "~16.11.0",
         "yargs": "~18.0.0"
     },

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "4.9.3",
+    "version": "4.10.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -25,7 +25,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "bluebird": "~3.7.2",
         "setimmediate": "~1.0.5"
     },
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "~1.2.0",
         "@types/elasticsearch": "~5.0.43",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.10.6",
+        "elasticsearch-store": "~1.11.0",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@~7.17.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@~8.15.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "1.10.6",
+    "version": "1.11.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,10 +30,10 @@
         "test:watch": "ts-scripts yarn workspace @terascope/scripts test --watch ../elasticsearch-store --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.8.4",
-        "@terascope/data-types": "~1.8.4",
+        "@terascope/data-mate": "~1.9.0",
+        "@terascope/data-types": "~1.9.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "ajv": "~8.17.1",
         "ajv-formats": "~3.0.1",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
@@ -43,7 +43,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@~2.12.0",
         "setimmediate": "~1.0.5",
         "uuid": "~11.1.0",
-        "xlucene-translator": "~1.8.3"
+        "xlucene-translator": "~1.9.0"
     },
     "devDependencies": {
         "@types/uuid": "~10.0.0"

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "1.10.3",
+    "version": "1.11.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.18.1",
+    "version": "1.19.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~1.3.0",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "execa": "~9.6.0",
         "fs-extra": "~11.3.0",
         "globby": "~14.1.0",

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "1.12.6",
+    "version": "1.13.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -30,14 +30,14 @@
     "dependencies": {
         "@terascope/file-asset-apis": "~1.1.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "bluebird": "~3.7.2",
         "bunyan": "~1.8.15",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.10.6",
+        "elasticsearch-store": "~1.11.0",
         "express": "~5.1.0",
         "js-yaml": "~4.1.0",
         "nanoid": "~5.1.5",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -44,7 +44,7 @@
     "devDependencies": {
         "@terascope/fetch-github-release": "~2.2.1",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "@types/decompress": "~4.2.7",
         "@types/ejs": "~3.1.5",
         "@types/js-yaml": "~4.0.9",
@@ -67,7 +67,7 @@
         "pretty-bytes": "~7.0.0",
         "prompts": "~2.4.2",
         "signale": "~1.4.0",
-        "teraslice-client-js": "~1.8.4",
+        "teraslice-client-js": "~1.9.0",
         "tmp": "~0.2.3",
         "tty-table": "~4.2.3",
         "yargs": "~18.0.0"

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "1.8.4",
+    "version": "1.9.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "auto-bind": "~5.0.1",
         "got": "~14.4.7"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "1.11.3",
+    "version": "1.12.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "get-port": "~7.1.0",
         "ms": "~2.1.3",
         "nanoid": "~5.1.5",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "1.9.3",
+    "version": "1.10.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -24,8 +24,8 @@
         "test:watch": "node ../scripts/bin/ts-scripts test --watch ../teraslice-state-storage --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "~4.9.3",
-        "@terascope/utils": "~1.8.3"
+        "@terascope/elasticsearch-api": "~4.10.0",
+        "@terascope/utils": "~1.9.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "~11.3.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "~1.10.3"
+        "@terascope/job-components": "~1.11.0"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=1.10.3"
+        "@terascope/job-components": ">=1.11.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -39,11 +39,11 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~1.3.0",
-        "@terascope/elasticsearch-api": "~4.9.3",
-        "@terascope/job-components": "~1.10.3",
-        "@terascope/teraslice-messaging": "~1.11.3",
+        "@terascope/elasticsearch-api": "~4.10.0",
+        "@terascope/job-components": "~1.11.0",
+        "@terascope/teraslice-messaging": "~1.12.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "async-mutex": "~0.5.0",
         "barbe": "~3.0.17",
         "body-parser": "~2.2.0",
@@ -62,7 +62,7 @@
         "semver": "~7.7.2",
         "socket.io": "~1.7.4",
         "socket.io-client": "~1.7.4",
-        "terafoundation": "~1.12.6",
+        "terafoundation": "~1.13.0",
         "uuid": "~11.1.0"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "1.8.5",
+    "version": "1.9.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -36,9 +36,9 @@
         "test:watch": "node ../scripts/bin/ts-scripts test --watch ../ts-transforms --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.8.4",
+        "@terascope/data-mate": "~1.9.0",
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "awesome-phonenumber": "~7.5.0",
         "graphlib": "~2.1.8",
         "jexl": "~2.3.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "1.8.3",
+    "version": "1.9.0",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/deps.ts
+++ b/packages/utils/src/deps.ts
@@ -14,7 +14,7 @@ import _clone from 'shallow-clone';
 import kindOf from 'kind-of';
 import jsStringEscape from 'js-string-escape';
 import geoHash from 'latlon-geohash';
-import pMap from 'p-map';
+import _pMap, { Options as PMapOptions } from 'p-map';
 import { AnyObject } from './interfaces.js';
 import { DataEntity } from './entities/index.js';
 import { isKey } from './objects.js';
@@ -116,13 +116,55 @@ export function escapeString(input: string | number): string {
     return jsStringEscape(`${input}`);
 }
 
+/**
+ * A wrapper around p-map that properly surfaces individual errors
+ * from an AggregateError when `stopOnError` is set to `false`.
+ * https://github.com/terascope/standard-assets/issues/1114
+ *
+ * This function is pMap but logs individual errors
+ * when multiple errors occur in parallel
+ *
+ * @template T - The type of items in the input
+ * @template R - The type of the result returned by the mapper function
+ *
+ * @returns {Promise<R[]>} A promise that resolves to an array of mapped results.
+ *
+ * @throws {AggregateError} When stopOnError is false and multiple errors occur,
+ *   this error will include all individual errors under the errors[] key array
+ */
+export async function pMap<T, R>(
+    input: Iterable<T>,
+    mapper: (element: T, index: number) => Promise<R> | R,
+    options?: PMapOptions
+): Promise<R[]> {
+    try {
+        return await _pMap(input, mapper, options);
+    } catch (err) {
+        // Check to ensure it's an aggregate error with an errors key that's an array
+        if (err instanceof AggregateError && Array.isArray(err.errors)) {
+            let message = `pMap failed with ${err.errors.length} error(s):\n`;
+
+            for (let i = 0; i < err.errors.length; i++) {
+                const error = err.errors[i];
+                // ensure this is also an instance of an error so it has a message property
+                const text = error instanceof Error ? error.message : String(error);
+                message += `\n[${i + 1}] ${text}`;
+            }
+
+            const combinedError = new Error(message);
+            throw combinedError;
+        }
+
+        throw err;
+    }
+}
+
 export {
     get,
     set,
     unset,
     has,
     geoHash,
-    pMap,
     merge,
     padEnd,
     debounce,

--- a/packages/utils/src/deps.ts
+++ b/packages/utils/src/deps.ts
@@ -149,7 +149,7 @@ export async function pMap<T, R>(
                     ? err.errors.length
                     : maxErrorLength;
 
-            let message = `pMap failed with ${err.errors.length} error(s):\n`;
+            let message = `pMap failed with an AggregateError containing ${err.errors.length} error(s):\n`;
 
             for (let i = 0; i < errorPrintLength; i++) {
                 const error = err.errors[i];

--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -480,7 +480,8 @@ export function stripErrorMessage(
 }
 
 /**
- * Formats an AggregateError into a user-friendly Error which shows the first five Errors from the Aggregate.
+ * Formats an AggregateError into a user-friendly Error which
+ * shows the first five Errors from the Aggregate.
  * @param aggregateError
  */
 export async function formatAggregateError(aggregateError: unknown) {

--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -478,3 +478,46 @@ export function stripErrorMessage(
     if (firstErr.includes(reason)) return msg;
     return `${reason}: ${msg}`;
 }
+
+/**
+ * Formats an AggregateError into a user-friendly Error.
+ * @param aggregateError
+ */
+export async function formatAggregateError(aggregateError: unknown) {
+    // Check to ensure it's an aggregate error with an errors key that's an array
+    if (aggregateError instanceof AggregateError && Array.isArray(aggregateError.errors)) {
+        // This will ensure we don't print more than 5 errors
+        const maxErrorLength = 5;
+        const errorPrintLength
+                    = aggregateError.errors.length < maxErrorLength
+                        ? aggregateError.errors.length
+                        : maxErrorLength;
+
+        let message = `Failed with an AggregateError containing ${aggregateError.errors.length} error(s):\n`;
+
+        for (let i = 0; i < errorPrintLength; i++) {
+            const error = aggregateError.errors[i];
+            // ensure this is also an instance of an error so it has a message property
+            let text: string;
+            if (error instanceof Error) {
+                text = error.message;
+            } else {
+                try {
+                    text = JSON.stringify(error);
+                } catch (innerError) {
+                    text = String(error);
+                }
+            }
+            message += `\n[${i + 1}] ${text}`;
+        }
+        if (aggregateError.errors.length > maxErrorLength) {
+            const remainingErrors = aggregateError.errors.length - maxErrorLength;
+            message += `\n... and ${remainingErrors} other errors.`;
+        }
+
+        const combinedError = new Error(message);
+        throw combinedError;
+    }
+
+    throw aggregateError;
+}

--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -480,7 +480,7 @@ export function stripErrorMessage(
 }
 
 /**
- * Formats an AggregateError into a user-friendly Error.
+ * Formats an AggregateError into a user-friendly Error which shows the first five Errors from the Aggregate.
  * @param aggregateError
  */
 export async function formatAggregateError(aggregateError: unknown) {

--- a/packages/utils/test/deps-spec.ts
+++ b/packages/utils/test/deps-spec.ts
@@ -1,6 +1,9 @@
 import 'jest-extended';
 import { DataEntity } from '../src/entities/index.js';
-import { getTypeOf, isPlainObject, cloneDeep } from '../src/deps.js';
+import {
+    getTypeOf, isPlainObject, cloneDeep,
+    pMap
+} from '../src/deps.js';
 
 describe('Dependency Utils', () => {
     class TestObj {
@@ -169,6 +172,46 @@ describe('Dependency Utils', () => {
             output.value = 456;
             expect(output.value).toBe(456);
             expect(input.value).toBe(123);
+        });
+    });
+
+    describe('pMap', () => {
+        it('should map values successfully', async () => {
+          const input = [1, 2, 3];
+          const result = await pMap(input, async (n) => n * 2);
+          expect(result).toEqual([2, 4, 6]);
+        });
+
+        it('should handle errors with stopOnError: true (default)', async () => {
+          const input = [1, 2, 3];
+          const mapper = async (n: number) => {
+            if (n === 2) throw new Error('Failed on 2');
+            return n;
+          };
+
+          await expect(pMap(input, mapper)).rejects.toThrow('Failed on 2');
+        });
+
+        it('should collect multiple errors when stopOnError is false', async () => {
+          const input = [1, 2, 3];
+          const mapper = async (n: number) => {
+            if (n !== 1) throw new Error(`Error on ${n}`);
+            return n;
+          };
+
+          try {
+            await pMap(input, mapper, { stopOnError: false });
+          } catch(err) {
+            console.log('BOI');
+            console.log(JSON.stringify(err.message));
+          }
+          await expect(
+            pMap(input, mapper, { stopOnError: false })
+          ).rejects.toThrow('pMap failed with 2 error(s):\n\n'
+            + '[1] Error on 2\n'
+            + '[2] Error on 3'
+          );
+
         });
     });
 });

--- a/packages/utils/test/deps-spec.ts
+++ b/packages/utils/test/deps-spec.ts
@@ -177,41 +177,34 @@ describe('Dependency Utils', () => {
 
     describe('pMap', () => {
         it('should map values successfully', async () => {
-          const input = [1, 2, 3];
-          const result = await pMap(input, async (n) => n * 2);
-          expect(result).toEqual([2, 4, 6]);
+            const input = [1, 2, 3];
+            const result = await pMap(input, async (n) => n * 2);
+            expect(result).toEqual([2, 4, 6]);
         });
 
         it('should handle errors with stopOnError: true (default)', async () => {
-          const input = [1, 2, 3];
-          const mapper = async (n: number) => {
-            if (n === 2) throw new Error('Failed on 2');
-            return n;
-          };
+            const input = [1, 2, 3];
+            const mapper = async (n: number) => {
+                if (n === 2) throw new Error('Failed on 2');
+                return n;
+            };
 
-          await expect(pMap(input, mapper)).rejects.toThrow('Failed on 2');
+            await expect(pMap(input, mapper)).rejects.toThrow('Failed on 2');
         });
 
         it('should collect multiple errors when stopOnError is false', async () => {
-          const input = [1, 2, 3];
-          const mapper = async (n: number) => {
-            if (n !== 1) throw new Error(`Error on ${n}`);
-            return n;
-          };
+            const input = [1, 2, 3];
+            const mapper = async (n: number) => {
+                if (n !== 1) throw new Error(`Error on ${n}`);
+                return n;
+            };
 
-          try {
-            await pMap(input, mapper, { stopOnError: false });
-          } catch(err) {
-            console.log('BOI');
-            console.log(JSON.stringify(err.message));
-          }
-          await expect(
-            pMap(input, mapper, { stopOnError: false })
-          ).rejects.toThrow('pMap failed with 2 error(s):\n\n'
-            + '[1] Error on 2\n'
-            + '[2] Error on 3'
-          );
-
+            await expect(
+                pMap(input, mapper, { stopOnError: false })
+            ).rejects.toThrow('pMap failed with 2 error(s):\n\n'
+                + '[1] Error on 2\n'
+                + '[2] Error on 3'
+            );
         });
     });
 });

--- a/packages/utils/test/deps-spec.ts
+++ b/packages/utils/test/deps-spec.ts
@@ -206,7 +206,7 @@ describe('Dependency Utils', () => {
             };
 
             await expect(pMap(input, mapper, { stopOnError: false })).rejects.toThrow(
-                'pMap failed with 2 error(s):\n\n'
+                'pMap failed with an AggregateError containing 2 error(s):\n\n'
                 + '[1] Failed on 1\n'
                 + '[2] {"error":"3 failed and returned a non Error type object"}'
             );
@@ -221,7 +221,7 @@ describe('Dependency Utils', () => {
 
             await expect(
                 pMap(input, mapper, { stopOnError: false })
-            ).rejects.toThrow('pMap failed with 2 error(s):\n\n'
+            ).rejects.toThrow('pMap failed with an AggregateError containing 2 error(s):\n\n'
                 + '[1] Error on 2\n'
                 + '[2] Error on 3'
             );
@@ -236,7 +236,7 @@ describe('Dependency Utils', () => {
 
             await expect(
                 pMap(input, mapper, { stopOnError: false })
-            ).rejects.toThrow('pMap failed with 6 error(s):\n\n'
+            ).rejects.toThrow('pMap failed with an AggregateError containing 6 error(s):\n\n'
                 + '[1] Error on 2\n'
                 + '[2] Error on 3\n'
                 + '[3] Error on 4\n'

--- a/packages/utils/test/deps-spec.ts
+++ b/packages/utils/test/deps-spec.ts
@@ -1,8 +1,7 @@
 import 'jest-extended';
 import { DataEntity } from '../src/entities/index.js';
 import {
-    getTypeOf, isPlainObject, cloneDeep,
-    pMap
+    getTypeOf, isPlainObject, cloneDeep
 } from '../src/deps.js';
 
 describe('Dependency Utils', () => {
@@ -172,79 +171,6 @@ describe('Dependency Utils', () => {
             output.value = 456;
             expect(output.value).toBe(456);
             expect(input.value).toBe(123);
-        });
-    });
-
-    describe('pMap', () => {
-        it('should map values successfully', async () => {
-            const input = [1, 2, 3];
-            const result = await pMap(input, async (n) => n * 2);
-            expect(result).toEqual([2, 4, 6]);
-        });
-
-        it('should handle errors with stopOnError: true (default)', async () => {
-            const input = [1, 2, 3];
-            const mapper = async (n: number) => {
-                if (n === 2) throw new Error('Failed on 2');
-                return n;
-            };
-
-            await expect(pMap(input, mapper)).rejects.toThrow('Failed on 2');
-        });
-
-        it('should handle errors that aren\'t error objects', async () => {
-            const input = [1, 2, 3];
-            const mapper = async (n: number) => {
-                if (n === 1) {
-                    throw new Error(`Failed on ${n}`);
-                } else if (n === 3) {
-                    throw {
-                        error: '3 failed and returned a non Error type object'
-                    };
-                }
-                return n;
-            };
-
-            await expect(pMap(input, mapper, { stopOnError: false })).rejects.toThrow(
-                'pMap failed with an AggregateError containing 2 error(s):\n\n'
-                + '[1] Failed on 1\n'
-                + '[2] {"error":"3 failed and returned a non Error type object"}'
-            );
-        });
-
-        it('should collect multiple errors when stopOnError is false', async () => {
-            const input = [1, 2, 3];
-            const mapper = async (n: number) => {
-                if (n !== 1) throw new Error(`Error on ${n}`);
-                return n;
-            };
-
-            await expect(
-                pMap(input, mapper, { stopOnError: false })
-            ).rejects.toThrow('pMap failed with an AggregateError containing 2 error(s):\n\n'
-                + '[1] Error on 2\n'
-                + '[2] Error on 3'
-            );
-        });
-
-        it('should show a maximum of 5 errors', async () => {
-            const input = [1, 2, 3, 4, 5, 6, 7];
-            const mapper = async (n: number) => {
-                if (n !== 1) throw new Error(`Error on ${n}`);
-                return n;
-            };
-
-            await expect(
-                pMap(input, mapper, { stopOnError: false })
-            ).rejects.toThrow('pMap failed with an AggregateError containing 6 error(s):\n\n'
-                + '[1] Error on 2\n'
-                + '[2] Error on 3\n'
-                + '[3] Error on 4\n'
-                + '[4] Error on 5\n'
-                + '[5] Error on 6\n'
-                + '... and 1 other errors.'
-
-            );
         });
     });
 });

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "1.8.3",
+    "version": "1.9.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "peggy": "~4.2.0",
         "ts-pegjs": "~4.2.1"
     },

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "1.8.3",
+    "version": "1.9.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -30,9 +30,9 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.1",
-        "@terascope/utils": "~1.8.3",
+        "@terascope/utils": "~1.9.0",
         "@types/elasticsearch": "~5.0.43",
-        "xlucene-parser": "~1.8.3"
+        "xlucene-parser": "~1.9.0"
     },
     "devDependencies": {
         "elasticsearch": "~15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "1.8.3",
+    "version": "1.9.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "node ../scripts/bin/ts-scripts test --watch ../xpressions --"
     },
     "dependencies": {
-        "@terascope/utils": "~1.8.3"
+        "@terascope/utils": "~1.9.0"
     },
     "devDependencies": {
         "@terascope/types": "~1.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3133,13 +3133,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/data-mate@npm:~1.8.4, @terascope/data-mate@workspace:packages/data-mate":
+"@terascope/data-mate@npm:~1.9.0, @terascope/data-mate@workspace:packages/data-mate":
   version: 0.0.0-use.local
   resolution: "@terascope/data-mate@workspace:packages/data-mate"
   dependencies:
-    "@terascope/data-types": "npm:~1.8.4"
+    "@terascope/data-types": "npm:~1.9.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     "@types/ip6addr": "npm:~0.2.6"
     "@types/uuid": "npm:~10.0.0"
     "@types/validator": "npm:~13.12.3"
@@ -3156,16 +3156,16 @@ __metadata:
     uuid: "npm:~11.1.0"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
-    xlucene-parser: "npm:~1.8.3"
+    xlucene-parser: "npm:~1.9.0"
   languageName: unknown
   linkType: soft
 
-"@terascope/data-types@npm:~1.8.4, @terascope/data-types@workspace:packages/data-types":
+"@terascope/data-types@npm:~1.9.0, @terascope/data-types@workspace:packages/data-types":
   version: 0.0.0-use.local
   resolution: "@terascope/data-types@workspace:packages/data-types"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     "@types/yargs": "npm:~17.0.33"
     graphql: "npm:~16.11.0"
     yargs: "npm:~18.0.0"
@@ -3182,17 +3182,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/elasticsearch-api@npm:~4.9.3, @terascope/elasticsearch-api@workspace:packages/elasticsearch-api":
+"@terascope/elasticsearch-api@npm:~4.10.0, @terascope/elasticsearch-api@workspace:packages/elasticsearch-api":
   version: 0.0.0-use.local
   resolution: "@terascope/elasticsearch-api@workspace:packages/elasticsearch-api"
   dependencies:
     "@opensearch-project/opensearch": "npm:~1.2.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     "@types/elasticsearch": "npm:~5.0.43"
     bluebird: "npm:~3.7.2"
     elasticsearch: "npm:~15.4.1"
-    elasticsearch-store: "npm:~1.10.6"
+    elasticsearch-store: "npm:~1.11.0"
     elasticsearch6: "npm:@elastic/elasticsearch@~6.8.0"
     elasticsearch7: "npm:@elastic/elasticsearch@~7.17.0"
     elasticsearch8: "npm:@elastic/elasticsearch@~8.15.0"
@@ -3254,12 +3254,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/job-components@npm:~1.10.3, @terascope/job-components@workspace:packages/job-components":
+"@terascope/job-components@npm:~1.11.0, @terascope/job-components@workspace:packages/job-components":
   version: 0.0.0-use.local
   resolution: "@terascope/job-components@workspace:packages/job-components"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     benchmark: "npm:~2.1.4"
     convict: "npm:~6.2.4"
     convict-format-with-moment: "npm:~6.2.0"
@@ -3274,12 +3274,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/scripts@npm:~1.18.1, @terascope/scripts@workspace:packages/scripts":
+"@terascope/scripts@npm:~1.19.0, @terascope/scripts@workspace:packages/scripts":
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
     "@kubernetes/client-node": "npm:~1.3.0"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     "@types/ip": "npm:~1.1.3"
     "@types/micromatch": "npm:~4.0.9"
     "@types/ms": "npm:~0.7.34"
@@ -3317,12 +3317,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/teraslice-messaging@npm:~1.11.3, @terascope/teraslice-messaging@workspace:packages/teraslice-messaging":
+"@terascope/teraslice-messaging@npm:~1.12.0, @terascope/teraslice-messaging@workspace:packages/teraslice-messaging":
   version: 0.0.0-use.local
   resolution: "@terascope/teraslice-messaging@workspace:packages/teraslice-messaging"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     "@types/ms": "npm:~0.7.34"
     "@types/socket.io": "npm:~2.1.13"
     "@types/socket.io-client": "npm:~1.4.36"
@@ -3339,8 +3339,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terascope/teraslice-state-storage@workspace:packages/teraslice-state-storage"
   dependencies:
-    "@terascope/elasticsearch-api": "npm:~4.9.3"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/elasticsearch-api": "npm:~4.10.0"
+    "@terascope/utils": "npm:~1.9.0"
   languageName: unknown
   linkType: soft
 
@@ -3352,7 +3352,51 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/utils@npm:~1.8.2, @terascope/utils@npm:~1.8.3, @terascope/utils@workspace:packages/utils":
+"@terascope/utils@npm:~1.8.2":
+  version: 1.8.3
+  resolution: "@terascope/utils@npm:1.8.3"
+  dependencies:
+    "@chainsafe/is-ip": "npm:~2.1.0"
+    "@terascope/types": "npm:~1.4.1"
+    "@turf/bbox": "npm:~7.2.0"
+    "@turf/bbox-polygon": "npm:~7.2.0"
+    "@turf/boolean-contains": "npm:~7.2.0"
+    "@turf/boolean-disjoint": "npm:~7.2.0"
+    "@turf/boolean-equal": "npm:~7.2.0"
+    "@turf/boolean-intersects": "npm:~7.2.0"
+    "@turf/boolean-point-in-polygon": "npm:~7.2.0"
+    "@turf/boolean-within": "npm:~7.2.0"
+    "@turf/circle": "npm:~7.2.0"
+    "@turf/helpers": "npm:~7.2.0"
+    "@turf/invariant": "npm:~7.2.0"
+    "@turf/line-to-polygon": "npm:~7.2.0"
+    "@types/lodash-es": "npm:~4.17.12"
+    "@types/validator": "npm:~13.12.3"
+    awesome-phonenumber: "npm:~7.5.0"
+    date-fns: "npm:~4.1.0"
+    date-fns-tz: "npm:~3.2.0"
+    datemath-parser: "npm:~1.0.6"
+    debug: "npm:~4.4.1"
+    geo-tz: "npm:~8.1.4"
+    ip-bigint: "npm:~8.2.1"
+    ip-cidr: "npm:~4.0.2"
+    ip6addr: "npm:~0.2.5"
+    ipaddr.js: "npm:~2.2.0"
+    is-cidr: "npm:~5.1.1"
+    is-plain-object: "npm:~5.0.0"
+    js-string-escape: "npm:~1.0.1"
+    kind-of: "npm:~6.0.3"
+    latlon-geohash: "npm:~2.0.0"
+    lodash-es: "npm:~4.17.21"
+    mnemonist: "npm:~0.40.3"
+    p-map: "npm:~7.0.3"
+    shallow-clone: "npm:~3.0.1"
+    validator: "npm:~13.12.0"
+  checksum: 10c0/95f5415f2a3d9f68eb1180d3c2467d78605c21372f0531a7114310bd92d4ab030d62a0b60b093fc240e96a562e80c1e5be8cf2fee2aa2eddbe69f09f8bfe36fb
+  languageName: node
+  linkType: hard
+
+"@terascope/utils@npm:~1.9.0, @terascope/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@terascope/utils@workspace:packages/utils"
   dependencies:
@@ -6742,11 +6786,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e@workspace:e2e"
   dependencies:
-    "@terascope/scripts": "npm:~1.18.1"
+    "@terascope/scripts": "npm:~1.19.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     bunyan: "npm:~1.8.15"
-    elasticsearch-store: "npm:~1.10.6"
+    elasticsearch-store: "npm:~1.11.0"
     fs-extra: "npm:~11.3.0"
     jest: "npm:~30.0.0"
     jest-extended: "npm:~6.0.0"
@@ -6809,14 +6853,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elasticsearch-store@npm:~1.10.6, elasticsearch-store@workspace:packages/elasticsearch-store":
+"elasticsearch-store@npm:~1.11.0, elasticsearch-store@workspace:packages/elasticsearch-store":
   version: 0.0.0-use.local
   resolution: "elasticsearch-store@workspace:packages/elasticsearch-store"
   dependencies:
-    "@terascope/data-mate": "npm:~1.8.4"
-    "@terascope/data-types": "npm:~1.8.4"
+    "@terascope/data-mate": "npm:~1.9.0"
+    "@terascope/data-types": "npm:~1.9.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     "@types/uuid": "npm:~10.0.0"
     ajv: "npm:~8.17.1"
     ajv-formats: "npm:~3.0.1"
@@ -6827,7 +6871,7 @@ __metadata:
     opensearch2: "npm:@opensearch-project/opensearch@~2.12.0"
     setimmediate: "npm:~1.0.5"
     uuid: "npm:~11.1.0"
-    xlucene-translator: "npm:~1.8.3"
+    xlucene-translator: "npm:~1.9.0"
   languageName: unknown
   linkType: soft
 
@@ -13680,13 +13724,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terafoundation@npm:~1.12.6, terafoundation@workspace:packages/terafoundation":
+"terafoundation@npm:~1.13.0, terafoundation@workspace:packages/terafoundation":
   version: 0.0.0-use.local
   resolution: "terafoundation@workspace:packages/terafoundation"
   dependencies:
     "@terascope/file-asset-apis": "npm:~1.1.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     "@types/bunyan": "npm:~1.8.11"
     "@types/elasticsearch": "npm:~5.0.43"
     "@types/express": "npm:~5.0.3"
@@ -13697,7 +13741,7 @@ __metadata:
     convict-format-with-moment: "npm:~6.2.0"
     convict-format-with-validator: "npm:~6.2.0"
     elasticsearch: "npm:~15.4.1"
-    elasticsearch-store: "npm:~1.10.6"
+    elasticsearch-store: "npm:~1.11.0"
     express: "npm:~5.1.0"
     got: "npm:~14.4.7"
     js-yaml: "npm:~4.1.0"
@@ -13714,7 +13758,7 @@ __metadata:
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.2.1"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     "@types/decompress": "npm:~4.2.7"
     "@types/ejs": "npm:~3.1.5"
     "@types/js-yaml": "npm:~4.0.9"
@@ -13738,7 +13782,7 @@ __metadata:
     pretty-bytes: "npm:~7.0.0"
     prompts: "npm:~2.4.2"
     signale: "npm:~1.4.0"
-    teraslice-client-js: "npm:~1.8.4"
+    teraslice-client-js: "npm:~1.9.0"
     tmp: "npm:~0.2.3"
     tty-table: "npm:~4.2.3"
     yargs: "npm:~18.0.0"
@@ -13748,12 +13792,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"teraslice-client-js@npm:~1.8.4, teraslice-client-js@workspace:packages/teraslice-client-js":
+"teraslice-client-js@npm:~1.9.0, teraslice-client-js@workspace:packages/teraslice-client-js":
   version: 0.0.0-use.local
   resolution: "teraslice-client-js@workspace:packages/teraslice-client-js"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     auto-bind: "npm:~5.0.1"
     got: "npm:~14.4.7"
     nock: "npm:~13.5.6"
@@ -13765,11 +13809,11 @@ __metadata:
   resolution: "teraslice-test-harness@workspace:packages/teraslice-test-harness"
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.2.1"
-    "@terascope/job-components": "npm:~1.10.3"
+    "@terascope/job-components": "npm:~1.11.0"
     decompress: "npm:~4.2.1"
     fs-extra: "npm:~11.3.0"
   peerDependencies:
-    "@terascope/job-components": ">=1.10.3"
+    "@terascope/job-components": ">=1.11.0"
   languageName: unknown
   linkType: soft
 
@@ -13780,7 +13824,7 @@ __metadata:
     "@eslint/js": "npm:~9.29.0"
     "@swc/core": "npm:1.12.1"
     "@swc/jest": "npm:~0.2.38"
-    "@terascope/scripts": "npm:~1.18.1"
+    "@terascope/scripts": "npm:~1.19.0"
     "@types/bluebird": "npm:~3.5.42"
     "@types/convict": "npm:~6.1.6"
     "@types/elasticsearch": "npm:~5.0.43"
@@ -13804,11 +13848,11 @@ __metadata:
   resolution: "teraslice@workspace:packages/teraslice"
   dependencies:
     "@kubernetes/client-node": "npm:~1.3.0"
-    "@terascope/elasticsearch-api": "npm:~4.9.3"
-    "@terascope/job-components": "npm:~1.10.3"
-    "@terascope/teraslice-messaging": "npm:~1.11.3"
+    "@terascope/elasticsearch-api": "npm:~4.10.0"
+    "@terascope/job-components": "npm:~1.11.0"
+    "@terascope/teraslice-messaging": "npm:~1.12.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     "@types/archiver": "npm:~6.0.3"
     "@types/express": "npm:~5.0.3"
     "@types/gc-stats": "npm:~1.4.3"
@@ -13839,7 +13883,7 @@ __metadata:
     semver: "npm:~7.7.2"
     socket.io: "npm:~1.7.4"
     socket.io-client: "npm:~1.7.4"
-    terafoundation: "npm:~1.12.6"
+    terafoundation: "npm:~1.13.0"
     uuid: "npm:~11.1.0"
   languageName: unknown
   linkType: soft
@@ -14056,9 +14100,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ts-transforms@workspace:packages/ts-transforms"
   dependencies:
-    "@terascope/data-mate": "npm:~1.8.4"
+    "@terascope/data-mate": "npm:~1.9.0"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     "@types/graphlib": "npm:~2.1.12"
     "@types/jexl": "npm:~2.3.4"
     "@types/valid-url": "npm:~1.0.7"
@@ -14892,12 +14936,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xlucene-parser@npm:~1.8.3, xlucene-parser@workspace:packages/xlucene-parser":
+"xlucene-parser@npm:~1.9.0, xlucene-parser@workspace:packages/xlucene-parser":
   version: 0.0.0-use.local
   resolution: "xlucene-parser@workspace:packages/xlucene-parser"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     "@turf/invariant": "npm:~7.2.0"
     "@turf/random": "npm:~7.2.0"
     peggy: "npm:~4.2.0"
@@ -14905,15 +14949,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"xlucene-translator@npm:~1.8.3, xlucene-translator@workspace:packages/xlucene-translator":
+"xlucene-translator@npm:~1.9.0, xlucene-translator@workspace:packages/xlucene-translator":
   version: 0.0.0-use.local
   resolution: "xlucene-translator@workspace:packages/xlucene-translator"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
     "@types/elasticsearch": "npm:~5.0.43"
     elasticsearch: "npm:~15.4.1"
-    xlucene-parser: "npm:~1.8.3"
+    xlucene-parser: "npm:~1.9.0"
   languageName: unknown
   linkType: soft
 
@@ -14929,7 +14973,7 @@ __metadata:
   resolution: "xpressions@workspace:packages/xpressions"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.3"
+    "@terascope/utils": "npm:~1.9.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR makes the following changes:

- Adds new helper function `formatAggregateError` that takes an Error and if it's an aggregate Error will parse it out into one error.
  - This will show a maximum of 5 errors 

ref to issues: #4076 

https://github.com/terascope/standard-assets/issues/1114