### PR TITLE
release: (patch) teraslice@2.17.3 

### DIFF
--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 2.17.0
-appVersion: v2.17.2
+version: 2.18.0
+appVersion: v2.17.3
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/helm/teraslice/values.yaml
+++ b/helm/teraslice/values.yaml
@@ -11,7 +11,7 @@ image:
   pullPolicy: IfNotPresent
   # node version will be inserted into the image tag (which defaults to the chart version)
   # setting the image tag will ignore this value
-  nodeVersion: v22.17.1
+  nodeVersion: v22.18.0
 
 imagePullSecrets: []
 nameOverride: ""

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "2.17.2",
+    "version": "2.17.3",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "2.17.2",
+    "version": "2.17.3",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:
- bump teraslice from 2.17.2 to 2.17.3
- this release will build on the teraslice base-docker-image containing:
  - `terafoundation_kafka_connector v1.6.0`
  - `node-rdkafka v3.5.0`
  - `librdkafka v2.11.1`
  - bump helmchart from 2.17.0 to 2.18.0