### PR TITLE
bump ts-scripts

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -47,7 +47,7 @@
     "devDependencies": {
         "@terascope/core-utils": "~2.0.0-dev.8",
         "@terascope/opensearch-client": "~2.0.0-dev.8",
-        "@terascope/scripts": "~2.0.0-dev.12",
+        "@terascope/scripts": "~2.0.0-dev.13",
         "@terascope/types": "~2.0.0-dev.7",
         "bunyan": "~1.8.15",
         "fs-extra": "~11.3.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@eslint/js": "~9.35.0",
         "@swc/core": "1.13.5",
         "@swc/jest": "~0.2.39",
-        "@terascope/scripts": "~2.0.0-dev.12",
+        "@terascope/scripts": "~2.0.0-dev.13",
         "@types/convict": "~6.1.6",
         "@types/elasticsearch": "~5.0.43",
         "@types/fs-extra": "~11.0.4",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.0.0-dev.12",
+    "version": "2.0.0-dev.13",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3202,7 +3202,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/scripts@npm:~2.0.0-dev.12, @terascope/scripts@workspace:packages/scripts":
+"@terascope/scripts@npm:~2.0.0-dev.13, @terascope/scripts@workspace:packages/scripts":
   version: 0.0.0-use.local
   resolution: "@terascope/scripts@workspace:packages/scripts"
   dependencies:
@@ -6468,7 +6468,7 @@ __metadata:
   dependencies:
     "@terascope/core-utils": "npm:~2.0.0-dev.8"
     "@terascope/opensearch-client": "npm:~2.0.0-dev.8"
-    "@terascope/scripts": "npm:~2.0.0-dev.12"
+    "@terascope/scripts": "npm:~2.0.0-dev.13"
     "@terascope/types": "npm:~2.0.0-dev.7"
     bunyan: "npm:~1.8.15"
     fs-extra: "npm:~11.3.1"
@@ -13322,7 +13322,7 @@ __metadata:
     "@eslint/js": "npm:~9.35.0"
     "@swc/core": "npm:1.13.5"
     "@swc/jest": "npm:~0.2.39"
-    "@terascope/scripts": "npm:~2.0.0-dev.12"
+    "@terascope/scripts": "npm:~2.0.0-dev.13"
     "@types/convict": "npm:~6.1.6"
     "@types/elasticsearch": "npm:~5.0.43"
     "@types/fs-extra": "npm:~11.0.4"


### PR DESCRIPTION
This PR makes the following changes:

- Bumps `@terascope/scripts` from `v2.0.0-dev.12` to `v2.0.0-dev.13`

I need this so I can use to fix a failing test in a kafka assets PR:
https://github.com/terascope/kafka-assets/actions/runs/19642124644/job/56249244755