### PR TITLE
[scripts] Fix docker image list script bug

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -49,7 +49,7 @@
     },
     "devDependencies": {
         "@terascope/opensearch-client": "~1.1.2",
-        "@terascope/scripts": "~1.21.2",
+        "@terascope/scripts": "~1.21.3",
         "@terascope/types": "~1.4.4",
         "@terascope/utils": "~1.10.2",
         "bunyan": "~1.8.15",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "@eslint/js": "~9.33.0",
         "@swc/core": "1.13.3",
         "@swc/jest": "~0.2.39",
-        "@terascope/scripts": "~1.21.2",
+        "@terascope/scripts": "~1.21.3",
         "@types/bluebird": "~3.5.42",
         "@types/convict": "~6.1.6",
         "@types/elasticsearch": "~5.0.43",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "1.21.2",
+    "version": "1.21.3",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/images/index.ts
+++ b/packages/scripts/src/helpers/images/index.ts
@@ -23,7 +23,7 @@ export async function createImageList(): Promise<void> {
     signale.info(`Creating Docker image list at ${config.DOCKER_IMAGE_LIST_PATH}`);
     const repo = getRootInfo().name;
     let list;
-    if (repo === 'elasticsearch-assets') {
+    if (repo === 'elasticsearch-asset-bundle') {
         list = `${config.ELASTICSEARCH_DOCKER_IMAGE}:${config.__DEFAULT_ELASTICSEARCH6_VERSION}\n`
             + `${config.ELASTICSEARCH_DOCKER_IMAGE}:${config.__DEFAULT_ELASTICSEARCH7_VERSION}\n`
             + `${config.OPENSEARCH_DOCKER_IMAGE}:${config.__DEFAULT_OPENSEARCH1_VERSION}\n`

--- a/packages/scripts/src/helpers/images/index.ts
+++ b/packages/scripts/src/helpers/images/index.ts
@@ -35,6 +35,8 @@ export async function createImageList(): Promise<void> {
             + `${config.ZOOKEEPER_DOCKER_IMAGE}:${config.KAFKA_IMAGE_VERSION}`;
     } else if (repo === 'file-assets-bundle') {
         list = `${config.MINIO_DOCKER_IMAGE}:${config.MINIO_VERSION}`;
+    } else if (repo === 'standard-assets-bundle') {
+        list = '';
     } else if (repo === 'teraslice-workspace') {
         const baseImages: string = config.TEST_NODE_VERSIONS
             .reduce((acc: string, version: string) => `${acc}${config.BASE_DOCKER_IMAGE}:${version}\n`, '');
@@ -51,7 +53,7 @@ export async function createImageList(): Promise<void> {
             + `${config.MINIO_DOCKER_IMAGE}:${config.MINIO_VERSION}\n`
             + `${config.KIND_DOCKER_IMAGE}:${config.KIND_VERSION}`;
     } else {
-        list = '';
+        throw new Error(`This command does not support repository ${repo}`);
     }
 
     if (!fse.existsSync(config.DOCKER_IMAGES_PATH)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3368,7 +3368,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/scripts@npm:~1.21.2, @terascope/scripts@workspace:packages/scripts":
+"@terascope/scripts@npm:~1.21.3, @terascope/scripts@workspace:packages/scripts":
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
@@ -6912,7 +6912,7 @@ __metadata:
   resolution: "e2e@workspace:e2e"
   dependencies:
     "@terascope/opensearch-client": "npm:~1.1.2"
-    "@terascope/scripts": "npm:~1.21.2"
+    "@terascope/scripts": "npm:~1.21.3"
     "@terascope/types": "npm:~1.4.4"
     "@terascope/utils": "npm:~1.10.2"
     bunyan: "npm:~1.8.15"
@@ -14210,7 +14210,7 @@ __metadata:
     "@eslint/js": "npm:~9.33.0"
     "@swc/core": "npm:1.13.3"
     "@swc/jest": "npm:~0.2.39"
-    "@terascope/scripts": "npm:~1.21.2"
+    "@terascope/scripts": "npm:~1.21.3"
     "@types/bluebird": "npm:~3.5.42"
     "@types/convict": "npm:~6.1.6"
     "@types/elasticsearch": "npm:~5.0.43"


### PR DESCRIPTION
This PR makes the following changes:
- Fix `ts-scripts images list` command
  - use correct elasticsearch assets repo name
  - throw if repo name not supported 
- bump ts-scripts from v1.21.2 to v1.21.3