### PR TITLE
[scripts] Add auto topic creation configuration to scripts

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.11.1",
+    "version": "2.12.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/config.ts
+++ b/packages/scripts/src/helpers/config.ts
@@ -281,6 +281,11 @@ const configSchema: Terafoundation.Schema<any> = {
         default: undefined,
         format: String,
     },
+    KAFKA_AUTO_CREATE_TOPICS_ENABLE: {
+        default: 'true',
+        format: String,
+        env: 'KAFKA_AUTO_CREATE_TOPICS_ENABLE'
+    },
     KAFKA_BROKER: {
         default: undefined,
         format: String,

--- a/packages/scripts/src/helpers/test-runner/services.ts
+++ b/packages/scripts/src/helpers/test-runner/services.ts
@@ -100,6 +100,7 @@ const services: Readonly<Record<Service, Readonly<DockerRunOptions>>> = {
             KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: `${config.KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}`,
             KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: config.KAFKA_TRANSACTION_STATE_LOG_MIN_ISR,
             KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: config.KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS,
+            KAFKA_AUTO_CREATE_TOPICS_ENABLE: config.KAFKA_AUTO_CREATE_TOPICS_ENABLE,
             // TLS related config
             ...(config.ENCRYPT_KAFKA
                 ? {


### PR DESCRIPTION
This PR makes the following changes:

- Adds new env variable `KAFKA_AUTO_CREATE_TOPICS_ENABLE` to scripts
  - This allows the ability to set `auto.create.topics.enable` on the broker
  - This setting is `true` by default
  - Bumps **@terascope/scripts** from `v2.11.1` to `v2.12.0`