### PR TITLE
[scripts] fix relative test path argument 

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -49,7 +49,7 @@
     },
     "devDependencies": {
         "@terascope/opensearch-client": "~1.0.0",
-        "@terascope/scripts": "~1.20.3",
+        "@terascope/scripts": "~1.20.4",
         "@terascope/types": "~1.4.3",
         "@terascope/utils": "~1.9.3",
         "bunyan": "~1.8.15",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "@eslint/js": "~9.31.0",
         "@swc/core": "1.13.1",
         "@swc/jest": "~0.2.39",
-        "@terascope/scripts": "~1.20.3",
+        "@terascope/scripts": "~1.20.4",
         "@types/bluebird": "~3.5.42",
         "@types/convict": "~6.1.6",
         "@types/elasticsearch": "~5.0.43",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.20.3",
+    "version": "1.20.4",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/cmds/test.ts
+++ b/packages/scripts/src/cmds/test.ts
@@ -220,10 +220,20 @@ function resolveJestArg(arg: string): string[] {
                 }
             }
         }
-
-        return ['--testPathPatterns', arg];
+        return ['--testPathPatterns', normalizeJestPathPattern(arg)];
     }
     return [arg];
+}
+
+/**
+ * Converts a relative path starting with `./` to a Jest 30+ compatible pattern
+ * by removing the leading `./` if present.
+ *
+ * @param testPath - The input path string
+ * @returns The cleaned path string without leading `./`
+ */
+function normalizeJestPathPattern(testPath: string): string {
+    return testPath.startsWith('./') ? testPath.slice(2) : testPath;
 }
 
 function getPkgInfos(packages?: PackageInfo[]): PackageInfo[] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3353,7 +3353,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/scripts@npm:~1.20.3, @terascope/scripts@workspace:packages/scripts":
+"@terascope/scripts@npm:~1.20.4, @terascope/scripts@workspace:packages/scripts":
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
@@ -6881,7 +6881,7 @@ __metadata:
   resolution: "e2e@workspace:e2e"
   dependencies:
     "@terascope/opensearch-client": "npm:~1.0.0"
-    "@terascope/scripts": "npm:~1.20.3"
+    "@terascope/scripts": "npm:~1.20.4"
     "@terascope/types": "npm:~1.4.3"
     "@terascope/utils": "npm:~1.9.3"
     bunyan: "npm:~1.8.15"
@@ -14092,7 +14092,7 @@ __metadata:
     "@eslint/js": "npm:~9.31.0"
     "@swc/core": "npm:1.13.1"
     "@swc/jest": "npm:~0.2.39"
-    "@terascope/scripts": "npm:~1.20.3"
+    "@terascope/scripts": "npm:~1.20.4"
     "@types/bluebird": "npm:~3.5.42"
     "@types/convict": "npm:~6.1.6"
     "@types/elasticsearch": "npm:~5.0.43"


### PR DESCRIPTION
This PR makes the following changes:

- Fixes issue from jest 30+ that broke `ts-scripts` functionality where running specific test files with relative paths is broken
  - **Example:** yarn test ./test/someTestFile.ts now works again 
- Bumps scripts from `v1.20.3` to `v1.20.4`

Ref to issue  #4131