### PR TITLE
[teraslice] add retry_count to slice record

### DIFF
--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.19.0
-appVersion: v3.7.0
+version: 3.20.0
+appVersion: v3.8.0
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "3.7.0",
+    "version": "3.8.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/job-components/src/execution-context/interfaces.ts
+++ b/packages/job-components/src/execution-context/interfaces.ts
@@ -38,6 +38,7 @@ export interface RunSliceResult {
     status: SliceStatus;
     analytics?: SliceAnalyticsData;
     results: DataEntity[];
+    retry_count?: number;
 }
 
 export type WorkerSliceState = {
@@ -46,4 +47,5 @@ export type WorkerSliceState = {
     position: number;
     slice: Slice;
     analytics?: SliceAnalyticsData;
+    retry_count?: number;
 };

--- a/packages/job-components/src/execution-context/worker.ts
+++ b/packages/job-components/src/execution-context/worker.ts
@@ -369,11 +369,14 @@ export class WorkerExecutionContext
                 results,
                 status: this.sliceState.status,
                 analytics: this.sliceState.analytics,
+                retry_count: this.sliceState.retry_count,
             };
         } catch (err) {
             this.logger.error(err, 'A slice error occurred', { slice: this.sliceState.slice });
 
             if (shouldRetry) {
+                this.sliceState.retry_count = (this.sliceState.retry_count ?? 0) + 1;
+
                 try {
                     await this.onSliceRetry();
                 } catch (retryErr) {

--- a/packages/job-components/test/execution-context/worker-spec.ts
+++ b/packages/job-components/test/execution-context/worker-spec.ts
@@ -260,6 +260,86 @@ describe('WorkerExecutionContext', () => {
         });
     });
 
+    describe('retry_count tracking', () => {
+        /**
+         * Helper that creates a WorkerExecutionContext using the flaky-reader fixture.
+         *
+         * @param failTimes  - how many times the fetcher throws before succeeding
+         * @param maxRetries - how many retries the execution config allows (default 3)
+         */
+        async function makeFlakeyContext(failTimes: number, maxRetries = 3) {
+            const executionConfig = newTestExecutionConfig({
+                max_retries: maxRetries,
+                operations: [
+                    { _op: 'flaky-reader', fail_times: failTimes },
+                    { _op: 'noop' },
+                ],
+            });
+
+            const ctx = await WorkerExecutionContext.createContext({
+                context,
+                executionConfig,
+                assetIds,
+            });
+
+            await ctx.initialize();
+            return ctx;
+        }
+
+        it('no retries — retry_count is absent when a slice succeeds on the first try', async () => {
+            const ctx = await makeFlakeyContext(0); // never fails
+            const result = await ctx.runSlice(newTestSlice());
+
+            expect(result.status).toEqual('completed');
+            // retry_count must be undefined — we don't want this field on clean slices
+            expect(result.retry_count).toBeUndefined();
+
+            await ctx.shutdown();
+        });
+
+        it('1 retry — retry_count is 1 when the slice fails once then succeeds', async () => {
+            const ctx = await makeFlakeyContext(1); // fails on attempt 1, succeeds on attempt 2
+            const result = await ctx.runSlice(newTestSlice());
+
+            expect(result.status).toEqual('completed');
+            expect(result.retry_count).toEqual(1);
+
+            await ctx.shutdown();
+        });
+
+        it('2 retries — retry_count is 2 when the slice fails twice then succeeds', async () => {
+            const ctx = await makeFlakeyContext(2); // fails on attempts 1-2, succeeds on attempt 3
+            const result = await ctx.runSlice(newTestSlice());
+
+            expect(result.status).toEqual('completed');
+            expect(result.retry_count).toEqual(2);
+
+            await ctx.shutdown();
+        });
+
+        it('3 retries — retry_count is 3 when the slice fails three times then succeeds', async () => {
+            const ctx = await makeFlakeyContext(3); // fails on attempts 1-3, succeeds on attempt 4
+            const result = await ctx.runSlice(newTestSlice());
+
+            expect(result.status).toEqual('completed');
+            expect(result.retry_count).toEqual(3);
+
+            await ctx.shutdown();
+        });
+
+        it('all retries exhausted — retry_count is still tracked on sliceState even when the slice never succeeds', async () => {
+            // fail_times(5) > max_retries(2), so all attempts throw and the slice is marked failed
+            const ctx = await makeFlakeyContext(5, 2);
+
+            await expect(ctx.runSlice(newTestSlice())).rejects.toThrow('intentional failure');
+
+            // Even though the slice failed, we still recorded how many retries were attempted
+            expect(ctx.sliceState?.retry_count).toEqual(2);
+
+            await ctx.shutdown();
+        });
+    });
+
     describe('when testing edge cases', () => {
         const executionConfig = newTestExecutionConfig();
         executionConfig.operations = [

--- a/packages/job-components/test/fixtures/asset/flaky-reader/fetcher.ts
+++ b/packages/job-components/test/fixtures/asset/flaky-reader/fetcher.ts
@@ -1,0 +1,22 @@
+import { DataEntity } from '@terascope/core-utils';
+import { Fetcher } from '../../../../src/index.js';
+
+/**
+ * A fetcher that throws a set number of times before succeeding.
+ * Controlled by the `fail_times` op config option.
+ *
+ * Example: fail_times: 2 means the first 2 calls throw, the 3rd succeeds.
+ */
+export default class FlakyFetcher extends Fetcher {
+    private attempts = 0;
+
+    async fetch(): Promise<DataEntity[]> {
+        this.attempts++;
+
+        if (this.attempts <= this.opConfig.fail_times) {
+            throw new Error(`intentional failure on attempt ${this.attempts}`);
+        }
+
+        return DataEntity.makeArray([{ hello: true }]);
+    }
+}

--- a/packages/job-components/test/fixtures/asset/flaky-reader/schema.ts
+++ b/packages/job-components/test/fixtures/asset/flaky-reader/schema.ts
@@ -1,0 +1,15 @@
+import { BaseSchema } from '../../../../src/index.js';
+
+export default class Schema extends BaseSchema<any, any> {
+    build(): Record<string, any> {
+        return {
+            // How many times this fetcher should throw before succeeding.
+            // Set to a number higher than max_retries to simulate total failure.
+            fail_times: {
+                default: 0,
+                doc: 'Number of times fetch() will throw before returning results',
+                format: 'nat',
+            }
+        };
+    }
+}

--- a/packages/job-components/test/fixtures/asset/flaky-reader/slicer.ts
+++ b/packages/job-components/test/fixtures/asset/flaky-reader/slicer.ts
@@ -1,0 +1,8 @@
+import { v4 as uuidv4 } from 'uuid';
+import { Slicer } from '../../../../src/index.js';
+
+export default class FlakyReaderSlicer extends Slicer {
+    async slice(): Promise<{ id: string }> {
+        return { id: uuidv4() };
+    }
+}

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/packages.ts
+++ b/packages/scripts/src/helpers/packages.ts
@@ -344,7 +344,10 @@ export async function getRemotePackageVersion(
             return pkgInfo.version;
         }
         if (err instanceof PackageNotFoundError) {
-            return '0.1.0';
+            // In the case a package doesn't exist, like making a new package
+            // this will ensure it gets pushed to npm
+            // We let npm handle any issues with publishing from there
+            return '0.0.0';
         }
         throw err;
     }

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "2.8.0",
+    "version": "2.9.0",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "3.7.0",
+    "version": "3.8.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/storage/state.ts
+++ b/packages/teraslice/src/lib/storage/state.ts
@@ -107,7 +107,7 @@ export class StateStorage {
     }
 
     // TODO: type this better
-    async updateState(slice: Slice, state: string, error?: Error) {
+    async updateState(slice: Slice, state: string, error?: Error, retryCount?: number) {
         if (!isKey(SliceState, state)) {
             throw new Error(`Unknown slice state "${state}" on update`);
         }
@@ -129,6 +129,10 @@ export class StateStorage {
             } else {
                 record.error = new Error('Unknown slice error').stack;
             }
+        }
+
+        if (retryCount != null && retryCount > 0) {
+            record.retry_count = retryCount;
         }
 
         let notFoundErrCount = 0;

--- a/packages/teraslice/src/lib/workers/worker/slice.ts
+++ b/packages/teraslice/src/lib/workers/worker/slice.ts
@@ -61,14 +61,14 @@ export class SliceExecution {
             result = await this.executionContext.runSlice();
 
             sliceSuccess = true;
-            await this._markCompleted();
+            await this._markCompleted(result.retry_count);
         } catch (err) {
             const error = err || new Error(`Unknown slice error, got ${getTypeOf(err)} error`);
             // avoid incorrectly marking
             // the slice as failed when it fails
             // to mark it as "complete"
             if (!sliceSuccess) {
-                await this._markFailed(error);
+                await this._markFailed(error, this.executionContext.sliceState?.retry_count);
             }
             throw error;
         } finally {
@@ -143,19 +143,19 @@ export class SliceExecution {
         }
     }
 
-    private async _markCompleted() {
+    private async _markCompleted(retryCount?: number) {
         const { slice } = this;
 
-        await this.stateStorage.updateState(slice, SliceState.completed);
+        await this.stateStorage.updateState(slice, SliceState.completed, undefined, retryCount);
 
         this.logger.trace(`completed slice for execution: ${this.executionContext.exId}`, slice);
         this.events.emit('slice:success', slice);
     }
 
-    private async _markFailed(err: Error) {
+    private async _markFailed(err: Error, retryCount?: number) {
         const { stateStorage, slice } = this;
 
-        await stateStorage.updateState(slice, SliceState.error, err);
+        await stateStorage.updateState(slice, SliceState.error, err, retryCount);
 
         logError(this.logger, err, `slice state for ${this.executionContext.exId} has been marked as error`);
 


### PR DESCRIPTION
This PR makes the following changes:

- Adds `retry_count` to slice records under the condition a slice fails at least once
  - This is so we don't add un-meaningful data to all slice records 
- Adds tests that ensure slice records include `retry_count` at the appropriate times

Ref to issue #596