### PR TITLE
[core-utils] SchemaValidator nested default bug fix

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/core-utils",
     "displayName": "Core Utils",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "A collection of Teraslice Core Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/core-utils#readme",
     "bugs": {

--- a/packages/core-utils/src/schemas.ts
+++ b/packages/core-utils/src/schemas.ts
@@ -388,12 +388,32 @@ export class SchemaValidator<T = AnyObject> {
                     value as TF.Schema<T>,
                     `${parentKey.toString()}.${key}`
                 );
-                defaults[key] = fields[key].parse({});
+                defaults[key] = this._extractSchemaDefaults(value as TF.Schema<T>);
             }
         }
 
         return z.looseObject(fields)
             .default(defaults) as z.ZodType<T>;
+    }
+
+    /**
+     * Recursively extract defaults from a schema that may contain nested objects
+     * @param { TF.Schema<T> } schema A convict style schema
+     * @returns { Record<string, unknown> } Object containing defaults for the given schema
+     */
+    private _extractSchemaDefaults(schema: TF.Schema<T>): Record<string, unknown> {
+        const defaults: Record<string, unknown> = {};
+        if (isSimpleObject(schema)) {
+            for (const key in schema) {
+                const value = (schema)[key];
+                if (isSchemaObj(value)) {
+                    defaults[key] = value.default;
+                } else {
+                    defaults[key] = this._extractSchemaDefaults(value as TF.Schema<T>);
+                }
+            }
+        }
+        return defaults;
     }
 
     /**

--- a/packages/core-utils/test/schemas-spec.ts
+++ b/packages/core-utils/test/schemas-spec.ts
@@ -2868,4 +2868,60 @@ describe('Schema Object validation', () => {
             }).toThrow('Format 2: Must be number');
         });
     });
+
+    describe('nested schemas with required_string fields and undefined defaults', () => {
+        const schema: Terafoundation.Schema<any> = {
+            store: {
+                connector: {
+                    doc: 'name of the terafoundation connector where the percent will be stored',
+                    default: undefined,
+                    format: 'required_string'
+                },
+                index: {
+                    doc: 'name of the index where the percent will be stored',
+                    default: undefined,
+                    format: 'required_string'
+                },
+                document_id: {
+                    doc: 'name of the document ID where the percent will be stored',
+                    default: undefined,
+                    format: 'required_string'
+                }
+            }
+        };
+
+        it('should construct SchemaValidator without throwing', () => {
+            expect(() => {
+                new SchemaValidator(schema, 'nested_required_string_test');
+            }).not.toThrow();
+        });
+
+        it('should validate a config with all required nested fields provided', () => {
+            const validator = new SchemaValidator(schema, 'nested_required_string_test');
+            const config = {
+                store: {
+                    connector: 'my-connector',
+                    index: 'my-index',
+                    document_id: 'my-doc-id'
+                }
+            };
+            expect(() => validator.validate(config)).not.toThrow();
+            const result = validator.validate(config);
+            expect(result.store.connector).toBe('my-connector');
+            expect(result.store.index).toBe('my-index');
+            expect(result.store.document_id).toBe('my-doc-id');
+        });
+
+        it('should throw when a required nested field is missing', () => {
+            const validator = new SchemaValidator(schema, 'nested_required_string_test');
+            const config = {
+                store: {
+                    connector: 'my-connector',
+                    index: 'my-index'
+                    // document_id is missing
+                }
+            };
+            expect(() => validator.validate(config)).toThrow();
+        });
+    });
 });

--- a/packages/core-utils/test/schemas-spec.ts
+++ b/packages/core-utils/test/schemas-spec.ts
@@ -2897,14 +2897,12 @@ describe('Schema Object validation', () => {
                 store: {
                     connector: 'my-connector',
                     index: 'my-index',
-                    document_id: 'my-doc-id'
                 }
             };
             expect(() => validator.validate(config)).not.toThrow();
             const result = validator.validate(config);
             expect(result.store.connector).toBe('my-connector');
             expect(result.store.index).toBe('my-index');
-            expect(result.store.document_id).toBe('my-doc-id');
         });
 
         it('should throw when a required nested field is missing', () => {
@@ -2912,11 +2910,86 @@ describe('Schema Object validation', () => {
             const config = {
                 store: {
                     connector: 'my-connector',
-                    index: 'my-index'
-                    // document_id is missing
+                    // index is missing
                 }
             };
             expect(() => validator.validate(config)).toThrow();
+        });
+    });
+
+    describe('_extractSchemaDefaults', () => {
+        function extractDefaults(schema: Terafoundation.Schema<any>) {
+            const validator = new SchemaValidator({ _placeholder: { doc: '', default: null, format: '*' } }, '_extract_test');
+            return (validator as any)._extractSchemaDefaults(schema);
+        }
+
+        it('extracts flat schema defaults', () => {
+            const schema: Terafoundation.Schema<any> = {
+                name: { doc: 'a name', default: 'alice', format: String },
+                count: { doc: 'a count', default: 0, format: Number },
+                enabled: { doc: 'flag', default: true, format: Boolean },
+            };
+            expect(extractDefaults(schema)).toEqual({ name: 'alice', count: 0, enabled: true });
+        });
+
+        it('extracts undefined and null defaults', () => {
+            const schema: Terafoundation.Schema<any> = {
+                required: { doc: 'required', default: undefined, format: 'required_string' },
+                nullable: { doc: 'nullable', default: null, format: '*' },
+            };
+            const result = extractDefaults(schema);
+            expect(result.required).toBeUndefined();
+            expect(result.nullable).toBeNull();
+        });
+
+        it('extracts defaults from a one-level nested schema', () => {
+            const schema: Terafoundation.Schema<any> = {
+                store: {
+                    connector: { doc: 'connector', default: undefined, format: 'required_string' },
+                    index: { doc: 'index', default: undefined, format: 'required_string' },
+                    document_id: { doc: 'doc id', default: undefined, format: 'required_string' },
+                }
+            };
+            expect(extractDefaults(schema)).toEqual({
+                store: {
+                    connector: undefined,
+                    index: undefined,
+                    document_id: undefined,
+                }
+            });
+        });
+
+        it('extracts defaults from a deeply nested schema', () => {
+            const schema: Terafoundation.Schema<any> = {
+                connection: {
+                    primary: {
+                        host: { doc: 'host', default: 'localhost', format: String },
+                        port: { doc: 'port', default: 9200, format: Number },
+                    },
+                    secondary: {
+                        host: { doc: 'host', default: undefined, format: 'optional_string' },
+                    }
+                }
+            };
+            expect(extractDefaults(schema)).toEqual({
+                connection: {
+                    primary: { host: 'localhost', port: 9200 },
+                    secondary: { host: undefined },
+                }
+            });
+        });
+
+        it('extracts defaults from a mixed flat-and-nested schema', () => {
+            const schema: Terafoundation.Schema<any> = {
+                top_level: { doc: 'top', default: 'value', format: String },
+                nested: {
+                    child: { doc: 'child', default: 42, format: Number },
+                }
+            };
+            expect(extractDefaults(schema)).toEqual({
+                top_level: 'value',
+                nested: { child: 42 },
+            });
         });
     });
 });

--- a/packages/core-utils/test/schemas-spec.ts
+++ b/packages/core-utils/test/schemas-spec.ts
@@ -2869,21 +2869,16 @@ describe('Schema Object validation', () => {
         });
     });
 
-    describe('nested schemas with required_string fields and undefined defaults', () => {
+    describe('nested schemas with required_string fields and null or undefined defaults', () => {
         const schema: Terafoundation.Schema<any> = {
             store: {
                 connector: {
-                    doc: 'name of the terafoundation connector where the percent will be stored',
-                    default: undefined,
+                    doc: 'name of the terafoundation connector',
+                    default: null,
                     format: 'required_string'
                 },
                 index: {
-                    doc: 'name of the index where the percent will be stored',
-                    default: undefined,
-                    format: 'required_string'
-                },
-                document_id: {
-                    doc: 'name of the document ID where the percent will be stored',
+                    doc: 'name of the index',
                     default: undefined,
                     format: 'required_string'
                 }

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "5.11.0",
+    "version": "5.11.1",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/geo-utils/package.json
+++ b/packages/geo-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/geo-utils",
     "displayName": "Geo Utils",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "A collection of Teraslice Geo Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/geo-utils#readme",
     "bugs": {

--- a/packages/ip-utils/package.json
+++ b/packages/ip-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/ip-utils",
     "displayName": "IP Utils",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "description": "A collection of Teraslice IP Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ip-utils#readme",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "2.13.0",
+    "version": "2.13.1",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/opensearch-client/package.json
+++ b/packages/opensearch-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/opensearch-client",
     "displayName": "Opensearch Client",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "A Node.js facade client for opensearch & elasticsearch.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/opensearch-client#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.16.0",
+    "version": "2.16.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "2.13.0",
+    "version": "2.13.1",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "2.14.0",
+    "version": "2.14.1",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/valkey",
     "displayName": "Valkey Connector",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "A Terafoundation connector and facade client for Valkey.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/valkey#readme",
     "bugs": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:
- Update `SchemaValidator` to safely create default values for a schema that uses nested objects with `null` or `undefined` default values for the `required_string` format.
- Add tests related to creating defaults and nested schemas

Ref: #4466 