### PR TITLE
remove prometheus format from cluster/stats

### DIFF
--- a/docs/management-apis/endpoints-json.md
+++ b/docs/management-apis/endpoints-json.md
@@ -115,23 +115,6 @@ $ curl 'http://localhost:5678/v1/cluster/stats'
 }
 ```
 
-Include the following header to receive stats in "prometheus exporter mode":
-```sh
-$ curl -H "Accept: application/openmetrics-text;" -sS http://localhost:5678/cluster/stats
-# TYPE teraslice_slices_processed counter
-teraslice_slices_processed{cluster="teraslice-dev1"} 2
-# TYPE teraslice_slices_failed counter
-teraslice_slices_failed{cluster="teraslice-dev1"} 0
-# TYPE teraslice_slices_queued counter
-teraslice_slices_queued{cluster="teraslice-dev1"} 0
-# TYPE teraslice_workers_joined counter
-teraslice_workers_joined{cluster="teraslice-dev1"} 1
-# TYPE teraslice_workers_disconnected counter
-teraslice_workers_disconnected{cluster="teraslice-dev1"} 0
-# TYPE teraslice_workers_reconnected counter
-teraslice_workers_reconnected{cluster="teraslice-dev1"} 0
-```
-
 ## GET /v1/assets
 
 Retreives a list of assets

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -14,9 +14,8 @@ import { makeLogger } from '../../workers/helpers/terafoundation.js';
 import { ExecutionService, JobsService, ClusterServiceType } from '../services/index.js';
 import type { JobsStorage, ExecutionStorage, StateStorage } from '../../storage/index.js';
 import {
-    makePrometheus, isPrometheusTerasliceRequest, makeTable,
-    sendError, handleTerasliceRequest, getSearchOptions,
-    createJobActiveQuery, addDeletedToQuery
+    makeTable, sendError, handleTerasliceRequest,
+    getSearchOptions, createJobActiveQuery, addDeletedToQuery
 } from '../../utils/api_utils.js';
 import { getPackageJSON } from '../../utils/file_utils.js';
 
@@ -487,16 +486,11 @@ export class ApiService {
         });
 
         v1routes.get('/cluster/stats', (req, res) => {
-            const { name: cluster } = this.context.sysconfig.teraslice;
-
             const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not get cluster statistics');
             requestHandler(async () => {
-                const stats = await executionService.getClusterAnalytics();
+                const stats = executionService.getClusterAnalytics();
 
-                if (isPrometheusTerasliceRequest(req as TerasliceRequest)) {
-                    return makePrometheus(stats, { cluster });
-                }
-                // for backwards compatability (unsupported for prometheus)
+                // for backwards compatability
                 // @ts-expect-error
                 stats.slicer = stats.controllers;
                 return stats;

--- a/packages/teraslice/test/utils/api_utils-spec.ts
+++ b/packages/teraslice/test/utils/api_utils-spec.ts
@@ -1,72 +1,8 @@
 import {
-    makePrometheus, isPrometheusTerasliceRequest, createJobActiveQuery, addDeletedToQuery
+    createJobActiveQuery, addDeletedToQuery
 } from '../../src/lib/utils/api_utils.js';
 
 describe('apiUtils', () => {
-    it('should be able make a prometheus text format', () => {
-        const stats = {
-            controllers: {
-                processed: 1000,
-                failed: 10,
-                queued: 5,
-                job_duration: 10,
-                workers_joined: 20,
-                workers_disconnected: 30,
-                workers_reconnected: 40
-            }
-        };
-        const r = `# TYPE teraslice_slices_processed counter
-teraslice_slices_processed ${stats.controllers.processed}
-# TYPE teraslice_slices_failed counter
-teraslice_slices_failed ${stats.controllers.failed}
-# TYPE teraslice_slices_queued counter
-teraslice_slices_queued ${stats.controllers.queued}
-# TYPE teraslice_workers_joined counter
-teraslice_workers_joined ${stats.controllers.workers_joined}
-# TYPE teraslice_workers_disconnected counter
-teraslice_workers_disconnected ${stats.controllers.workers_disconnected}
-# TYPE teraslice_workers_reconnected counter
-teraslice_workers_reconnected ${stats.controllers.workers_reconnected}
-`;
-        expect(makePrometheus(stats)).toEqual(r);
-    });
-
-    it('should be able make a prometheus text format with labels', () => {
-        const stats = {
-            controllers: {
-                processed: 1000,
-                failed: 10,
-                queued: 5,
-                job_duration: 10,
-                workers_joined: 20,
-                workers_disconnected: 30,
-                workers_reconnected: 40
-            }
-        };
-        const r = `# TYPE teraslice_slices_processed counter
-teraslice_slices_processed{foo="bar"} ${stats.controllers.processed}
-# TYPE teraslice_slices_failed counter
-teraslice_slices_failed{foo="bar"} ${stats.controllers.failed}
-# TYPE teraslice_slices_queued counter
-teraslice_slices_queued{foo="bar"} ${stats.controllers.queued}
-# TYPE teraslice_workers_joined counter
-teraslice_workers_joined{foo="bar"} ${stats.controllers.workers_joined}
-# TYPE teraslice_workers_disconnected counter
-teraslice_workers_disconnected{foo="bar"} ${stats.controllers.workers_disconnected}
-# TYPE teraslice_workers_reconnected counter
-teraslice_workers_reconnected{foo="bar"} ${stats.controllers.workers_reconnected}
-`;
-        expect(makePrometheus(stats, { foo: 'bar' })).toEqual(r);
-    });
-
-    it('should be able to detect if a request is prometheus', () => {
-        expect(isPrometheusTerasliceRequest({
-            headers: {
-                accept: 'blah application/openmetrics-text; blah blah'
-            }
-        } as any)).toBeTruthy();
-    });
-
     it('should be able to create the proper job queries', () => {
         let query: string;
 


### PR DESCRIPTION
This PR makes the following changes:
- Removes the ability of the `cluster/stats` endpoint to return stats in a prom metrics compatible format
- Updates docs

Ref: #4159

TODO: ensure this functionality is not used anywhere before merging