### PR TITLE
fix publish workflow permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,9 @@ on:
 
 permissions:
   id-token: write  # Required for OIDC
-  contents: read
+  contents: write
+  packages: write
+  pages: write
 
 jobs:
   call-publish-master:


### PR DESCRIPTION
The PR fixes the permissions on the new publish.yml workflow to match all needed in the workflows it triggers:
- contents: write
- packages: write
- pages: write