### PR TITLE
[CI] Give docker publish correct permissions

### DIFF
--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write
     steps:
       # we login to docker to publish new teraslice image
       - name: Login to Docker Hub


### PR DESCRIPTION
Setting permissions on the `build-release` job of publish-master.yml overwrote the default repo permissions which included `packages: write`. This caused docker publish to fail here: https://github.com/terascope/teraslice/actions/runs/22927208819/job/66540424795.

This PR adds the missing permission