### PR TITLE
[teraslice] Add curl back into teraslice image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ ENV NODE_ENV=production \
     NPM_CONFIG_LOGLEVEL=error
 
 # Minimal for runtime: tini for PID1, certs for HTTPS; and bash for exec
-RUN apk --no-cache add tini ca-certificates bash
+RUN apk --no-cache add tini ca-certificates bash curl
 
 WORKDIR /app/source
 RUN corepack enable

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,7 +6,7 @@ FROM node:${NODE_VERSION}-alpine
 ENV NODE_ENV=production
 WORKDIR /app/source
 
-RUN apk --no-cache add tini ca-certificates bash
+RUN apk --no-cache add tini ca-certificates bash curl
 
 # Install nodemon globally so we can use it with the CMD
 ENV PNPM_HOME=/usr/local/bin

--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.15.0
-appVersion: v3.5.2
+version: 3.16.0
+appVersion: v3.5.3
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "3.5.2",
+    "version": "3.5.3",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "3.5.2",
+    "version": "3.5.3",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:

- Adds `curl` to the teraslice image
  - We had this back in our old base image and need it 
- Bumps `teraslice` from `v3.5.2` to `v3.5.3`