### PR TITLE
[CI] add release branch to test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Teraslice CI Tests
 # this will technically run again on merge to master, should limit it
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ master, release/teraslice-v* ]
 env:
   NODE_VERSIONS: '[22, 24.4]'
   NODE_VERSION_MAIN: '22'


### PR DESCRIPTION
This PR updates `test.yml` to run on pull requests to branches named `release/teraslice-v*` as well as to master.