### PR TITLE
[valkey] Push patched version of valkey package to npm

### DIFF
--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -25,6 +25,7 @@
         "test:watch": "TEST_VALKEY='true' ts-scripts test --watch . --"
     },
     "dependencies": {
+        "@terascope/core-utils": "workspace:~",
         "@valkey/valkey-glide": "~2.3.1"
     },
     "devDependencies": {

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/valkey",
     "displayName": "Valkey Connector",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "A Terafoundation connector and facade client for Valkey.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/valkey#readme",
     "bugs": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1134,6 +1134,9 @@ importers:
 
   packages/valkey:
     dependencies:
+      '@terascope/core-utils':
+        specifier: workspace:~
+        version: link:../core-utils
       '@valkey/valkey-glide':
         specifier: ~2.3.1
         version: 2.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ onlyBuiltDependencies:
   - esbuild
   - event-loop-stats
   - gc-stats
+  - protobufjs
   - unrs-resolver
   - xlucene-parser
 


### PR DESCRIPTION
This PR makes the following changes:

- bump: (patch) @terascope/valkey@0.1.1 [9bee887]
  - This is because valkey [v0.1.0](https://www.npmjs.com/package/@terascope/valkey/v/0.1.0) was just a placeholder to make the npm package. We never pushed the final singed version of this package that goes through our `publish.yml` workflow. Essentially `v0.1.0` is dead and has no content in it
- Added `protobufjs` to `onlyBuiltDependencies` list [361b2cc]
  - Valkey Glide requires this to be built 
- Added `core-utils` to valkey package.json [3028778]

Closes https://github.com/terascope/teraslice/issues/4432