### PR TITLE
remove release trigger from publish-tag.yml

### DIFF
--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -2,8 +2,6 @@ name: Publish Release Teraslice NPM Packages and Docker Image
 
 on:
   workflow_call:
-  release:
-    types: [published]
 
 jobs:
   ensure-non-pre-release:


### PR DESCRIPTION
The `publish-tag.yml` workflow no longer needs to be triggered by a publish event.