### PR TITLE
[teraslice] Add relocatable label to ex pods

### DIFF
--- a/docs/configuration/clustering-k8s.md
+++ b/docs/configuration/clustering-k8s.md
@@ -508,7 +508,7 @@ For resources related to specific jobs they will be labeled with the following:
 
 The following labels are applied only to execution controller resources:
 
-* `job-property.teraslice.terascope.io/relocatable` - `true` if the execution controller can be safely drained/deleted, `false` otherwise. This is determined by calling `isRelocatable()` on the job's slicer at execution start.
+* `job.teraslice.terascope.io/relocatable` - `true` if the execution controller can be safely drained/deleted, `false` otherwise. This is determined by calling `isRelocatable()` on the job's slicer at execution start.
 
 Note that the Teraslice job name is used in creating and labelling some of the
 Kubernetes resources.  Rather than enforce kubernetes strict DNS naming

--- a/docs/configuration/clustering-k8s.md
+++ b/docs/configuration/clustering-k8s.md
@@ -505,6 +505,7 @@ For resources related to specific jobs they will be labeled with the following:
 * `teraslice.terascope.io/exId` - the `exId`
 * `teraslice.terascope.io/jobId` - the `jobId`
 * `teraslice.terascope.io/jobName` - Teraslice job name, possibly modified
+* `job.teraslice.terascope.io/relocatable` - `true` if the node running the execution controller can be safely drained, `false` otherwise
 
 Note that the Teraslice job name is used in creating and labelling some of the
 Kubernetes resources.  Rather than enforce kubernetes strict DNS naming

--- a/docs/configuration/clustering-k8s.md
+++ b/docs/configuration/clustering-k8s.md
@@ -505,7 +505,10 @@ For resources related to specific jobs they will be labeled with the following:
 * `teraslice.terascope.io/exId` - the `exId`
 * `teraslice.terascope.io/jobId` - the `jobId`
 * `teraslice.terascope.io/jobName` - Teraslice job name, possibly modified
-* `job.teraslice.terascope.io/relocatable` - `true` if the node running the execution controller can be safely drained, `false` otherwise
+
+The following labels are applied only to execution controller resources:
+
+* `job-property.teraslice.terascope.io/relocatable` - `true` if the execution controller can be safely drained/deleted, `false` otherwise. This is determined by calling `isRelocatable()` on the job's slicer at execution start.
 
 Note that the Teraslice job name is used in creating and labelling some of the
 Kubernetes resources.  Rather than enforce kubernetes strict DNS naming

--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.24.0
-appVersion: v3.10.0
+version: 3.25.0
+appVersion: v3.11.0
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/helm/teraslice/values.yaml
+++ b/helm/teraslice/values.yaml
@@ -11,7 +11,7 @@ image:
   pullPolicy: IfNotPresent
   # node version will be inserted into the image tag (which defaults to the chart version)
   # setting the image tag will ignore this value
-  nodeVersion: v24.15.0
+  nodeVersion: v24.16.0
 
 imagePullSecrets: []
 nameOverride: ""

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "3.10.0",
+    "version": "3.11.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/core-utils",
     "displayName": "Core Utils",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "A collection of Teraslice Core Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/core-utils#readme",
     "bugs": {

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "2.11.1",
+    "version": "2.12.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "5.10.1",
+    "version": "5.11.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/geo-utils/package.json
+++ b/packages/geo-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/geo-utils",
     "displayName": "Geo Utils",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "A collection of Teraslice Geo Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/geo-utils#readme",
     "bugs": {

--- a/packages/ip-utils/package.json
+++ b/packages/ip-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/ip-utils",
     "displayName": "IP Utils",
-    "version": "2.11.1",
+    "version": "2.12.0",
     "description": "A collection of Teraslice IP Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ip-utils#readme",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "2.12.1",
+    "version": "2.13.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/job-components/src/job-validator.ts
+++ b/packages/job-components/src/job-validator.ts
@@ -11,6 +11,7 @@ import { registerApis } from './register-apis.js';
 import {
     OperationAPIConstructor,
     OperationModule,
+    ReaderModule,
 } from './operations/index.js';
 
 export class JobValidator {
@@ -151,7 +152,34 @@ export class JobValidator {
             this.context.apis.executionContext.addToRegistry(name, api);
         });
 
+        await this._applyRelocatable(jobConfig);
+
         return jobConfig;
+    }
+
+    /**
+     * Loads the slicer for the given job to determine if it is relocatable,
+     * then sets that value as a property on the jobConfig so it is persisted
+     * on the EX record. The K8s backend reads this property to apply the
+     * appropriate pod label.
+     */
+    private async _applyRelocatable(jobConfig: ValidatedJobConfig): Promise<void> {
+        try {
+            const readerModule = await this.opLoader.loadReader(
+                jobConfig.operations[0]._op,
+                jobConfig.assets || []
+            );
+            const slicerInstance = new readerModule.Slicer(
+                this.context as any,
+                cloneDeep(jobConfig.operations[0]),
+                jobConfig as any
+            );
+            if (typeof slicerInstance.isRelocatable === 'function') {
+                jobConfig.relocatable = slicerInstance.isRelocatable();
+            }
+        } catch (err) {
+            this.context.logger.warn(`Unable to determine relocatable for job: ${err}`);
+        }
     }
 
     hasSchema(obj: Record<string, any>, name: string): void {

--- a/packages/job-components/src/job-validator.ts
+++ b/packages/job-components/src/job-validator.ts
@@ -11,7 +11,6 @@ import { registerApis } from './register-apis.js';
 import {
     OperationAPIConstructor,
     OperationModule,
-    ReaderModule,
 } from './operations/index.js';
 
 export class JobValidator {

--- a/packages/opensearch-client/package.json
+++ b/packages/opensearch-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/opensearch-client",
     "displayName": "Opensearch Client",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "A Node.js facade client for opensearch & elasticsearch.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/opensearch-client#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.15.0",
+    "version": "2.16.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "2.12.1",
+    "version": "2.13.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "2.13.1",
+    "version": "2.14.0",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "3.10.0",
+    "version": "3.11.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/index.ts
@@ -2,6 +2,7 @@ import {
     TSError, logError, get,
     cloneDeep, pRetry, Logger
 } from '@terascope/core-utils';
+import { OperationLoader } from '@terascope/job-components';
 import type { Context, ExecutionConfig } from '@terascope/job-components';
 import { ClusterState } from '@terascope/types';
 import { makeLogger } from '../../../../../workers/helpers/terafoundation.js';
@@ -95,6 +96,33 @@ export class KubernetesClusterBackendV2 {
     }
 
     /**
+     * Loads in the slicer on the execution to check if its restartable or not.
+     * Will add the label from the job prefix value relocatable=<boolean>
+     * Will log on failure and set it to false.
+     * @param execution An execution config
+     */
+    private async _getRelocatable(execution: ExecutionConfig): Promise<boolean> {
+        try {
+            const loader = new OperationLoader({
+                assetPath: this.context.sysconfig.teraslice.assets_directory
+            });
+            const readerModule = await loader.loadReader(
+                execution.operations[0]._op,
+                execution.assets as string[]
+            );
+            const slicerInstance = new readerModule.Slicer(
+                this.context as any,
+                cloneDeep(execution.operations[0]),
+                execution
+            );
+            return slicerInstance.isRelocatable();
+        } catch (err) {
+            this.logger.warn(`Unable to determine relocatable status for execution ${execution.ex_id}: ${err}`);
+            return false;
+        }
+    }
+
+    /**
      * Creates k8s Service and Job for the Teraslice Execution Controller
      * (formerly slicer).  This currently works by creating a service with a
      * hostname that contains the exId in it listening on a well known port.
@@ -108,10 +136,13 @@ export class KubernetesClusterBackendV2 {
 
         execution.slicer_port = 45680;
 
+        const relocatable = await this._getRelocatable(execution);
+
         const exJobResource = new K8sJobResource(
             this.context.sysconfig.teraslice,
             execution,
-            this.logger
+            this.logger,
+            relocatable
         );
 
         const exJob = exJobResource.resource;

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/index.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/index.ts
@@ -2,7 +2,6 @@ import {
     TSError, logError, get,
     cloneDeep, pRetry, Logger
 } from '@terascope/core-utils';
-import { OperationLoader } from '@terascope/job-components';
 import type { Context, ExecutionConfig } from '@terascope/job-components';
 import { ClusterState } from '@terascope/types';
 import { makeLogger } from '../../../../../workers/helpers/terafoundation.js';
@@ -96,33 +95,6 @@ export class KubernetesClusterBackendV2 {
     }
 
     /**
-     * Loads in the slicer on the execution to check if its restartable or not.
-     * Will add the label from the job prefix value relocatable=<boolean>
-     * Will log on failure and set it to false.
-     * @param execution An execution config
-     */
-    private async _getRelocatable(execution: ExecutionConfig): Promise<boolean> {
-        try {
-            const loader = new OperationLoader({
-                assetPath: this.context.sysconfig.teraslice.assets_directory
-            });
-            const readerModule = await loader.loadReader(
-                execution.operations[0]._op,
-                execution.assets as string[]
-            );
-            const slicerInstance = new readerModule.Slicer(
-                this.context as any,
-                cloneDeep(execution.operations[0]),
-                execution
-            );
-            return slicerInstance.isRelocatable();
-        } catch (err) {
-            this.logger.warn(`Unable to determine relocatable status for execution ${execution.ex_id}: ${err}`);
-            return false;
-        }
-    }
-
-    /**
      * Creates k8s Service and Job for the Teraslice Execution Controller
      * (formerly slicer).  This currently works by creating a service with a
      * hostname that contains the exId in it listening on a well known port.
@@ -136,13 +108,10 @@ export class KubernetesClusterBackendV2 {
 
         execution.slicer_port = 45680;
 
-        const relocatable = await this._getRelocatable(execution);
-
         const exJobResource = new K8sJobResource(
             this.context.sysconfig.teraslice,
             execution,
-            this.logger,
-            relocatable
+            this.logger
         );
 
         const exJob = exJobResource.resource;

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sJobResource.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sJobResource.ts
@@ -24,7 +24,8 @@ export class K8sJobResource extends K8sResource<TSJob> {
     constructor(
         terasliceConfig: Config,
         execution: ExecutionConfig,
-        logger: Logger
+        logger: Logger,
+        relocatable = false
     ) {
         super(terasliceConfig, execution, logger);
         this.templateGenerator = makeTemplate('jobs', this.nodeType);
@@ -34,6 +35,7 @@ export class K8sJobResource extends K8sResource<TSJob> {
         this.resource = convertToTSResource(k8sJob);
 
         this._setJobLabels(this.resource);
+        this._setRelocatableLabel(this.resource, relocatable);
 
         // Apply job `targets` setting as k8s nodeAffinity
         // We assume that multiple targets require both to match ...

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sJobResource.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sJobResource.ts
@@ -24,8 +24,7 @@ export class K8sJobResource extends K8sResource<TSJob> {
     constructor(
         terasliceConfig: Config,
         execution: ExecutionConfig,
-        logger: Logger,
-        relocatable = false
+        logger: Logger
     ) {
         super(terasliceConfig, execution, logger);
         this.templateGenerator = makeTemplate('jobs', this.nodeType);
@@ -35,7 +34,7 @@ export class K8sJobResource extends K8sResource<TSJob> {
         this.resource = convertToTSResource(k8sJob);
 
         this._setJobLabels(this.resource);
-        this._setRelocatableLabel(this.resource, relocatable);
+        this._setRelocatableLabel(this.resource, execution.relocatable ?? false);
 
         // Apply job `targets` setting as k8s nodeAffinity
         // We assume that multiple targets require both to match ...

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sResource.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sResource.ts
@@ -238,6 +238,13 @@ export abstract class K8sResource<T extends TSService | TSDeployment | TSJob> {
         }
     }
 
+    _setRelocatableLabel(resource: TSJob | TSDeployment, relocatable: boolean) {
+        const key = `${this.jobPropertyLabelPrefix}/relocatable`;
+        const value = String(relocatable);
+        resource.metadata.labels[key] = value;
+        resource.spec.template.metadata.labels[key] = value;
+    }
+
     _setJobLabels(resource: TSJob | TSDeployment) {
         if (this.execution.labels != null) {
             Object.entries(this.execution.labels).forEach(([k, v]) => {

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sResource.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sResource.ts
@@ -239,7 +239,7 @@ export abstract class K8sResource<T extends TSService | TSDeployment | TSJob> {
     }
 
     _setRelocatableLabel(resource: TSJob | TSDeployment, relocatable: boolean) {
-        const key = `${this.jobPropertyLabelPrefix}/relocatable`;
+        const key = `${this.jobLabelPrefix}/relocatable`;
         const value = String(relocatable);
         resource.metadata.labels[key] = value;
         resource.spec.template.metadata.labels[key] = value;

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -4,7 +4,7 @@ import {
     Logger, defaultsDeep, makeISODate
 } from '@terascope/core-utils';
 import {
-    JobConfigParams, JobValidator, RecoveryCleanupType,
+    JobConfigParams, JobValidator, OperationLoader, RecoveryCleanupType,
     ValidatedJobConfig, parseName
 } from '@terascope/job-components';
 import { JobConfig, ExecutionConfig } from '@terascope/types';
@@ -67,6 +67,49 @@ export class JobsService {
         return validJob;
     }
 
+    /**
+     * Loads in the slicer on the validated job to check if its restartable or not.
+     * Will add the label job.teraslice.terascope.io/relocatable=<boolean>
+     * Will log on failure but not throw.
+     * @param validJob A validated job config
+     */
+    private async _applyRelocatableLabel(
+        validJob: ValidatedJobConfig | JobConfig): Promise<void> {
+        try {
+            const loader = new OperationLoader({
+                assetPath: this.context.sysconfig.teraslice.assets_directory
+            });
+            const readerModule = await loader.loadReader(
+                // The first operation is always a slicer
+                validJob.operations[0]._op,
+                validJob.assets as string[]
+            );
+            const slicerInstance = new readerModule.Slicer(
+                this.context as any,
+                cloneDeep(validJob.operations[0]),
+                // Have to do some type manipulation because I don't have an ex config
+                // the relocatable function doesn't really need it though as it just
+                // returns a boolean. Either way it extends the ValidatedJobConfig
+                validJob as unknown as ExecutionConfig
+            );
+            let relocatable: boolean;
+            if (typeof slicerInstance.isRelocatable === 'function') {
+                relocatable = slicerInstance.isRelocatable();
+            } else {
+                this.logger.warn('Unable to add relocatable label to execution as the slicer'
+                    + ' doesn\'t support it. Ensure the asset supports teraslice version 3 or greater'
+                );
+                return;
+            }
+            validJob.labels = {
+                ...(validJob.labels ?? {}),
+                relocatable: String(relocatable)
+            };
+        } catch (err) {
+            this.logger.warn(`Unable to add relocatable label to execution due to error: ${err}`);
+        }
+    }
+
     async submitJob(jobSpec: Partial<JobConfig | JobConfigParams>, shouldRun?: boolean) {
         // @ts-expect-error
         if (jobSpec.job_id) {
@@ -78,6 +121,8 @@ export class JobsService {
         this.addExternalPortsToJobSpec(jobSpec);
 
         const validJob = await this._validateJobSpec(jobSpec);
+        // We need to apply the relocatable function here in the case shouldRun is true
+        await this._applyRelocatableLabel(validJob);
 
         // We don't create with the fully parsed validJob as it changes the asset names
         // to their asset id which we don't want stored as at the job level
@@ -173,6 +218,9 @@ export class JobsService {
         }
 
         const validJob = await this._validateJobSpec(jobSpec) as JobConfig;
+
+        // Add relocatable label to ex here.
+        await this._applyRelocatableLabel(validJob);
 
         if (validJob.autorecover) {
             return this._recoverValidJob(validJob);

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -4,7 +4,7 @@ import {
     Logger, defaultsDeep, makeISODate
 } from '@terascope/core-utils';
 import {
-    JobConfigParams, JobValidator, RecoveryCleanupType,
+    JobConfigParams, JobValidator, OperationLoader, RecoveryCleanupType,
     ValidatedJobConfig, parseName
 } from '@terascope/job-components';
 import { JobConfig, ExecutionConfig } from '@terascope/types';
@@ -67,6 +67,39 @@ export class JobsService {
         return validJob;
     }
 
+    /**
+     * Loads the slicer for the given job to determine if it is relocatable,
+     * then sets that value as a property on the validJob so it is persisted
+     * on the EX record. The K8s backend reads this property to apply the
+     * appropriate pod label.
+     */
+    private async _applyRelocatable(
+        validJob: ValidatedJobConfig | JobConfig): Promise<void> {
+        try {
+            const loader = new OperationLoader({
+                assetPath: this.context.sysconfig.teraslice.assets_directory
+            });
+            const readerModule = await loader.loadReader(
+                validJob.operations[0]._op,
+                validJob.assets as string[]
+            );
+            const slicerInstance = new readerModule.Slicer(
+                this.context as any,
+                cloneDeep(validJob.operations[0]),
+                validJob as unknown as ExecutionConfig
+            );
+            if (typeof slicerInstance.isRelocatable === 'function') {
+                validJob.relocatable = slicerInstance.isRelocatable();
+            } else {
+                this.logger.warn('Unable to set relocatable on execution: slicer does not'
+                    + ' implement isRelocatable(). Ensure the asset supports teraslice v3 or greater.'
+                );
+            }
+        } catch (err) {
+            this.logger.warn(`Unable to set relocatable on execution due to error: ${err}`);
+        }
+    }
+
     async submitJob(jobSpec: Partial<JobConfig | JobConfigParams>, shouldRun?: boolean) {
         // @ts-expect-error
         if (jobSpec.job_id) {
@@ -90,6 +123,8 @@ export class JobsService {
         const jobRecord = Object.assign({}, jobSpec, validJob, {
             job_id: job.job_id
         }) as JobConfig;
+
+        await this._applyRelocatable(jobRecord);
 
         return this.executionService.createExecutionContext(jobRecord);
     }
@@ -173,6 +208,8 @@ export class JobsService {
         }
 
         const validJob = await this._validateJobSpec(jobSpec) as JobConfig;
+
+        await this._applyRelocatable(validJob);
 
         if (validJob.autorecover) {
             return this._recoverValidJob(validJob);

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -4,7 +4,7 @@ import {
     Logger, defaultsDeep, makeISODate
 } from '@terascope/core-utils';
 import {
-    JobConfigParams, JobValidator, OperationLoader, RecoveryCleanupType,
+    JobConfigParams, JobValidator, RecoveryCleanupType,
     ValidatedJobConfig, parseName
 } from '@terascope/job-components';
 import { JobConfig, ExecutionConfig } from '@terascope/types';
@@ -67,39 +67,6 @@ export class JobsService {
         return validJob;
     }
 
-    /**
-     * Loads the slicer for the given job to determine if it is relocatable,
-     * then sets that value as a property on the validJob so it is persisted
-     * on the EX record. The K8s backend reads this property to apply the
-     * appropriate pod label.
-     */
-    private async _applyRelocatable(
-        validJob: ValidatedJobConfig | JobConfig): Promise<void> {
-        try {
-            const loader = new OperationLoader({
-                assetPath: this.context.sysconfig.teraslice.assets_directory
-            });
-            const readerModule = await loader.loadReader(
-                validJob.operations[0]._op,
-                validJob.assets as string[]
-            );
-            const slicerInstance = new readerModule.Slicer(
-                this.context as any,
-                cloneDeep(validJob.operations[0]),
-                validJob as unknown as ExecutionConfig
-            );
-            if (typeof slicerInstance.isRelocatable === 'function') {
-                validJob.relocatable = slicerInstance.isRelocatable();
-            } else {
-                this.logger.warn('Unable to set relocatable on execution: slicer does not'
-                    + ' implement isRelocatable(). Ensure the asset supports teraslice v3 or greater.'
-                );
-            }
-        } catch (err) {
-            this.logger.warn(`Unable to set relocatable on execution due to error: ${err}`);
-        }
-    }
-
     async submitJob(jobSpec: Partial<JobConfig | JobConfigParams>, shouldRun?: boolean) {
         // @ts-expect-error
         if (jobSpec.job_id) {
@@ -123,8 +90,6 @@ export class JobsService {
         const jobRecord = Object.assign({}, jobSpec, validJob, {
             job_id: job.job_id
         }) as JobConfig;
-
-        await this._applyRelocatable(jobRecord);
 
         return this.executionService.createExecutionContext(jobRecord);
     }
@@ -208,8 +173,6 @@ export class JobsService {
         }
 
         const validJob = await this._validateJobSpec(jobSpec) as JobConfig;
-
-        await this._applyRelocatable(validJob);
 
         if (validJob.autorecover) {
             return this._recoverValidJob(validJob);

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -4,7 +4,7 @@ import {
     Logger, defaultsDeep, makeISODate
 } from '@terascope/core-utils';
 import {
-    JobConfigParams, JobValidator, OperationLoader, RecoveryCleanupType,
+    JobConfigParams, JobValidator, RecoveryCleanupType,
     ValidatedJobConfig, parseName
 } from '@terascope/job-components';
 import { JobConfig, ExecutionConfig } from '@terascope/types';
@@ -67,49 +67,6 @@ export class JobsService {
         return validJob;
     }
 
-    /**
-     * Loads in the slicer on the validated job to check if its restartable or not.
-     * Will add the label job.teraslice.terascope.io/relocatable=<boolean>
-     * Will log on failure but not throw.
-     * @param validJob A validated job config
-     */
-    private async _applyRelocatableLabel(
-        validJob: ValidatedJobConfig | JobConfig): Promise<void> {
-        try {
-            const loader = new OperationLoader({
-                assetPath: this.context.sysconfig.teraslice.assets_directory
-            });
-            const readerModule = await loader.loadReader(
-                // The first operation is always a slicer
-                validJob.operations[0]._op,
-                validJob.assets as string[]
-            );
-            const slicerInstance = new readerModule.Slicer(
-                this.context as any,
-                cloneDeep(validJob.operations[0]),
-                // Have to do some type manipulation because I don't have an ex config
-                // the relocatable function doesn't really need it though as it just
-                // returns a boolean. Either way it extends the ValidatedJobConfig
-                validJob as unknown as ExecutionConfig
-            );
-            let relocatable: boolean;
-            if (typeof slicerInstance.isRelocatable === 'function') {
-                relocatable = slicerInstance.isRelocatable();
-            } else {
-                this.logger.warn('Unable to add relocatable label to execution as the slicer'
-                    + ' doesn\'t support it. Ensure the asset supports teraslice version 3 or greater'
-                );
-                return;
-            }
-            validJob.labels = {
-                ...(validJob.labels ?? {}),
-                relocatable: String(relocatable)
-            };
-        } catch (err) {
-            this.logger.warn(`Unable to add relocatable label to execution due to error: ${err}`);
-        }
-    }
-
     async submitJob(jobSpec: Partial<JobConfig | JobConfigParams>, shouldRun?: boolean) {
         // @ts-expect-error
         if (jobSpec.job_id) {
@@ -121,8 +78,6 @@ export class JobsService {
         this.addExternalPortsToJobSpec(jobSpec);
 
         const validJob = await this._validateJobSpec(jobSpec);
-        // We need to apply the relocatable function here in the case shouldRun is true
-        await this._applyRelocatableLabel(validJob);
 
         // We don't create with the fully parsed validJob as it changes the asset names
         // to their asset id which we don't want stored as at the job level
@@ -218,9 +173,6 @@ export class JobsService {
         }
 
         const validJob = await this._validateJobSpec(jobSpec) as JobConfig;
-
-        // Add relocatable label to ex here.
-        await this._applyRelocatableLabel(validJob);
 
         if (validJob.autorecover) {
             return this._recoverValidJob(validJob);

--- a/packages/teraslice/src/lib/storage/backends/mappings/ex.ts
+++ b/packages/teraslice/src/lib/storage/backends/mappings/ex.ts
@@ -47,6 +47,7 @@ export const executionDataTypeConfig: DataTypeConfig = {
         kubernetes_image: { type: FieldType.Keyword },
         prom_metrics_enabled: { type: FieldType.Boolean },
         prom_metrics_port: { type: FieldType.Integer },
-        prom_metrics_add_default: { type: FieldType.Boolean }
+        prom_metrics_add_default: { type: FieldType.Boolean },
+        relocatable: { type: FieldType.Boolean }
     }
 };

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "2.11.1",
+    "version": "2.12.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/types",
     "displayName": "Types",
-    "version": "2.10.0",
+    "version": "2.11.0",
     "description": "A collection of typescript interfaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/types#readme",
     "bugs": {

--- a/packages/types/src/teraslice.ts
+++ b/packages/types/src/teraslice.ts
@@ -310,6 +310,8 @@ export interface ValidatedJobConfig {
     prom_metrics_port?: number;
     /** This will only be available in the context of k8s */
     prom_metrics_add_default?: boolean;
+    /** This will only be available in the context of k8s. Set by the system at execution start. */
+    relocatable?: boolean;
 }
 
 // TODO: rename ExecutionControllerTargets???

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/valkey",
     "displayName": "Valkey Connector",
-    "version": "0.5.1",
+    "version": "0.6.0",
     "description": "A Terafoundation connector and facade client for Valkey.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/valkey#readme",
     "bugs": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "2.11.1",
+    "version": "2.12.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:

- Adds a new boolean label `job-property.teraslice.terascope.io/relocatable` to execution pods
  - This lets operators know if an execution living on a node can be relocated or not
- Bumps teraslice from `v3.10.0` to `v3.11.0`

Ref to issue #4450