### PR TITLE
[terafoundation] Add core fields to root logger

### DIFF
--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.20.0
-appVersion: v3.8.0
+version: 3.21.0
+appVersion: v3.9.0
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "3.8.0",
+    "version": "3.9.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/core-utils",
     "displayName": "Core Utils",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "A collection of Teraslice Core Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/core-utils#readme",
     "bugs": {

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "2.8.0",
+    "version": "2.9.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "5.7.0",
+    "version": "5.8.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/geo-utils/package.json
+++ b/packages/geo-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/geo-utils",
     "displayName": "Geo Utils",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "A collection of Teraslice Geo Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/geo-utils#readme",
     "bugs": {

--- a/packages/ip-utils/package.json
+++ b/packages/ip-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/ip-utils",
     "displayName": "IP Utils",
-    "version": "2.8.0",
+    "version": "2.9.0",
     "description": "A collection of Teraslice IP Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ip-utils#readme",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/job-components/src/execution-context/api.ts
+++ b/packages/job-components/src/execution-context/api.ts
@@ -10,7 +10,6 @@ import {
 import { isOperationAPI, getOperationAPIType } from './utils.js';
 import { Observer, APIConstructor } from '../operations/index.js';
 import { JobAPIInstances } from './interfaces.js';
-import { makeExContextLogger } from '../utils.js';
 
 export interface MetadataFns {
     update: (exId: string, metadata: Record<string, any>) => Promise<void>;
@@ -150,11 +149,8 @@ export class ExecutionContextAPI {
         return api.opAPI as T;
     }
 
-    /**
-     * Make a logger with a the job_id and ex_id in the logger context
-     */
     makeLogger(moduleName: string, extra: Record<string, any> = {}): Logger {
-        return makeExContextLogger(this._context, this._executionConfig, moduleName, extra);
+        return this._context.apis.foundation.makeLogger({ module: moduleName, ...extra });
     }
 
     /**

--- a/packages/job-components/src/operations/core/api-core.ts
+++ b/packages/job-components/src/operations/core/api-core.ts
@@ -8,7 +8,6 @@ import {
     DeadLetterAction,
     DeadLetterAPIFn
 } from '../../interfaces/index.js';
-import { makeExContextLogger } from '../../utils.js';
 
 /**
  * A base class for supporting APIs that run within an Execution Context.
@@ -25,9 +24,7 @@ export default abstract class APICore<T = APIConfig>
         apiConfig: APIConfig & T,
         executionConfig: ExecutionConfig
     ) {
-        const logger = makeExContextLogger(context, executionConfig, 'operation-api', {
-            apiName: apiConfig._name,
-        });
+        const logger = context.apis.foundation.makeLogger({ module: 'operation-api', apiName: apiConfig._name });
 
         super(context, executionConfig, logger);
         this.apiConfig = apiConfig;

--- a/packages/job-components/src/operations/core/operation-core.ts
+++ b/packages/job-components/src/operations/core/operation-core.ts
@@ -4,7 +4,6 @@ import {
     OpConfig, Context, DeadLetterAction,
     DeadLetterAPIFn,
 } from '../../interfaces/index.js';
-import { makeExContextLogger } from '../../utils.js';
 
 /**
  * A base class for supporting operations that run on a "Worker",
@@ -23,9 +22,7 @@ export default class OperationCore<T = OpConfig>
     deadLetterAction: DeadLetterAction;
 
     constructor(context: Context, opConfig: OpConfig & T, executionConfig: ExecutionConfig) {
-        const logger = makeExContextLogger(context, executionConfig, 'operation', {
-            opName: opConfig._op,
-        });
+        const logger = context.apis.foundation.makeLogger({ module: 'operation', opName: opConfig._op });
         super(context, executionConfig, logger);
 
         this.deadLetterAction = opConfig._dead_letter_action || 'throw';

--- a/packages/job-components/src/operations/core/slicer-core.ts
+++ b/packages/job-components/src/operations/core/slicer-core.ts
@@ -7,7 +7,6 @@ import {
     OpAPI
 } from '../../interfaces/index.js';
 import Core from './core.js';
-import { makeExContextLogger } from '../../utils.js';
 
 /**
  * A base class for supporting "Slicers" that run on a "Execution Controller",
@@ -28,9 +27,7 @@ export default abstract class SlicerCore<T = OpConfig>
     private readonly queue: Queue<Slice>;
 
     constructor(context: Context, opConfig: OpConfig & T, executionConfig: ExecutionConfig) {
-        const logger = makeExContextLogger(context, executionConfig, 'slicer', {
-            opName: opConfig._op,
-        });
+        const logger = context.apis.foundation.makeLogger({ module: 'slicer', opName: opConfig._op });
 
         super(context, executionConfig, logger);
         this.opConfig = opConfig;

--- a/packages/job-components/src/utils.ts
+++ b/packages/job-components/src/utils.ts
@@ -1,33 +1,4 @@
-import { get, Logger } from '@terascope/core-utils';
-import { Context, ExecutionConfig } from './interfaces/index';
-
-export function makeContextLogger(context: Context, moduleName: string, extra = {}): Logger {
-    const meta = Object.assign(
-        {
-            module: moduleName,
-            worker_id: get(context, 'cluster.worker.id'),
-            assignment: get(context, 'assignment'),
-        },
-        extra
-    ) as Record<string, any>;
-
-    return context.apis.foundation.makeLogger(meta);
-}
-
-export function makeExContextLogger(
-    context: Context,
-    config: ExecutionConfig,
-    moduleName: string,
-    extra = {}
-): Logger {
-    const { ex_id: exId, job_id: jobId } = config;
-
-    return makeContextLogger(context, moduleName, {
-        ex_id: exId,
-        job_id: jobId,
-        ...extra
-    });
-}
+import { Context } from './interfaces/index';
 
 export function isPromAvailable(context: Context) {
     return context.apis.foundation.promMetrics !== undefined

--- a/packages/opensearch-client/package.json
+++ b/packages/opensearch-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/opensearch-client",
     "displayName": "Opensearch Client",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "A Node.js facade client for opensearch & elasticsearch.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/opensearch-client#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "2.8.0",
+    "version": "2.9.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/terafoundation/src/api/index.ts
+++ b/packages/terafoundation/src/api/index.ts
@@ -8,10 +8,13 @@ import { PromMetrics } from './prom-metrics/prom-metrics-api.js';
 /*
  * This module controls the API endpoints that are exposed under context.apis.
  */
-export default function registerApis(context: Terafoundation.Context): void {
+export default function registerApis(
+    context: Terafoundation.Context,
+    extraLoggerFields: Record<string, any> = {}
+): void {
     const foundationConfig = context.sysconfig.terafoundation;
     const events = new EventEmitter();
-    context.logger = createRootLogger(context);
+    context.logger = createRootLogger(context, extraLoggerFields);
 
     // connection cache
     const connections = Object.create(null);

--- a/packages/terafoundation/src/api/index.ts
+++ b/packages/terafoundation/src/api/index.ts
@@ -10,11 +10,11 @@ import { PromMetrics } from './prom-metrics/prom-metrics-api.js';
  */
 export default function registerApis(
     context: Terafoundation.Context,
-    extraLoggerFields: Record<string, any> = {}
+    loggerMetadataFields: Record<string, any> = {}
 ): void {
     const foundationConfig = context.sysconfig.terafoundation;
     const events = new EventEmitter();
-    context.logger = createRootLogger(context, extraLoggerFields);
+    context.logger = createRootLogger(context, loggerMetadataFields);
 
     // connection cache
     const connections = Object.create(null);

--- a/packages/terafoundation/src/api/utils.ts
+++ b/packages/terafoundation/src/api/utils.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import bunyan from 'bunyan';
 import {
     toBoolean, debugLogger, isTest,
-    Logger, includes
+    Logger, includes, get
 } from '@terascope/core-utils';
 import { Terafoundation } from '@terascope/types';
 
@@ -40,7 +40,10 @@ export function createRootLogger(
 
     if (useDebugLogger) {
         const logger = debugLogger(`${filename}:${name}`);
-        Object.assign(logger.fields, extraFields);
+        Object.assign(logger.fields, {
+            worker_id: get(context, 'cluster.worker.id'),
+            ...extraFields,
+        });
         return logger;
     }
 
@@ -78,6 +81,7 @@ export function createRootLogger(
         name: filename,
         streams: streamConfig,
         assignment: context.assignment,
+        worker_id: get(context, 'cluster.worker.id'),
         ...extraFields,
     };
 

--- a/packages/terafoundation/src/api/utils.ts
+++ b/packages/terafoundation/src/api/utils.ts
@@ -40,7 +40,8 @@ export function createRootLogger(
 
     if (useDebugLogger) {
         const logger = debugLogger(`${filename}:${name}`);
-        Object.assign(logger.fields, {
+        // We add a fields object as we mainly use bunyan
+        logger.fields = Object.assign(logger.fields ?? {}, {
             worker_id: get(context, 'cluster.worker.id'),
             ...extraFields,
         });

--- a/packages/terafoundation/src/api/utils.ts
+++ b/packages/terafoundation/src/api/utils.ts
@@ -28,7 +28,8 @@ function getLogLevel(level: Terafoundation.LogLevelConfig): LogLevelObj {
 }
 
 export function createRootLogger(
-    context: Terafoundation.Context<Record<string, any>>
+    context: Terafoundation.Context<Record<string, any>>,
+    extraFields: Record<string, any> = {}
 ): Logger {
     const useDebugLogger = (toBoolean(process.env.USE_DEBUG_LOGGER || isTest))
         && !toBoolean(process.env.TESTING_LOG_LEVEL);
@@ -38,7 +39,9 @@ export function createRootLogger(
     const logLevel = getLogLevel(foundationConfig.log_level);
 
     if (useDebugLogger) {
-        return debugLogger(`${filename}:${name}`);
+        const logger = debugLogger(`${filename}:${name}`);
+        Object.assign(logger.fields, extraFields);
+        return logger;
     }
 
     const streamConfig: bunyan.Stream[] = [];
@@ -75,6 +78,7 @@ export function createRootLogger(
         name: filename,
         streams: streamConfig,
         assignment: context.assignment,
+        ...extraFields,
     };
 
     const logger = bunyan.createLogger(loggerConfig) as Logger;

--- a/packages/terafoundation/src/core-context.ts
+++ b/packages/terafoundation/src/core-context.ts
@@ -51,7 +51,7 @@ export class CoreContext<
             this.cluster_name = config.cluster_name;
         }
 
-        registerApis(this);
+        registerApis(this, config.extraLoggerFields ?? {});
     }
 }
 

--- a/packages/terafoundation/src/core-context.ts
+++ b/packages/terafoundation/src/core-context.ts
@@ -51,7 +51,7 @@ export class CoreContext<
             this.cluster_name = config.cluster_name;
         }
 
-        registerApis(this, config.extraLoggerFields ?? {});
+        registerApis(this, config.loggerMetadataFields ?? {});
     }
 }
 

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "3.8.0",
+    "version": "3.9.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/config/index.ts
+++ b/packages/teraslice/src/lib/config/index.ts
@@ -10,7 +10,7 @@ export function clusterName(configFile: TerasliceConfig) {
     return get(configFile, 'teraslice.name', null);
 }
 
-export function getTerasliceConfig(sysconfig?: Terafoundation.Config): Terafoundation.Config {
+export function getTerasliceConfig(sysconfig?: Partial<Terafoundation.Config>): Terafoundation.Config {
     return Object.assign({
         name: 'teraslice',
         default_config_file: path.join(filePath, 'default-sysconfig.js'),

--- a/packages/teraslice/src/lib/config/index.ts
+++ b/packages/teraslice/src/lib/config/index.ts
@@ -10,7 +10,9 @@ export function clusterName(configFile: TerasliceConfig) {
     return get(configFile, 'teraslice.name', null);
 }
 
-export function getTerasliceConfig(sysconfig?: Partial<Terafoundation.Config>): Terafoundation.Config {
+export function getTerasliceConfig(
+    sysconfig?: Partial<Terafoundation.Config>
+): Terafoundation.Config {
     return Object.assign({
         name: 'teraslice',
         default_config_file: path.join(filePath, 'default-sysconfig.js'),

--- a/packages/teraslice/src/lib/workers/context/terafoundation-context.ts
+++ b/packages/teraslice/src/lib/workers/context/terafoundation-context.ts
@@ -1,8 +1,24 @@
 import { ProcessContext } from 'terafoundation';
 import { getTerasliceConfig } from '../../config/index.js';
+import { safeDecode } from '../../utils/encoding_utils.js';
 
 export async function makeTerafoundationContext({ sysconfig } = {} as any) {
-    return ProcessContext.createContext(getTerasliceConfig(), sysconfig
-        ? { configfile: sysconfig }
-        : undefined);
+    const extraLoggerFields: Record<string, any> = {};
+
+    if (process.env.EX) {
+        try {
+            const ex = safeDecode(process.env.EX);
+            if (ex?.ex_id) extraLoggerFields.ex_id = ex.ex_id;
+            if (ex?.job_id) extraLoggerFields.job_id = ex.job_id;
+        } catch (_err) {
+            // an invalid ex will be caught and thrown
+            // with a proper error message by _getExecutionConfigFromEnv()
+            // after context creation, where a logger is available.
+        }
+    }
+
+    return ProcessContext.createContext(
+        getTerasliceConfig({ extraLoggerFields }),
+        sysconfig ? { configfile: sysconfig } : undefined
+    );
 }

--- a/packages/teraslice/src/lib/workers/context/terafoundation-context.ts
+++ b/packages/teraslice/src/lib/workers/context/terafoundation-context.ts
@@ -3,13 +3,13 @@ import { getTerasliceConfig } from '../../config/index.js';
 import { safeDecode } from '../../utils/encoding_utils.js';
 
 export async function makeTerafoundationContext({ sysconfig } = {} as any) {
-    const extraLoggerFields: Record<string, any> = {};
+    const loggerMetadataFields: Record<string, any> = {};
 
     if (process.env.EX) {
         try {
             const ex = safeDecode(process.env.EX);
-            if (ex?.ex_id) extraLoggerFields.ex_id = ex.ex_id;
-            if (ex?.job_id) extraLoggerFields.job_id = ex.job_id;
+            if (ex?.ex_id) loggerMetadataFields.ex_id = ex.ex_id;
+            if (ex?.job_id) loggerMetadataFields.job_id = ex.job_id;
         } catch (_err) {
             // an invalid ex will be caught and thrown
             // with a proper error message by _getExecutionConfigFromEnv()
@@ -18,7 +18,7 @@ export async function makeTerafoundationContext({ sysconfig } = {} as any) {
     }
 
     return ProcessContext.createContext(
-        getTerasliceConfig({ extraLoggerFields }),
+        getTerasliceConfig({ loggerMetadataFields }),
         sysconfig ? { configfile: sysconfig } : undefined
     );
 }

--- a/packages/teraslice/src/lib/workers/helpers/terafoundation.ts
+++ b/packages/teraslice/src/lib/workers/helpers/terafoundation.ts
@@ -2,8 +2,7 @@ import {
     Logger, get, isFunction,
     isString
 } from '@terascope/core-utils';
-import { makeContextLogger, Context } from '@terascope/job-components';
-import { safeDecode } from '../../utils/encoding_utils.js';
+import { Context } from '@terascope/job-components';
 
 export function generateWorkerId(context: Context) {
     const { hostname } = context.sysconfig.teraslice;
@@ -27,18 +26,5 @@ export function makeLogger(
         return exAPI.makeLogger(moduleName, extra);
     }
 
-    const defaultContext: Record<string, any> = {};
-    if (process.env.EX) {
-        const ex = safeDecode(process.env.EX);
-        const exId = get(ex, 'ex_id');
-        const jobId = get(ex, 'job_id');
-        if (exId) {
-            defaultContext.ex_id = exId;
-        }
-        if (jobId) {
-            defaultContext.job_id = jobId;
-        }
-    }
-
-    return makeContextLogger(context, moduleName, Object.assign(defaultContext, extra));
+    return context.apis.foundation.makeLogger({ module: moduleName, ...extra });
 }

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "2.8.0",
+    "version": "2.9.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/types",
     "displayName": "Types",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "A collection of typescript interfaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/types#readme",
     "bugs": {

--- a/packages/types/src/terafoundation.ts
+++ b/packages/types/src/terafoundation.ts
@@ -88,8 +88,8 @@ export type Config<
     ) => void | Promise<void>;
     start_workers?: boolean;
     shutdownMessaging?: boolean;
-    // Extra fields to include in the root logger at creation time
-    extraLoggerFields?: Record<string, any>;
+    // Metadata fields to include in the root logger at creation time
+    loggerMetadataFields?: Record<string, any>;
 };
 
 export interface ConnectionConfig {

--- a/packages/types/src/terafoundation.ts
+++ b/packages/types/src/terafoundation.ts
@@ -88,6 +88,8 @@ export type Config<
     ) => void | Promise<void>;
     start_workers?: boolean;
     shutdownMessaging?: boolean;
+    // Extra fields to include in the root logger at creation time
+    extraLoggerFields?: Record<string, any>;
 };
 
 export interface ConnectionConfig {

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/valkey",
     "displayName": "Valkey Connector",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "A Terafoundation connector and facade client for Valkey.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/valkey#readme",
     "bugs": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "2.8.0",
+    "version": "2.9.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:

## Terafoundation

- Adds new param `loggerMetadataFields` to context creation
  - This allows terafoundation apps to add logger fields to the root logger on context creation

## Teraslice

- Rework EX string decoder to get information before context creation
  - This fixes an issue where the root logger is missing filterable fields like `ex_id`, `job_id`, and `worker_id` on logs
  - This also fixes an issue where we use have to use helper functions `makeContextLogger` or `makeExContextLogger` to create child loggers because the root logger was missing fields

This relates to  #4429 #4430