### PR TITLE
[elasticsearch-api] circuit breaker error handling

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/core-utils",
     "displayName": "Core Utils",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "A collection of Teraslice Core Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/core-utils#readme",
     "bugs": {

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "5.6.0",
+    "version": "5.7.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-api/src/index.ts
+++ b/packages/elasticsearch-api/src/index.ts
@@ -8,7 +8,7 @@ import {
 import { Client as OpenClient } from '@terascope/opensearch-client';
 import {
     ElasticsearchDistribution, SearchResult, ClientParams,
-    ClientResponse, isStructuredErrorResponse, ESTypes, OpenSearchErrorBody
+    ClientResponse, ESTypes
 } from '@terascope/types';
 // @ts-expect-error  TODO: do we still need this after getting rid of es6?
 import('setimmediate');
@@ -864,9 +864,9 @@ export default function elasticsearchApi(
             return true;
         }
 
-        if (isStructuredErrorResponse(err)) {
+        if (ESTypes.isStructuredErrorResponse(err)) {
             const shouldRetry: boolean[] = [];
-            const body = err.body as OpenSearchErrorBody;
+            const body = err.body as ESTypes.OpenSearchErrorBody;
             const errList: ESTypes.ErrorCause[] = getErrorCauses(body);
 
             errList.forEach((cause) => {
@@ -920,7 +920,7 @@ export default function elasticsearchApi(
     }
 
     function getErrorCauses(
-        body: OpenSearchErrorBody
+        body: ESTypes.OpenSearchErrorBody
     ): ESTypes.ErrorCause[] {
         const causes: ESTypes.ErrorCause[] = [];
         causes.push(...findNestedErrors(body.error));

--- a/packages/elasticsearch-api/src/index.ts
+++ b/packages/elasticsearch-api/src/index.ts
@@ -859,30 +859,39 @@ export default function elasticsearchApi(
             return true;
         }
 
+        // Check this ASAP since it is the most likely error type
+        if (isQueueOverflowError(get(err, 'body.error.type', ''))) {
+            logger.debug('Client error isRejectedError, will retry');
+            return true;
+        }
+
         if (isConnectionErrorMessage(err)) {
             logger.debug('Client error isConnectionErrorMessage, will retry');
             return true;
         }
 
+        // Errors are often wrapped by search_phase_execution_exception when occurring on
+        // a data node. We need to parse the error for the underlying cause.
         if (ESTypes.isStructuredErrorResponse(err)) {
             const shouldRetry: boolean[] = [];
             const body = err.body as ESTypes.OpenSearchErrorBody;
             const errList: ESTypes.ErrorCause[] = getErrorCauses(body);
 
-            errList.forEach((cause) => {
+            for (const cause of errList) {
                 const isRejectedError = isQueueOverflowError(cause.type);
-                const isRetryableCircuitBreaker = isRetryableCircuitBreakerError(cause);
-
                 if (isRejectedError) {
                     logger.debug('Client error isRejectedError, will retry');
                     shouldRetry.push(true);
+                    continue;
                 }
 
+                const isRetryableCircuitBreaker = isRetryableCircuitBreakerError(cause);
                 if (isRetryableCircuitBreaker) {
                     logger.debug('Client error isRetryableCircuitBreaker, will retry');
                     shouldRetry.push(true);
+                    continue;
                 }
-            });
+            }
 
             // TODO: this assumes that having any retryable error in the list means we should retry
             // It may be necessary to have a list of errors that, if present, we never retry

--- a/packages/elasticsearch-api/src/index.ts
+++ b/packages/elasticsearch-api/src/index.ts
@@ -893,6 +893,32 @@ export default function elasticsearchApi(
         return false;
     }
 
+    function _errorHandler(
+        fn: any,
+        data: any,
+        reject: (args?: any) => void,
+        fnName = '->unknown()'
+    ) {
+        const retry = _retryFn(fn, data, reject);
+
+        return function _errorHandlerFn(err: Error) {
+            const retryable = isErrorRetryable(err);
+
+            if (retryable) {
+                retry();
+            } else {
+                reject(
+                    new TSError(err, {
+                        context: {
+                            fnName,
+                            connection,
+                        },
+                    })
+                );
+            }
+        };
+    }
+
     function getErrorCauses(
         body: OpenSearchErrorBody
     ): ESTypes.ErrorCause[] {

--- a/packages/elasticsearch-api/src/index.ts
+++ b/packages/elasticsearch-api/src/index.ts
@@ -731,7 +731,7 @@ export default function elasticsearchApi(
                             retry();
                         } else if (
                             reasonReason.length === 1
-                            && isRetryableCircuitBreakerError(failuresReasons[0])
+                            && isRetryableCircuitBreakerError(failuresReasons[0].reason)
                         ) {
                             logger.debug(`Search shard failure is retryable: ${reasonReason[0]}`);
                             retry();

--- a/packages/elasticsearch-api/src/index.ts
+++ b/packages/elasticsearch-api/src/index.ts
@@ -8,7 +8,7 @@ import {
 import { Client as OpenClient } from '@terascope/opensearch-client';
 import {
     ElasticsearchDistribution, SearchResult, ClientParams,
-    ClientResponse,
+    ClientResponse, isResponseError, ESTypes, OpenSearchErrorBody
 } from '@terascope/types';
 // @ts-expect-error  TODO: do we still need this after getting rid of es6?
 import('setimmediate');
@@ -821,47 +821,102 @@ export default function elasticsearchApi(
         return msg.includes('No Living connections') || msg.includes('ECONNREFUSED');
     }
 
+    function isRetryableCircuitBreakerError(cause: ESTypes.ErrorCause) {
+        let reason = '';
+        if (cause.type === 'circuit_breaking_exception') {
+            reason = cause.reason.toLowerCase();
+
+            /**
+             * Non-retryable circuit breakers. These are unlikely to change between retries.
+             * [fielddata] - field data cache loading - cache would need to be evicted
+             * [accounting] - already-loaded memory - would need segments merged or index deletion
+             * [request] — request-level memory (aggregations, etc.)
+            */
+            if (reason.includes('[fielddata]') || reason.includes('[accounting]')) return false;
+
+            /**
+             * Retryable circuit breakers. These are more likely to change between retries.
+             * [in_flight_requests] - concurrent in-flight HTTP/transport requests
+             * [parent] - total memory usage - will drop with GC and other requests finishing
+            */
+            if (reason.includes('[parent]') || reason.includes('[in_flight_requests]')) return true;
+
+            /**
+             * Circuit breakers we should never see will default to false
+             * [model_inference] — ML model memory (if ML plugin is enabled)
+             * [eql_sequence] — EQL sequence queries consuming too much memory
+             * **NOTE**: Opensearch plugins can also define their own circuit breaker exceptions
+            */
+        }
+        return false;
+    }
+
     function isErrorRetryable(err: Error) {
         const checkErrorMsg = isRetryableError(err);
 
         if (checkErrorMsg) {
+            logger.debug('Client error isRetryableError, will retry');
             return true;
         }
 
-        const isRejectedError = isQueueOverflowError(get(err, 'body.error.type', ''));
-        const isConnectionError = isConnectionErrorMessage(err);
-
-        if (isRejectedError || isConnectionError) {
+        if (isConnectionErrorMessage(err)) {
+            logger.debug('Client error isConnectionErrorMessage, will retry');
             return true;
         }
 
+        if (isResponseError(err)) {
+            const shouldRetry: boolean[] = [];
+            const body = err.body as OpenSearchErrorBody;
+            const errList: ESTypes.ErrorCause[] = getErrorCauses(body);
+
+            errList.forEach((cause) => {
+                const isRejectedError = isQueueOverflowError(cause.type);
+                const isRetryableCircuitBreaker = isRetryableCircuitBreakerError(cause);
+
+                if (isRejectedError) {
+                    logger.debug('Client error isRejectedError, will retry');
+                    shouldRetry.push(true);
+                }
+
+                if (isRetryableCircuitBreaker) {
+                    logger.debug('Client error isRetryableCircuitBreaker, will retry');
+                    shouldRetry.push(true);
+                }
+            });
+
+            // TODO: this assumes that having any retryable error in the list means we should retry
+            // It may be necessary to have a list of errors that if present we never retry
+            if (shouldRetry.includes(true)) return true;
+        }
+
+        logger.trace('Client error is not retryable');
         return false;
     }
 
-    function _errorHandler(
-        fn: any,
-        data: any,
-        reject: (args?: any) => void,
-        fnName = '->unknown()'
-    ) {
-        const retry = _retryFn(fn, data, reject);
+    function getErrorCauses(
+        body: OpenSearchErrorBody
+    ): ESTypes.ErrorCause[] {
+        const causes: ESTypes.ErrorCause[] = [];
+        causes.push(...findNestedErrors(body.error));
+        if (body.error.root_cause) {
+            body.error.root_cause.forEach((cause) => causes.push(...findNestedErrors(cause)));
+        }
+        return causes;
+    }
 
-        return function _errorHandlerFn(err: Error) {
-            const retryable = isErrorRetryable(err);
+    function findNestedErrors(
+        cause: ESTypes.ErrorCause
+    ): ESTypes.ErrorCause[] {
+        const causes: ESTypes.ErrorCause[] = [];
+        causes.push({ type: cause.type, reason: cause.reason });
+        if (cause.caused_by) {
+            causes.push(...findNestedErrors(cause.caused_by));
+        }
+        if (cause.failed_shards) {
+            cause.failed_shards.forEach((shard) => causes.push(...findNestedErrors(shard.reason)));
+        }
 
-            if (retryable) {
-                retry();
-            } else {
-                reject(
-                    new TSError(err, {
-                        context: {
-                            fnName,
-                            connection,
-                        },
-                    })
-                );
-            }
-        };
+        return causes;
     }
 
     async function isAvailable(index: string) {

--- a/packages/elasticsearch-api/src/index.ts
+++ b/packages/elasticsearch-api/src/index.ts
@@ -715,28 +715,28 @@ export default function elasticsearchApi(
 
                         failuresReasons.push(...failures);
 
-                        const reasonType = uniq(
+                        const reasonTypes = uniq(
                             flatten(failuresReasons.map((shard) => shard.reason.type))
                         ) as string[];
 
-                        const reasonReason = uniq(
+                        const reasonReasons = uniq(
                             flatten(failuresReasons.map((shard) => shard.reason.reason))
                         ) as string[];
 
                         if (
-                            reasonType.length === 1
-                            && isQueueOverflowError(reasonType[0])
+                            reasonTypes.length === 1
+                            && isQueueOverflowError(reasonTypes[0])
                         ) {
-                            logger.debug(`Search shard failure is retryable: ${reasonType[0]}`);
+                            logger.debug(`Shard failure during search - retryable: ${reasonTypes[0]}`);
                             retry();
                         } else if (
-                            reasonReason.length === 1
+                            reasonReasons.length === 1
                             && isRetryableCircuitBreakerError(failuresReasons[0].reason)
                         ) {
-                            logger.debug(`Search shard failure is retryable: ${reasonReason[0]}`);
+                            logger.debug(`Shard failure during search - retryable: ${reasonReasons[0]}`);
                             retry();
                         } else {
-                            const errorReason = reasonType.join(' | ');
+                            const errorReason = reasonTypes.join(' | ');
                             const error = new TSError(errorReason, {
                                 reason: 'Not all shards returned successful',
                                 context: {

--- a/packages/elasticsearch-api/src/index.ts
+++ b/packages/elasticsearch-api/src/index.ts
@@ -8,7 +8,7 @@ import {
 import { Client as OpenClient } from '@terascope/opensearch-client';
 import {
     ElasticsearchDistribution, SearchResult, ClientParams,
-    ClientResponse, isResponseError, ESTypes, OpenSearchErrorBody
+    ClientResponse, isStructuredErrorResponse, ESTypes, OpenSearchErrorBody
 } from '@terascope/types';
 // @ts-expect-error  TODO: do we still need this after getting rid of es6?
 import('setimmediate');
@@ -864,7 +864,7 @@ export default function elasticsearchApi(
             return true;
         }
 
-        if (isResponseError(err)) {
+        if (isStructuredErrorResponse(err)) {
             const shouldRetry: boolean[] = [];
             const body = err.body as OpenSearchErrorBody;
             const errList: ESTypes.ErrorCause[] = getErrorCauses(body);
@@ -885,7 +885,7 @@ export default function elasticsearchApi(
             });
 
             // TODO: this assumes that having any retryable error in the list means we should retry
-            // It may be necessary to have a list of errors that if present we never retry
+            // It may be necessary to have a list of errors that, if present, we never retry
             if (shouldRetry.includes(true)) return true;
         }
 

--- a/packages/elasticsearch-api/src/index.ts
+++ b/packages/elasticsearch-api/src/index.ts
@@ -336,7 +336,11 @@ export default function elasticsearchApi(
                     continue;
                 }
 
-                if (item.status === TOO_MANY_REQUESTS || isQueueOverflowError(item.error.type)) {
+                if (
+                    item.status === TOO_MANY_REQUESTS
+                    || isQueueOverflowError(item.error.type)
+                    || containsRetryableCircuitBreaker(item.error)
+                ) {
                     if (actionRecords[i] == null) {
                         // this error should not happen in production,
                         // only in tests where the bulk function is mocked
@@ -711,15 +715,28 @@ export default function elasticsearchApi(
 
                         failuresReasons.push(...failures);
 
-                        const reasons = uniq(
+                        const reasonType = uniq(
                             flatten(failuresReasons.map((shard) => shard.reason.type))
                         ) as string[];
 
+                        const reasonReason = uniq(
+                            flatten(failuresReasons.map((shard) => shard.reason.reason))
+                        ) as string[];
+
                         if (
-                            reasons.length > 1
-                            || !isQueueOverflowError(reasons[0])
+                            reasonType.length === 1
+                            && isQueueOverflowError(reasonType[0])
                         ) {
-                            const errorReason = reasons.join(' | ');
+                            logger.debug(`Search shard failure is retryable: ${reasonType[0]}`);
+                            retry();
+                        } else if (
+                            reasonReason.length === 1
+                            && isRetryableCircuitBreakerError(failuresReasons[0])
+                        ) {
+                            logger.debug(`Search shard failure is retryable: ${reasonReason[0]}`);
+                            retry();
+                        } else {
+                            const errorReason = reasonType.join(' | ');
                             const error = new TSError(errorReason, {
                                 reason: 'Not all shards returned successful',
                                 context: {
@@ -727,8 +744,6 @@ export default function elasticsearchApi(
                                 },
                             });
                             reject(error);
-                        } else {
-                            retry();
                         }
                     })
                     .catch(errHandler);
@@ -855,50 +870,51 @@ export default function elasticsearchApi(
         const checkErrorMsg = isRetryableError(err);
 
         if (checkErrorMsg) {
-            logger.debug('Client error isRetryableError, will retry');
+            logger.debug(`Client error is retryable: isRetryableError - ${err.name}: ${err.message}`);
             return true;
         }
 
         // Check this ASAP since it is the most likely error type
         if (isQueueOverflowError(get(err, 'body.error.type', ''))) {
-            logger.debug('Client error isRejectedError, will retry');
+            logger.debug(`Client error is retryable: isRejectedError - ${err.name}: ${err.message}`);
             return true;
         }
 
         if (isConnectionErrorMessage(err)) {
-            logger.debug('Client error isConnectionErrorMessage, will retry');
+            logger.debug(`Client error is retryable: isConnectionErrorMessage - ${err.name}: ${err.message}`);
             return true;
         }
 
-        // Errors are often wrapped by search_phase_execution_exception when occurring on
-        // a data node. We need to parse the error for the underlying cause.
-        if (ESTypes.isStructuredErrorResponse(err)) {
-            const shouldRetry: boolean[] = [];
+        // Errors are often wrapped by other errors (like search_phase_execution_exception)
+        // when occurring on a data node. We need to parse the error for the underlying cause.
+        if (isStructuredErrorResponse(err)) {
+            const retryableList: string[] = [];
             const body = err.body as ESTypes.OpenSearchErrorBody;
             const errList: ESTypes.ErrorCause[] = getErrorCauses(body);
 
             for (const cause of errList) {
                 const isRejectedError = isQueueOverflowError(cause.type);
                 if (isRejectedError) {
-                    logger.debug('Client error isRejectedError, will retry');
-                    shouldRetry.push(true);
+                    retryableList.push('isRejectedError');
                     continue;
                 }
 
                 const isRetryableCircuitBreaker = isRetryableCircuitBreakerError(cause);
                 if (isRetryableCircuitBreaker) {
-                    logger.debug('Client error isRetryableCircuitBreaker, will retry');
-                    shouldRetry.push(true);
+                    retryableList.push('isRetryableCircuitBreaker');
                     continue;
                 }
             }
 
             // TODO: this assumes that having any retryable error in the list means we should retry
             // It may be necessary to have a list of errors that, if present, we never retry
-            if (shouldRetry.includes(true)) return true;
+            if (retryableList.length > 0) {
+                logger.debug(`Client error is retryable: ${retryableList.toString()} - ${err.name}: ${err.message}`);
+                return true;
+            }
         }
 
-        logger.trace('Client error is not retryable');
+        logger.debug(`Client error is not retryable - ${err.name}: ${err.message}`);
         return false;
     }
 
@@ -939,6 +955,13 @@ export default function elasticsearchApi(
         return causes;
     }
 
+    function containsRetryableCircuitBreaker(errorCause: ESTypes.ErrorCause): boolean {
+        return findNestedErrors(errorCause)
+            .map((cause) => isRetryableCircuitBreakerError(cause))
+            .filter(Boolean)
+            .length > 0;
+    }
+
     function findNestedErrors(
         cause: ESTypes.ErrorCause
     ): ESTypes.ErrorCause[] {
@@ -952,6 +975,17 @@ export default function elasticsearchApi(
         }
 
         return causes;
+    }
+
+    function isStructuredErrorResponse(err: unknown): err is ESTypes.ResponseError {
+        return (
+            typeof err === 'object'
+            && err !== null
+            && 'body' in err
+            && typeof (err as any).body === 'object'
+            && (err as any).body !== null
+            && 'error' in (err as any).body
+        );
     }
 
     async function isAvailable(index: string) {

--- a/packages/elasticsearch-api/test/api-spec.ts
+++ b/packages/elasticsearch-api/test/api-spec.ts
@@ -420,7 +420,7 @@ describe('elasticsearch-api', () => {
         const query = { body: 'someQuery' } as any;
         const api = esApi(client, logger);
         let queryFailed = false;
-        searchError = { body: { error: { type: 'es_rejected_execution_exception' } } } as any;
+        searchError = { statusCode: 429, body: { error: { type: 'es_rejected_execution_exception' }, status: 429 } } as any;
         recordsReturned = [{ _source: { some: 'data' } }];
 
         const [results] = await Promise.all([
@@ -443,7 +443,7 @@ describe('elasticsearch-api', () => {
         const query = { body: 'someQuery' } as any;
         const api = esApi(client, logger);
         let queryFailed = false;
-        searchError = { body: { error: { type: 'rejected_execution_exception' } } } as any;
+        searchError = { statusCode: 429, body: { error: { type: 'rejected_execution_exception' }, status: 429 } } as any;
         recordsReturned = [{ _source: { some: 'data' } }];
 
         const [results] = await Promise.all([

--- a/packages/elasticsearch-api/test/retry-spec.ts
+++ b/packages/elasticsearch-api/test/retry-spec.ts
@@ -10,6 +10,22 @@ const { data } = ElasticsearchTestHelpers.EvenDateData;
 
 const body = ElasticsearchTestHelpers.formatUploadData('retry-error-test', data);
 
+type RootCause = Array<{ type: string; reason: string }>;
+
+function makeResponseError(type: string, reason: string, status = 400, rootCause?: RootCause) {
+    return {
+        statusCode: status,
+        body: {
+            error: {
+                type,
+                reason,
+                ...(rootCause ? { root_cause: rootCause } : {})
+            },
+            status
+        }
+    } as any;
+}
+
 describe('retry behavior', () => {
     it('will work with opensearch when connection cannot be established', async () => {
         expect.assertions(4);
@@ -32,5 +48,205 @@ describe('retry behavior', () => {
             expect(err).toBeDefined();
             expect(isErrorRetryable(err)).toBeTruthy();
         }
+    });
+});
+
+describe('isErrorRetryable', () => {
+    let isErrorRetryable: (err: Error) => boolean;
+
+    beforeAll(() => {
+        const client = new opensearch.Client({ node: `http://127.0.0.1:${port}` }) as any;
+        ({ isErrorRetryable } = API(client, logger));
+    });
+
+    describe('retryable errors', () => {
+        it('returns true when err.retryable is true', () => {
+            const err = Object.assign(new Error('some error'), { retryable: true });
+            expect(isErrorRetryable(err)).toBe(true);
+        });
+
+        it('returns true for ECONNREFUSED connection error', () => {
+            const err = new Error('connect ECONNREFUSED 127.0.0.1:9200');
+            expect(isErrorRetryable(err)).toBe(true);
+        });
+
+        it('returns true for No Living connections error', () => {
+            const err = new Error('No Living connections');
+            expect(isErrorRetryable(err)).toBe(true);
+        });
+
+        it('returns true for es_rejected_execution_exception', () => {
+            const err = makeResponseError('es_rejected_execution_exception', 'rejected execution of coordinating operation', 429);
+            expect(isErrorRetryable(err)).toBe(true);
+        });
+
+        it('returns true for rejected_execution_exception', () => {
+            const err = makeResponseError('rejected_execution_exception', 'rejected execution of coordinating operation', 429);
+            expect(isErrorRetryable(err)).toBe(true);
+        });
+
+        it('returns true for circuit_breaking_exception with [parent] reason', () => {
+            const err = makeResponseError('circuit_breaking_exception', '[parent] Data too large, data for [<http_request>] would be [1234567890/1.1gb], which is larger than the limit of [1073741824/1gb]', 429);
+            expect(isErrorRetryable(err)).toBe(true);
+        });
+
+        it('returns true for circuit_breaking_exception with [in_flight_requests] reason', () => {
+            const err = makeResponseError('circuit_breaking_exception', '[in_flight_requests] Data too large, data for [<transport_request>] would be [1234567890/1.1gb]', 429);
+            expect(isErrorRetryable(err)).toBe(true);
+        });
+
+        it('returns true when root_cause contains es_rejected_execution_exception', () => {
+            const err = makeResponseError(
+                'search_phase_execution_exception',
+                'all shards failed',
+                429,
+                [{ type: 'es_rejected_execution_exception', reason: 'rejected execution of coordinating operation' }]
+            );
+            expect(isErrorRetryable(err)).toBe(true);
+        });
+
+        it('returns true when root_cause contains retryable circuit_breaking_exception', () => {
+            const err = makeResponseError(
+                'search_phase_execution_exception',
+                'all shards failed',
+                429,
+                [{ type: 'circuit_breaking_exception', reason: '[parent] Data too large' }]
+            );
+            expect(isErrorRetryable(err)).toBe(true);
+        });
+
+        it('returns true when root_cause[i].caused_by contains a retryable error', () => {
+            const err = {
+                statusCode: 429,
+                body: {
+                    error: {
+                        type: 'search_phase_execution_exception',
+                        reason: 'all shards failed',
+                        root_cause: [{
+                            type: 'some_wrapper_exception',
+                            reason: 'wrapper',
+                            caused_by: {
+                                type: 'es_rejected_execution_exception',
+                                reason: 'rejected execution of coordinating operation'
+                            }
+                        }]
+                    },
+                    status: 429
+                }
+            } as any;
+            expect(isErrorRetryable(err)).toBe(true);
+        });
+
+        it('returns true when root_cause[i].failed_shards[j].reason contains a retryable error', () => {
+            const err = {
+                statusCode: 429,
+                body: {
+                    error: {
+                        type: 'search_phase_execution_exception',
+                        reason: 'all shards failed',
+                        root_cause: [{
+                            type: 'some_wrapper_exception',
+                            reason: 'wrapper',
+                            failed_shards: [{
+                                shard: 0,
+                                index: 'my-index',
+                                node: 'node1',
+                                reason: {
+                                    type: 'es_rejected_execution_exception',
+                                    reason: 'rejected execution of coordinating operation'
+                                }
+                            }]
+                        }]
+                    },
+                    status: 429
+                }
+            } as any;
+            expect(isErrorRetryable(err)).toBe(true);
+        });
+    });
+
+    describe('non-retryable errors', () => {
+        it('returns false for a plain error', () => {
+            const err = new Error('some unrelated error');
+            expect(isErrorRetryable(err)).toBe(false);
+        });
+
+        it('returns false when fatalError is true even if retryable is true', () => {
+            const err = Object.assign(new Error('fatal'), { retryable: true, fatalError: true });
+            expect(isErrorRetryable(err)).toBe(false);
+        });
+
+        it('returns false for circuit_breaking_exception with [fielddata] reason', () => {
+            const err = makeResponseError('circuit_breaking_exception', '[fielddata] Data too large, data for [my_field] would be [1234567890/1.1gb]', 429);
+            expect(isErrorRetryable(err)).toBe(false);
+        });
+
+        it('returns false for circuit_breaking_exception with [accounting] reason', () => {
+            const err = makeResponseError('circuit_breaking_exception', '[accounting] Data too large, data for [<segment_reader>] would be [1234567890/1.1gb]', 429);
+            expect(isErrorRetryable(err)).toBe(false);
+        });
+
+        it('returns false for illegal_argument_exception', () => {
+            const err = makeResponseError('illegal_argument_exception', 'Result window is too large, from + size must be less than or equal to: [5] but was [10]', 400);
+            expect(isErrorRetryable(err)).toBe(false);
+        });
+
+        it('returns false for index_not_found_exception', () => {
+            const err = makeResponseError('index_not_found_exception', 'no such index [my-index]', 404);
+            expect(isErrorRetryable(err)).toBe(false);
+        });
+
+        it('returns false when root_cause only contains non-retryable errors', () => {
+            const err = makeResponseError(
+                'search_phase_execution_exception',
+                'all shards failed',
+                400,
+                [{ type: 'illegal_argument_exception', reason: 'some argument error' }]
+            );
+            expect(isErrorRetryable(err)).toBe(false);
+        });
+    });
+
+    describe('caused_by and failed_shards on body.error', () => {
+        it('returns true when body.error.caused_by contains a retryable error', () => {
+            const err = {
+                statusCode: 429,
+                body: {
+                    error: {
+                        type: 'search_phase_execution_exception',
+                        reason: 'all shards failed',
+                        caused_by: {
+                            type: 'es_rejected_execution_exception',
+                            reason: 'rejected execution of coordinating operation'
+                        }
+                    },
+                    status: 429
+                }
+            } as any;
+            expect(isErrorRetryable(err)).toBe(true);
+        });
+
+        it('returns true when body.error.failed_shards[j].reason contains a retryable error', () => {
+            const err = {
+                statusCode: 429,
+                body: {
+                    error: {
+                        type: 'search_phase_execution_exception',
+                        reason: 'all shards failed',
+                        failed_shards: [{
+                            shard: 0,
+                            index: 'my-index',
+                            node: 'node1',
+                            reason: {
+                                type: 'es_rejected_execution_exception',
+                                reason: 'rejected execution of coordinating operation'
+                            }
+                        }]
+                    },
+                    status: 429
+                }
+            } as any;
+            expect(isErrorRetryable(err)).toBe(true);
+        });
     });
 });

--- a/packages/elasticsearch-api/test/retry-spec.ts
+++ b/packages/elasticsearch-api/test/retry-spec.ts
@@ -126,8 +126,8 @@ describe('isErrorRetryable', () => {
                             type: 'some_wrapper_exception',
                             reason: 'wrapper',
                             caused_by: {
-                                type: 'es_rejected_execution_exception',
-                                reason: 'rejected execution of coordinating operation'
+                                type: 'circuit_breaking_exception',
+                                reason: '[parent] Data too large'
                             }
                         }]
                     },
@@ -152,8 +152,8 @@ describe('isErrorRetryable', () => {
                                 index: 'my-index',
                                 node: 'node1',
                                 reason: {
-                                    type: 'es_rejected_execution_exception',
-                                    reason: 'rejected execution of coordinating operation'
+                                    type: 'circuit_breaking_exception',
+                                    reason: '[parent] Data too large'
                                 }
                             }]
                         }]
@@ -249,8 +249,8 @@ describe('isErrorRetryable', () => {
                         type: 'search_phase_execution_exception',
                         reason: 'all shards failed',
                         caused_by: {
-                            type: 'es_rejected_execution_exception',
-                            reason: 'rejected execution of coordinating operation'
+                            type: 'circuit_breaking_exception',
+                            reason: '[parent] Data too large'
                         }
                     },
                     status: 429
@@ -271,8 +271,8 @@ describe('isErrorRetryable', () => {
                             index: 'my-index',
                             node: 'node1',
                             reason: {
-                                type: 'es_rejected_execution_exception',
-                                reason: 'rejected execution of coordinating operation'
+                                type: 'circuit_breaking_exception',
+                                reason: '[parent] Data too large'
                             }
                         }]
                     },

--- a/packages/elasticsearch-api/test/retry-spec.ts
+++ b/packages/elasticsearch-api/test/retry-spec.ts
@@ -205,6 +205,39 @@ describe('isErrorRetryable', () => {
             );
             expect(isErrorRetryable(err)).toBe(false);
         });
+
+        it('returns false for a 404 document-not-found ResponseError (body has no error field)', () => {
+            // Real OpenSearch ResponseError when a document is not found:
+            // body contains found: false instead of an error object,
+            // so isResponseError returns false and the error is non-retryable
+            const err = Object.assign(new Error('Response Error'), {
+                statusCode: 404,
+                body: {
+                    _index: 'ts_test',
+                    _id: '15598b6369e0913845e1bbfb806cc98f8a8d0ec0',
+                    found: false
+                },
+                meta: {
+                    body: {
+                        _index: 'ts_test',
+                        _id: '15598b6369e0913845e1bbfb806cc98f8a8d0ec0',
+                        found: false
+                    },
+                    statusCode: 404,
+                    headers: {
+                        'content-type': 'application/json; charset=UTF-8',
+                        'content-length': '111'
+                    },
+                    meta: {
+                        context: null,
+                        name: 'opensearch-js',
+                        attempts: 0,
+                        aborted: false
+                    }
+                }
+            });
+            expect(isErrorRetryable(err)).toBe(false);
+        });
     });
 
     describe('caused_by and failed_shards on body.error', () => {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/geo-utils/package.json
+++ b/packages/geo-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/geo-utils",
     "displayName": "Geo Utils",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "A collection of Teraslice Geo Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/geo-utils#readme",
     "bugs": {

--- a/packages/ip-utils/package.json
+++ b/packages/ip-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/ip-utils",
     "displayName": "IP Utils",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "A collection of Teraslice IP Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ip-utils#readme",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "2.8.0",
+    "version": "2.9.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/opensearch-client/package.json
+++ b/packages/opensearch-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/opensearch-client",
     "displayName": "Opensearch Client",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "A Node.js facade client for opensearch & elasticsearch.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/opensearch-client#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "2.9.0",
+    "version": "2.10.0",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/teraslice/test/services/assets-spec.ts
+++ b/packages/teraslice/test/services/assets-spec.ts
@@ -149,7 +149,7 @@ describe('Assets Service', () => {
         });
     });
 
-    describe('Testing /txt/assets enpoint', () => {
+    describe('Testing /txt/assets endpoint', () => {
         it('Should return proper table with specific format', async () => {
             const filePathOne = 'packages/teraslice/test/fixtures/assets/asset-with-long-description.zip';
             const filePathOneStream = fs.readFileSync(filePathOne);

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/types",
     "displayName": "Types",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "A collection of typescript interfaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/types#readme",
     "bugs": {

--- a/packages/types/src/elasticsearch-client/elasticsearch-types.ts
+++ b/packages/types/src/elasticsearch-client/elasticsearch-types.ts
@@ -2560,20 +2560,9 @@ export interface OpenSearchErrorBody {
     status?: number;
 }
 
-interface ResponseError {
+export interface ResponseError {
     name?: string;
     message?: string;
     statusCode?: number;
     body: OpenSearchErrorBody;
-}
-
-export function isStructuredErrorResponse(err: unknown): err is ResponseError {
-    return (
-        typeof err === 'object'
-        && err !== null
-        && 'body' in err
-        && typeof (err as any).body === 'object'
-        && (err as any).body !== null
-        && 'error' in (err as any).body
-    );
 }

--- a/packages/types/src/elasticsearch-client/elasticsearch-types.ts
+++ b/packages/types/src/elasticsearch-client/elasticsearch-types.ts
@@ -2562,13 +2562,13 @@ export interface IndicesStatsShardCommit {
 
 export interface OpenSearchErrorBody {
     error: ErrorCause;
-    status: number;
+    status?: number;
 }
 
 interface ResponseError {
-    name: string;
-    message: string;
-    statusCode: number;
+    name?: string;
+    message?: string;
+    statusCode?: number;
     body: OpenSearchErrorBody;
 }
 
@@ -2576,8 +2576,9 @@ export function isResponseError(err: unknown): err is ResponseError {
     return (
         typeof err === 'object'
         && err !== null
-        && 'statusCode' in err
         && 'body' in err
-        && typeof (err as any).statusCode === 'number'
+        && typeof (err as any).body === 'object'
+        && (err as any).body !== null
+        && 'error' in (err as any).body
     );
 }

--- a/packages/types/src/elasticsearch-client/elasticsearch-types.ts
+++ b/packages/types/src/elasticsearch-client/elasticsearch-types.ts
@@ -32,11 +32,6 @@ export interface ErrorCauseKeys {
     caused_by?: ErrorCause;
     root_cause?: ErrorCause[];
     suppressed?: ErrorCause[];
-    phase?: string;
-    grouped?: boolean;
-    bytes_wanted?: number;
-    bytes_limit?: number;
-    durability?: 'TRANSIENT' | 'PERMANENT';
     failed_shards?: ShardFailure[];
 }
 

--- a/packages/types/src/elasticsearch-client/elasticsearch-types.ts
+++ b/packages/types/src/elasticsearch-client/elasticsearch-types.ts
@@ -32,6 +32,12 @@ export interface ErrorCauseKeys {
     caused_by?: ErrorCause;
     root_cause?: ErrorCause[];
     suppressed?: ErrorCause[];
+    phase?: string;
+    grouped?: boolean;
+    bytes_wanted?: number;
+    bytes_limit?: number;
+    durability?: 'TRANSIENT' | 'PERMANENT';
+    failed_shards?: ShardFailure[];
 }
 
 export declare type ErrorCause = ErrorCauseKeys & {
@@ -1418,12 +1424,7 @@ export interface SearchRecordResponse<T = Record<string, unknown>> {
     max_score?: number;
     fields?: Record<string, any>;
     aggregations?: SearchAggregations;
-    _shards: {
-        total: number;
-        successful: number;
-        skipped: number;
-        failed: number;
-    };
+    _shards: ShardStatistics;
     hits: {
         total: number | HitsTotal;
         max_score: number;
@@ -2557,4 +2558,26 @@ export interface IndicesStatsShardCommit {
     id: string;
     num_docs: number;
     user_data: Record<string, string>;
+}
+
+export interface OpenSearchErrorBody {
+    error: ErrorCause;
+    status: number;
+}
+
+interface ResponseError {
+    name: string;
+    message: string;
+    statusCode: number;
+    body: OpenSearchErrorBody;
+}
+
+export function isResponseError(err: unknown): err is ResponseError {
+    return (
+        typeof err === 'object'
+        && err !== null
+        && 'statusCode' in err
+        && 'body' in err
+        && typeof (err as any).statusCode === 'number'
+    );
 }

--- a/packages/types/src/elasticsearch-client/elasticsearch-types.ts
+++ b/packages/types/src/elasticsearch-client/elasticsearch-types.ts
@@ -2572,7 +2572,7 @@ interface ResponseError {
     body: OpenSearchErrorBody;
 }
 
-export function isResponseError(err: unknown): err is ResponseError {
+export function isStructuredErrorResponse(err: unknown): err is ResponseError {
     return (
         typeof err === 'object'
         && err !== null

--- a/packages/types/src/elasticsearch-interfaces.ts
+++ b/packages/types/src/elasticsearch-interfaces.ts
@@ -2864,13 +2864,13 @@ export interface IndicesStatsShardCommit {
 
 export interface OpenSearchErrorBody {
     error: ErrorCause;
-    status: number;
+    status?: number;
 }
 
 interface ResponseError {
-    name: string;
-    message: string;
-    statusCode: number;
+    name?: string;
+    message?: string;
+    statusCode?: number;
     body: OpenSearchErrorBody;
 }
 
@@ -2878,8 +2878,9 @@ export function isResponseError(err: unknown): err is ResponseError {
     return (
         typeof err === 'object'
         && err !== null
-        && 'statusCode' in err
         && 'body' in err
-        && typeof (err as any).statusCode === 'number'
+        && typeof (err as any).body === 'object'
+        && (err as any).body !== null
+        && 'error' in (err as any).body
     );
 }

--- a/packages/types/src/elasticsearch-interfaces.ts
+++ b/packages/types/src/elasticsearch-interfaces.ts
@@ -2874,7 +2874,7 @@ interface ResponseError {
     body: OpenSearchErrorBody;
 }
 
-export function isResponseError(err: unknown): err is ResponseError {
+export function isStructuredErrorResponse(err: unknown): err is ResponseError {
     return (
         typeof err === 'object'
         && err !== null

--- a/packages/types/src/elasticsearch-interfaces.ts
+++ b/packages/types/src/elasticsearch-interfaces.ts
@@ -334,11 +334,6 @@ export interface ErrorCauseKeys {
     caused_by?: ErrorCause;
     root_cause?: ErrorCause[];
     suppressed?: ErrorCause[];
-    phase?: string;
-    grouped?: boolean;
-    bytes_wanted?: number;
-    bytes_limit?: number;
-    durability?: 'TRANSIENT' | 'PERMANENT';
     failed_shards?: ShardFailure[];
 }
 
@@ -2860,27 +2855,4 @@ export interface IndicesStatsShardCommit {
     id: string;
     num_docs: number;
     user_data: Record<string, string>;
-}
-
-export interface OpenSearchErrorBody {
-    error: ErrorCause;
-    status?: number;
-}
-
-interface ResponseError {
-    name?: string;
-    message?: string;
-    statusCode?: number;
-    body: OpenSearchErrorBody;
-}
-
-export function isStructuredErrorResponse(err: unknown): err is ResponseError {
-    return (
-        typeof err === 'object'
-        && err !== null
-        && 'body' in err
-        && typeof (err as any).body === 'object'
-        && (err as any).body !== null
-        && 'error' in (err as any).body
-    );
 }

--- a/packages/types/src/elasticsearch-interfaces.ts
+++ b/packages/types/src/elasticsearch-interfaces.ts
@@ -334,6 +334,12 @@ export interface ErrorCauseKeys {
     caused_by?: ErrorCause;
     root_cause?: ErrorCause[];
     suppressed?: ErrorCause[];
+    phase?: string;
+    grouped?: boolean;
+    bytes_wanted?: number;
+    bytes_limit?: number;
+    durability?: 'TRANSIENT' | 'PERMANENT';
+    failed_shards?: ShardFailure[];
 }
 
 export declare type ErrorCause = ErrorCauseKeys & {
@@ -1720,12 +1726,7 @@ export interface SearchRecordResponse<T = Record<string, unknown>> {
     max_score?: number;
     fields?: Record<string, any>;
     aggregations?: SearchAggregations;
-    _shards: {
-        total: number;
-        successful: number;
-        skipped: number;
-        failed: number;
-    };
+    _shards: ShardStatistics;
     hits: {
         total: number | HitsTotal;
         max_score: number;
@@ -2859,4 +2860,26 @@ export interface IndicesStatsShardCommit {
     id: string;
     num_docs: number;
     user_data: Record<string, string>;
+}
+
+export interface OpenSearchErrorBody {
+    error: ErrorCause;
+    status: number;
+}
+
+interface ResponseError {
+    name: string;
+    message: string;
+    statusCode: number;
+    body: OpenSearchErrorBody;
+}
+
+export function isResponseError(err: unknown): err is ResponseError {
+    return (
+        typeof err === 'object'
+        && err !== null
+        && 'statusCode' in err
+        && 'body' in err
+        && typeof (err as any).statusCode === 'number'
+    );
 }

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/valkey",
     "displayName": "Valkey Connector",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "description": "A Terafoundation connector and facade client for Valkey.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/valkey#readme",
     "bugs": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:
- parse opensearch client errors and retry on `parent` and `in_flight_requests` circuit breaker errors
- add more tests for `isErrorRetryable()`
- update elasticsearch types

ref: https://github.com/terascope/elasticsearch-assets/issues/1585, #4428