### PR TITLE
[teraslice, terafoundation] Update terafoundation_kafka_connector to v2.2.0

### DIFF
--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.16.0
-appVersion: v3.5.3
+version: 3.17.0
+appVersion: v3.6.0
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/helm/teraslice/values.yaml
+++ b/helm/teraslice/values.yaml
@@ -11,7 +11,7 @@ image:
   pullPolicy: IfNotPresent
   # node version will be inserted into the image tag (which defaults to the chart version)
   # setting the image tag will ignore this value
-  nodeVersion: v24.14.1
+  nodeVersion: v24.15.0
 
 imagePullSecrets: []
 nameOverride: ""

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "3.5.3",
+    "version": "3.6.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -48,7 +48,7 @@
         "got": "~14.6.6"
     },
     "peerDependencies": {
-        "terafoundation_kafka_connector": "~2.1.1"
+        "terafoundation_kafka_connector": "~2.2.0"
     },
     "peerDependenciesMeta": {
         "terafoundation_kafka_connector": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "2.5.1",
+    "version": "2.6.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "3.5.3",
+    "version": "3.6.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -57,7 +57,7 @@
         "socket.io": "~4.8.3",
         "socket.io-client": "~4.8.3",
         "terafoundation": "workspace:~",
-        "terafoundation_kafka_connector": "~2.1.1",
+        "terafoundation_kafka_connector": "~2.2.0",
         "uuid": "~13.0.0"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -710,8 +710,8 @@ importers:
         specifier: ~15.1.3
         version: 15.1.3
       terafoundation_kafka_connector:
-        specifier: ~2.1.1
-        version: 2.1.1
+        specifier: ~2.2.0
+        version: 2.2.0
       yargs:
         specifier: ~18.0.0
         version: 18.0.0
@@ -1519,10 +1519,6 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
-
-  '@confluentinc/kafka-javascript@1.8.2':
-    resolution: {integrity: sha512-sH607B4S00IO8omtpnUlcHeHsZ7hR2C441E4erZyFb+yXNVTl++8+BjIfIcflzW07iGHE5r5McD3oO3vxHi+ww==}
-    engines: {node: '>=18.0.0'}
 
   '@confluentinc/kafka-javascript@1.9.0':
     resolution: {integrity: sha512-bIH0IEkpgTAiU7h+MBg7aDhS8+hxVVO5LA3XdlP28aNNIWauI31z50Y5LWjkwbWbH/1i2UBE8H5qvA7gLcttWg==}
@@ -5857,10 +5853,6 @@ packages:
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
-  terafoundation_kafka_connector@2.1.1:
-    resolution: {integrity: sha512-hzelhbBgTvAP9zEvSlMe29OLhzs4xoyFqzdZ141axj7tgtECOKZyfJq9dtE2A0pkEGXeYcfcg3HWlnRcZRXeyA==}
-    engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
-
   terafoundation_kafka_connector@2.2.0:
     resolution: {integrity: sha512-GOXqJ+D6+L159Sqc5BUraAmXYgNlSlCi/WeEGgoR8sMOtPNdzSaU18OZasR+DUXJDgGamBKgjN2/Jx3aV5HZNQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
@@ -6920,15 +6912,6 @@ snapshots:
 
   '@colors/colors@1.5.0':
     optional: true
-
-  '@confluentinc/kafka-javascript@1.8.2':
-    dependencies:
-      '@mapbox/node-pre-gyp': 2.0.3
-      bindings: 1.5.0
-      nan: 2.22.2
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   '@confluentinc/kafka-javascript@1.9.0':
     dependencies:
@@ -12189,13 +12172,6 @@ snapshots:
   tdigest@0.1.2:
     dependencies:
       bintrees: 1.0.2
-
-  terafoundation_kafka_connector@2.1.1:
-    dependencies:
-      '@confluentinc/kafka-javascript': 1.8.2
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   terafoundation_kafka_connector@2.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,8 +810,8 @@ importers:
         specifier: workspace:~
         version: link:../terafoundation
       terafoundation_kafka_connector:
-        specifier: ~2.1.1
-        version: 2.1.1
+        specifier: ~2.2.0
+        version: 2.2.0
       uuid:
         specifier: ~13.0.0
         version: 13.0.0
@@ -1522,6 +1522,10 @@ packages:
 
   '@confluentinc/kafka-javascript@1.8.2':
     resolution: {integrity: sha512-sH607B4S00IO8omtpnUlcHeHsZ7hR2C441E4erZyFb+yXNVTl++8+BjIfIcflzW07iGHE5r5McD3oO3vxHi+ww==}
+    engines: {node: '>=18.0.0'}
+
+  '@confluentinc/kafka-javascript@1.9.0':
+    resolution: {integrity: sha512-bIH0IEkpgTAiU7h+MBg7aDhS8+hxVVO5LA3XdlP28aNNIWauI31z50Y5LWjkwbWbH/1i2UBE8H5qvA7gLcttWg==}
     engines: {node: '>=18.0.0'}
 
   '@emnapi/core@1.9.1':
@@ -5857,6 +5861,10 @@ packages:
     resolution: {integrity: sha512-hzelhbBgTvAP9zEvSlMe29OLhzs4xoyFqzdZ141axj7tgtECOKZyfJq9dtE2A0pkEGXeYcfcg3HWlnRcZRXeyA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
+  terafoundation_kafka_connector@2.2.0:
+    resolution: {integrity: sha512-GOXqJ+D6+L159Sqc5BUraAmXYgNlSlCi/WeEGgoR8sMOtPNdzSaU18OZasR+DUXJDgGamBKgjN2/Jx3aV5HZNQ==}
+    engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
+
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
@@ -6914,6 +6922,15 @@ snapshots:
     optional: true
 
   '@confluentinc/kafka-javascript@1.8.2':
+    dependencies:
+      '@mapbox/node-pre-gyp': 2.0.3
+      bindings: 1.5.0
+      nan: 2.22.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@confluentinc/kafka-javascript@1.9.0':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
       bindings: 1.5.0
@@ -12176,6 +12193,13 @@ snapshots:
   terafoundation_kafka_connector@2.1.1:
     dependencies:
       '@confluentinc/kafka-javascript': 1.8.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  terafoundation_kafka_connector@2.2.0:
+    dependencies:
+      '@confluentinc/kafka-javascript': 1.9.0
     transitivePeerDependencies:
       - encoding
       - supports-color


### PR DESCRIPTION
This PR makes the following changes:

- Updates `terafoundation_kafka_connector` from `v2.1.1` to `v2.2.0`
  - This updates librdkakfa from [2.13.2](https://github.com/confluentinc/librdkafka/releases/tag/v2.13.2) to [2.14.0](https://github.com/confluentinc/librdkafka/releases/tag/v2.14.0)
  - `terafoundation_kafka_connector` PR with more information: 
  - https://github.com/terascope/kafka-assets/pull/1135
- Bumps `terafoundation` from `v2.5.1` to `v2.6.0`
- Bumps `teraslice` from `v3.5.3` to `v3.6.0`