### PR TITLE
[CI] fix release-tag.yml workflow - get Teraslice version from github release object

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -198,3 +198,5 @@ teraslice__jobs              open            1            0      5.6kb          
 random-data-1                open        10000            0        7mb            7mb
 teraslice__analytics-2024.11 open            4            0     23.9kb         23.9kb
 ```
+
+v2-fix-1 change


### PR DESCRIPTION
This PR makes the following change:
- uses the `github.event.release.tag_name` to determine the teraslice version that was just released 