### PR TITLE
[terafoundation] Add logger registry and setLogLevel to foundation APIs

### DIFF
--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -4,26 +4,17 @@ title: Logging
 
 ## Overview
 
-Use **child loggers** for structured logging.
+Use **child loggers** for structured logging. All code — both teraslice internals and assets — should use `makeExContextLogger` as the primary way to create a logger. Assets always run inside a worker or execution controller and always have access to `context` and `executionConfig`.
 
-- **Assets:** `context.apis.foundation.makeLogger(meta)`
-- **Teraslice code:** `makeLogger(context, moduleName)`
+## Example
 
-Both helpers return a child logger that includes your metadata and context. The `makeLogger` function which can be found in `<teraslice_repo_dir>/packages/teraslice/src/lib/workers/helpers/terafoundation.ts` is used only within teraslice itself as it isn't exported out for assets to use.
+```ts
+import { makeExContextLogger } from '@terascope/job-components';
 
-## Asset example
-
-```js
-import { BatchProcessor } from '@terascope/job-components';
-
-export default class Example extends BatchProcessor {
-    onBatch(dataArray) {
-        // Adding a child logger with the module name 'example-processor'
-        this.context.apis.foundation.makeLogger({ module: 'example-processor'});
-        return dataArray;
-    }
-}
+const logger = makeExContextLogger(this.context, this.executionConfig, 'my-reader');
 ```
+
+This automatically attaches `module`, `ex_id`, `job_id`, `worker_id`, and `assignment` to every log line.
 
 ## Teraslice example
 
@@ -58,6 +49,141 @@ Numeric mapping: trace `10`, debug `20`, info `30`, warn `40`, error `50`, fatal
 - **trace** — extremely fine-grained, temporary diagnostics only.
 
 For the full list and guidance, see [Bunyan’s Levels section](https://github.com/trentm/node-bunyan?tab=readme-ov-file#levels).
+
+## Changing log levels at runtime
+
+Use `context.apis.foundation.setLogLevel(level)` to change the log level for all loggers at once. This updates the root logger and every registered child logger simultaneously.
+
+```ts
+context.apis.foundation.setLogLevel('debug');
+```
+
+Do **not** call `.level()` directly on individual loggers — child loggers changed in isolation will fall out of sync with the rest of the application.
+
+## Bunyan child logger pitfalls
+
+- **Level changes don't propagate automatically.** In Bunyan, setting a level on a parent logger does not update existing child loggers. This is why `setLogLevel` exists — always use it instead of setting levels directly.
+- **Child loggers created outside of `makeLogger` are not tracked.** Only loggers created via `context.apis.foundation.makeLogger()` (or the helper functions below) are registered and updated by `setLogLevel`. Loggers created directly via `context.logger.child()` will be missed.
+- **Child logger references are held via `WeakRef`.** The registry stores each child logger as a `WeakRef` so that loggers which are no longer referenced elsewhere can be garbage collected normally — the registry won't keep them alive. A `FinalizationRegistry` callback cleans up the dead `WeakRef` from the set after GC runs, so the set doesn't grow unboundedly over the lifetime of the process.
+
+## Preferred logger helpers
+
+For most teraslice internal code, prefer `makeExContextLogger` over calling `makeLogger` directly. It automatically attaches execution context fields (`ex_id`, `job_id`, `worker_id`, `assignment`) along with your module name:
+
+```ts
+import { makeExContextLogger } from '@terascope/job-components';
+
+// Inside a class that has access to context and executionConfig
+const logger: Logger = makeExContextLogger(this.context, this.executionConfig, 'my-module');
+```
+
+If you're outside of an execution context (no `ExecutionConfig`), use `makeContextLogger` instead:
+
+```ts
+import { makeContextLogger } from '@terascope/job-components';
+
+const logger: Logger = makeContextLogger(context, 'my-module');
+```
+
+Assets always run inside a worker or execution controller, so they always have an `ExecutionConfig` available. Asset operations extend from `OperationCore`, which sets up a base logger via `makeExContextLogger` automatically. When an asset needs an additional child logger for a sub-component, use `makeExContextLogger` the same way internal teraslice code does.
+
+## Logger field conventions
+
+Child loggers are structured with fields that appear on every log line. Use the following standard fields consistently — do not invent new names for things already covered here:
+
+| Field | Type | Description |
+|---|---|---|
+| `module` | `string` | The component or sub-module producing the log. Use `snake_case`. Required on all child loggers. |
+| `ex_id` | `string` | Execution ID. Added automatically by `makeExContextLogger`. |
+| `job_id` | `string` | Job ID. Added automatically by `makeExContextLogger`. |
+| `worker_id` | `number` | Cluster worker ID. Added automatically by `makeContextLogger` and `makeExContextLogger`. |
+| `assignment` | `string` | Process role (e.g. `worker`, `execution_controller`). Added automatically. |
+| `slice_id` | `string` | ID of the current slice being processed. Added at the slice level when relevant. |
+
+For the `module` field, follow the naming pattern already used throughout the codebase: short, descriptive, `snake_case` names that reflect the component — for example `asset_loader`, `execution_scheduler`, `prom_metrics`. Avoid generic names like `handler` or `util` without a qualifying prefix.
+
+## When to add a log
+
+| Situation | Level |
+|---|---|
+| Service/component startup and shutdown | `info` |
+| Operationally significant state changes (connection lost, limit hit, rebalance) | `warn` |
+| Internal flow steps useful during troubleshooting | `debug` |
+| Errors that stop processing | `error` |
+| Unrecoverable failures | `fatal` |
+| Temporary, extremely fine-grained diagnostics | `trace` |
+
+Do not add a log line just because something happened — add it because an operator watching a live system would want to know. If a line would only be useful to the person who wrote it, it belongs at `debug` or `trace`, not `info`.
+
+Log **before** an action, not after. If the action hangs or throws, the message still appears:
+
+```ts
+// Good — message appears even if the call hangs or throws
+logger.debug('Flushing queue before writing next batch');
+await this.flush();
+
+// Bad — message is lost if flush() throws
+await this.flush();
+logger.debug('Flushed queue');
+```
+
+## Writing useful log messages
+
+Logs are read by operators searching through output from multiple workers — not by the person who wrote the code. Write every message from that perspective.
+
+**Be specific — include the actual values that matter.**
+
+An operator cannot act on a vague message. Include config parameter names, current values, limits, and what action is being taken:
+
+```ts
+// Bad
+logger.warn('Buffer is full, flushing...');
+
+// Good
+logger.warn(`Buffer size limit reached: max_buffer_size = ${this._maxSize}, current = ${current}. Flushing to prevent overflow`);
+```
+
+**Use consistent key phrases across related log lines.**
+
+If an operator greps for a term, every log line in that flow should match. Pick a phrase and use it on every related line:
+
+```ts
+// Bad — inconsistent wording, hard to grep
+logger.warn('dropping connection');
+logger.debug('reconnecting');
+logger.info('connection restored');
+
+// Good — "client connection" appears on every related line
+logger.warn('client connection lost, initiating reconnect');
+logger.debug('client connection attempt starting');
+logger.info('client connection restored');
+```
+
+**Prefix messages with the subsystem name.**
+
+When multiple operations run in the same worker, log lines from many components are interleaved. A clear prefix makes it immediately obvious where a line came from:
+
+```ts
+logger.debug(`Reader flushing queue after processing ${total} records in slice`);
+```
+
+**Format lists compactly.**
+
+```ts
+// Bad
+'assigned partitions: partition: 0, partition: 1, partition: 2'
+
+// Good
+`assigned partitions: [${partitions.join(', ')}]`
+```
+
+**Use Teraslice domain vocabulary.**
+
+Use `slice` when referring to a Teraslice slice — not `batch`, `chunk`, or `message set`. Consistent terminology makes logs easier to cross-reference with Teraslice documentation and other tooling.
+
+**Read your logs in context before merging.**
+
+Run a real test job that triggers the conditions your logs cover. Read the actual output alongside surrounding log lines from other components. Ask: would an operator understand what happened and why, without access to the source code?
 
 ## Notes
 

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -4,17 +4,15 @@ title: Logging
 
 ## Overview
 
-Use **child loggers** for structured logging. All code — both teraslice internals and assets — should use `makeExContextLogger` as the primary way to create a logger. Assets always run inside a worker or execution controller and always have access to `context` and `executionConfig`.
+Use **child loggers** for structured logging. All code — both teraslice internals and assets — should create loggers via `context.apis.foundation.makeLogger()`. The fields `ex_id`, `job_id`, `worker_id`, and `assignment` are inherited automatically from the root logger, so callers only need to supply a `module` name and any operation-specific fields.
 
 ## Example
 
 ```ts
-import { makeExContextLogger } from '@terascope/job-components';
-
-const logger = makeExContextLogger(this.context, this.executionConfig, 'my-reader');
+const logger = context.apis.foundation.makeLogger({ module: 'my-reader' });
 ```
 
-This automatically attaches `module`, `ex_id`, `job_id`, `worker_id`, and `assignment` to every log line.
+This automatically attaches `ex_id`, `job_id`, `worker_id`, and `assignment` to every log line via the root logger.
 
 ## Teraslice example
 
@@ -63,29 +61,24 @@ Do **not** call `.level()` directly on individual loggers — child loggers chan
 ## Bunyan child logger pitfalls
 
 - **Level changes don't propagate automatically.** In Bunyan, setting a level on a parent logger does not update existing child loggers. This is why `setLogLevel` exists — always use it instead of setting levels directly.
-- **Child loggers created outside of `makeLogger` are not tracked.** Only loggers created via `context.apis.foundation.makeLogger()` (or the helper functions below) are registered and updated by `setLogLevel`. Loggers created directly via `context.logger.child()` will be missed.
+- **Child loggers created outside of `makeLogger` are not tracked.** Only loggers created via `context.apis.foundation.makeLogger()` are registered and updated by `setLogLevel`. Loggers created directly via `context.logger.child()` will be missed.
 - **Child logger references are held via `WeakRef`.** The registry stores each child logger as a `WeakRef` so that loggers which are no longer referenced elsewhere can be garbage collected normally — the registry won't keep them alive. A `FinalizationRegistry` callback cleans up the dead `WeakRef` from the set after GC runs, so the set doesn't grow unboundedly over the lifetime of the process.
 
-## Preferred logger helpers
+## Creating loggers
 
-For most teraslice internal code, prefer `makeExContextLogger` over calling `makeLogger` directly. It automatically attaches execution context fields (`ex_id`, `job_id`, `worker_id`, `assignment`) along with your module name:
-
-```ts
-import { makeExContextLogger } from '@terascope/job-components';
-
-// Inside a class that has access to context and executionConfig
-const logger: Logger = makeExContextLogger(this.context, this.executionConfig, 'my-module');
-```
-
-If you're outside of an execution context (no `ExecutionConfig`), use `makeContextLogger` instead:
+Use `context.apis.foundation.makeLogger()` directly in all cases — whether inside an execution context or not. The fields `ex_id`, `job_id`, `worker_id`, and `assignment` are set on the root logger at process startup and inherited by every child logger automatically.
 
 ```ts
-import { makeContextLogger } from '@terascope/job-components';
-
-const logger: Logger = makeContextLogger(context, 'my-module');
+const logger: Logger = context.apis.foundation.makeLogger({ module: 'my-module' });
 ```
 
-Assets always run inside a worker or execution controller, so they always have an `ExecutionConfig` available. Asset operations extend from `OperationCore`, which sets up a base logger via `makeExContextLogger` automatically. When an asset needs an additional child logger for a sub-component, use `makeExContextLogger` the same way internal teraslice code does.
+Pass any additional operation-specific fields alongside `module`:
+
+```ts
+const logger: Logger = context.apis.foundation.makeLogger({ module: 'operation', opName: opConfig._op });
+```
+
+Asset operations extend from `OperationCore`, which sets up a base logger via `makeLogger` automatically. When an asset needs an additional child logger for a sub-component, call `context.apis.foundation.makeLogger()` the same way.
 
 ## Logger field conventions
 
@@ -94,10 +87,10 @@ Child loggers are structured with fields that appear on every log line. Use the 
 | Field | Type | Description |
 |---|---|---|
 | `module` | `string` | The component or sub-module producing the log. Use `snake_case`. Required on all child loggers. |
-| `ex_id` | `string` | Execution ID. Added automatically by `makeExContextLogger`. |
-| `job_id` | `string` | Job ID. Added automatically by `makeExContextLogger`. |
-| `worker_id` | `number` | Cluster worker ID. Added automatically by `makeContextLogger` and `makeExContextLogger`. |
-| `assignment` | `string` | Process role (e.g. `worker`, `execution_controller`). Added automatically. |
+| `ex_id` | `string` | Execution ID. Inherited from the root logger when running inside a worker or execution controller. |
+| `job_id` | `string` | Job ID. Inherited from the root logger when running inside a worker or execution controller. |
+| `worker_id` | `number` | Cluster worker ID. Inherited from the root logger. |
+| `assignment` | `string` | Process role (e.g. `worker`, `execution_controller`). Inherited from the root logger. |
 | `slice_id` | `string` | ID of the current slice being processed. Added at the slice level when relevant. |
 
 For the `module` field, follow the naming pattern already used throughout the codebase: short, descriptive, `snake_case` names that reflect the component — for example `asset_loader`, `execution_scheduler`, `prom_metrics`. Avoid generic names like `handler` or `util` without a qualifying prefix.

--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.22.0
-appVersion: v3.9.1
+version: 3.23.0
+appVersion: v3.9.2
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "3.9.1",
+    "version": "3.9.2",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/core-utils",
     "displayName": "Core Utils",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "A collection of Teraslice Core Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/core-utils#readme",
     "bugs": {

--- a/packages/core-utils/src/logger.ts
+++ b/packages/core-utils/src/logger.ts
@@ -54,6 +54,7 @@ export function debugLogger(testName: string, param?: DebugParam, otherName?: st
 
     const name = parts.join(':');
 
+    logger.fields = {};
     logger.streams = [];
 
     logger.addStream = () => {};

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "5.9.0",
+    "version": "5.9.1",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/geo-utils/package.json
+++ b/packages/geo-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/geo-utils",
     "displayName": "Geo Utils",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "A collection of Teraslice Geo Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/geo-utils#readme",
     "bugs": {

--- a/packages/ip-utils/package.json
+++ b/packages/ip-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/ip-utils",
     "displayName": "IP Utils",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "A collection of Teraslice IP Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ip-utils#readme",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/job-components/src/test-helpers.ts
+++ b/packages/job-components/src/test-helpers.ts
@@ -252,6 +252,7 @@ export class TestContext implements i.Context {
 
                     return client;
                 },
+                setLogLevel(_level: Logger.LogLevel) { /* no-op in tests */ },
                 getSystemEvents(): EventEmitter {
                     return events;
                 },

--- a/packages/opensearch-client/package.json
+++ b/packages/opensearch-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/opensearch-client",
     "displayName": "Opensearch Client",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "A Node.js facade client for opensearch & elasticsearch.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/opensearch-client#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.13.0",
+    "version": "2.13.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "2.10.0",
+    "version": "2.11.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/terafoundation/src/api/index.ts
+++ b/packages/terafoundation/src/api/index.ts
@@ -23,7 +23,7 @@ export default function registerApis(
     const childLoggers = new Set<WeakRef<ChildLogger>>();
     const childLoggerRegistry = new FinalizationRegistry((ref: WeakRef<ChildLogger>) => {
         childLoggers.delete(ref);
-        context.logger.debug('child logger GC\'d and pruned from registry');
+        context.logger.debug('child logger collected and removed from logger registry');
     });
 
     // connection cache
@@ -113,7 +113,7 @@ export default function registerApis(
                     const currentLevel = Object.keys(logLevels).find(
                         (key) => logLevels[key as keyof typeof logLevels] === logger.level());
                     logger.level(level);
-                    logger.info(`child logger "${name}" log level is set from ${currentLevel} to ${level}`);
+                    logger.info(`child logger "${name}" log level changed from ${currentLevel} to ${level}`);
                 }
             }
         },

--- a/packages/terafoundation/src/api/index.ts
+++ b/packages/terafoundation/src/api/index.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
-import { isPlainObject, times } from '@terascope/core-utils';
-import type { Terafoundation, TerafoundationEnv } from '@terascope/types';
+import { isPlainObject, times, logLevels } from '@terascope/core-utils';
+import type { Terafoundation, TerafoundationEnv, Logger } from '@terascope/types';
 import { createClient as createDBClient } from '../connector-utils.js';
 import { createRootLogger } from './utils.js';
 import { PromMetrics } from './prom-metrics/prom-metrics-api.js';
@@ -15,6 +15,16 @@ export default function registerApis(
     const foundationConfig = context.sysconfig.terafoundation;
     const events = new EventEmitter();
     context.logger = createRootLogger(context, loggerMetadataFields);
+
+    // Tracks all child loggers so setLogLevel can update them all.
+    // WeakRefs allow GC'd loggers to be collected, and FinalizationRegistry
+    // removes their dead references from the Set to prevent unbounded growth.
+    type ChildLogger = ReturnType<typeof context.logger.child>;
+    const childLoggers = new Set<WeakRef<ChildLogger>>();
+    const childLoggerRegistry = new FinalizationRegistry((ref: WeakRef<ChildLogger>) => {
+        childLoggers.delete(ref);
+        context.logger.debug('child logger GC\'d and pruned from registry');
+    });
 
     // connection cache
     const connections = Object.create(null);
@@ -81,7 +91,31 @@ export default function registerApis(
             // add flush fn to the new logger
             childLogger.flush = context.logger.flush;
 
+            const childRef = new WeakRef(childLogger);
+            childLoggers.add(childRef);
+            childLoggerRegistry.register(childLogger, childRef);
+
             return childLogger;
+        },
+        /**
+         * Sets the log level for the root logger and all registered child loggers simultaneously.
+         * Use this instead of setting log levels on individual loggers to ensure consistent
+         * log level across the entire application.
+         */
+        setLogLevel(level: Logger.LogLevel) {
+            context.logger.level(level);
+            context.logger.info(`root logger level set to ${level}`);
+            for (const ref of childLoggers) {
+                const logger = ref.deref();
+                if (logger) {
+                    const name = logger.fields?.module ?? logger.fields?.name ?? '(unnamed)';
+                    // converts numeric log level to string so we can use it in our info log
+                    const currentLevel = Object.keys(logLevels).find(
+                        (key) => logLevels[key as keyof typeof logLevels] === logger.level());
+                    logger.level(level);
+                    logger.info(`child logger "${name}" log level is set from ${currentLevel} to ${level}`);
+                }
+            }
         },
         getSystemEvents() {
             return events;

--- a/packages/terafoundation/src/api/index.ts
+++ b/packages/terafoundation/src/api/index.ts
@@ -23,7 +23,7 @@ export default function registerApis(
     const childLoggers = new Set<WeakRef<ChildLogger>>();
     const childLoggerRegistry = new FinalizationRegistry((ref: WeakRef<ChildLogger>) => {
         childLoggers.delete(ref);
-        context.logger.debug('child logger collected and removed from logger registry');
+        context.logger.debug('child logger garbage collected and removed from logger registry');
     });
 
     // connection cache

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "3.9.1",
+    "version": "3.9.2",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/workers/worker/slice.ts
+++ b/packages/teraslice/src/lib/workers/worker/slice.ts
@@ -18,7 +18,7 @@ export class SliceExecution {
     readonly stateStorage: StateStorage;
     readonly analyticsStorage: AnalyticsStorage;
     events: events.EventEmitter;
-    private logger!: Logger;
+    private logger: Logger;
     private isShutdown!: boolean;
     slice!: Slice;
     analyticsData!: SliceAnalyticsData;
@@ -34,6 +34,7 @@ export class SliceExecution {
         this.executionContext = executionContext;
         this.stateStorage = stateStorage;
         this.analyticsStorage = analyticsStorage;
+        this.logger = makeLogger(this.context, 'slice');
     }
 
     async initialize(slice: Slice) {
@@ -42,10 +43,7 @@ export class SliceExecution {
         await this.stateStorage.updateState(slice, SliceState.start);
 
         this.slice = slice;
-        this.logger = makeLogger(this.context, 'slice', {
-            slice_id: sliceId
-        });
-
+        this.logger.fields.slice_id = sliceId;
         await this.executionContext.initializeSlice(slice);
     }
 

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/types",
     "displayName": "Types",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "A collection of typescript interfaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/types#readme",
     "bugs": {

--- a/packages/types/src/terafoundation.ts
+++ b/packages/types/src/terafoundation.ts
@@ -114,6 +114,8 @@ export interface FoundationAPIs {
     makeLogger(metadata?: Record<string, string>): Logger;
     /** Create the root logger (usually done automatically) */
     makeLogger(name: string, filename: string): Logger;
+    /** Set log level on the root logger and all child loggers created via makeLogger */
+    setLogLevel(level: Logger.LogLevel): void;
     getSystemEvents(): EventEmitter;
     createClient(config: ConnectionConfig): Promise<ConnectorOutput>;
     startWorkers(num: number, envOptions: Record<string, any>): FoundationWorker[];

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/valkey",
     "displayName": "Valkey Connector",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "A Terafoundation connector and facade client for Valkey.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/valkey#readme",
     "bugs": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:

- Adds a new foundation api `setLogLevel` [b1bee05]
  - This is paired with a registry that keeps track of all child loggers that are made with the `makeLogger` api
  - Now developers can change all log levels across all child loggers to the same log level
- Fixes issue where we create a new logger for every new slice that gets initialized [32343b4]
  - Now we use one logger that dynamically changes the `slice_id` field on init
- Updates development logging documentation [628119f] [ae14229]
  - We now define a set of rules when making loggers and state best practices for wording logs
- Bumps **terafoundation** from `v2.10.0` to `v2.11.0` [60984a0]

Ref to issue #4429  