### PR TITLE
[core-utils] fix schema validator logger

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/core-utils",
     "displayName": "Core Utils",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "A collection of Teraslice Core Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/core-utils#readme",
     "bugs": {

--- a/packages/core-utils/src/schemas.ts
+++ b/packages/core-utils/src/schemas.ts
@@ -10,7 +10,6 @@ import { isFunction } from './functions.js';
 import { isInteger, toInteger, toNumber } from './numbers.js';
 import { isSimpleObject } from './objects.js';
 import { isString, startsWith } from './strings.js';
-import { Context } from 'packages/types/dist/src/terafoundation.js';
 
 const convictCompatibleBooleanFn = (value: unknown) => {
     if (value === 'true' || value === '1' || value === 1) return true;
@@ -245,7 +244,7 @@ export class SchemaValidator<T = AnyObject> {
         name: string,
         extraFormats: TF.Format[] = [],
         checkUndeclaredKeys: CheckUndeclaredKeys = 'warn',
-        context?: Context
+        context?: TF.Context
     ) {
         extraFormats.forEach((newFormat) => {
             let unique = true;

--- a/packages/core-utils/src/schemas.ts
+++ b/packages/core-utils/src/schemas.ts
@@ -3,13 +3,14 @@ import bunyan from 'bunyan';
 import dateMath from 'datemath-parser';
 import moment from 'moment';
 import { z, type ZodType, type RefinementCtx } from 'zod';
-import { AnyObject, Terafoundation as TF } from '@terascope/types';
+import { AnyObject, Logger, Terafoundation as TF } from '@terascope/types';
 import { isBoolean, toBoolean } from './booleans.js';
 import { isValidDate, makeISODate } from './dates.js';
 import { isFunction } from './functions.js';
 import { isInteger, toInteger, toNumber } from './numbers.js';
 import { isSimpleObject } from './objects.js';
 import { isString, startsWith } from './strings.js';
+import { Context } from 'packages/types/dist/src/terafoundation.js';
 
 const convictCompatibleBooleanFn = (value: unknown) => {
     if (value === 'true' || value === '1' || value === 1) return true;
@@ -237,13 +238,14 @@ export class SchemaValidator<T = AnyObject> {
     checkUndeclaredKeys: CheckUndeclaredKeys;
     envMap: Record<string, { envName: string; format: TF.ConvictFormat }> = {};
     argsMap: Record<string, { argName: string; format: TF.ConvictFormat }> = {};
-    logger: bunyan;
+    logger: Logger;
 
     constructor(
         schema: TF.Schema<T>,
         name: string,
         extraFormats: TF.Format[] = [],
-        checkUndeclaredKeys: CheckUndeclaredKeys = 'warn'
+        checkUndeclaredKeys: CheckUndeclaredKeys = 'warn',
+        context?: Context
     ) {
         extraFormats.forEach((newFormat) => {
             let unique = true;
@@ -264,7 +266,9 @@ export class SchemaValidator<T = AnyObject> {
         });
 
         this.name = name;
-        this.logger = bunyan.createLogger({ name: 'SchemaValidator' });
+        this.logger = context
+            ? context.apis.foundation.makeLogger({ module: 'schema_validator', schema: this.name })
+            : bunyan.createLogger({ name: 'schema_validator', module: 'schema_validator', schema: this.name }) as unknown as Logger;
         this.inputSchema = schema;
         this.zodSchema = this._convictStyleSchemaToZod(schema, name);
         this.checkUndeclaredKeys = checkUndeclaredKeys;

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "5.10.0",
+    "version": "5.10.1",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/geo-utils/package.json
+++ b/packages/geo-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/geo-utils",
     "displayName": "Geo Utils",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "A collection of Teraslice Geo Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/geo-utils#readme",
     "bugs": {

--- a/packages/ip-utils/package.json
+++ b/packages/ip-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/ip-utils",
     "displayName": "IP Utils",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "A collection of Teraslice IP Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ip-utils#readme",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/job-components/src/config-validators.ts
+++ b/packages/job-components/src/config-validators.ts
@@ -8,10 +8,15 @@ import { opSchema, apiSchema } from './job-schemas.js';
  * provided opConfig against the resulting schema.
  */
 export function validateOpConfig<T>(
-    inputSchema: TF.Schema<any>, inputConfig: Record<string, any>
+    inputSchema: TF.Schema<any>, inputConfig: Record<string, any>, context: TF.Context
 ): OpConfig & T {
     const schema = Object.assign({}, opSchema, inputSchema) as TF.Schema<OpConfig & T>;
-    const validator = new SchemaValidator<OpConfig & T>(schema, inputConfig._op);
+    const validator = new SchemaValidator<OpConfig & T>(
+        schema,
+        inputConfig._op,
+        undefined,
+        undefined,
+        context);
     try {
         return validator.validate(inputConfig);
     } catch (err) {
@@ -24,10 +29,16 @@ export function validateOpConfig<T>(
  * provided apiConfig against the resulting schema.
  */
 export function validateAPIConfig<T>(
-    inputSchema: TF.Schema<any>, inputConfig: Record<string, any>
+    inputSchema: TF.Schema<any>, inputConfig: Record<string, any>, context: TF.Context
 ): APIConfig & T {
     const schema = Object.assign({}, apiSchema, inputSchema) as TF.Schema<APIConfig & T>;
-    const validator = new SchemaValidator<APIConfig & T>(schema, inputConfig._name);
+    const validator = new SchemaValidator<APIConfig & T>(
+        schema,
+        inputConfig._name,
+        undefined,
+        undefined,
+        context
+    );
 
     try {
         return validator.validate(inputConfig);
@@ -41,11 +52,14 @@ export function validateAPIConfig<T>(
  * provided jobConfig against the resulting schema.
  */
 export function validateJobConfig<T>(
-    inputSchema: TF.Schema<any>, inputConfig: Record<string, any>
+    inputSchema: TF.Schema<any>, inputConfig: Record<string, any>, context: TF.Context
 ): ValidatedJobConfig & T {
     const validator = new SchemaValidator<ValidatedJobConfig & T>(
         inputSchema as TF.Schema<ValidatedJobConfig & T>,
-        inputConfig.name
+        inputConfig.name,
+        undefined,
+        undefined,
+        context
     );
 
     try {

--- a/packages/job-components/src/job-validator.ts
+++ b/packages/job-components/src/job-validator.ts
@@ -32,7 +32,7 @@ export class JobValidator {
         jobSpec: Partial<Teraslice.JobConfig | Teraslice.JobConfigParams>,
     ): Promise<ValidatedJobConfig> {
         // top level job validation occurs, but not operations
-        const jobConfig = validateJobConfig(this.schema, cloneDeep(jobSpec));
+        const jobConfig = validateJobConfig(this.schema, cloneDeep(jobSpec), this.context);
         const assetIds = jobConfig.assets || [];
         const apis: Record<string, OperationAPIConstructor> = {};
 

--- a/packages/job-components/src/operations/base-schema.ts
+++ b/packages/job-components/src/operations/base-schema.ts
@@ -23,9 +23,9 @@ export default abstract class BaseSchema<T extends Record<string, any>, S = any>
     validate(inputConfig: Record<string, any>): OpConfig & T;
     validate(inputConfig: Record<string, any>): OpConfig | APIConfig & T {
         if (this.opType === 'api') {
-            return validateAPIConfig<T>(this.schema, inputConfig);
+            return validateAPIConfig<T>(this.schema, inputConfig, this.context);
         }
-        return validateOpConfig<T>(this.schema, inputConfig);
+        return validateOpConfig<T>(this.schema, inputConfig, this.context);
     }
 
     validateJob(_job: ValidatedJobConfig): void {

--- a/packages/job-components/test/config-validators-spec.ts
+++ b/packages/job-components/test/config-validators-spec.ts
@@ -37,7 +37,7 @@ describe('when using native clustering', () => {
                 slicers: 1,
             };
 
-            const jobConfig = validateJobConfig(schema, job);
+            const jobConfig = validateJobConfig(schema, job, context);
             delete (jobConfig as any).workers;
             expect(jobConfig).toMatchObject(validJob);
         });
@@ -72,7 +72,7 @@ describe('when using native clustering', () => {
             };
 
             expect(() => {
-                validateJobConfig(schema, job);
+                validateJobConfig(schema, job, context);
             }).toThrow(/Invalid Operation config in operations, got Number/);
         });
     });
@@ -100,7 +100,7 @@ describe('when using native clustering', () => {
             };
 
             expect(() => {
-                validateJobConfig(schema, job);
+                validateJobConfig(schema, job, context);
             }).toThrow(/Operations need to be of type array with at least two operations in it/);
         });
     });
@@ -139,7 +139,7 @@ describe('when using native clustering', () => {
             };
 
             expect(() => {
-                validateJobConfig(schema, job);
+                validateJobConfig(schema, job, context);
             }).toThrow(/Operation example-reader refers to connection \\"unknown\\" which is unavailable/);
         });
     });
@@ -176,7 +176,7 @@ describe('when using native clustering', () => {
             };
 
             expect(() => {
-                validateJobConfig(schema, job);
+                validateJobConfig(schema, job, context);
             }).toThrow(/Invalid API config in apis, got Number/);
         });
     });
@@ -212,7 +212,7 @@ describe('when using native clustering', () => {
                 ],
             };
             expect(() => {
-                validateJobConfig(schema, job);
+                validateJobConfig(schema, job, context);
             }).toThrow(/API requires an _name/);
         });
     });
@@ -255,7 +255,7 @@ describe('when using native clustering', () => {
                 ],
             };
             expect(() => {
-                validateJobConfig(schema, job);
+                validateJobConfig(schema, job, context);
             }).toThrow(/Duplicate API configurations for/);
         });
     });
@@ -297,7 +297,7 @@ describe('when using native clustering', () => {
             };
 
             try {
-                validateJobConfig(schema, job);
+                validateJobConfig(schema, job, context);
                 throw new Error('expected validateJobConfig to throw');
             } catch (err) {
                 const correctMessage = err.message.includes('API test-api refers to connection');
@@ -307,6 +307,7 @@ describe('when using native clustering', () => {
     });
 
     describe('when validating opConfig', () => {
+        const context = new TestContext('teraslice-operations');
         const schema: Terafoundation.Schema<any> = {
             example: {
                 default: undefined,
@@ -341,7 +342,7 @@ describe('when using native clustering', () => {
                 formatted_value: 'hi',
             };
 
-            const config = validateOpConfig(schema, op);
+            const config = validateOpConfig(schema, op, context);
             expect(config).toEqual({
                 _op: 'some-op',
                 _encoding: 'json',
@@ -360,7 +361,7 @@ describe('when using native clustering', () => {
                 formatted_value: 'hi',
             };
 
-            const config = validateOpConfig(schema, op);
+            const config = validateOpConfig(schema, op, context);
             expect(config).toEqual({
                 _op: 'some-op',
                 _encoding: 'json',
@@ -380,7 +381,7 @@ describe('when using native clustering', () => {
             };
 
             expect(() => {
-                validateOpConfig(schema, op);
+                validateOpConfig(schema, op, context);
             }).toThrow();
         });
 
@@ -393,7 +394,7 @@ describe('when using native clustering', () => {
             };
 
             expect(() => {
-                validateOpConfig(schema, op);
+                validateOpConfig(schema, op, context);
             }).toThrow();
         });
 
@@ -406,7 +407,7 @@ describe('when using native clustering', () => {
                 formatted_value: 'hi',
             };
 
-            const config = validateOpConfig(schema, op);
+            const config = validateOpConfig(schema, op, context);
             expect(config).toEqual({
                 _op: 'some-op',
                 _encoding: 'json',
@@ -426,7 +427,7 @@ describe('when using native clustering', () => {
             };
 
             expect(() => {
-                validateOpConfig(schema, op);
+                validateOpConfig(schema, op, context);
             }).toThrow();
         });
 
@@ -438,12 +439,13 @@ describe('when using native clustering', () => {
             };
 
             expect(() => {
-                validateOpConfig(schema, op);
+                validateOpConfig(schema, op, context);
             }).toThrow(/Invalid schema for formatted value/);
         });
     });
 
     describe('when validating apiConfig', () => {
+        const context = new TestContext('teraslice-operations');
         const schema: Terafoundation.Schema<any> = {
             example: {
                 default: undefined,
@@ -478,7 +480,7 @@ describe('when using native clustering', () => {
                 formatted_value: 'hi'
             };
 
-            const config = validateAPIConfig(schema, api);
+            const config = validateAPIConfig(schema, api, context);
             expect(config).toEqual({
                 _name: 'some-api',
                 example: 'example',
@@ -497,7 +499,7 @@ describe('when using native clustering', () => {
             };
 
             expect(() => {
-                validateAPIConfig(schema, api);
+                validateAPIConfig(schema, api, context);
             }).toThrow(/Invalid schema for formatted value/);
         });
     });
@@ -534,7 +536,7 @@ describe('when using native clustering', () => {
                     slicers: 1,
                 };
 
-                const jobConfig = validateJobConfig(schema, job);
+                const jobConfig = validateJobConfig(schema, job, context);
                 delete (jobConfig as any).workers;
                 expect(jobConfig).toMatchObject(validJob);
             });
@@ -554,7 +556,7 @@ describe('when using native clustering', () => {
                         },
                     ],
                 };
-                expect(() => validateJobConfig(schema, job)).toThrow('must be object');
+                expect(() => validateJobConfig(schema, job, context)).toThrow('must be object');
             });
 
             it('should throw an error when given an empty key', () => {
@@ -572,7 +574,7 @@ describe('when using native clustering', () => {
                         },
                     ],
                 };
-                expect(() => validateJobConfig(schema, job)).toThrow('key must be not empty');
+                expect(() => validateJobConfig(schema, job, context)).toThrow('key must be not empty');
             });
 
             it('should throw an error when given an empty value', () => {
@@ -590,7 +592,7 @@ describe('when using native clustering', () => {
                         },
                     ],
                 };
-                expect(() => validateJobConfig(schema, job)).toThrow(
+                expect(() => validateJobConfig(schema, job, context)).toThrow(
                     'value for key \\"foo\\" must be not empty'
                 );
             });
@@ -621,7 +623,7 @@ describe('when using native clustering', () => {
                     slicers: 1,
                 };
 
-                const jobConfig = validateJobConfig(schema, job);
+                const jobConfig = validateJobConfig(schema, job, context);
                 delete (jobConfig as any).workers;
                 expect(jobConfig).toMatchObject(validJob);
             });
@@ -643,7 +645,7 @@ describe('when using native clustering', () => {
                         },
                     ],
                 };
-                expect(() => validateJobConfig(schema, job)).toThrow(`must be one of the following: ${logLevelStrings}`);
+                expect(() => validateJobConfig(schema, job, context)).toThrow(`must be one of the following: ${logLevelStrings}`);
             });
 
             it('should throw an error when given a string that isn\'t a log level', () => {
@@ -659,7 +661,7 @@ describe('when using native clustering', () => {
                         },
                     ],
                 };
-                expect(() => validateJobConfig(schema, job)).toThrow(`must be one of the following: ${logLevelStrings}`);
+                expect(() => validateJobConfig(schema, job, context)).toThrow(`must be one of the following: ${logLevelStrings}`);
             });
         });
 
@@ -677,7 +679,7 @@ describe('when using native clustering', () => {
                         },
                     ],
                 };
-                expect(() => validateJobConfig(schema, job)).toThrow('must be valid integer greater than zero');
+                expect(() => validateJobConfig(schema, job, context)).toThrow('must be valid integer greater than zero');
             });
         });
 
@@ -695,7 +697,7 @@ describe('when using native clustering', () => {
                         },
                     ],
                 };
-                expect(() => validateJobConfig(schema, job)).toThrow('must be valid integer greater than zero');
+                expect(() => validateJobConfig(schema, job, context)).toThrow('must be valid integer greater than zero');
             });
         });
     });
@@ -721,7 +723,7 @@ describe('when validating k8s v2 clustering', () => {
                 ],
             };
 
-            const jobConfig = validateJobConfig(schema, job);
+            const jobConfig = validateJobConfig(schema, job, context);
             expect(jobConfig.cpu).toEqual(job.cpu);
             expect(jobConfig.memory).toEqual(job.memory);
         });
@@ -745,7 +747,7 @@ describe('when validating k8s v2 clustering', () => {
                 ],
             };
 
-            const jobConfig = validateJobConfig(schema, job);
+            const jobConfig = validateJobConfig(schema, job, context);
             expect(jobConfig.resources_requests_cpu).toEqual(job.resources_requests_cpu);
             expect(jobConfig.resources_requests_memory).toEqual(job.resources_requests_memory);
             expect(jobConfig.resources_limits_cpu).toEqual(job.resources_limits_cpu);
@@ -774,7 +776,7 @@ describe('when validating k8s v2 clustering', () => {
             };
 
             expect(() => {
-                validateJobConfig(schema, job);
+                validateJobConfig(schema, job, context);
             }).toThrow('Validation failed for job config: undefined - cpu/memory can\'t be mixed with resource settings of the same type.');
         });
     });
@@ -818,7 +820,7 @@ describe('when validating k8s v2 clustering', () => {
                 volumes: [],
             };
 
-            const jobConfig = validateJobConfig(schema, job);
+            const jobConfig = validateJobConfig(schema, job, context);
             delete (jobConfig as any).workers;
             expect(jobConfig).toMatchObject(validJob);
         });
@@ -863,7 +865,7 @@ describe('when validating k8s v2 clustering', () => {
                 slicers: 1,
             };
 
-            const jobConfig = validateJobConfig(schema, job);
+            const jobConfig = validateJobConfig(schema, job, context);
             delete (jobConfig as any).workers;
             expect(jobConfig).toMatchObject(validJob);
         });

--- a/packages/opensearch-client/package.json
+++ b/packages/opensearch-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/opensearch-client",
     "displayName": "Opensearch Client",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "A Node.js facade client for opensearch & elasticsearch.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/opensearch-client#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.14.0",
+    "version": "2.14.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "2.13.0",
+    "version": "2.13.1",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/valkey",
     "displayName": "Valkey Connector",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "A Terafoundation connector and facade client for Valkey.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/valkey#readme",
     "bugs": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:
- Update the SchemaValidator constructor to accept a context. If provided we use it to create a logger, otherwise we make a new bunyan logger.

ref: #4449