### PR TITLE
check root if config not found

### DIFF
--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -31,6 +31,7 @@
         "@terascope/core-utils": "workspace:~",
         "@terascope/file-asset-apis": "~2.1.0",
         "@terascope/opensearch-client": "workspace:~",
+        "@terascope/scripts": "workspace:~",
         "@terascope/types": "workspace:~",
         "bunyan": "~1.8.15",
         "express": "~5.2.1",

--- a/packages/terafoundation/src/sysconfig.ts
+++ b/packages/terafoundation/src/sysconfig.ts
@@ -4,6 +4,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import yaml from 'js-yaml';
 import { ParsedArgs } from './interfaces.js';
+import { getRootDir } from '@terascope/scripts';
 
 export function getDefaultConfigFile(): string | undefined {
     const cwd = process.cwd();
@@ -65,10 +66,18 @@ export async function getArgs<S = Record<string, unknown>>(
 }
 
 export async function parseConfigFile<D = Record<string, any>>(file: string): Promise<D> {
-    const configFile = file ? path.resolve(file) : undefined;
+    let configFile = file ? path.resolve(file) : undefined;
 
-    if (!configFile || !fs.existsSync(configFile)) {
-        throw new Error(`Could not find a usable config file at the path: ${configFile}`);
+    const errMsg = `Could not find a usable config file at the path: ${configFile}`;
+    if (!configFile) throw new Error(errMsg);
+
+    if (!fs.existsSync(configFile)) {
+        const root = getRootDir();
+        if (fs.existsSync(`${root}/${configFile}`)) {
+            configFile = `${root}/${configFile}`;
+        } else {
+            throw new Error(errMsg);
+        }
     }
 
     if (['.yaml', '.yml'].includes(path.extname(configFile))) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -748,6 +748,9 @@ importers:
       '@terascope/opensearch-client':
         specifier: workspace:~
         version: link:../opensearch-client
+      '@terascope/scripts':
+        specifier: workspace:~
+        version: link:../scripts
       '@terascope/types':
         specifier: workspace:~
         version: link:../types


### PR DESCRIPTION
adjusts config flag if not found but found at root - realized maybe this doesn't help for most repos so closing for now and adjusted for sps.