### PR TITLE
[Helm] Remove legacy metrics exporter and stop scraping /cluster/stats

### DIFF
--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,7 +4,7 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 2.18.0
+version: 2.19.0
 appVersion: v2.17.3
 sources:
   - https://github.com/terascope/teraslice

--- a/helm/teraslice/README.md
+++ b/helm/teraslice/README.md
@@ -77,12 +77,6 @@ View the `values.yaml` for charts configuration settings.
 | `persistence.accessModes`         | Storage access modes                            | `["ReadWriteMany"]`       |
 | `extraVolumes`                    | Additional volumes                              | `[]`                      |
 | `extraVolumeMounts`               | Additional volume mounts                        | `[]`                      |
-| `exporter.enabled`                | Enable external exporter                        | `false`                   |
-| `exporter.image.repository`       | Exporter image repository                       | `terascope/teraslice-exporter` |
-| `exporter.image.tag`              | Exporter image tag. This image is archived as of right now. See repo [here](https://github.com/terascope/teraslice-exporter)                | `v0.4.0`                  |
-| `exporter.image.pullPolicy`       | Exporter image pull policy                      | `IfNotPresent`            |
-| `exporter.env.TERASLICE_URL`      | URL for the Teraslice service                   | `http://localhost:5678`   |
-| `exporter.env.PORT`               | Exporter port                                   | `8080`                    |
 | `serviceMonitor.enabled`          | Enable Prometheus service monitor               | `false`                   |
 | `serviceMonitor.interval`         | Scrape interval                                | `60s`                     |
 | `serviceMonitor.metricRelabelings` | Metric relabeling rules                        | `[]`                      |

--- a/helm/teraslice/templates/deployment.yaml
+++ b/helm/teraslice/templates/deployment.yaml
@@ -1,6 +1,3 @@
-{{- if and .Values.terafoundation.prom_metrics_enabled .Values.exporter.enabled }}
-{{- fail "Do not enable both internal and external metrics (terafoundation.prom_metrics_enabled and exporter.enabled)" }}
-{{- end}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -89,24 +86,6 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.extraContainers }}
         {{- tpl .Values.extraContainers . | nindent 8 }}
-        {{- end }}
-        {{- if .Values.exporter.enabled }}
-        - name: {{ .Chart.Name }}-exporter
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}
-          imagePullPolicy: {{ .Values.exporter.image.pullPolicy }}
-          env:
-          {{- range $key, $value := .Values.exporter.env }}
-          - name: "{{ $key }}"
-            value: "{{ $value }}"
-          {{- end }}
-          ports:
-            - name: metrics
-              containerPort: {{ .Values.exporter.env.PORT }}
-              protocol: TCP
-          resources:
-            {{- toYaml .Values.exporter.resources | nindent 12 }}
         {{- end }}
       volumes:
         - name: config

--- a/helm/teraslice/templates/service.yaml
+++ b/helm/teraslice/templates/service.yaml
@@ -47,11 +47,5 @@ spec:
       protocol: TCP
       name: metrics
     {{- end }}
-    {{- if .Values.exporter.enabled }}
-    - port: {{ .Values.exporter.env.PORT }}
-      targetPort: metrics
-      protocol: TCP
-      name: metrics
-    {{- end }}
   selector:
     {{- include "teraslice.master.selectorLabels" . | nindent 4 }}

--- a/helm/teraslice/templates/servicemonitor.yaml
+++ b/helm/teraslice/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if and .Values.serviceMonitor.enabled .Values.terafoundation.prom_metrics_enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -7,14 +7,6 @@ metadata:
     {{- include "teraslice.master.labels" . | nindent 4 }}
 spec:
   endpoints:
-    - path: /cluster/stats
-      port: api
-      interval: {{ .Values.serviceMonitor.interval }}
-      metricRelabelings:
-        {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 8 }}
-      relabelings:
-        {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
-    {{- if or .Values.terafoundation.prom_metrics_enabled .Values.exporter.enabled }}
     - path: /metrics
       port: metrics
       interval: {{ .Values.serviceMonitor.interval }}
@@ -22,7 +14,6 @@ spec:
         {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 8 }}
       relabelings:
         {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
-    {{- end }}
   jobLabel: app.kubernetes.io/instance
   selector:
     matchLabels:

--- a/helm/teraslice/values.yaml
+++ b/helm/teraslice/values.yaml
@@ -50,8 +50,7 @@ worker:
 terafoundation:
   environment: production
   log_level: info
-  # internal metrics exporter.  Do not combine with the external metrics server
-  # exporter.enabled: false
+  # internal metrics exporter.
   prom_metrics_enabled: false
   prom_metrics_port: 3333
   prom_metrics_add_default: true
@@ -90,7 +89,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: master-service-account
+  name: ""
 
 podSecurityContext: {} # fsGroup: 2000
 
@@ -172,18 +171,6 @@ extraVolumeMounts: []
   # - name: extras
   #   mountPath: /usr/share/extras
   #   readOnly: true
-
-# external exporter.  Do not combine with the internal metrics server
-# terafoundation.prom_metrics_enabled: false
-exporter:
-  enabled: false
-  image:
-    repository: terascope/teraslice-exporter
-    tag: v0.4.0
-    pullPolicy: IfNotPresent
-  env:
-    TERASLICE_URL: http://localhost:5678
-    PORT: 8080
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
This PR makes the following changes:
- Remove references and templating for the EOL external metrics exporter: https://github.com/terascope/teraslice-exporter
- Stop scraping /cluster/stats  (redundant and has other compatibility issues)
- Don't hard-code service account name; avoid collisions in shared namespaces (reverts [this change](https://github.com/terascope/teraslice/commit/c2bfb2230ef47352cf8cca41a21423faa1fb2d6f#diff-1be2e204031160fc47f1612c395d4ca824f12ccdd4590495e2e7b6b38fbed8aaR93))

fixes #3910