### PR TITLE
Core utils precision

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/core-utils",
     "displayName": "Core Utils",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "A collection of Teraslice Core Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/core-utils#readme",
     "bugs": {

--- a/packages/core-utils/src/numbers.ts
+++ b/packages/core-utils/src/numbers.ts
@@ -295,7 +295,7 @@ export function setPrecision(
         return parseFloat(num.toFixed(fractionDigits));
     }
     return parseFloat(
-        setPrecisionFromString(num.toString(), fractionDigits)
+        setPrecisionFromString(num, fractionDigits)
     );
 }
 
@@ -316,12 +316,14 @@ export function setPrecisionFP(
 
 /**
  * this will always truncate (not round)
+ * numbers over 2^53 - 1 (over 9 Quadrillion) cannot be truncated with this function
 */
 function setPrecisionFromString(
-    input: string,
+    input: number,
     fractionDigits: number,
 ): string {
-    const [int, points] = input.toString().split('.');
+    const str = input.toFixed(fractionDigits + 5)
+    const [int, points] = str.toString().split('.');
     if (!points) return int || '0';
 
     const remainingPoints = points.slice(0, fractionDigits);

--- a/packages/core-utils/src/numbers.ts
+++ b/packages/core-utils/src/numbers.ts
@@ -295,7 +295,7 @@ export function setPrecision(
         return parseFloat(num.toFixed(fractionDigits));
     }
     return parseFloat(
-        setPrecisionFromString(num, fractionDigits)
+        truncateNumber(num, fractionDigits)
     );
 }
 
@@ -318,12 +318,12 @@ export function setPrecisionFP(
  * this will always truncate (not round)
  * numbers over 2^53 - 1 (over 9 Quadrillion) cannot be truncated with this function
 */
-function setPrecisionFromString(
+function truncateNumber(
     input: number,
     fractionDigits: number,
 ): string {
     const str = input.toFixed(fractionDigits + 5)
-    const [int, points] = str.toString().split('.');
+    const [int, points] = str.split('.');
     if (!points) return int || '0';
 
     const remainingPoints = points.slice(0, fractionDigits);

--- a/packages/core-utils/src/numbers.ts
+++ b/packages/core-utils/src/numbers.ts
@@ -322,7 +322,7 @@ function truncateNumber(
     input: number,
     fractionDigits: number,
 ): string {
-    const str = input.toFixed(fractionDigits + 5)
+    const str = input.toFixed(fractionDigits + 5);
     const [int, points] = str.split('.');
     if (!points) return int || '0';
 

--- a/packages/core-utils/test/numbers-spec.ts
+++ b/packages/core-utils/test/numbers-spec.ts
@@ -200,6 +200,7 @@ describe('Numbers', () => {
             [10.125, 2, true, 10.12],
             [Math.PI, 0, true, 3],
             [1000, 10, true, 1000],
+            [0.0000034543543435, 6, true, 0.000003],
         ])('should convert %p with (digits: %p, truncate: %p) to %p', (input, digits, truncate, expected) => {
             expect(setPrecision(input, digits, truncate)).toEqual(expected);
         });

--- a/packages/core-utils/test/numbers-spec.ts
+++ b/packages/core-utils/test/numbers-spec.ts
@@ -200,7 +200,16 @@ describe('Numbers', () => {
             [10.125, 2, true, 10.12],
             [Math.PI, 0, true, 3],
             [1000, 10, true, 1000],
-            [0.0000034543543435, 6, true, 0.000003],
+            [0.00000012777405852461998, 8, true, 0.00000012],
+            [0.00000012777405852461998, 2, true, 0],
+            [-0.00000012777405852461998, 8, true, -0.00000012],
+            [1.9999999, 2, true, 1.99],
+            [1.9999999, 2, false, 2],
+            [90, 6, true, 90],
+            [0.000001, 2, true, 0],
+            [-1.2999994343243, 4, true, -1.2999],
+            [0.30000000000000004, 4, true, 0.3],
+            [342342343345.01123432234, 2, true, 342342343345.01]
         ])('should convert %p with (digits: %p, truncate: %p) to %p', (input, digits, truncate, expected) => {
             expect(setPrecision(input, digits, truncate)).toEqual(expected);
         });

--- a/packages/core-utils/test/numbers-spec.ts
+++ b/packages/core-utils/test/numbers-spec.ts
@@ -209,7 +209,7 @@ describe('Numbers', () => {
             [0.000001, 2, true, 0],
             [-1.2999994343243, 4, true, -1.2999],
             [0.30000000000000004, 4, true, 0.3],
-            [342342343345.01123432234, 2, true, 342342343345.01]
+            [3423443.011234, 2, true, 3423443.01]
         ])('should convert %p with (digits: %p, truncate: %p) to %p', (input, digits, truncate, expected) => {
             expect(setPrecision(input, digits, truncate)).toEqual(expected);
         });

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "5.5.0",
+    "version": "5.5.1",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/geo-utils/package.json
+++ b/packages/geo-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/geo-utils",
     "displayName": "Geo Utils",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "A collection of Teraslice Geo Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/geo-utils#readme",
     "bugs": {

--- a/packages/ip-utils/package.json
+++ b/packages/ip-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/ip-utils",
     "displayName": "IP Utils",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "A collection of Teraslice IP Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ip-utils#readme",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/opensearch-client/package.json
+++ b/packages/opensearch-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/opensearch-client",
     "displayName": "Opensearch Client",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "A Node.js facade client for opensearch & elasticsearch.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/opensearch-client#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {


### PR DESCRIPTION
  There's an issue where the setPrecision function in core-utils does not properly truncate very small or very large numbers.  The reason is that setPrecision coverts the input to a string via `input.toString()` and then passes the value to setPrecisionFromString which uses the decimal index position to truncate the number string.   In cases where the number is   < 1×10^-6 or > 1×10^21`, toString()` converts the number to scientific notation which moves the decimal and throws off the truncation logic. 

An example is `0.00000012777405852461998.toString()` becomes `1.2777405852461998e-7`

The fix below should handle numbers between  ±`2^53 - 1`, which is just over 9 quadrillion. 