### PR TITLE
[scripts] Docker image list update

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/images/index.ts
+++ b/packages/scripts/src/helpers/images/index.ts
@@ -34,9 +34,10 @@ export async function createImageList(): Promise<void> {
         list = `${config.MINIO_DOCKER_IMAGE}:${config.MINIO_VERSION}\n`
             + `${config.OPENSEARCH_DOCKER_IMAGE}:${config.DEFAULT_OPENSEARCH2_VERSION}\n`;
     } else if (repo === 'standard-assets-bundle') {
-        list = `${config.OPENSEARCH_DOCKER_IMAGE}:${config.DEFAULT_OPENSEARCH2_VERSION}`;
+        list = `${config.OPENSEARCH_DOCKER_IMAGE}:${config.DEFAULT_OPENSEARCH2_VERSION}\n`
+            + `${config.KAFKA_DOCKER_IMAGE}:${config.KAFKA_VERSION}`;
     } else if (repo === 'chaos-assets-bundle') {
-        list = '';
+        list = `${config.MINIO_DOCKER_IMAGE}:${config.MINIO_VERSION}`;
     } else if (repo === 'teraslice-workspace') {
         list = `${config.OPENSEARCH_DOCKER_IMAGE}:${config.DEFAULT_OPENSEARCH1_VERSION}\n`
             + `${config.OPENSEARCH_DOCKER_IMAGE}:${config.DEFAULT_OPENSEARCH2_VERSION}\n`


### PR DESCRIPTION
This PR makes the following changes:
- Updates the `ts-scripts images list` command to include
  - minio in the chaos-assets list
  - kafka in the standard-assets list
- Bump scripts from v2.17.1 to v2.17.2