### PR TITLE
Deprecated event handler removal

### DIFF
--- a/packages/job-components/src/interfaces/context.ts
+++ b/packages/job-components/src/interfaces/context.ts
@@ -10,8 +10,6 @@ export interface GetClientConfig {
 /*
 * This will request a connection based on the 'connection' attribute of
 * an opConfig. Intended as a context API endpoint.
-* If there is an error getting the connection, it will not throw an error
-* it will log it and emit `client:initialization:error`
 */
 export interface OpRunnerAPI {
     getClient(config: GetClientConfig, type: string): Promise<any>;

--- a/packages/teraslice/src/lib/workers/helpers/worker-shutdown.ts
+++ b/packages/teraslice/src/lib/workers/helpers/worker-shutdown.ts
@@ -160,14 +160,6 @@ export function shutdownHandler(
     process.stdout.on('error', handleStdError);
     process.stderr.on('error', handleStdError);
 
-    // event is fired from terafoundation when an error occurs during instantiation of a client
-    // **DEPRECATED:** This handler should be removed on teraslice v1
-    events.once('client:initialization:error', (err) => {
-        logError(logger, err, `${assignment} received a client initialization error, ${exitingIn()}`);
-        setStatusCode(1);
-        exit('client:initialization:error', err);
-    });
-
     events.once('worker:shutdown:complete', (err) => {
         setStatusCode(0);
         if (err) {


### PR DESCRIPTION
This PR removes the event handler for `client:initialization:error`. Terafoundation no longer emits that error. It was removed in #1393

ref: #3793