### PR TITLE
[teraslice] Add dynamic job settings via slice object

### DIFF
--- a/docs/management-apis/endpoints-json.md
+++ b/docs/management-apis/endpoints-json.md
@@ -1089,26 +1089,6 @@ $ curl -XPOST 'localhost:5678/v1/ex/863678b3-daf3-4ea9-8cb0-88b846cd7e57/_worker
 "5 workers have been add for execution: 863678b3-daf3-4ea9-8cb0-88b846cd7e57"
 ```
 
-## POST /v1/ex/\{exId\}/_settings
-
-Dynamically updates runtime settings for the running execution without requiring a restart. Currently supports changing the log level.
-
-The log level change is propagated to the execution controller and then applied to all workers on a per-slice basis. Workers update their log level when they receive a slice tagged with the new level.
-
-**Query Options:**
-
-- `log_level: string` — one of `trace`, `debug`, `info`, `warn`, `error`, `fatal`
-
-**Usage:**
-
-```sh
-$ curl -XPOST 'localhost:5678/v1/ex/863678b3-daf3-4ea9-8cb0-88b846cd7e57/_settings?log_level=debug'
-{
-    "exId": "863678b3-daf3-4ea9-8cb0-88b846cd7e57",
-    "level": "debug"
-}
-```
-
 ## GET /v1/ex/\{exId\}/controller
 
 Same concept as cluster/controllers, but only get stats on execution controller associated with the given execution context id.

--- a/docs/management-apis/endpoints-json.md
+++ b/docs/management-apis/endpoints-json.md
@@ -554,6 +554,26 @@ $ curl -XPOST 'localhost:5678/v1/jobs/5a50580c-4a50-48d9-80f8-ac70a00f3dbd/_work
 "5 workers have been add for execution: 863678b3-daf3-4ea9-8cb0-88b846cd7e57"
 ```
 
+## POST /v1/jobs/\{jobId\}/_settings
+
+Dynamically updates runtime settings for the running job execution without requiring a restart. Currently supports changing the log level.
+
+The log level change is propagated to the execution controller and then applied to all workers on a per-slice basis. Workers update their log level when they receive a slice tagged with the new level.
+
+**Query Options:**
+
+- `log_level: string` — one of `trace`, `debug`, `info`, `warn`, `error`, `fatal`
+
+**Usage:**
+
+```sh
+$ curl -XPOST 'localhost:5678/v1/jobs/5a50580c-4a50-48d9-80f8-ac70a00f3dbd/_settings?log_level=debug'
+{
+    "exId": "863678b3-daf3-4ea9-8cb0-88b846cd7e57",
+    "level": "debug"
+}
+```
+
 ## POST /v1/jobs/\{jobId\}/_active
 
 **DEPRECATED** - Jobs should instead be deleted
@@ -1067,6 +1087,26 @@ If you use total, it will dynamically determine if it needs to add or remove to 
 ```sh
 $ curl -XPOST 'localhost:5678/v1/ex/863678b3-daf3-4ea9-8cb0-88b846cd7e57/_workers?add=5'
 "5 workers have been add for execution: 863678b3-daf3-4ea9-8cb0-88b846cd7e57"
+```
+
+## POST /v1/ex/\{exId\}/_settings
+
+Dynamically updates runtime settings for the running execution without requiring a restart. Currently supports changing the log level.
+
+The log level change is propagated to the execution controller and then applied to all workers on a per-slice basis. Workers update their log level when they receive a slice tagged with the new level.
+
+**Query Options:**
+
+- `log_level: string` — one of `trace`, `debug`, `info`, `warn`, `error`, `fatal`
+
+**Usage:**
+
+```sh
+$ curl -XPOST 'localhost:5678/v1/ex/863678b3-daf3-4ea9-8cb0-88b846cd7e57/_settings?log_level=debug'
+{
+    "exId": "863678b3-daf3-4ea9-8cb0-88b846cd7e57",
+    "level": "debug"
+}
 ```
 
 ## GET /v1/ex/\{exId\}/controller

--- a/docs/management-apis/overview.md
+++ b/docs/management-apis/overview.md
@@ -88,6 +88,16 @@ curl -XPOST "$YOUR_MASTER_IP:5678/v1/jobs/${job_id}/_active"
 curl -XPOST "$YOUR_MASTER_IP:5678/v1/jobs/${job_id}/_inactive"
 ```
 
+### Changing job settings at runtime
+
+You can dynamically change certain job settings without restarting the job. Currently `log_level` is supported.
+
+```sh
+curl -XPOST "$YOUR_MASTER_IP:5678/v1/jobs/${job_id}/_settings?log_level=debug"
+```
+
+Valid log levels are: `trace`, `debug`, `info`, `warn`, `error`, `fatal`.
+
 ### Viewing Slicer statistics for a job
 
 This provides information related to the execution controller and can be useful

--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.23.0
-appVersion: v3.9.2
+version: 3.24.0
+appVersion: v3.10.0
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "3.9.2",
+    "version": "3.10.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/core-utils",
     "displayName": "Core Utils",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "description": "A collection of Teraslice Core Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/core-utils#readme",
     "bugs": {

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "5.9.1",
+    "version": "5.10.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/geo-utils/package.json
+++ b/packages/geo-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/geo-utils",
     "displayName": "Geo Utils",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "description": "A collection of Teraslice Geo Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/geo-utils#readme",
     "bugs": {

--- a/packages/ip-utils/package.json
+++ b/packages/ip-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/ip-utils",
     "displayName": "IP Utils",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "A collection of Teraslice IP Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ip-utils#readme",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "2.11.1",
+    "version": "2.12.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/opensearch-client/package.json
+++ b/packages/opensearch-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/opensearch-client",
     "displayName": "Opensearch Client",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "description": "A Node.js facade client for opensearch & elasticsearch.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/opensearch-client#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.13.1",
+    "version": "2.14.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "2.11.0",
+    "version": "2.12.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {

--- a/packages/teraslice-messaging/src/cluster-master/client.ts
+++ b/packages/teraslice-messaging/src/cluster-master/client.ts
@@ -88,4 +88,8 @@ export class Client extends core.Client {
     onExecutionResume(fn: core.MessageHandler) {
         this.handleResponse(this.socket, 'execution:resume', fn);
     }
+
+    onExecutionLogLevel(fn: core.MessageHandler) {
+        this.handleResponse(this.socket, 'execution:loglevel', fn);
+    }
 }

--- a/packages/teraslice-messaging/src/cluster-master/server.ts
+++ b/packages/teraslice-messaging/src/cluster-master/server.ts
@@ -67,6 +67,10 @@ export class Server extends _Server {
         return this.send(exId, 'execution:resume');
     }
 
+    sendExecutionLogLevel(exId: string, level: string): Promise<Message | null> {
+        return this.send(exId, 'execution:loglevel', { level });
+    }
+
     sendExecutionAnalyticsRequest(exId: string): Promise<Message | null> {
         return this.send(exId, 'execution:analytics');
     }

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "2.12.1",
+    "version": "2.13.0",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "3.9.2",
+    "version": "3.10.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -418,9 +418,11 @@ export class ApiService {
             });
         });
 
-        v1routes.post(['/jobs/:jobId/_settings', '/ex/:exId/_settings'], (req, res) => {
+        v1routes.post('/jobs/:jobId/_settings', (req, res) => {
+            // @ts-expect-error
             const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not update dynamic job settings');
             requestHandler(async () => {
+                // @ts-expect-error
                 const exId = await this._getExIdFromRequest(req as TerasliceRequest);
                 const { log_level } = req.query;
                 return executionService.setLogLevel(exId, log_level as string);

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -418,6 +418,15 @@ export class ApiService {
             });
         });
 
+        v1routes.post(['/jobs/:jobId/_settings', '/ex/:exId/_settings'], (req, res) => {
+            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not update dynamic job settings');
+            requestHandler(async () => {
+                const exId = await this._getExIdFromRequest(req as TerasliceRequest);
+                const { log_level } = req.query;
+                return executionService.setLogLevel(exId, log_level as string);
+            });
+        });
+
         v1routes.post(['/jobs/:jobId/_workers', '/ex/:exId/_workers'], (req, res) => {
             const { query } = req;
 

--- a/packages/teraslice/src/lib/cluster/services/execution.ts
+++ b/packages/teraslice/src/lib/cluster/services/execution.ts
@@ -302,6 +302,25 @@ export class ExecutionService {
         this.waitForExecutionStatus(exId);
     }
 
+    async setLogLevel(exId: string, level: string) {
+        const valid = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
+        if (!level || !valid.includes(level)) {
+            throw new TSError(`Invalid log level "${level}", must be one of: ${valid.join(', ')}`, {
+                statusCode: 400
+            });
+        }
+
+        const execution = await this.executionStorage.getActiveExecution(exId);
+
+        if (!this.clusterMasterServer.isClientReady(execution.ex_id)) {
+            throw new TSError(`Execution ${exId} is not available`, { statusCode: 404 });
+        }
+
+        await this.clusterMasterServer.sendExecutionLogLevel(exId, level);
+
+        return { exId, level };
+    }
+
     async pauseExecution(exId: string) {
         const status = 'paused';
         const execution = await this.executionStorage.getActiveExecution(exId);

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -60,6 +60,7 @@ export class ExecutionController {
     private slicerFailed = false;
     private startTime: number | undefined;
     private isDoneDispatching!: boolean | undefined;
+    private _logLevel: Logger.LogLevel | undefined;
 
     constructor(context: Context, executionContext: SlicerExecutionContext) {
         const workerId = generateWorkerId(context);
@@ -238,6 +239,15 @@ export class ExecutionController {
 
         this.client.onExecutionPause(() => this.pause());
         this.client.onExecutionResume(() => this.resume());
+        // Update log level by user api request
+        // TODO: keep track of original value on the ex and
+        // set this._logLevel to undefined if the same
+        this.client.onExecutionLogLevel((msg) => {
+            const { level } = msg.payload as { level: Logger.LogLevel };
+            this._logLevel = level;
+            this.logger.level(level);
+            this.logger.debug(`log level updated to ${level}`);
+        });
 
         this.server.onSliceSuccess((workerId, response) => {
             process.nextTick(() => {
@@ -659,6 +669,12 @@ export class ExecutionController {
 
     _dispatchSlice(slice: Slice, workerId: string) {
         this.logger.trace(`dispatching slice ${slice.slice_id} for worker ${workerId}`);
+
+        // When set, we bolt on the log_level to the slice
+        // We don't care about persistence right now
+        if (this._logLevel) {
+            slice.log_level = this._logLevel as string;
+        }
 
         return this.server
             .dispatchSlice(slice, workerId)

--- a/packages/teraslice/src/lib/workers/execution-controller/index.ts
+++ b/packages/teraslice/src/lib/workers/execution-controller/index.ts
@@ -245,7 +245,7 @@ export class ExecutionController {
         this.client.onExecutionLogLevel((msg) => {
             const { level } = msg.payload as { level: Logger.LogLevel };
             this._logLevel = level;
-            this.logger.level(level);
+            this.context.apis.foundation.setLogLevel(level);
             this.logger.debug(`log level updated to ${level}`);
         });
 

--- a/packages/teraslice/src/lib/workers/worker/index.ts
+++ b/packages/teraslice/src/lib/workers/worker/index.ts
@@ -2,7 +2,7 @@
 
 import {
     get, getFullErrorStack, isFatalError,
-    logError, pWhile, Logger
+    logError, pWhile, Logger, logLevels
 } from '@terascope/core-utils';
 import type { EventEmitter } from 'node:events';
 import { ExecutionController, formatURL } from '@terascope/teraslice-messaging';
@@ -198,9 +198,9 @@ export class Worker {
             // After we init the slice we check for log level on the slice
             // We update in the case it differs from what the worker has
             if (msg.log_level) {
-                const prevLevel = this.logger.level();
-                this.logger.level(msg.log_level as Logger.LogLevel);
-                if (this.logger.level() !== prevLevel) {
+                const sliceLogLevel = logLevels[msg.log_level as keyof typeof logLevels];
+                if (sliceLogLevel != null && this.logger.level() !== sliceLogLevel) {
+                    this.context.apis.foundation.setLogLevel(msg.log_level as Logger.LogLevel);
                     this.logger.info(`log level updated to ${msg.log_level} for slice ${sliceId}`);
                 }
             }

--- a/packages/teraslice/src/lib/workers/worker/index.ts
+++ b/packages/teraslice/src/lib/workers/worker/index.ts
@@ -195,6 +195,16 @@ export class Worker {
         try {
             await this.slice.initialize(msg);
 
+            // After we init the slice we check for log level on the slice
+            // We update in the case it differs from what the worker has
+            if (msg.log_level) {
+                const prevLevel = this.logger.level();
+                this.logger.level(msg.log_level as Logger.LogLevel);
+                if (this.logger.level() !== prevLevel) {
+                    this.logger.info(`log level updated to ${msg.log_level} for slice ${sliceId}`);
+                }
+            }
+
             await this.slice.run();
 
             this.logger.info(`slice ${sliceId} completed`);

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/types",
     "displayName": "Types",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "description": "A collection of typescript interfaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/types#readme",
     "bugs": {

--- a/packages/types/src/teraslice.ts
+++ b/packages/types/src/teraslice.ts
@@ -172,6 +172,11 @@ export interface Slice {
     slicer_order: number;
     request: SliceRequest;
     _created: string;
+    /**
+     * Optional log level override for workers processing this slice.
+     * When set, the worker will apply this log level before running the slice.
+     */
+    log_level?: string;
 }
 
 /**

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/valkey",
     "displayName": "Valkey Connector",
-    "version": "0.4.1",
+    "version": "0.5.0",
     "description": "A Terafoundation connector and facade client for Valkey.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/valkey#readme",
     "bugs": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:

- Adds a new `POST /v1/jobs/:jobId/_settings` API endpoint [0634579da]
  - Accepts a `log_level` query parameter (`trace`, `debug`, `info`, `warn`, `error`, `fatal`)
  - Returns `{ exId, level }` on success, `400` on invalid level
- Adds `onExecutionLogLevel` to the cluster-master socket client and `sendExecutionLogLevel` to the cluster-master server [0634579da]
- Updates the ExecutionController to handle `execution:loglevel` socket messages [be68b2d48]
  - Applies the new log level to itself immediately via `setLogLevel`
  - Stores the active log level and injects it as `log_level` onto each dispatched slice
- Updates the Worker to check for `log_level` on each received slice [7463a5917]
  - Applies the log level before running the slice if it differs from the current level
- Adds optional `log_level` field to the `Slice` type [4e49fa6f3]
- Adds API documentation for `_settings` endpoint and an overview entry for runtime job settings

Ref to issue #4397