### PR TITLE
[eslint-config] Add ignores rule for test/.cache

### DIFF
--- a/packages/eslint-config/lib/ignores.js
+++ b/packages/eslint-config/lib/ignores.js
@@ -14,6 +14,7 @@ export default [
     'build/**',
     'builds/**',
     '.cache/',
+    '**/test/.cache',
     '.eslintcache/',
     '.yarn-cache/',
     '.yarn/**',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/eslint-config",
     "displayName": "Terascope ESLint Config",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "A shared eslint config based on eslint-config-airbnb",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/eslint-config#readme",
     "bugs": {


### PR DESCRIPTION
This adds a new eslint config ignore. `**/test/.cache` will ignore test caches. These often contain built assets that should not follow our lint rules.