### PR TITLE
[CI] run subset of e2e tests when testing encrypted services

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -389,7 +389,7 @@ jobs:
           export KAFKA_PORT=$(../scripts/get-random-port.sh)
           export MINIO_PORT=$(../scripts/get-random-port.sh)
           export TERASLICE_PORT=$(../scripts/get-random-port.sh)
-          NODE_VERSION=${{ matrix.node-version }} DEV_DOCKER_IMAGE=${{ github.run_id }} SKIP_DOCKER_BUILD_IN_E2E='true' yarn test:k8sV2HelmfileEncrypted'
+          NODE_VERSION=${{ matrix.node-version }} DEV_DOCKER_IMAGE=${{ github.run_id }} SKIP_DOCKER_BUILD_IN_E2E='true' yarn test:k8sV2HelmfileEncrypted
         working-directory: ./e2e
 
   e2e-external-storage-tests:


### PR DESCRIPTION
This PR updates the `e2e-k8s-v2-encrypted-tests` job in the `test.yml` workflow to run only a subset of all e2e tests:
- elasticsearch-bulk-spec.ts
- elasticsearch-ssl-spec.ts
- kafka-spec.ts
- simple-spec.ts

ref: #4174 