### PR TITLE
[CI, scripts] Randomize ports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -364,7 +364,7 @@ jobs:
           command -v helmfile
 
       - name: Test k8s V2 opensearch2
-        run: 
+        run: |
           export OPENSEARCH_PORT=$(../scripts/get-random-port.sh)
           export KAFKA_PORT=$(../scripts/get-random-port.sh)
           export MINIO_PORT=$(../scripts/get-random-port.sh)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       NODE_VERSIONS: ${{ steps.step1.outputs.NODE_VERSIONS }}
       NODE_VERSION_MAIN: ${{ steps.step2.outputs.NODE_VERSION_MAIN }}
-      NODE_VERSIONS_EXT_K8S: ${{ steps.step3.outputs.NODE_VERSIONS_K8S }}
+      NODE_VERSIONS_K8S: ${{ steps.step3.outputs.NODE_VERSIONS_K8S }}
       NODE_VERSIONS_EXT_STORAGE: ${{ steps.step4.outputs.NODE_VERSIONS_EXT_STORAGE }}
     steps:
       - id: step1
@@ -110,7 +110,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_K8S) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_K8S) }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -169,7 +169,12 @@ jobs:
           install_only: "true"
 
       - name: Test k8s elasticsearch7
-        run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8s
+        run: | 
+          export ELASTICSEARCH_PORT=$(../scripts/get-random-port.sh)
+          export KAFKA_PORT=$(../scripts/get-random-port.sh)
+          export ZOOKEEPER_PORT=$(../scripts/get-random-port.sh)
+          export TERASLICE_PORT=$(../scripts/get-random-port.sh)
+          NODE_VERSION=${{ matrix.node-version }} yarn test:k8s
         working-directory: ./e2e
 
   e2e-k8s-v2-tests:
@@ -181,7 +186,7 @@ jobs:
       # opensearch is finiky, keep testing others if it fails
       fail-fast: false
       matrix:
-        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_EXT_K8S) }}
+        node-version: ${{ fromJSON(needs.compute-node-version-vars.outputs.NODE_VERSIONS_K8S) }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -257,7 +262,11 @@ jobs:
           command -v helmfile
 
       - name: Test k8s V2 opensearch2
-        run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8sV2Helmfile
+        run: |
+          export OPENSEARCH_PORT=$(../scripts/get-random-port.sh)
+          export KAFKA_PORT=$(../scripts/get-random-port.sh)
+          export TERASLICE_PORT=$(../scripts/get-random-port.sh)
+          NODE_VERSION=${{ matrix.node-version }} yarn test:k8sV2Helmfile
         working-directory: ./e2e
 
   e2e-k8s-v2-encrypted-tests:
@@ -355,7 +364,12 @@ jobs:
           command -v helmfile
 
       - name: Test k8s V2 opensearch2
-        run: NODE_VERSION=${{ matrix.node-version }} yarn test:k8sV2HelmfileEncrypted
+        run: 
+          export OPENSEARCH_PORT=$(../scripts/get-random-port.sh)
+          export KAFKA_PORT=$(../scripts/get-random-port.sh)
+          export MINIO_PORT=$(../scripts/get-random-port.sh)
+          export TERASLICE_PORT=$(../scripts/get-random-port.sh)
+          NODE_VERSION=${{ matrix.node-version }} yarn test:k8sV2HelmfileEncrypted
         working-directory: ./e2e
 
   e2e-external-storage-tests:
@@ -421,7 +435,13 @@ jobs:
           key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
 
       - name: Test external Asset Storage opensearch1
-        run: NODE_VERSION=${{ matrix.node-version }} yarn test:s3AssetStorage
+        run: |
+          export OPENSEARCH_PORT=$(../scripts/get-random-port.sh)
+          export KAFKA_PORT=$(../scripts/get-random-port.sh)
+          export ZOOKEEPER_PORT=$(../scripts/get-random-port.sh)
+          export MINIO_PORT=$(../scripts/get-random-port.sh)
+          export TERASLICE_PORT=$(../scripts/get-random-port.sh)
+          NODE_VERSION=${{ matrix.node-version }} yarn test:s3AssetStorage
         working-directory: ./e2e
 
   teraslice-elasticsearch-tests:
@@ -471,7 +491,11 @@ jobs:
       - name: Test ${{ matrix.search-version }}
         env:
           REPORT_COVERAGE: true
-        run: yarn test:${{ matrix.search-version }}
+        run: |
+          export ELASTICSEARCH_PORT=$(../../scripts/get-random-port.sh)
+          export OPENSEARCH_PORT=$(../scripts/get-random-port.sh)
+          export MINIO_PORT=$(../../scripts/get-random-port.sh)
+          yarn test:${{ matrix.search-version }}
         working-directory: ./packages/teraslice
 
       - name: Upload teraslice node-${{ matrix.node-version }} ${{ matrix.search-version }} test coverage
@@ -531,7 +555,10 @@ jobs:
       - name: Test ${{ matrix.search-version }}
         env:
           REPORT_COVERAGE: true
-        run: yarn test:${{ matrix.search-version }}
+        run: |
+          export ELASTICSEARCH_PORT=$(../scripts/get-random-port.sh)
+          export OPENSEARCH_PORT=$(../scripts/get-random-port.sh)
+          yarn test:${{ matrix.search-version }}
         working-directory: ./packages/elasticsearch-store
 
       - name: Upload elasticsearch-store node-${{ matrix.node-version }} ${{ matrix.search-version }} test coverage
@@ -615,7 +642,10 @@ jobs:
       - name: Test ${{ matrix.search-version }}
         env:
           REPORT_COVERAGE: true
-        run: yarn test:${{ matrix.search-version }}
+        run: |
+          export ELASTICSEARCH_PORT=$(../scripts/get-random-port.sh)
+          export OPENSEARCH_PORT=$(../scripts/get-random-port.sh)
+          yarn test:${{ matrix.search-version }}
         working-directory: ./packages/elasticsearch-api
 
       - name: Upload es-api node-${{ matrix.node-version }} ${{ matrix.search-version }} test coverage
@@ -692,7 +722,14 @@ jobs:
           key: asset-bundles-${{ hashFiles('./e2e/scripts/ci_asset_bundle_list.txt') }}
 
       - name: Test ${{ matrix.search-version }}
-        run: NODE_VERSION=${{ matrix.node-version }} yarn test:${{ matrix.search-version }}
+        run: |
+          export ELASTICSEARCH_PORT=$(../scripts/get-random-port.sh)
+          export OPENSEARCH_PORT=$(../scripts/get-random-port.sh)
+          export KAFKA_PORT=$(../scripts/get-random-port.sh)
+          export ZOOKEEPER_PORT=$(../scripts/get-random-port.sh)
+          export MINIO_PORT=$(../scripts/get-random-port.sh)
+          export TERASLICE_PORT=$(../scripts/get-random-port.sh)
+          NODE_VERSION=${{ matrix.node-version }} yarn test:${{ matrix.search-version }}
         working-directory: ./e2e
 
   test-website:

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     teraslice-master:
         image: teraslice-workspace:e2e-nodev${NODE_VERSION}
         ports:
-            - '45678:45678'
+            - ${TERASLICE_PORT}:${TERASLICE_PORT}
         deploy:
           replicas: 1
         restart: 'no'

--- a/e2e/k8s/kindConfigTestPorts.yaml
+++ b/e2e/k8s/kindConfigTestPorts.yaml
@@ -4,16 +4,16 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
   image: kindest/node:v1.28.12@sha256:fa0e48b1e83bb8688a5724aa7eebffbd6337abd7909ad089a2700bf08c30c6ea
-  extraPortMappings:
-  # teraslice port mapping needs to be at index 0 in this array
-  - containerPort: 30678 # Map internal teraslice service to host port
-    hostPort: 45678
+  extraPortMappings: []
 
   # Leaving this commented out instead if removing. `hostPort` is now dynamic but
   # `containerPort` is still hardcoded and is useful information to list
   # These values are dynamically set here:
   # https://github.com/terascope/teraslice/blob/c83e68c196d926c96bffb37f544c2751ffcc78d3/packages/scripts/src/helpers/kind.ts#L52-L80
   #
+  # teraslice port mapping needs to be at index 0 in this array
+  # - containerPort: 30678 # Map internal teraslice service to host port
+  #   hostPort: 45678
   # - containerPort: 30200 # Map internal elasticsearch service to host port
   #   hostPort: 49200
   # - containerPort: 30210 # Map internal opensearch service to host port

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -47,11 +47,11 @@
         "ms": "~2.1.3"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.19.3",
+        "@terascope/scripts": "~1.19.4",
         "@terascope/types": "~1.4.3",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "bunyan": "~1.8.15",
-        "elasticsearch-store": "~1.11.2",
+        "elasticsearch-store": "~1.11.3",
         "fs-extra": "~11.3.0",
         "jest": "~30.0.3",
         "jest-extended": "~6.0.0",

--- a/e2e/test/teraslice-harness.ts
+++ b/e2e/test/teraslice-harness.ts
@@ -548,9 +548,9 @@ export class TerasliceHarness {
         const nodes = await this.waitForClusterState();
 
         if (TEST_PLATFORM === 'kubernetes' || TEST_PLATFORM === 'kubernetesV2') {
-            signale.success('Teraslice is ready to go', getElapsed(startTime));
+            signale.success(`Teraslice is ready to go at port ${TERASLICE_PORT}`, getElapsed(startTime));
         } else {
-            signale.success(`Teraslice is ready to go with ${nodes} nodes`, getElapsed(startTime));
+            signale.success(`Teraslice is ready to go at port ${TERASLICE_PORT} with ${nodes} nodes`, getElapsed(startTime));
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@eslint/js": "~9.30.0",
         "@swc/core": "1.12.7",
         "@swc/jest": "~0.2.38",
-        "@terascope/scripts": "~1.19.3",
+        "@terascope/scripts": "~1.19.4",
         "@types/bluebird": "~3.5.42",
         "@types/convict": "~6.1.6",
         "@types/elasticsearch": "~5.0.43",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "1.9.2",
+    "version": "1.9.3",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {
@@ -30,9 +30,9 @@
         "test:watch": "node ../scripts/bin/ts-scripts test --watch ../data-mate --"
     },
     "dependencies": {
-        "@terascope/data-types": "~1.9.2",
+        "@terascope/data-types": "~1.9.3",
         "@terascope/types": "~1.4.3",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "@types/validator": "~13.12.3",
         "awesome-phonenumber": "~7.5.0",
         "date-fns": "~4.1.0",
@@ -45,7 +45,7 @@
         "uuid": "~11.1.0",
         "valid-url": "~1.0.9",
         "validator": "~13.12.0",
-        "xlucene-parser": "~1.9.2"
+        "xlucene-parser": "~1.9.3"
     },
     "devDependencies": {
         "@types/ip6addr": "~0.2.6",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "1.9.2",
+    "version": "1.9.3",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.3",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "graphql": "~16.11.0",
         "yargs": "~18.0.0"
     },

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "4.10.2",
+    "version": "4.10.3",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {
@@ -25,7 +25,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.3",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "bluebird": "~3.7.2",
         "setimmediate": "~1.0.5"
     },
@@ -33,7 +33,7 @@
         "@opensearch-project/opensearch": "~1.2.0",
         "@types/elasticsearch": "~5.0.43",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.11.2",
+        "elasticsearch-store": "~1.11.3",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
         "elasticsearch7": "npm:@elastic/elasticsearch@~7.17.0",
         "elasticsearch8": "npm:@elastic/elasticsearch@~8.15.0"

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "1.11.2",
+    "version": "1.11.3",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {
@@ -30,10 +30,10 @@
         "test:watch": "ts-scripts yarn workspace @terascope/scripts test --watch ../elasticsearch-store --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.9.2",
-        "@terascope/data-types": "~1.9.2",
+        "@terascope/data-mate": "~1.9.3",
+        "@terascope/data-types": "~1.9.3",
         "@terascope/types": "~1.4.3",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "ajv": "~8.17.1",
         "ajv-formats": "~3.0.1",
         "elasticsearch6": "npm:@elastic/elasticsearch@~6.8.0",
@@ -43,7 +43,7 @@
         "opensearch2": "npm:@opensearch-project/opensearch@~2.12.0",
         "setimmediate": "~1.0.5",
         "uuid": "~11.1.0",
-        "xlucene-translator": "~1.9.2"
+        "xlucene-translator": "~1.9.3"
     },
     "devDependencies": {
         "@types/uuid": "~10.0.0"

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "1.11.2",
+    "version": "1.11.3",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.3",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",

--- a/packages/scripts/bin/ts-scripts.js
+++ b/packages/scripts/bin/ts-scripts.js
@@ -2,62 +2,10 @@
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { isPortInUse, getAvailablePort, toBoolean } from '@terascope/utils';
-import signale from '../dist/src/helpers/signale.js';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // this path.join is only used for pkg asset injection
 path.join(dirname, '../package.json');
-
-// An object that contains all possible port environment variables used in scripts
-// NOTE: The defaults set here override the defaults in the scripts/src/helpers/config.ts file
-const allPorts = {
-    TEST_ELASTICSEARCH: {
-        ELASTICSEARCH_PORT: process.env.ELASTICSEARCH_PORT || '49200'
-    },
-    TEST_RESTRAINED_ELASTICSEARCH: {
-        RESTRAINED_ELASTICSEARCH_PORT: process.env.RESTRAINED_ELASTICSEARCH_PORT || '49202'
-    },
-    TEST_KAFKA: {
-        KAFKA_PORT: process.env.KAFKA_PORT || '49094',
-        ZOOKEEPER_CLIENT_PORT: process.env.ZOOKEEPER_CLIENT_PORT || '42181',
-    },
-    TEST_MINIO: {
-        MINIO_PORT: process.env.MINIO_PORT || '49000',
-        MINIO_UI_PORT: process.env.MINIO_UI_PORT || '49001'
-    },
-    TEST_RABBITMQ: {
-        RABBITMQ_PORT: process.env.RABBITMQ_PORT || '45672',
-        RABBITMQ_MANAGEMENT_PORT: process.env.RABBITMQ_MANAGEMENT_PORT || '55672',
-    },
-    TEST_OPENSEARCH: {
-        OPENSEARCH_PORT: process.env.OPENSEARCH_PORT || '49210'
-    },
-    TEST_RESTRAINED_OPENSEARCH: {
-        RESTRAINED_OPENSEARCH_PORT: process.env.RESTRAINED_OPENSEARCH_PORT || '49206'
-    }
-};
-
-// Iterates over the `allports` object to see if any TEST_{SERVICE_NAME} variable is set
-for (const [testKey, portsObj] of Object.entries(allPorts)) {
-    // We only want to check ports for services that are set to 'true'
-    const serviceEnabled = toBoolean(process.env[testKey]);
-
-    if (serviceEnabled) {
-        for (const [envVarName, port] of Object.entries(portsObj)) {
-            signale.debug(`Checking availability of port ${port}`);
-
-            if (await isPortInUse(Number.parseInt(port))) {
-                signale.warn(`port ${port} is in use. Switching ${envVarName} to different port..`);
-                const newPort = await getAvailablePort();
-                process.env[envVarName] = newPort.toString();
-                signale.warn(`${envVarName} env variable now uses port ${newPort}`);
-            } else {
-                signale.debug(`port ${port} is valid for env variable ${envVarName}`);
-            }
-        }
-    }
-}
 
 import('../dist/src/command.js');

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.19.3",
+    "version": "1.19.4",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~1.3.0",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "execa": "~9.6.0",
         "fs-extra": "~11.3.0",
         "globby": "~14.1.0",

--- a/packages/scripts/src/helpers/k8s-env/k8s.ts
+++ b/packages/scripts/src/helpers/k8s-env/k8s.ts
@@ -185,7 +185,7 @@ export class K8s {
 
         const elapsed = Date.now() - startTime;
 
-        signale.success('Teraslice is ready to go,', `took ${ms(elapsed)}`);
+        signale.success(`Teraslice is ready to go at port ${config.TERASLICE_PORT}, took ${ms(elapsed)}`);
     }
 
     waitForTerasliceResponse(timeoutMs = 120000) {

--- a/packages/scripts/src/helpers/kind.ts
+++ b/packages/scripts/src/helpers/kind.ts
@@ -50,6 +50,10 @@ export class Kind {
         const configFile = yaml.load(fs.readFileSync(configPath, 'utf8')) as KindCluster;
 
         // Map external ports from kind to the host machine based off of config variables
+        configFile.nodes[0].extraPortMappings.push({
+            containerPort: 30678,
+            hostPort: Number.parseInt(TERASLICE_PORT)
+        });
         for (const service of ENV_SERVICES) {
             if (service === 'elasticsearch') {
                 configFile.nodes[0].extraPortMappings.push({

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -932,9 +932,6 @@ export async function helmfileCommand(command: string, clusteringType: 'kubernet
     let subprocess;
     try {
         subprocess = await execaCommand(`helmfile --state-values-file ${valuesPath} ${command} -f ${helmfilePath}`);
-        if (subprocess.stderr) {
-            throw new Error(subprocess.stderr);
-        }
     } catch (err) {
         throw new TSError(`Helmfile ${command} command failed:\n${err}`);
     } finally {

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -857,7 +857,7 @@ async function showAssets(tsPort: string) {
     }
 }
 
-export async function logTCPPorts() {
+export async function logTCPPorts(service: string) {
     try {
         const command = 'netstat -an | grep \'^tcp\' | awk \'{print $4}\' | tr ".:" " " | awk \'{print $NF}\' | sort -n | uniq | tr "\n" " "';
         const subprocess = await execaCommand(command, { shell: true, reject: false });
@@ -866,7 +866,7 @@ export async function logTCPPorts() {
         if (stderr) {
             throw new Error(stderr);
         }
-        signale.info(`TCP Ports currently in use:\n ${stdout}`);
+        signale.info(`TCP Ports currently in use when starting ${service}:\n ${stdout}`);
     } catch (err) {
         signale.error(`Execa command failed trying to log ports: ${err}`);
     }

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -862,14 +862,14 @@ async function startService(options: TestOptions, service: Service): Promise<() 
             options.skipImageDeletion
         );
         await k8sStopService(service);
-        await logTCPPorts();
+        await logTCPPorts(serviceName);
         await k8sStartService(service, services[service].image, version, kind);
         return () => { };
     }
 
     await stopService(service);
 
-    await logTCPPorts();
+    await logTCPPorts(serviceName);
 
     const fn = await dockerRun(
         services[service],

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "1.13.3",
+    "version": "1.13.4",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {
@@ -30,14 +30,14 @@
     "dependencies": {
         "@terascope/file-asset-apis": "~1.1.1",
         "@terascope/types": "~1.4.3",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "bluebird": "~3.7.2",
         "bunyan": "~1.8.15",
         "convict": "~6.2.4",
         "convict-format-with-moment": "~6.2.0",
         "convict-format-with-validator": "~6.2.0",
         "elasticsearch": "~15.4.1",
-        "elasticsearch-store": "~1.11.2",
+        "elasticsearch-store": "~1.11.3",
         "express": "~5.1.0",
         "js-yaml": "~4.1.0",
         "nanoid": "~5.1.5",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -44,7 +44,7 @@
     "devDependencies": {
         "@terascope/fetch-github-release": "~2.2.1",
         "@terascope/types": "~1.4.3",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "@types/decompress": "~4.2.7",
         "@types/ejs": "~3.1.5",
         "@types/js-yaml": "~4.0.9",
@@ -67,7 +67,7 @@
         "pretty-bytes": "~7.0.0",
         "prompts": "~2.4.2",
         "signale": "~1.4.0",
-        "teraslice-client-js": "~1.9.2",
+        "teraslice-client-js": "~1.9.3",
         "tmp": "~0.2.3",
         "tty-table": "~4.2.3",
         "yargs": "~18.0.0"

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "1.9.2",
+    "version": "1.9.3",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.3",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "auto-bind": "~5.0.1",
         "got": "~14.4.7"
     },

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "1.12.2",
+    "version": "1.12.3",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.3",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "get-port": "~7.1.0",
         "ms": "~2.1.3",
         "nanoid": "~5.1.5",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "1.10.2",
+    "version": "1.10.3",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {
@@ -24,8 +24,8 @@
         "test:watch": "node ../scripts/bin/ts-scripts test --watch ../teraslice-state-storage --"
     },
     "dependencies": {
-        "@terascope/elasticsearch-api": "~4.10.2",
-        "@terascope/utils": "~1.9.2"
+        "@terascope/elasticsearch-api": "~4.10.3",
+        "@terascope/utils": "~1.9.3"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -36,10 +36,10 @@
         "fs-extra": "~11.3.0"
     },
     "devDependencies": {
-        "@terascope/job-components": "~1.11.2"
+        "@terascope/job-components": "~1.11.3"
     },
     "peerDependencies": {
-        "@terascope/job-components": ">=1.11.2"
+        "@terascope/job-components": ">=1.11.3"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -39,11 +39,11 @@
     },
     "dependencies": {
         "@kubernetes/client-node": "~1.3.0",
-        "@terascope/elasticsearch-api": "~4.10.2",
-        "@terascope/job-components": "~1.11.2",
-        "@terascope/teraslice-messaging": "~1.12.2",
+        "@terascope/elasticsearch-api": "~4.10.3",
+        "@terascope/job-components": "~1.11.3",
+        "@terascope/teraslice-messaging": "~1.12.3",
         "@terascope/types": "~1.4.3",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "async-mutex": "~0.5.0",
         "barbe": "~3.0.17",
         "body-parser": "~2.2.0",
@@ -62,7 +62,7 @@
         "semver": "~7.7.2",
         "socket.io": "~1.7.4",
         "socket.io-client": "~1.7.4",
-        "terafoundation": "~1.13.3",
+        "terafoundation": "~1.13.4",
         "uuid": "~11.1.0"
     },
     "devDependencies": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "1.9.2",
+    "version": "1.9.3",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {
@@ -36,9 +36,9 @@
         "test:watch": "node ../scripts/bin/ts-scripts test --watch ../ts-transforms --"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.9.2",
+        "@terascope/data-mate": "~1.9.3",
         "@terascope/types": "~1.4.3",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "awesome-phonenumber": "~7.5.0",
         "graphlib": "~2.1.8",
         "jexl": "~2.3.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/utils",
     "displayName": "Utils",
-    "version": "1.9.2",
+    "version": "1.9.3",
     "description": "A collection of Teraslice Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/utils#readme",
     "bugs": {

--- a/packages/utils/src/ip.ts
+++ b/packages/utils/src/ip.ts
@@ -7,7 +7,6 @@ import isCidr from 'is-cidr';
 import ipaddr, { IPv4, IPv6 } from 'ipaddr.js';
 import { parseIp, stringifyIp } from 'ip-bigint';
 import ip6addr from 'ip6addr';
-import net from 'node:net';
 import { isString } from './strings.js';
 import {
     toInteger, isNumberLike, toBigIntOrThrow,
@@ -389,50 +388,4 @@ function _expandIPv6Part(part: string) {
     }
 
     return expandedPart;
-}
-
-/**
- * Given a port, will attempt to create a Server on said port to verify it's not in use.
- * If successful, will close the server and return false.
- * @param port The port that will be checked
- * @param host The host that the port will check against. Defaults to localhost
- * @returns A boolean of true if the address is in use or false if not
- */
-export function isPortInUse(port: number): Promise<boolean> {
-    return new Promise((resolve) => {
-        const testServer = net.createServer()
-            .once('error', (err: any) => {
-                // Close the server in all error cases
-                testServer.close();
-                if (err.code === 'EADDRINUSE') {
-                    resolve(true);
-                } else {
-                    resolve(false);
-                }
-            })
-            .once('listening', () => {
-                testServer.close(() => {
-                    resolve(false);
-                });
-            })
-            .listen(port);
-    });
-}
-
-/**
- * Grabs a random port and checks if it's in use. Will recurse until a random unused
- * port is found and return it.
- * @param min The minimum port number to use
- * @param max The maximum port number to use
- * @returns A port that is available for use
- */
-export async function getAvailablePort(min = 10000, max = 60000): Promise<number> {
-    const maxAttempts = 50;
-    for (let i = 0; i < maxAttempts; i++) {
-        const port = Math.floor(Math.random() * (max - min + 1)) + min;
-        if (!(await isPortInUse(port))) {
-            return port;
-        }
-    }
-    throw new Error(`No available ports found in range ${min}-${max}`);
 }

--- a/packages/utils/test/ip-spec.ts
+++ b/packages/utils/test/ip-spec.ts
@@ -1,6 +1,5 @@
 import 'jest-extended';
 
-import net from 'node:net';
 import {
     isIP,
     isIPv6,
@@ -23,9 +22,7 @@ import {
     getLastIPInCIDR,
     shortenIPv6Address,
     getFirstUsableIPInCIDR,
-    getLastUsableIPInCIDR,
-    isPortInUse,
-    getAvailablePort
+    getLastUsableIPInCIDR
 } from '../src/ip.js';
 
 describe('IP Utils', () => {
@@ -573,68 +570,6 @@ describe('IP Utils', () => {
             expect(() => {
                 toCIDR('2001:0db8:0123:4567:89ab:cdef:1234:5678', 223);
             }).toThrow('input must be a valid IP address and suffix must be a value <= 32 for IPv4 or <= 128 for IPv6');
-        });
-    });
-
-    describe('getAvailablePort', () => {
-        let server: net.Server;
-        let takenPort: number;
-
-        beforeAll(async () => {
-            takenPort = await isPortInUse(28333) ? await getAvailablePort() : 28333;
-            server = net.createServer();
-        });
-
-        afterAll(async () => {
-            server.close();
-        });
-
-        it('Should give a valid port', async () => {
-            const minPort = 10000;
-            const maxPort = 30000;
-            const port = await getAvailablePort(minPort, maxPort);
-            expect(port).toBeNumber();
-            expect(port).toBeLessThanOrEqual(maxPort);
-            expect(port).toBeGreaterThanOrEqual(minPort);
-        });
-
-        it('Should throw if no ports are available within a given range', async () => {
-            server.listen(takenPort)
-                .once('listening', async () => {
-                    const expectedError = `No available ports found in range ${takenPort}-${takenPort}`;
-                    await expect(getAvailablePort(takenPort, takenPort))
-                        .rejects.toThrow(expectedError);
-                });
-        });
-    });
-
-    describe('isPortInUse', () => {
-        let server: net.Server;
-        let takenPort: number;
-
-        beforeAll(async () => {
-            takenPort = await isPortInUse(28333) ? await getAvailablePort() : 28333;
-            server = net.createServer();
-        });
-
-        afterAll(async () => {
-            server.close();
-        });
-
-        it('Should be false if port is NOT in use', async () => {
-            const port = await getAvailablePort();
-            const portInUse = await isPortInUse(port);
-
-            expect(portInUse).toBeFalse();
-        });
-
-        it('Should be true if port IS in use', async () => {
-            server.listen(takenPort)
-                .once('listening', async () => {
-                    const portInUse = await isPortInUse(takenPort);
-
-                    expect(portInUse).toBeTrue();
-                });
         });
     });
 });

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "1.9.2",
+    "version": "1.9.3",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.3",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "peggy": "~4.2.0",
         "ts-pegjs": "~4.2.1"
     },

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "1.9.2",
+    "version": "1.9.3",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {
@@ -30,9 +30,9 @@
     },
     "dependencies": {
         "@terascope/types": "~1.4.3",
-        "@terascope/utils": "~1.9.2",
+        "@terascope/utils": "~1.9.3",
         "@types/elasticsearch": "~5.0.43",
-        "xlucene-parser": "~1.9.2"
+        "xlucene-parser": "~1.9.3"
     },
     "devDependencies": {
         "elasticsearch": "~15.4.1"

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "1.9.2",
+    "version": "1.9.3",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {
@@ -24,7 +24,7 @@
         "test:watch": "node ../scripts/bin/ts-scripts test --watch ../xpressions --"
     },
     "dependencies": {
-        "@terascope/utils": "~1.9.2"
+        "@terascope/utils": "~1.9.3"
     },
     "devDependencies": {
         "@terascope/types": "~1.4.3"

--- a/scripts/get-random-port.sh
+++ b/scripts/get-random-port.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e
+
+cmdname=$(basename "$0")
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi; }
+
+usage() {
+    cat <<USAGE >&2
+Usage:
+    $cmdname
+
+    Get a random port
+USAGE
+    exit 1
+}
+
+find_port() {
+    local used_ports;
+
+    local port;
+    for i in $(seq 1 10); do
+        # get a random port between 40000 and 65535
+        port="$((40000 + RANDOM % 25536))"
+        used_ports="$(netstat -an | grep '^tcp' | awk '{print $4}' | tr '.:' ' ' | awk '{print $NF}' | sort -n | uniq)"
+
+        if [[ " $used_ports " =~ $port ]]; then
+            [ "$i" != "1" ] && echoerr "* port $port is NOT available (attempt $i)"
+        else
+            [ "$i" != "1" ] && echoerr "* port $port is available (attempt $i)"
+            echo "$port"
+            return 0;
+        fi
+    done
+
+    echo "$port"
+}
+
+main() {
+    local arg="$1"
+
+    case "$arg" in
+    -h | --help | help)
+        usage
+        ;;
+    esac
+
+    find_port
+}
+
+main "$@"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,13 +3167,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/data-mate@npm:~1.9.2, @terascope/data-mate@workspace:packages/data-mate":
+"@terascope/data-mate@npm:~1.9.3, @terascope/data-mate@workspace:packages/data-mate":
   version: 0.0.0-use.local
   resolution: "@terascope/data-mate@workspace:packages/data-mate"
   dependencies:
-    "@terascope/data-types": "npm:~1.9.2"
+    "@terascope/data-types": "npm:~1.9.3"
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     "@types/ip6addr": "npm:~0.2.6"
     "@types/uuid": "npm:~10.0.0"
     "@types/validator": "npm:~13.12.3"
@@ -3190,16 +3190,16 @@ __metadata:
     uuid: "npm:~11.1.0"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
-    xlucene-parser: "npm:~1.9.2"
+    xlucene-parser: "npm:~1.9.3"
   languageName: unknown
   linkType: soft
 
-"@terascope/data-types@npm:~1.9.2, @terascope/data-types@workspace:packages/data-types":
+"@terascope/data-types@npm:~1.9.3, @terascope/data-types@workspace:packages/data-types":
   version: 0.0.0-use.local
   resolution: "@terascope/data-types@workspace:packages/data-types"
   dependencies:
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     "@types/yargs": "npm:~17.0.33"
     graphql: "npm:~16.11.0"
     yargs: "npm:~18.0.0"
@@ -3216,17 +3216,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/elasticsearch-api@npm:~4.10.2, @terascope/elasticsearch-api@workspace:packages/elasticsearch-api":
+"@terascope/elasticsearch-api@npm:~4.10.3, @terascope/elasticsearch-api@workspace:packages/elasticsearch-api":
   version: 0.0.0-use.local
   resolution: "@terascope/elasticsearch-api@workspace:packages/elasticsearch-api"
   dependencies:
     "@opensearch-project/opensearch": "npm:~1.2.0"
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     "@types/elasticsearch": "npm:~5.0.43"
     bluebird: "npm:~3.7.2"
     elasticsearch: "npm:~15.4.1"
-    elasticsearch-store: "npm:~1.11.2"
+    elasticsearch-store: "npm:~1.11.3"
     elasticsearch6: "npm:@elastic/elasticsearch@~6.8.0"
     elasticsearch7: "npm:@elastic/elasticsearch@~7.17.0"
     elasticsearch8: "npm:@elastic/elasticsearch@~8.15.0"
@@ -3288,12 +3288,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/job-components@npm:~1.11.2, @terascope/job-components@workspace:packages/job-components":
+"@terascope/job-components@npm:~1.11.3, @terascope/job-components@workspace:packages/job-components":
   version: 0.0.0-use.local
   resolution: "@terascope/job-components@workspace:packages/job-components"
   dependencies:
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     benchmark: "npm:~2.1.4"
     convict: "npm:~6.2.4"
     convict-format-with-moment: "npm:~6.2.0"
@@ -3308,12 +3308,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/scripts@npm:~1.19.3, @terascope/scripts@workspace:packages/scripts":
+"@terascope/scripts@npm:~1.19.4, @terascope/scripts@workspace:packages/scripts":
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
     "@kubernetes/client-node": "npm:~1.3.0"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     "@types/ip": "npm:~1.1.3"
     "@types/micromatch": "npm:~4.0.9"
     "@types/ms": "npm:~0.7.34"
@@ -3351,12 +3351,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/teraslice-messaging@npm:~1.12.2, @terascope/teraslice-messaging@workspace:packages/teraslice-messaging":
+"@terascope/teraslice-messaging@npm:~1.12.3, @terascope/teraslice-messaging@workspace:packages/teraslice-messaging":
   version: 0.0.0-use.local
   resolution: "@terascope/teraslice-messaging@workspace:packages/teraslice-messaging"
   dependencies:
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     "@types/ms": "npm:~0.7.34"
     "@types/socket.io": "npm:~2.1.13"
     "@types/socket.io-client": "npm:~1.4.36"
@@ -3373,8 +3373,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terascope/teraslice-state-storage@workspace:packages/teraslice-state-storage"
   dependencies:
-    "@terascope/elasticsearch-api": "npm:~4.10.2"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/elasticsearch-api": "npm:~4.10.3"
+    "@terascope/utils": "npm:~1.9.3"
   languageName: unknown
   linkType: soft
 
@@ -3430,7 +3430,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/utils@npm:~1.9.2, @terascope/utils@workspace:packages/utils":
+"@terascope/utils@npm:~1.9.3, @terascope/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@terascope/utils@workspace:packages/utils"
   dependencies:
@@ -6757,11 +6757,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e@workspace:e2e"
   dependencies:
-    "@terascope/scripts": "npm:~1.19.3"
+    "@terascope/scripts": "npm:~1.19.4"
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     bunyan: "npm:~1.8.15"
-    elasticsearch-store: "npm:~1.11.2"
+    elasticsearch-store: "npm:~1.11.3"
     fs-extra: "npm:~11.3.0"
     jest: "npm:~30.0.3"
     jest-extended: "npm:~6.0.0"
@@ -6824,14 +6824,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elasticsearch-store@npm:~1.11.2, elasticsearch-store@workspace:packages/elasticsearch-store":
+"elasticsearch-store@npm:~1.11.3, elasticsearch-store@workspace:packages/elasticsearch-store":
   version: 0.0.0-use.local
   resolution: "elasticsearch-store@workspace:packages/elasticsearch-store"
   dependencies:
-    "@terascope/data-mate": "npm:~1.9.2"
-    "@terascope/data-types": "npm:~1.9.2"
+    "@terascope/data-mate": "npm:~1.9.3"
+    "@terascope/data-types": "npm:~1.9.3"
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     "@types/uuid": "npm:~10.0.0"
     ajv: "npm:~8.17.1"
     ajv-formats: "npm:~3.0.1"
@@ -6842,7 +6842,7 @@ __metadata:
     opensearch2: "npm:@opensearch-project/opensearch@~2.12.0"
     setimmediate: "npm:~1.0.5"
     uuid: "npm:~11.1.0"
-    xlucene-translator: "npm:~1.9.2"
+    xlucene-translator: "npm:~1.9.3"
   languageName: unknown
   linkType: soft
 
@@ -13824,13 +13824,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terafoundation@npm:~1.13.3, terafoundation@workspace:packages/terafoundation":
+"terafoundation@npm:~1.13.4, terafoundation@workspace:packages/terafoundation":
   version: 0.0.0-use.local
   resolution: "terafoundation@workspace:packages/terafoundation"
   dependencies:
     "@terascope/file-asset-apis": "npm:~1.1.1"
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     "@types/bunyan": "npm:~1.8.11"
     "@types/elasticsearch": "npm:~5.0.43"
     "@types/express": "npm:~5.0.3"
@@ -13841,7 +13841,7 @@ __metadata:
     convict-format-with-moment: "npm:~6.2.0"
     convict-format-with-validator: "npm:~6.2.0"
     elasticsearch: "npm:~15.4.1"
-    elasticsearch-store: "npm:~1.11.2"
+    elasticsearch-store: "npm:~1.11.3"
     express: "npm:~5.1.0"
     got: "npm:~14.4.7"
     js-yaml: "npm:~4.1.0"
@@ -13858,7 +13858,7 @@ __metadata:
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.2.1"
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     "@types/decompress": "npm:~4.2.7"
     "@types/ejs": "npm:~3.1.5"
     "@types/js-yaml": "npm:~4.0.9"
@@ -13882,7 +13882,7 @@ __metadata:
     pretty-bytes: "npm:~7.0.0"
     prompts: "npm:~2.4.2"
     signale: "npm:~1.4.0"
-    teraslice-client-js: "npm:~1.9.2"
+    teraslice-client-js: "npm:~1.9.3"
     tmp: "npm:~0.2.3"
     tty-table: "npm:~4.2.3"
     yargs: "npm:~18.0.0"
@@ -13892,12 +13892,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"teraslice-client-js@npm:~1.9.2, teraslice-client-js@workspace:packages/teraslice-client-js":
+"teraslice-client-js@npm:~1.9.3, teraslice-client-js@workspace:packages/teraslice-client-js":
   version: 0.0.0-use.local
   resolution: "teraslice-client-js@workspace:packages/teraslice-client-js"
   dependencies:
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     auto-bind: "npm:~5.0.1"
     got: "npm:~14.4.7"
     nock: "npm:~13.5.6"
@@ -13909,11 +13909,11 @@ __metadata:
   resolution: "teraslice-test-harness@workspace:packages/teraslice-test-harness"
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.2.1"
-    "@terascope/job-components": "npm:~1.11.2"
+    "@terascope/job-components": "npm:~1.11.3"
     decompress: "npm:~4.2.1"
     fs-extra: "npm:~11.3.0"
   peerDependencies:
-    "@terascope/job-components": ">=1.11.2"
+    "@terascope/job-components": ">=1.11.3"
   languageName: unknown
   linkType: soft
 
@@ -13924,7 +13924,7 @@ __metadata:
     "@eslint/js": "npm:~9.30.0"
     "@swc/core": "npm:1.12.7"
     "@swc/jest": "npm:~0.2.38"
-    "@terascope/scripts": "npm:~1.19.3"
+    "@terascope/scripts": "npm:~1.19.4"
     "@types/bluebird": "npm:~3.5.42"
     "@types/convict": "npm:~6.1.6"
     "@types/elasticsearch": "npm:~5.0.43"
@@ -13948,11 +13948,11 @@ __metadata:
   resolution: "teraslice@workspace:packages/teraslice"
   dependencies:
     "@kubernetes/client-node": "npm:~1.3.0"
-    "@terascope/elasticsearch-api": "npm:~4.10.2"
-    "@terascope/job-components": "npm:~1.11.2"
-    "@terascope/teraslice-messaging": "npm:~1.12.2"
+    "@terascope/elasticsearch-api": "npm:~4.10.3"
+    "@terascope/job-components": "npm:~1.11.3"
+    "@terascope/teraslice-messaging": "npm:~1.12.3"
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     "@types/archiver": "npm:~6.0.3"
     "@types/express": "npm:~5.0.3"
     "@types/gc-stats": "npm:~1.4.3"
@@ -13983,7 +13983,7 @@ __metadata:
     semver: "npm:~7.7.2"
     socket.io: "npm:~1.7.4"
     socket.io-client: "npm:~1.7.4"
-    terafoundation: "npm:~1.13.3"
+    terafoundation: "npm:~1.13.4"
     uuid: "npm:~11.1.0"
   languageName: unknown
   linkType: soft
@@ -14200,9 +14200,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ts-transforms@workspace:packages/ts-transforms"
   dependencies:
-    "@terascope/data-mate": "npm:~1.9.2"
+    "@terascope/data-mate": "npm:~1.9.3"
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     "@types/graphlib": "npm:~2.1.12"
     "@types/jexl": "npm:~2.3.4"
     "@types/valid-url": "npm:~1.0.7"
@@ -15051,12 +15051,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xlucene-parser@npm:~1.9.2, xlucene-parser@workspace:packages/xlucene-parser":
+"xlucene-parser@npm:~1.9.3, xlucene-parser@workspace:packages/xlucene-parser":
   version: 0.0.0-use.local
   resolution: "xlucene-parser@workspace:packages/xlucene-parser"
   dependencies:
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     "@turf/invariant": "npm:~7.2.0"
     "@turf/random": "npm:~7.2.0"
     peggy: "npm:~4.2.0"
@@ -15064,15 +15064,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"xlucene-translator@npm:~1.9.2, xlucene-translator@workspace:packages/xlucene-translator":
+"xlucene-translator@npm:~1.9.3, xlucene-translator@workspace:packages/xlucene-translator":
   version: 0.0.0-use.local
   resolution: "xlucene-translator@workspace:packages/xlucene-translator"
   dependencies:
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
     "@types/elasticsearch": "npm:~5.0.43"
     elasticsearch: "npm:~15.4.1"
-    xlucene-parser: "npm:~1.9.2"
+    xlucene-parser: "npm:~1.9.3"
   languageName: unknown
   linkType: soft
 
@@ -15088,7 +15088,7 @@ __metadata:
   resolution: "xpressions@workspace:packages/xpressions"
   dependencies:
     "@terascope/types": "npm:~1.4.3"
-    "@terascope/utils": "npm:~1.9.2"
+    "@terascope/utils": "npm:~1.9.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR makes the following changes:
- add `get-random-port.sh` script
- remove `getAvailablePort()` and `isPortInUse()` functions
- `test.yml` workflow now gets random ports for teraslice and services using the script
- `logTCPPorts()` uses the same `netstat` script as `get-random-ports.sh`. This should work well on both MacOS and Linux systems.
- Fix some error logging issues in ts-scripts

ref: #3898 