### PR TITLE
[eslint-config] enable import checks

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -66,6 +66,7 @@
         "nanoid": "~5.1.11",
         "semver": "~7.8.0",
         "signale": "~1.4.0",
+        "teraslice": "workspace:~",
         "teraslice-cli": "workspace:~",
         "teraslice-client-js": "workspace:~",
         "ts-jest": "~29.4.9",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -55,7 +55,8 @@
         "@types/lodash-es": "~4.17.12",
         "@types/ms": "~0.7.34",
         "@types/validator": "~13.15.10",
-        "benchmark": "~2.1.4"
+        "benchmark": "~2.1.4",
+        "jest-extended": "~7.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -56,7 +56,8 @@
         "@types/chance": "^1.1.7",
         "@types/jexl": "^2.3.4",
         "@types/valid-url": "~1.0.7",
-        "benchmark": "~2.1.4"
+        "benchmark": "~2.1.4",
+        "jest-extended": "~7.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -28,7 +28,8 @@
     "dependencies": {
         "@terascope/core-utils": "workspace:~",
         "@terascope/types": "workspace:~",
-        "graphql": "~16.12.0"
+        "graphql": "~16.12.0",
+        "jest-extended": "~7.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/docker-compose-js/package.json
+++ b/packages/docker-compose-js/package.json
@@ -37,7 +37,8 @@
     },
     "devDependencies": {
         "@jest/globals": "^30.4.1",
-        "@types/debug": "~4.1.13"
+        "@types/debug": "~4.1.13",
+        "jest-extended": "~7.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -39,6 +39,9 @@
         "uuid": "~14.0.0",
         "xlucene-translator": "workspace:~"
     },
+    "devDependencies": {
+        "jest-extended": "~7.0.0"
+    },
     "engines": {
         "node": ">=22.0.0",
         "pnpm": ">=10.25.0"

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,3 +1,5 @@
+import path from 'node:path';
+import { readdirSync, existsSync } from 'node:fs';
 import { fixupPluginRules } from '@eslint/compat';
 import jest from 'eslint-plugin-jest';
 import jestDOM from 'eslint-plugin-jest-dom';
@@ -8,11 +10,27 @@ import react from 'eslint-plugin-react';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
 import stylistic from '@stylistic/eslint-plugin';
 import tsEslint from 'typescript-eslint';
+import importPlugin from 'eslint-plugin-import';
 import { rules, ignores } from './lib/index.js';
 
-/**
-    TODO: check to see if import plugins works with eslint 9
- */
+function findPackageDirs(dir, depth = 2) {
+    if (depth === 0) return [];
+    const result = [];
+    try {
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+            if (!entry.isDirectory() || entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+            const subdir = path.join(dir, entry.name);
+            if (existsSync(path.join(subdir, 'package.json'))) result.push(subdir);
+            result.push(...findPackageDirs(subdir, depth - 1));
+        }
+    } catch {
+        // skip inaccessible directories
+    }
+    return result;
+}
+
+const rootDir = process.cwd();
+const packageDirs = [rootDir, ...findPackageDirs(rootDir)];
 
 const typescriptLint = tsEslint.config(
     ...tsEslint.configs.recommended,
@@ -40,6 +58,11 @@ const eslintConfig = [
         // In your eslint.config.js file, if an ignores key is used without any other
         // keys in the configuration object, then the patterns act as global ignores.
         ignores
+    },
+    {
+        plugins: {
+            import: importPlugin
+        }
     },
     {
         files: ['**/*.{js,mjs,cjs}'],
@@ -78,6 +101,26 @@ const eslintConfig = [
         },
         rules: {
             ...rules.jest,
+            'import/no-extraneous-dependencies': ['error',
+                {
+                    devDependencies: false,
+                    optionalDependencies: false,
+                    peerDependencies: false,
+                    packageDir: packageDirs
+                }]
+        }
+    },
+    {
+        // overrides for js/ts files in test directories
+        files: ['**/test/**/*.{js,ts,tsx,jsx}'],
+        rules: {
+            'import/no-extraneous-dependencies': ['error',
+                {
+                    devDependencies: true,
+                    optionalDependencies: false,
+                    peerDependencies: false,
+                    packageDir: packageDirs
+                }]
         }
     },
     {

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -79,7 +79,7 @@ const eslintConfig = [
     },
     {
         // import rules for js/ts files in src and test directories
-        files: ['**/*.{js,ts,tsx,jsx}'],
+        files: ['**/{src,test}/*.{js,ts,tsx,jsx}'],
         plugins: {
             import: importPlugin
         },

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,5 +1,3 @@
-import path from 'node:path';
-import { readdirSync, existsSync } from 'node:fs';
 import { fixupPluginRules } from '@eslint/compat';
 import jest from 'eslint-plugin-jest';
 import jestDOM from 'eslint-plugin-jest-dom';
@@ -12,25 +10,6 @@ import stylistic from '@stylistic/eslint-plugin';
 import tsEslint from 'typescript-eslint';
 import importPlugin from 'eslint-plugin-import';
 import { rules, ignores } from './lib/index.js';
-
-function findPackageDirs(dir, depth = 2) {
-    if (depth === 0) return [];
-    const result = [];
-    try {
-        for (const entry of readdirSync(dir, { withFileTypes: true })) {
-            if (!entry.isDirectory() || entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
-            const subdir = path.join(dir, entry.name);
-            if (existsSync(path.join(subdir, 'package.json'))) result.push(subdir);
-            result.push(...findPackageDirs(subdir, depth - 1));
-        }
-    } catch {
-        // skip inaccessible directories
-    }
-    return result;
-}
-
-const rootDir = process.cwd();
-const packageDirs = [rootDir, ...findPackageDirs(rootDir)];
 
 const typescriptLint = tsEslint.config(
     ...tsEslint.configs.recommended,
@@ -58,11 +37,6 @@ const eslintConfig = [
         // In your eslint.config.js file, if an ignores key is used without any other
         // keys in the configuration object, then the patterns act as global ignores.
         ignores
-    },
-    {
-        plugins: {
-            import: importPlugin
-        }
     },
     {
         files: ['**/*.{js,mjs,cjs}'],
@@ -100,27 +74,26 @@ const eslintConfig = [
             'jest-dom': jestDOM
         },
         rules: {
-            ...rules.jest,
-            'import/no-extraneous-dependencies': ['error',
-                {
-                    devDependencies: false,
-                    optionalDependencies: false,
-                    peerDependencies: false,
-                    packageDir: packageDirs
-                }]
+            ...rules.jest
         }
     },
     {
-        // overrides for js/ts files in test directories
-        files: ['**/test/**/*.{js,ts,tsx,jsx}'],
+        // import rules for js/ts files in src and test directories
+        files: ['**/*.{js,ts,tsx,jsx}'],
+        plugins: {
+            import: importPlugin
+        },
+        settings: {
+            ...importPlugin.flatConfigs.typescript.settings
+        },
         rules: {
             'import/no-extraneous-dependencies': ['error',
                 {
                     devDependencies: true,
                     optionalDependencies: false,
                     peerDependencies: false,
-                    packageDir: packageDirs
-                }]
+                }
+            ]
         }
     },
     {

--- a/packages/eslint-config/lib/ignores.js
+++ b/packages/eslint-config/lib/ignores.js
@@ -29,8 +29,6 @@ export default [
     'e2e/dist/',
     'packages/**/dist',
     'packages/**/build',
-    'packages/teraslice-cli/generator-templates/**',
-    'packages/generator-teraslice/generators/*/templates/**/*.ts',
     'packages/xlucene-parser/src/peg-engine.ts',
     'packages/job-components/examples/**',
     'website/',

--- a/packages/eslint-config/lib/ignores.js
+++ b/packages/eslint-config/lib/ignores.js
@@ -21,7 +21,7 @@ export default [
     '.vscode/',
     'assets/**',
     'e2e/assets/**',
-    'examples/assets/**',
+    'examples/**',
     'packages/teraslice/assets/**',
     'autoload',
     'e2e/.config/',
@@ -37,6 +37,8 @@ export default [
     'dist/',
     '**/dist/**',
     '**/build/**',
+    '**/bench/**',
+    '**/scripts/**',
     '.pnp.**',
     '*.min.js',
     '*.min.css'

--- a/packages/eslint-config/lib/ignores.js
+++ b/packages/eslint-config/lib/ignores.js
@@ -37,8 +37,6 @@ export default [
     'dist/',
     '**/dist/**',
     '**/build/**',
-    '**/bench/**',
-    '**/scripts/**',
     '.pnp.**',
     '*.min.js',
     '*.min.css'

--- a/packages/eslint-config/lib/rules/javascript.js
+++ b/packages/eslint-config/lib/rules/javascript.js
@@ -23,7 +23,12 @@ export default {
             ignoreDestructuring: true,
         }],
     'handle-callback-err': ['error', 'error'],
-    'import/no-extraneous-dependencies': 'off',
+    'import/no-extraneous-dependencies': ['error',
+        {
+            devDependencies: true,
+            optionalDependencies: false,
+            peerDependencies: false,
+        }],
     'class-methods-use-this': 'off',
     'no-restricted-syntax': 'off',
     'no-await-in-loop': 'off',

--- a/packages/eslint-config/lib/rules/javascript.js
+++ b/packages/eslint-config/lib/rules/javascript.js
@@ -23,12 +23,6 @@ export default {
             ignoreDestructuring: true,
         }],
     'handle-callback-err': ['error', 'error'],
-    'import/no-extraneous-dependencies': ['error',
-        {
-            devDependencies: true,
-            optionalDependencies: false,
-            peerDependencies: false,
-        }],
     'class-methods-use-this': 'off',
     'no-restricted-syntax': 'off',
     'no-await-in-loop': 'off',

--- a/packages/eslint-config/lib/rules/typescript.js
+++ b/packages/eslint-config/lib/rules/typescript.js
@@ -75,12 +75,6 @@ export default Object.assign({}, jsRules, {
             classes: false,
             typedefs: false
         }],
-    'import/no-extraneous-dependencies': ['error',
-        {
-            devDependencies: true,
-            optionalDependencies: false,
-            peerDependencies: false,
-        }],
     'import/no-unresolved': 'off',
     'import/extensions': 'off',
     'no-unused-vars': 'off',

--- a/packages/eslint-config/lib/rules/typescript.js
+++ b/packages/eslint-config/lib/rules/typescript.js
@@ -75,6 +75,12 @@ export default Object.assign({}, jsRules, {
             classes: false,
             typedefs: false
         }],
+    'import/no-extraneous-dependencies': ['error',
+        {
+            devDependencies: true,
+            optionalDependencies: false,
+            peerDependencies: false,
+        }],
     'import/no-unresolved': 'off',
     'import/extensions': 'off',
     'no-unused-vars': 'off',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -35,6 +35,9 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "~8.54.0"
     },
+    "devDependencies": {
+        "jest-extended": "~7.0.0"
+    },
     "engines": {
         "node": ">=22.0.0",
         "pnpm": ">=10.25.0"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/eslint-config",
     "displayName": "Terascope ESLint Config",
-    "version": "1.1.32",
+    "version": "1.2.0",
     "description": "A shared eslint config based on eslint-config-airbnb",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/eslint-config#readme",
     "bugs": {

--- a/packages/geo-utils/package.json
+++ b/packages/geo-utils/package.json
@@ -43,7 +43,8 @@
         "latlon-geohash": "~2.0.0"
     },
     "devDependencies": {
-        "@types/geojson": "~7946.0.16"
+        "@types/geojson": "~7946.0.16",
+        "jest-extended": "~7.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/ip-utils/package.json
+++ b/packages/ip-utils/package.json
@@ -27,7 +27,9 @@
     },
     "dependencies": {
         "@terascope/core-utils": "workspace:~",
-        "@terascope/types": "workspace:~",
+        "@terascope/types": "workspace:~"
+    },
+    "devDependencies": {
         "jest-extended": "~7.0.0"
     },
     "engines": {

--- a/packages/ip-utils/package.json
+++ b/packages/ip-utils/package.json
@@ -27,7 +27,8 @@
     },
     "dependencies": {
         "@terascope/core-utils": "workspace:~",
-        "@terascope/types": "workspace:~"
+        "@terascope/types": "workspace:~",
+        "jest-extended": "~7.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -44,6 +44,7 @@
         "@types/semver": "~7.7.1",
         "benchmark": "~2.1.4",
         "fs-extra": "~11.3.5",
+        "jest-extended": "~7.0.0",
         "jest-fixtures": "~0.6.0"
     },
     "engines": {

--- a/packages/opensearch-client/package.json
+++ b/packages/opensearch-client/package.json
@@ -37,7 +37,8 @@
         "setimmediate": "~1.0.5"
     },
     "devDependencies": {
-        "@jest/globals": "^30.4.1"
+        "@jest/globals": "^30.4.1",
+        "jest-extended": "~7.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -63,6 +63,7 @@
         "@types/signale": "~1.4.7",
         "@types/toposort": "~2.0.7",
         "@types/yargs": "~17.0.35",
+        "jest-extended": "~7.0.0",
         "typescript": "~5.9.3"
     },
     "peerDependencies": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -45,6 +45,7 @@
         "@types/express": "~5.0.6",
         "@types/js-yaml": "~4.0.9",
         "@types/yargs": "~17.0.35",
+        "jest-extended": "~7.0.0",
         "got": "~15.0.5"
     },
     "peerDependencies": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -45,8 +45,8 @@
         "@types/express": "~5.0.6",
         "@types/js-yaml": "~4.0.9",
         "@types/yargs": "~17.0.35",
-        "jest-extended": "~7.0.0",
-        "got": "~15.0.5"
+        "got": "~15.0.5",
+        "jest-extended": "~7.0.0"
     },
     "peerDependencies": {
         "@terascope/valkey": "workspace:~",

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -62,6 +62,7 @@
         "execa": "~9.6.1",
         "fs-extra": "~11.3.5",
         "globby": "~16.2.0",
+        "jest-extended": "~7.0.0",
         "jest-fixtures": "~0.6.0",
         "js-yaml": "~4.1.1",
         "nock": "~14.0.15",

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -35,10 +35,10 @@
         "@terascope/core-utils": "workspace:~",
         "@terascope/types": "workspace:~",
         "auto-bind": "~5.0.1",
-        "got": "~15.0.5",
-        "jest-extended": "~7.0.0"
+        "got": "~15.0.5"
     },
     "devDependencies": {
+        "jest-extended": "~7.0.0",
         "nock": "~14.0.15"
     },
     "engines": {

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -35,7 +35,8 @@
         "@terascope/core-utils": "workspace:~",
         "@terascope/types": "workspace:~",
         "auto-bind": "~5.0.1",
-        "got": "~15.0.5"
+        "got": "~15.0.5",
+        "jest-extended": "~7.0.0"
     },
     "devDependencies": {
         "nock": "~14.0.15"

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -34,6 +34,7 @@
         "@terascope/core-utils": "workspace:~",
         "@terascope/types": "workspace:~",
         "get-port": "~7.2.0",
+        "jest-extended": "~7.0.0",
         "ms": "~2.1.3",
         "nanoid": "~5.1.11",
         "p-event": "~7.1.0",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -34,7 +34,6 @@
         "@terascope/core-utils": "workspace:~",
         "@terascope/types": "workspace:~",
         "get-port": "~7.2.0",
-        "jest-extended": "~7.0.0",
         "ms": "~2.1.3",
         "nanoid": "~5.1.11",
         "p-event": "~7.1.0",
@@ -43,7 +42,8 @@
     },
     "devDependencies": {
         "@jest/globals": "^30.4.1",
-        "@types/ms": "~0.7.34"
+        "@types/ms": "~0.7.34",
+        "jest-extended": "~7.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -29,7 +29,8 @@
         "@terascope/types": "workspace:~"
     },
     "devDependencies": {
-        "@terascope/opensearch-client": "workspace:~"
+        "@terascope/opensearch-client": "workspace:~",
+        "jest-extended": "~7.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -40,6 +40,7 @@
         "@jest/globals": "^30.4.1",
         "@terascope/core-utils": "workspace:~",
         "@types/decompress": "~4.2.7",
+        "jest-extended": "~7.0.0",
         "nock": "~14.0.15"
     },
     "engines": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -64,6 +64,7 @@
     "devDependencies": {
         "@jest/globals": "^30.4.1",
         "@terascope/opensearch-client": "workspace:~",
+        "@terascope/scripts": "workspace:~",
         "@types/archiver": "~7.0.0",
         "@types/body-parser": "~1.19.6",
         "@types/decompress": "~4.2.7",
@@ -75,6 +76,7 @@
         "archiver": "~7.0.1",
         "bufferstreams": "~6.0.1",
         "chance": "~1.1.13",
+        "jest-extended": "~7.0.0",
         "jest-fixtures": "~0.6.0",
         "js-yaml": "~4.1.1",
         "nock": "~14.0.15"

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -55,7 +55,8 @@
         "@types/valid-url": "~1.0.7",
         "@types/validator": "~13.15.10",
         "@types/yargs": "~17.0.35",
-        "execa": "~9.6.1"
+        "execa": "~9.6.1",
+        "jest-extended": "~7.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -27,6 +27,9 @@
     "dependencies": {
         "prom-client": "~15.1.3"
     },
+    "devDependencies": {
+        "jest-extended": "~7.0.0"
+    },
     "engines": {
         "node": ">=22.0.0",
         "pnpm": ">=10.25.0"

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -40,7 +40,8 @@
     "devDependencies": {
         "@turf/invariant": "~7.3.5",
         "@turf/random": "~7.3.5",
-        "date-fns": "~4.2.1"
+        "date-fns": "~4.2.1",
+        "jest-extended": "~7.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -39,7 +39,8 @@
     },
     "devDependencies": {
         "@terascope/data-types": "workspace:~",
-        "@terascope/opensearch-client": "workspace:~"
+        "@terascope/opensearch-client": "workspace:~",
+        "jest-extended": "~7.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -27,7 +27,8 @@
         "@terascope/core-utils": "workspace:~"
     },
     "devDependencies": {
-        "@terascope/types": "workspace:~"
+        "@terascope/types": "workspace:~",
+        "jest-extended": "~7.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,6 +552,7 @@ importers:
       '@terascope/types':
         specifier: workspace:~
         version: link:../types
+    devDependencies:
       jest-extended:
         specifier: ~7.0.0
         version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
@@ -887,9 +888,6 @@ importers:
       '@terascope/opensearch-client':
         specifier: workspace:~
         version: link:../opensearch-client
-      '@terascope/scripts':
-        specifier: workspace:~
-        version: link:../scripts
       '@types/archiver':
         specifier: ~7.0.0
         version: 7.0.0
@@ -1053,10 +1051,10 @@ importers:
       got:
         specifier: ~15.0.5
         version: 15.0.5
+    devDependencies:
       jest-extended:
         specifier: ~7.0.0
         version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
-    devDependencies:
       nock:
         specifier: ~14.0.15
         version: 14.0.15
@@ -1072,9 +1070,6 @@ importers:
       get-port:
         specifier: ~7.2.0
         version: 7.2.0
-      jest-extended:
-        specifier: ~7.0.0
-        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
       ms:
         specifier: ~2.1.3
         version: 2.1.3
@@ -1097,6 +1092,9 @@ importers:
       '@types/ms':
         specifier: ~0.7.34
         version: 0.7.34
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/teraslice-state-storage:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       signale:
         specifier: ~1.4.0
         version: 1.4.0
+      teraslice:
+        specifier: workspace:~
+        version: link:../packages/teraslice
       teraslice-cli:
         specifier: workspace:~
         version: link:../packages/teraslice-cli
@@ -252,6 +255,9 @@ importers:
       benchmark:
         specifier: ~2.1.4
         version: 2.1.4
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/data-mate:
     dependencies:
@@ -331,6 +337,9 @@ importers:
       benchmark:
         specifier: ~2.1.4
         version: 2.1.4
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/data-types:
     dependencies:
@@ -343,6 +352,9 @@ importers:
       graphql:
         specifier: ~16.12.0
         version: 16.12.0
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/docker-compose-js:
     dependencies:
@@ -356,6 +368,9 @@ importers:
       '@types/debug':
         specifier: ~4.1.13
         version: 4.1.13
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/elasticsearch-api:
     dependencies:
@@ -411,6 +426,10 @@ importers:
       xlucene-translator:
         specifier: workspace:~
         version: link:../xlucene-translator
+    devDependencies:
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/eslint-config:
     dependencies:
@@ -462,6 +481,10 @@ importers:
       typescript-eslint:
         specifier: ~8.54.0
         version: 8.54.0(eslint@9.39.3)(typescript@5.9.3)
+    devDependencies:
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/geo-utils:
     dependencies:
@@ -517,6 +540,9 @@ importers:
       '@types/geojson':
         specifier: ~7946.0.16
         version: 7946.0.16
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/ip-utils:
     dependencies:
@@ -526,6 +552,9 @@ importers:
       '@terascope/types':
         specifier: workspace:~
         version: link:../types
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/job-components:
     dependencies:
@@ -560,6 +589,9 @@ importers:
       fs-extra:
         specifier: ~11.3.5
         version: 11.3.5
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
       jest-fixtures:
         specifier: ~0.6.0
         version: 0.6.0
@@ -591,6 +623,9 @@ importers:
       '@jest/globals':
         specifier: ^30.4.1
         version: 30.4.1
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/scripts:
     dependencies:
@@ -694,6 +729,9 @@ importers:
       '@types/yargs':
         specifier: ~17.0.35
         version: 17.0.35
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -755,6 +793,9 @@ importers:
       got:
         specifier: ~15.0.5
         version: 15.0.5
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/teraslice:
     dependencies:
@@ -846,6 +887,9 @@ importers:
       '@terascope/opensearch-client':
         specifier: workspace:~
         version: link:../opensearch-client
+      '@terascope/scripts':
+        specifier: workspace:~
+        version: link:../scripts
       '@types/archiver':
         specifier: ~7.0.0
         version: 7.0.0
@@ -879,6 +923,9 @@ importers:
       chance:
         specifier: ~1.1.13
         version: 1.1.13
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
       jest-fixtures:
         specifier: ~0.6.0
         version: 0.6.0
@@ -955,6 +1002,9 @@ importers:
       globby:
         specifier: ~16.2.0
         version: 16.2.0
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
       jest-fixtures:
         specifier: ~0.6.0
         version: 0.6.0
@@ -1003,6 +1053,9 @@ importers:
       got:
         specifier: ~15.0.5
         version: 15.0.5
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
     devDependencies:
       nock:
         specifier: ~14.0.15
@@ -1019,6 +1072,9 @@ importers:
       get-port:
         specifier: ~7.2.0
         version: 7.2.0
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
       ms:
         specifier: ~2.1.3
         version: 2.1.3
@@ -1057,6 +1113,9 @@ importers:
       '@terascope/opensearch-client':
         specifier: workspace:~
         version: link:../opensearch-client
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/teraslice-test-harness:
     dependencies:
@@ -1082,6 +1141,9 @@ importers:
       '@types/decompress':
         specifier: ~4.2.7
         version: 4.2.7
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
       nock:
         specifier: ~14.0.15
         version: 14.0.15
@@ -1143,12 +1205,19 @@ importers:
       execa:
         specifier: ~9.6.1
         version: 9.6.1
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/types:
     dependencies:
       prom-client:
         specifier: ~15.1.3
         version: 15.1.3
+    devDependencies:
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/valkey:
     dependencies:
@@ -1193,6 +1262,9 @@ importers:
       date-fns:
         specifier: ~4.2.1
         version: 4.2.1
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/xlucene-translator:
     dependencies:
@@ -1215,6 +1287,9 @@ importers:
       '@terascope/opensearch-client':
         specifier: workspace:~
         version: link:../opensearch-client
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
   packages/xpressions:
     dependencies:
@@ -1225,6 +1300,9 @@ importers:
       '@terascope/types':
         specifier: workspace:~
         version: link:../types
+      jest-extended:
+        specifier: ~7.0.0
+        version: 7.0.0(jest@30.4.2(@types/node@25.9.0)(node-notifier@10.0.1))(typescript@5.9.3)
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -888,6 +888,9 @@ importers:
       '@terascope/opensearch-client':
         specifier: workspace:~
         version: link:../opensearch-client
+      '@terascope/scripts':
+        specifier: workspace:~
+        version: link:../scripts
       '@types/archiver':
         specifier: ~7.0.0
         version: 7.0.0


### PR DESCRIPTION
This PR makes the following changes:
- Installs `eslint-plugin-import` in the `eslint-config` package
- Set the `import/no-extraneous-dependencies` rule to error for .ts and .js files within src and test directories. We exclude devDependencies because it would require moving any typescript types imports from `devDependencies` to `dependencies`.


Ref: #4441