### PR TITLE
[CI] fix semver comparison command in workflows

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -109,7 +109,7 @@ jobs:
           echo "current version:" $LOCAL_TERASLICE_VERSION
           echo "npm version:" $NPM_PRERELEASE_VERSION
 
-          COMP_OUTPUT=$(./scripts/semver-tool.sh $LOCAL_TERASLICE_VERSION $NPM_PRERELEASE_VERSION)
+          COMP_OUTPUT=$(./scripts/semver-tool.sh compare $LOCAL_TERASLICE_VERSION $NPM_PRERELEASE_VERSION)
           echo "Semver comparison output:" $COMP_OUTPUT
 
           PRERELEASE_TAG=$(./scripts/semver-tool.sh get prerelease $LOCAL_TERASLICE_VERSION)

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -73,7 +73,7 @@ jobs:
           NPM_VERSION=$(yarn npm info teraslice --json | jq -r '.["dist-tags"].latest')
           echo "npm version:" $NPM_VERSION
 
-          COMP_OUTPUT=$(./scripts/semver-tool.sh $CURRENT_VERSION $NPM_VERSION)
+          COMP_OUTPUT=$(./scripts/semver-tool.sh compare $CURRENT_VERSION $NPM_VERSION)
           echo "Semver comparison output:" $COMP_OUTPUT
 
           if [ "$COMP_OUTPUT" = "1" ]; then


### PR DESCRIPTION
This PR fixes the `semver-tools.sh compare` commands in `release-master.yml` and `release-dev.yml` added in #4181