### PR TITLE
(feat) job config deprecations

### DIFF
--- a/docs/development/pnpm.md
+++ b/docs/development/pnpm.md
@@ -46,3 +46,5 @@ To update the pnpm version, follow these steps:
     ```
 
 5. Update the `packageManager` field in the `package.json` file located in the `teraslice/website` directory to reflect the updated pnpm version.
+
+6. Update the hardcoded `engines.pnpm` value in `_getRootInfo` in `packages/scripts/src/helpers/misc.ts` to match the updated pnpm version.

--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.31.0
-appVersion: v3.14.0
+version: 3.32.0
+appVersion: v3.15.0
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "3.14.0",
+    "version": "3.15.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/core-utils",
     "displayName": "Core Utils",
-    "version": "2.13.0",
+    "version": "2.14.0",
     "description": "A collection of Teraslice Core Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/core-utils#readme",
     "bugs": {

--- a/packages/core-utils/src/schemas.ts
+++ b/packages/core-utils/src/schemas.ts
@@ -237,7 +237,8 @@ export class SchemaValidator<T = AnyObject> {
     checkUndeclaredKeys: CheckUndeclaredKeys;
     envMap: Record<string, { envName: string; format: TF.ConvictFormat }> = {};
     argsMap: Record<string, { argName: string; format: TF.ConvictFormat }> = {};
-    deprecationWarnings: TF.JobWarning[] = [];
+    // subcategory and assetId are added by config-validators once the job context is known
+    deprecationWarnings: { field: string; description: string }[] = [];
     logger: Logger;
 
     constructor(
@@ -340,7 +341,7 @@ export class SchemaValidator<T = AnyObject> {
                 // user must have provided this field with a value
                 && config[key] !== undefined
             ) {
-                this.deprecationWarnings.push({ type: 'deprecation', description: field.deprecated });
+                this.deprecationWarnings.push({ field: key, description: field.deprecated });
             }
         }
 

--- a/packages/core-utils/src/schemas.ts
+++ b/packages/core-utils/src/schemas.ts
@@ -237,6 +237,7 @@ export class SchemaValidator<T = AnyObject> {
     checkUndeclaredKeys: CheckUndeclaredKeys;
     envMap: Record<string, { envName: string; format: TF.ConvictFormat }> = {};
     argsMap: Record<string, { argName: string; format: TF.ConvictFormat }> = {};
+    deprecationWarnings: TF.JobWarning[] = [];
     logger: Logger;
 
     constructor(
@@ -324,6 +325,22 @@ export class SchemaValidator<T = AnyObject> {
                     argValue = toNumber(argValue);
                 }
                 finalConfig[key] = argValue;
+            }
+        }
+
+        // Logic that checks input schema for deprecated field
+        this.deprecationWarnings = [];
+        for (const key in this.inputSchema) {
+            const field = (this.inputSchema as any)[key];
+            if (
+                // Ensure its not nested
+                isSchemaObj(field)
+                // field needs to have the deprecated key on it
+                && field.deprecated
+                // user must have provided this field with a value
+                && config[key] !== undefined
+            ) {
+                this.deprecationWarnings.push({ type: 'deprecation', description: field.deprecated });
             }
         }
 

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "2.14.0",
+    "version": "2.15.0",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "2.13.0",
+    "version": "2.14.0",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "5.13.0",
+    "version": "5.14.0",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "2.13.0",
+    "version": "2.14.0",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/geo-utils/package.json
+++ b/packages/geo-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/geo-utils",
     "displayName": "Geo Utils",
-    "version": "2.13.0",
+    "version": "2.14.0",
     "description": "A collection of Teraslice Geo Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/geo-utils#readme",
     "bugs": {

--- a/packages/ip-utils/package.json
+++ b/packages/ip-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/ip-utils",
     "displayName": "IP Utils",
-    "version": "2.14.0",
+    "version": "2.15.0",
     "description": "A collection of Teraslice IP Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ip-utils#readme",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "2.15.0",
+    "version": "2.16.0",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/job-components/src/config-validators.ts
+++ b/packages/job-components/src/config-validators.ts
@@ -20,11 +20,18 @@ export function validateOpConfig<T>(
     try {
         const config = validator.validate(inputConfig);
         const warnings: TF.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
-            category: 'deprecation',
-            subcategory: 'assetOperationProperty',
-            name: inputConfig._op,
-            field: schemaWarning.field,
-            description: schemaWarning.description,
+            type: 'JobValidation',
+            reason: {
+                type: 'assetOperationProperty',
+                reason: {
+                    name: inputConfig._op,
+                    type: 'deprecation',
+                    reason: {
+                        name: schemaWarning.field,
+                        description: schemaWarning.description,
+                    },
+                },
+            },
         }));
         return { config, warnings };
     } catch (err) {
@@ -51,11 +58,18 @@ export function validateAPIConfig<T>(
     try {
         const config = validator.validate(inputConfig);
         const warnings: TF.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
-            category: 'deprecation',
-            subcategory: 'assetAPIProperty',
-            name: inputConfig._name,
-            field: schemaWarning.field,
-            description: schemaWarning.description,
+            type: 'JobValidation',
+            reason: {
+                type: 'assetAPIProperty',
+                reason: {
+                    name: inputConfig._name,
+                    type: 'deprecation',
+                    reason: {
+                        name: schemaWarning.field,
+                        description: schemaWarning.description,
+                    },
+                },
+            },
         }));
         return { config, warnings };
     } catch (err) {

--- a/packages/job-components/src/config-validators.ts
+++ b/packages/job-components/src/config-validators.ts
@@ -9,7 +9,7 @@ import { opSchema, apiSchema } from './job-schemas.js';
  */
 export function validateOpConfig<T>(
     inputSchema: TF.Schema<any>, inputConfig: Record<string, any>, context: TF.Context
-): OpConfig & T {
+): { config: OpConfig & T, warnings: TF.JobWarning[] } {
     const schema = Object.assign({}, opSchema, inputSchema) as TF.Schema<OpConfig & T>;
     const validator = new SchemaValidator<OpConfig & T>(
         schema,
@@ -18,7 +18,8 @@ export function validateOpConfig<T>(
         undefined,
         context);
     try {
-        return validator.validate(inputConfig);
+        const config = validator.validate(inputConfig);
+        return { config, warnings: validator.deprecationWarnings };
     } catch (err) {
         throw new Error(`Validation failed for operation config: ${inputConfig._op} - ${err.message}`);
     }
@@ -30,7 +31,7 @@ export function validateOpConfig<T>(
  */
 export function validateAPIConfig<T>(
     inputSchema: TF.Schema<any>, inputConfig: Record<string, any>, context: TF.Context
-): APIConfig & T {
+): { config: APIConfig & T, warnings: TF.JobWarning[] } {
     const schema = Object.assign({}, apiSchema, inputSchema) as TF.Schema<APIConfig & T>;
     const validator = new SchemaValidator<APIConfig & T>(
         schema,
@@ -41,7 +42,8 @@ export function validateAPIConfig<T>(
     );
 
     try {
-        return validator.validate(inputConfig);
+        const config = validator.validate(inputConfig);
+        return { config, warnings: validator.deprecationWarnings };
     } catch (err) {
         throw new Error(`Validation failed for api config: ${inputConfig._name} - ${err.message}`);
     }

--- a/packages/job-components/src/config-validators.ts
+++ b/packages/job-components/src/config-validators.ts
@@ -22,14 +22,12 @@ export function validateOpConfig<T>(
         const warnings: TF.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
             type: 'JobValidation',
             reason: {
-                type: 'assetOperationProperty',
+                type: 'assetOperation',
+                kind: 'deprecation',
                 reason: {
-                    name: inputConfig._op,
-                    type: 'deprecation',
-                    reason: {
-                        name: schemaWarning.field,
-                        description: schemaWarning.description,
-                    },
+                    _op: inputConfig._op,
+                    field: schemaWarning.field,
+                    description: schemaWarning.description,
                 },
             },
         }));
@@ -61,13 +59,11 @@ export function validateAPIConfig<T>(
             type: 'JobValidation',
             reason: {
                 type: 'assetAPIProperty',
+                kind: 'deprecation',
                 reason: {
-                    name: inputConfig._name,
-                    type: 'deprecation',
-                    reason: {
-                        name: schemaWarning.field,
-                        description: schemaWarning.description,
-                    },
+                    api_name: inputConfig._name,
+                    field: schemaWarning.field,
+                    description: schemaWarning.description,
                 },
             },
         }));
@@ -108,13 +104,10 @@ export function validateJobConfig<T>(
             type: 'JobValidation',
             reason: {
                 type: 'jobProperty',
+                kind: 'deprecation',
                 reason: {
-                    name: inputConfig.name,
-                    type: 'deprecation',
-                    reason: {
-                        name: schemaWarning.field,
-                        description: schemaWarning.description,
-                    },
+                    field: schemaWarning.field,
+                    description: schemaWarning.description,
                 },
             },
         }));

--- a/packages/job-components/src/config-validators.ts
+++ b/packages/job-components/src/config-validators.ts
@@ -19,18 +19,19 @@ export function validateOpConfig<T>(
         context);
     try {
         const config = validator.validate(inputConfig);
-        const warnings: Teraslice.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
-            type: 'JobValidation',
-            reason: {
-                type: 'assetOperation',
-                kind: 'deprecation',
+        const warnings: Teraslice.JobWarning[] = validator.deprecationWarnings
+            .map((schemaWarning) => ({
+                type: 'JobValidation',
                 reason: {
-                    _op: inputConfig._op,
-                    field: schemaWarning.field,
-                    description: schemaWarning.description,
+                    type: 'assetOperation',
+                    kind: 'deprecation',
+                    reason: {
+                        _op: inputConfig._op,
+                        field: schemaWarning.field,
+                        description: schemaWarning.description,
+                    },
                 },
-            },
-        }));
+            }));
         return { config, warnings };
     } catch (err) {
         throw new Error(`Validation failed for operation config: ${inputConfig._op} - ${err.message}`);
@@ -55,18 +56,19 @@ export function validateAPIConfig<T>(
 
     try {
         const config = validator.validate(inputConfig);
-        const warnings: Teraslice.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
-            type: 'JobValidation',
-            reason: {
-                type: 'assetAPIProperty',
-                kind: 'deprecation',
+        const warnings: Teraslice.JobWarning[] = validator.deprecationWarnings
+            .map((schemaWarning) => ({
+                type: 'JobValidation',
                 reason: {
-                    api_name: inputConfig._name,
-                    field: schemaWarning.field,
-                    description: schemaWarning.description,
+                    type: 'assetAPIProperty',
+                    kind: 'deprecation',
+                    reason: {
+                        api_name: inputConfig._name,
+                        field: schemaWarning.field,
+                        description: schemaWarning.description,
+                    },
                 },
-            },
-        }));
+            }));
         return { config, warnings };
     } catch (err) {
         throw new Error(`Validation failed for api config: ${inputConfig._name} - ${err.message}`);
@@ -100,17 +102,18 @@ export function validateJobConfig<T>(
         }
 
         // collect warnings from job fields
-        const warnings: Teraslice.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
-            type: 'JobValidation',
-            reason: {
-                type: 'jobProperty',
-                kind: 'deprecation',
+        const warnings: Teraslice.JobWarning[] = validator.deprecationWarnings
+            .map((schemaWarning) => ({
+                type: 'JobValidation',
                 reason: {
-                    field: schemaWarning.field,
-                    description: schemaWarning.description,
+                    type: 'jobProperty',
+                    kind: 'deprecation',
+                    reason: {
+                        field: schemaWarning.field,
+                        description: schemaWarning.description,
+                    },
                 },
-            },
-        }));
+            }));
 
         return { config: jobProperties, warnings };
     } catch (err) {

--- a/packages/job-components/src/config-validators.ts
+++ b/packages/job-components/src/config-validators.ts
@@ -1,5 +1,5 @@
 import { SchemaValidator } from '@terascope/core-utils';
-import { Terafoundation as TF } from '@terascope/types';
+import { Teraslice, Terafoundation as TF } from '@terascope/types';
 import { ValidatedJobConfig, OpConfig, APIConfig } from './interfaces/index.js';
 import { opSchema, apiSchema } from './job-schemas.js';
 
@@ -9,7 +9,7 @@ import { opSchema, apiSchema } from './job-schemas.js';
  */
 export function validateOpConfig<T>(
     inputSchema: TF.Schema<any>, inputConfig: Record<string, any>, context: TF.Context
-): { config: OpConfig & T; warnings: TF.JobWarning[] } {
+): { config: OpConfig & T; warnings: Teraslice.JobWarning[] } {
     const schema = Object.assign({}, opSchema, inputSchema) as TF.Schema<OpConfig & T>;
     const validator = new SchemaValidator<OpConfig & T>(
         schema,
@@ -19,7 +19,7 @@ export function validateOpConfig<T>(
         context);
     try {
         const config = validator.validate(inputConfig);
-        const warnings: TF.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
+        const warnings: Teraslice.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
             type: 'JobValidation',
             reason: {
                 type: 'assetOperation',
@@ -43,7 +43,7 @@ export function validateOpConfig<T>(
  */
 export function validateAPIConfig<T>(
     inputSchema: TF.Schema<any>, inputConfig: Record<string, any>, context: TF.Context
-): { config: APIConfig & T; warnings: TF.JobWarning[] } {
+): { config: APIConfig & T; warnings: Teraslice.JobWarning[] } {
     const schema = Object.assign({}, apiSchema, inputSchema) as TF.Schema<APIConfig & T>;
     const validator = new SchemaValidator<APIConfig & T>(
         schema,
@@ -55,7 +55,7 @@ export function validateAPIConfig<T>(
 
     try {
         const config = validator.validate(inputConfig);
-        const warnings: TF.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
+        const warnings: Teraslice.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
             type: 'JobValidation',
             reason: {
                 type: 'assetAPIProperty',
@@ -79,7 +79,7 @@ export function validateAPIConfig<T>(
  */
 export function validateJobConfig<T>(
     inputSchema: TF.Schema<any>, inputConfig: Record<string, any>, context: TF.Context
-): { config: ValidatedJobConfig & T; warnings: TF.JobWarning[] } {
+): { config: ValidatedJobConfig & T; warnings: Teraslice.JobWarning[] } {
     const validator = new SchemaValidator<ValidatedJobConfig & T>(
         inputSchema as TF.Schema<ValidatedJobConfig & T>,
         inputConfig.name,
@@ -100,7 +100,7 @@ export function validateJobConfig<T>(
         }
 
         // collect warnings from job fields
-        const warnings: TF.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
+        const warnings: Teraslice.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
             type: 'JobValidation',
             reason: {
                 type: 'jobProperty',

--- a/packages/job-components/src/config-validators.ts
+++ b/packages/job-components/src/config-validators.ts
@@ -83,7 +83,7 @@ export function validateAPIConfig<T>(
  */
 export function validateJobConfig<T>(
     inputSchema: TF.Schema<any>, inputConfig: Record<string, any>, context: TF.Context
-): ValidatedJobConfig & T {
+): { config: ValidatedJobConfig & T; warnings: TF.JobWarning[] } {
     const validator = new SchemaValidator<ValidatedJobConfig & T>(
         inputSchema as TF.Schema<ValidatedJobConfig & T>,
         inputConfig.name,
@@ -102,7 +102,24 @@ export function validateJobConfig<T>(
         ) {
             throw new Error(`cpu/memory can't be mixed with resource settings of the same type.`);
         }
-        return jobProperties;
+
+        // collect warnings from job fields
+        const warnings: TF.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
+            type: 'JobValidation',
+            reason: {
+                type: 'jobProperty',
+                reason: {
+                    name: inputConfig.name,
+                    type: 'deprecation',
+                    reason: {
+                        name: schemaWarning.field,
+                        description: schemaWarning.description,
+                    },
+                },
+            },
+        }));
+
+        return { config: jobProperties, warnings };
     } catch (err) {
         throw new Error(`Validation failed for job config: ${inputConfig.name} - ${err.message}`);
     }

--- a/packages/job-components/src/config-validators.ts
+++ b/packages/job-components/src/config-validators.ts
@@ -9,7 +9,7 @@ import { opSchema, apiSchema } from './job-schemas.js';
  */
 export function validateOpConfig<T>(
     inputSchema: TF.Schema<any>, inputConfig: Record<string, any>, context: TF.Context
-): { config: OpConfig & T, warnings: TF.JobWarning[] } {
+): { config: OpConfig & T; warnings: TF.JobWarning[] } {
     const schema = Object.assign({}, opSchema, inputSchema) as TF.Schema<OpConfig & T>;
     const validator = new SchemaValidator<OpConfig & T>(
         schema,
@@ -31,7 +31,7 @@ export function validateOpConfig<T>(
  */
 export function validateAPIConfig<T>(
     inputSchema: TF.Schema<any>, inputConfig: Record<string, any>, context: TF.Context
-): { config: APIConfig & T, warnings: TF.JobWarning[] } {
+): { config: APIConfig & T; warnings: TF.JobWarning[] } {
     const schema = Object.assign({}, apiSchema, inputSchema) as TF.Schema<APIConfig & T>;
     const validator = new SchemaValidator<APIConfig & T>(
         schema,

--- a/packages/job-components/src/config-validators.ts
+++ b/packages/job-components/src/config-validators.ts
@@ -19,7 +19,14 @@ export function validateOpConfig<T>(
         context);
     try {
         const config = validator.validate(inputConfig);
-        return { config, warnings: validator.deprecationWarnings };
+        const warnings: TF.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
+            category: 'deprecation',
+            subcategory: 'assetOperationProperty',
+            name: inputConfig._op,
+            field: schemaWarning.field,
+            description: schemaWarning.description,
+        }));
+        return { config, warnings };
     } catch (err) {
         throw new Error(`Validation failed for operation config: ${inputConfig._op} - ${err.message}`);
     }
@@ -43,7 +50,14 @@ export function validateAPIConfig<T>(
 
     try {
         const config = validator.validate(inputConfig);
-        return { config, warnings: validator.deprecationWarnings };
+        const warnings: TF.JobWarning[] = validator.deprecationWarnings.map((schemaWarning) => ({
+            category: 'deprecation',
+            subcategory: 'assetAPIProperty',
+            name: inputConfig._name,
+            field: schemaWarning.field,
+            description: schemaWarning.description,
+        }));
+        return { config, warnings };
     } catch (err) {
         throw new Error(`Validation failed for api config: ${inputConfig._name} - ${err.message}`);
     }

--- a/packages/job-components/src/job-schemas.ts
+++ b/packages/job-components/src/job-schemas.ts
@@ -238,6 +238,7 @@ export function jobSchema(context: Context): Terafoundation.Schema<any> {
             doc: 'DEPRECATED: number of cpus to reserve per teraslice worker in kubernetes',
             default: undefined,
             format: 'Number',
+            deprecated: '"cpu" on a job is deprecated and should use "resources_requests_cpu" instead'
         };
 
         schemas.cpu_execution_controller = {
@@ -302,6 +303,7 @@ export function jobSchema(context: Context): Terafoundation.Schema<any> {
             doc: 'DEPRECATED: memory, in bytes, to reserve per teraslice worker in Kubernetes',
             default: undefined,
             format: 'Number',
+            deprecated: '"memory" on a job is deprecated and should use "resources_requests_memory" instead'
         };
 
         schemas.memory_execution_controller = {

--- a/packages/job-components/src/job-validator.ts
+++ b/packages/job-components/src/job-validator.ts
@@ -203,16 +203,22 @@ export class JobValidator {
 }
 
 /**
- * Type guard to distinguish new-style schema validate() results ({ config, warnings })
+ * The shape returned by new-style schema validate() methods.
+ *
+ * @backwards-compat: v3 schemas return the config directly instead of this shape.
+ * Support for the old shape will be dropped in Teraslice v4.
+ */
+type ValidateResult = { config: any; warnings: Terafoundation.JobWarning[] };
+
+/**
+ * Type guard to distinguish new-style schema validate() results (ValidateResult)
  * from old-style results (plain config object).
  *
  * @backwards-compat: v3 schemas return the config directly. This guard exists to
  * support both shapes during the deprecation window. Will be removed in Teraslice v4
  * when all schemas are required to return { config, warnings }.
  */
-function isValidateResult(
-    result: any
-): result is { config: any; warnings: Terafoundation.JobWarning[] } {
+function isValidateResult(result: any): result is ValidateResult {
     return result != null
         && typeof result === 'object'
         && 'config' in result

--- a/packages/job-components/src/job-validator.ts
+++ b/packages/job-components/src/job-validator.ts
@@ -131,7 +131,7 @@ export class JobValidator {
             });
 
             const apiResult = schema.validate(apiConfig);
-            // @backwards-compat: v3 schemas may return the config directly instead of
+            // TODO: v3 schemas may return the config directly instead of
             // { config, warnings }. Support for the old shape will be dropped in Teraslice v4.
             const validatedApiConfig = isValidateResult(apiResult) ? apiResult.config : apiResult;
             const apiWarnings = isValidateResult(apiResult) ? (apiResult.warnings ?? []) : [];
@@ -219,8 +219,12 @@ type ValidateResult = { config: any; warnings: Terafoundation.JobWarning[] };
  * when all schemas are required to return { config, warnings }.
  */
 function isValidateResult(result: any): result is ValidateResult {
+    // Check for both 'config' and 'warnings' to avoid false positives on legacy op
+    // configs that happen to have a 'config' property.
     return result != null
         && typeof result === 'object'
         && 'config' in result
-        && typeof result.config === 'object';
+        && typeof result.config === 'object'
+        && 'warnings' in result
+        && Array.isArray(result.warnings);
 }

--- a/packages/job-components/src/job-validator.ts
+++ b/packages/job-components/src/job-validator.ts
@@ -32,14 +32,14 @@ export class JobValidator {
         jobSpec: Partial<Teraslice.JobConfig | Teraslice.JobConfigParams>,
     ): Promise<{ jobConfig: ValidatedJobConfig; warnings: Terafoundation.JobWarning[] }> {
         // top level job validation occurs, but not operations
-        const jobConfig = validateJobConfig(this.schema, cloneDeep(jobSpec), this.context);
+        const { config: jobConfig, warnings: jobWarnings } = validateJobConfig(this.schema, cloneDeep(jobSpec), this.context);
         const assetIds = jobConfig.assets || [];
         const apis: Record<string, OperationAPIConstructor> = {};
 
         type ValidateJobFn = (job: ValidatedJobConfig) => void;
         const validateJobFns: ValidateJobFn[] = [];
         const validateApisFns: ValidateJobFn[] = [];
-        const allWarnings: Terafoundation.JobWarning[] = [];
+        const allWarnings: Terafoundation.JobWarning[] = [...jobWarnings];
         const opAPIMapping = new Map<string, string>();
 
         const handleModule = (

--- a/packages/job-components/src/job-validator.ts
+++ b/packages/job-components/src/job-validator.ts
@@ -74,6 +74,7 @@ export class JobValidator {
             const opResult = schema.validate(opConfig);
             // TODO: v3 schemas may return the config directly instead of
             // { config, warnings }. Support for the old shape will be dropped in Teraslice v4.
+            // See https://github.com/terascope/teraslice/issues/4501
             const validatedConfig = isValidateResult(opResult) ? opResult.config : opResult;
             const warnings = isValidateResult(opResult) ? (opResult.warnings ?? []) : [];
             allWarnings.push(...warnings);
@@ -136,6 +137,7 @@ export class JobValidator {
             const apiResult = schema.validate(apiConfig);
             // TODO: v3 schemas may return the config directly instead of
             // { config, warnings }. Support for the old shape will be dropped in Teraslice v4.
+            // See https://github.com/terascope/teraslice/issues/4501
             const validatedApiConfig = isValidateResult(apiResult) ? apiResult.config : apiResult;
             const apiWarnings = isValidateResult(apiResult) ? (apiResult.warnings ?? []) : [];
             allWarnings.push(...apiWarnings);
@@ -210,6 +212,7 @@ export class JobValidator {
  *
  * @backwards-compat: v3 schemas return the config directly instead of this shape.
  * Support for the old shape will be dropped in Teraslice v4.
+ * See https://github.com/terascope/teraslice/issues/4501
  */
 type ValidateResult = { config: any; warnings: Teraslice.JobWarning[] };
 
@@ -220,6 +223,7 @@ type ValidateResult = { config: any; warnings: Teraslice.JobWarning[] };
  * @backwards-compat: v3 schemas return the config directly. This guard exists to
  * support both shapes during the deprecation window. Will be removed in Teraslice v4
  * when all schemas are required to return { config, warnings }.
+ * See https://github.com/terascope/teraslice/issues/4501
  */
 function isValidateResult(result: any): result is ValidateResult {
     // Check for both 'config' and 'warnings' to avoid false positives on legacy op

--- a/packages/job-components/src/job-validator.ts
+++ b/packages/job-components/src/job-validator.ts
@@ -30,7 +30,7 @@ export class JobValidator {
     /** Validate the job configuration, including the Operations and APIs configuration */
     async validateConfig(
         jobSpec: Partial<Teraslice.JobConfig | Teraslice.JobConfigParams>,
-    ): Promise<{ jobConfig: ValidatedJobConfig; warnings: Terafoundation.JobWarning[] }> {
+    ): Promise<{ jobConfig: ValidatedJobConfig; warnings: Teraslice.JobWarning[] }> {
         // top level job validation occurs, but not operations
         const {
             config: jobConfig,
@@ -42,7 +42,7 @@ export class JobValidator {
         type ValidateJobFn = (job: ValidatedJobConfig) => void;
         const validateJobFns: ValidateJobFn[] = [];
         const validateApisFns: ValidateJobFn[] = [];
-        const allWarnings: Terafoundation.JobWarning[] = [...jobWarnings];
+        const allWarnings: Teraslice.JobWarning[] = [...jobWarnings];
         const opAPIMapping = new Map<string, string>();
 
         const handleModule = (
@@ -211,7 +211,7 @@ export class JobValidator {
  * @backwards-compat: v3 schemas return the config directly instead of this shape.
  * Support for the old shape will be dropped in Teraslice v4.
  */
-type ValidateResult = { config: any; warnings: Terafoundation.JobWarning[] };
+type ValidateResult = { config: any; warnings: Teraslice.JobWarning[] };
 
 /**
  * Type guard to distinguish new-style schema validate() results (ValidateResult)

--- a/packages/job-components/src/job-validator.ts
+++ b/packages/job-components/src/job-validator.ts
@@ -30,7 +30,7 @@ export class JobValidator {
     /** Validate the job configuration, including the Operations and APIs configuration */
     async validateConfig(
         jobSpec: Partial<Teraslice.JobConfig | Teraslice.JobConfigParams>,
-    ): Promise<ValidatedJobConfig> {
+    ): Promise<{ jobConfig: ValidatedJobConfig, warnings: Terafoundation.JobWarning[] }> {
         // top level job validation occurs, but not operations
         const jobConfig = validateJobConfig(this.schema, cloneDeep(jobSpec), this.context);
         const assetIds = jobConfig.assets || [];
@@ -39,6 +39,7 @@ export class JobValidator {
         type ValidateJobFn = (job: ValidatedJobConfig) => void;
         const validateJobFns: ValidateJobFn[] = [];
         const validateApisFns: ValidateJobFn[] = [];
+        const allWarnings: Terafoundation.JobWarning[] = [];
         const opAPIMapping = new Map<string, string>();
 
         const handleModule = (
@@ -67,7 +68,12 @@ export class JobValidator {
                 job.operations[index]._op = originalName;
             });
 
-            const validatedConfig = schema.validate(opConfig);
+            const opResult = schema.validate(opConfig);
+            // TODO: v3 schemas may return the config directly instead of
+            // { config, warnings }. Support for the old shape will be dropped in Teraslice v4.
+            const validatedConfig = isValidateResult(opResult) ? opResult.config : opResult;
+            const warnings = isValidateResult(opResult) ? (opResult.warnings ?? []) : [];
+            allWarnings.push(...warnings);
 
             const needsAPI = has(validatedConfig, '_api_name') || has(validatedConfig, 'api_name');
 
@@ -124,7 +130,13 @@ export class JobValidator {
                 job.apis[index]._name = originalName;
             });
 
-            return schema.validate(apiConfig);
+            const apiResult = schema.validate(apiConfig);
+            // @backwards-compat: v3 schemas may return the config directly instead of
+            // { config, warnings }. Support for the old shape will be dropped in Teraslice v4.
+            const validatedApiConfig = isValidateResult(apiResult) ? apiResult.config : apiResult;
+            const apiWarnings = isValidateResult(apiResult) ? (apiResult.warnings ?? []) : [];
+            allWarnings.push(...apiWarnings);
+            return validatedApiConfig;
         });
 
         // this can mutate the job
@@ -153,7 +165,7 @@ export class JobValidator {
 
         await this._applyRelocatable(jobConfig);
 
-        return jobConfig;
+        return { jobConfig, warnings: allWarnings };
     }
 
     /**
@@ -188,4 +200,19 @@ export class JobValidator {
             throw new Error(`${name} schema needs to return an object`);
         }
     }
+}
+
+/**
+ * Type guard to distinguish new-style schema validate() results ({ config, warnings })
+ * from old-style results (plain config object).
+ *
+ * @backwards-compat: v3 schemas return the config directly. This guard exists to
+ * support both shapes during the deprecation window. Will be removed in Teraslice v4
+ * when all schemas are required to return { config, warnings }.
+ */
+function isValidateResult(result: any): result is { config: any; warnings: Terafoundation.JobWarning[] } {
+    return result != null
+        && typeof result === 'object'
+        && 'config' in result
+        && typeof result.config === 'object';
 }

--- a/packages/job-components/src/job-validator.ts
+++ b/packages/job-components/src/job-validator.ts
@@ -32,7 +32,10 @@ export class JobValidator {
         jobSpec: Partial<Teraslice.JobConfig | Teraslice.JobConfigParams>,
     ): Promise<{ jobConfig: ValidatedJobConfig; warnings: Terafoundation.JobWarning[] }> {
         // top level job validation occurs, but not operations
-        const { config: jobConfig, warnings: jobWarnings } = validateJobConfig(this.schema, cloneDeep(jobSpec), this.context);
+        const {
+            config: jobConfig,
+            warnings: jobWarnings
+        } = validateJobConfig(this.schema, cloneDeep(jobSpec), this.context);
         const assetIds = jobConfig.assets || [];
         const apis: Record<string, OperationAPIConstructor> = {};
 

--- a/packages/job-components/src/job-validator.ts
+++ b/packages/job-components/src/job-validator.ts
@@ -30,7 +30,7 @@ export class JobValidator {
     /** Validate the job configuration, including the Operations and APIs configuration */
     async validateConfig(
         jobSpec: Partial<Teraslice.JobConfig | Teraslice.JobConfigParams>,
-    ): Promise<{ jobConfig: ValidatedJobConfig, warnings: Terafoundation.JobWarning[] }> {
+    ): Promise<{ jobConfig: ValidatedJobConfig; warnings: Terafoundation.JobWarning[] }> {
         // top level job validation occurs, but not operations
         const jobConfig = validateJobConfig(this.schema, cloneDeep(jobSpec), this.context);
         const assetIds = jobConfig.assets || [];
@@ -210,7 +210,9 @@ export class JobValidator {
  * support both shapes during the deprecation window. Will be removed in Teraslice v4
  * when all schemas are required to return { config, warnings }.
  */
-function isValidateResult(result: any): result is { config: any; warnings: Terafoundation.JobWarning[] } {
+function isValidateResult(
+    result: any
+): result is { config: any; warnings: Terafoundation.JobWarning[] } {
     return result != null
         && typeof result === 'object'
         && 'config' in result

--- a/packages/job-components/src/operations/base-schema.ts
+++ b/packages/job-components/src/operations/base-schema.ts
@@ -1,4 +1,4 @@
-import { Terafoundation } from '@terascope/types';
+import { Teraslice, Terafoundation } from '@terascope/types';
 import SchemaCore, { OpType } from './core/schema-core.js';
 import {
     Context, OpConfig, APIConfig,
@@ -20,14 +20,14 @@ export default abstract class BaseSchema<T extends Record<string, any>, S = any>
     }
 
     validate(inputConfig: Record<string, any>): {
-        config: APIConfig & T; warnings: Terafoundation.JobWarning[];
+        config: APIConfig & T; warnings: Teraslice.JobWarning[];
     };
     validate(inputConfig: Record<string, any>): {
-        config: OpConfig & T; warnings: Terafoundation.JobWarning[];
+        config: OpConfig & T; warnings: Teraslice.JobWarning[];
     };
     validate(
         inputConfig: Record<string, any>
-    ): { config: OpConfig | APIConfig & T; warnings: Terafoundation.JobWarning[] } {
+    ): { config: OpConfig | APIConfig & T; warnings: Teraslice.JobWarning[] } {
         if (this.opType === 'api') {
             return validateAPIConfig<T>(this.schema, inputConfig, this.context);
         }

--- a/packages/job-components/src/operations/base-schema.ts
+++ b/packages/job-components/src/operations/base-schema.ts
@@ -19,9 +19,9 @@ export default abstract class BaseSchema<T extends Record<string, any>, S = any>
         this.schema = this.build(context);
     }
 
-    validate(inputConfig: Record<string, any>): APIConfig & T;
-    validate(inputConfig: Record<string, any>): OpConfig & T;
-    validate(inputConfig: Record<string, any>): OpConfig | APIConfig & T {
+    validate(inputConfig: Record<string, any>): { config: APIConfig & T, warnings: Terafoundation.JobWarning[] };
+    validate(inputConfig: Record<string, any>): { config: OpConfig & T, warnings: Terafoundation.JobWarning[] };
+    validate(inputConfig: Record<string, any>): { config: OpConfig | APIConfig & T, warnings: Terafoundation.JobWarning[] } {
         if (this.opType === 'api') {
             return validateAPIConfig<T>(this.schema, inputConfig, this.context);
         }

--- a/packages/job-components/src/operations/base-schema.ts
+++ b/packages/job-components/src/operations/base-schema.ts
@@ -19,9 +19,15 @@ export default abstract class BaseSchema<T extends Record<string, any>, S = any>
         this.schema = this.build(context);
     }
 
-    validate(inputConfig: Record<string, any>): { config: APIConfig & T, warnings: Terafoundation.JobWarning[] };
-    validate(inputConfig: Record<string, any>): { config: OpConfig & T, warnings: Terafoundation.JobWarning[] };
-    validate(inputConfig: Record<string, any>): { config: OpConfig | APIConfig & T, warnings: Terafoundation.JobWarning[] } {
+    validate(inputConfig: Record<string, any>): {
+        config: APIConfig & T; warnings: Terafoundation.JobWarning[];
+    };
+    validate(inputConfig: Record<string, any>): {
+        config: OpConfig & T; warnings: Terafoundation.JobWarning[];
+    };
+    validate(
+        inputConfig: Record<string, any>
+    ): { config: OpConfig | APIConfig & T; warnings: Terafoundation.JobWarning[] } {
         if (this.opType === 'api') {
             return validateAPIConfig<T>(this.schema, inputConfig, this.context);
         }

--- a/packages/job-components/src/operations/core/schema-core.ts
+++ b/packages/job-components/src/operations/core/schema-core.ts
@@ -1,4 +1,4 @@
-import { Terafoundation } from '@terascope/types';
+import { Teraslice } from '@terascope/types';
 import { Context, OpConfig, ValidatedJobConfig } from '../../interfaces/index.js';
 
 /**
@@ -17,7 +17,7 @@ export default abstract class SchemaCore<T> {
     abstract build(context?: Context): any;
     abstract validate(
         inputConfig: Record<string, any>
-    ): { config: OpConfig & T; warnings: Terafoundation.JobWarning[] };
+    ): { config: OpConfig & T; warnings: Teraslice.JobWarning[] };
     abstract validateJob?(job: ValidatedJobConfig): void;
 }
 

--- a/packages/job-components/src/operations/core/schema-core.ts
+++ b/packages/job-components/src/operations/core/schema-core.ts
@@ -1,3 +1,4 @@
+import { Terafoundation } from '@terascope/types';
 import { Context, OpConfig, ValidatedJobConfig } from '../../interfaces/index.js';
 
 /**
@@ -14,7 +15,7 @@ export default abstract class SchemaCore<T> {
     }
 
     abstract build(context?: Context): any;
-    abstract validate(inputConfig: Record<string, any>): OpConfig & T;
+    abstract validate(inputConfig: Record<string, any>): { config: OpConfig & T, warnings: Terafoundation.JobWarning[] };
     abstract validateJob?(job: ValidatedJobConfig): void;
 }
 

--- a/packages/job-components/src/operations/core/schema-core.ts
+++ b/packages/job-components/src/operations/core/schema-core.ts
@@ -15,7 +15,9 @@ export default abstract class SchemaCore<T> {
     }
 
     abstract build(context?: Context): any;
-    abstract validate(inputConfig: Record<string, any>): { config: OpConfig & T, warnings: Terafoundation.JobWarning[] };
+    abstract validate(
+        inputConfig: Record<string, any>
+    ): { config: OpConfig & T; warnings: Terafoundation.JobWarning[] };
     abstract validateJob?(job: ValidatedJobConfig): void;
 }
 

--- a/packages/job-components/test/builtin/collect-spec.ts
+++ b/packages/job-components/test/builtin/collect-spec.ts
@@ -32,13 +32,13 @@ describe('Collect Processor', () => {
 
     it('should be able to pass validation', () => {
         const schema = new Schema(context);
-        const result = schema.validate({
+        const { config } = schema.validate({
             _op: 'collect',
             size: 100,
             wait: 100
         });
-        expect(result).toHaveProperty('wait', 100);
-        expect(result).toHaveProperty('size', 100);
+        expect(config).toHaveProperty('wait', 100);
+        expect(config).toHaveProperty('size', 100);
     });
 
     it('should be able to fail validation', () => {

--- a/packages/job-components/test/builtin/delay-spec.ts
+++ b/packages/job-components/test/builtin/delay-spec.ts
@@ -25,8 +25,8 @@ describe('Delay Processor', () => {
     });
 
     it('should be able to pass validation', () => {
-        const result = schema.validate({ _op: 'delay' });
-        expect(result).toHaveProperty('ms', 100);
+        const { config } = schema.validate({ _op: 'delay' });
+        expect(config).toHaveProperty('ms', 100);
     });
 
     it('should delay at least 100ms', async () => {

--- a/packages/job-components/test/builtin/noop-spec.ts
+++ b/packages/job-components/test/builtin/noop-spec.ts
@@ -25,8 +25,8 @@ describe('Noop Processor', () => {
     });
 
     it('should be able to pass validation', () => {
-        const result = schema.validate({ _op: 'delay' });
-        expect(result).toMatchObject({ _op: 'delay' });
+        const { config } = schema.validate({ _op: 'delay' });
+        expect(config).toMatchObject({ _op: 'delay' });
     });
 
     it('should not mutate the data when given an empty array', () => {

--- a/packages/job-components/test/builtin/test-reader-spec.ts
+++ b/packages/job-components/test/builtin/test-reader-spec.ts
@@ -18,19 +18,19 @@ describe('Test Reader', () => {
         const schema = new Schema(context);
 
         it('should be able to return the correct opConfig with not additional config', () => {
-            const result = schema.validate({ _op: 'test-reader' });
-            expect(result).toHaveProperty('fetcher_data_file_path', null);
-            expect(result).toHaveProperty('slicer_data_file_path', null);
+            const { config } = schema.validate({ _op: 'test-reader' });
+            expect(config).toHaveProperty('fetcher_data_file_path', null);
+            expect(config).toHaveProperty('slicer_data_file_path', null);
         });
 
         it('should be able to return the correct opConfig with additional config', () => {
-            const result = schema.validate({
+            const { config } = schema.validate({
                 _op: 'test-reader',
                 fetcher_data_file_path: 'hello',
                 slicer_data_file_path: 'hi',
             });
-            expect(result).toHaveProperty('fetcher_data_file_path', 'hello');
-            expect(result).toHaveProperty('slicer_data_file_path', 'hi');
+            expect(config).toHaveProperty('fetcher_data_file_path', 'hello');
+            expect(config).toHaveProperty('slicer_data_file_path', 'hi');
         });
     });
 

--- a/packages/job-components/test/config-validators-spec.ts
+++ b/packages/job-components/test/config-validators-spec.ts
@@ -442,6 +442,49 @@ describe('when using native clustering', () => {
                 validateOpConfig(schema, op, context);
             }).toThrow(/Invalid schema for formatted value/);
         });
+
+        it('should return a deprecation warning when a deprecated field is provided', () => {
+            const deprecatedSchema: Terafoundation.Schema<any> = {
+                old_value: {
+                    default: 'default_value',
+                    doc: 'a deprecated field',
+                    format: 'String',
+                    deprecated: 'use example instead',
+                },
+            };
+            const op = {
+                _op: 'some-op',
+                old_value: 'changed',
+            };
+
+            const { warnings } = validateOpConfig(deprecatedSchema, op, context);
+            expect(warnings).toBeArrayOfSize(1);
+            expect(warnings[0]).toMatchObject({
+                type: 'JobValidation',
+                reason: {
+                    type: 'assetOperationProperty',
+                    reason: {
+                        name: 'some-op',
+                        type: 'deprecation',
+                        reason: {
+                            name: 'old_value',
+                            description: 'use example instead',
+                        },
+                    },
+                },
+            });
+        });
+
+        it('should return no warnings when no deprecated fields are used', () => {
+            const op = {
+                _op: 'some-op',
+                example: 'example',
+                formatted_value: 'hi',
+            };
+
+            const { warnings } = validateOpConfig(schema, op, context);
+            expect(warnings).toBeArrayOfSize(0);
+        });
     });
 
     describe('when validating apiConfig', () => {
@@ -501,6 +544,49 @@ describe('when using native clustering', () => {
             expect(() => {
                 validateAPIConfig(schema, api, context);
             }).toThrow(/Invalid schema for formatted value/);
+        });
+
+        it('should return a deprecation warning when a deprecated field is provided', () => {
+            const deprecatedSchema: Terafoundation.Schema<any> = {
+                old_value: {
+                    default: 'default_value',
+                    doc: 'a deprecated field',
+                    format: 'String',
+                    deprecated: 'use example instead',
+                },
+            };
+            const api = {
+                _name: 'some-api',
+                old_value: 'changed',
+            };
+
+            const { warnings } = validateAPIConfig(deprecatedSchema, api, context);
+            expect(warnings).toBeArrayOfSize(1);
+            expect(warnings[0]).toMatchObject({
+                type: 'JobValidation',
+                reason: {
+                    type: 'assetAPIProperty',
+                    reason: {
+                        name: 'some-api',
+                        type: 'deprecation',
+                        reason: {
+                            name: 'old_value',
+                            description: 'use example instead',
+                        },
+                    },
+                },
+            });
+        });
+
+        it('should return no warnings when no deprecated fields are used', () => {
+            const api = {
+                _name: 'some-api',
+                example: 'example',
+                formatted_value: 'hi',
+            };
+
+            const { warnings } = validateAPIConfig(schema, api, context);
+            expect(warnings).toBeArrayOfSize(0);
         });
     });
 
@@ -726,6 +812,56 @@ describe('when validating k8s v2 clustering', () => {
             const { config: jobConfig } = validateJobConfig(schema, job, context);
             expect(jobConfig.cpu).toEqual(job.cpu);
             expect(jobConfig.memory).toEqual(job.memory);
+        });
+    });
+
+    describe('when passed a jobConfig with deprecated cpu and memory', () => {
+        it('should return jobProperty deprecation warnings', () => {
+            const schema = jobSchema(context);
+            const job = {
+                name: 'test-job',
+                cpu: 1,
+                memory: 805306368,
+                operations: [
+                    {
+                        _op: 'noop',
+                    },
+                    {
+                        _op: 'noop',
+                    },
+                ],
+            };
+
+            const { warnings } = validateJobConfig(schema, job, context);
+            expect(warnings).toBeArrayOfSize(2);
+            expect(warnings[0]).toMatchObject({
+                type: 'JobValidation',
+                reason: {
+                    type: 'jobProperty',
+                    reason: {
+                        name: 'test-job',
+                        type: 'deprecation',
+                        reason: {
+                            name: 'cpu',
+                            description: '"cpu" on a job is deprecated and should use "resources_requests_cpu" instead',
+                        },
+                    },
+                },
+            });
+            expect(warnings[1]).toMatchObject({
+                type: 'JobValidation',
+                reason: {
+                    type: 'jobProperty',
+                    reason: {
+                        name: 'test-job',
+                        type: 'deprecation',
+                        reason: {
+                            name: 'memory',
+                            description: '"memory" on a job is deprecated and should use "resources_requests_memory" instead',
+                        },
+                    },
+                },
+            });
         });
     });
 

--- a/packages/job-components/test/config-validators-spec.ts
+++ b/packages/job-components/test/config-validators-spec.ts
@@ -342,7 +342,7 @@ describe('when using native clustering', () => {
                 formatted_value: 'hi',
             };
 
-            const config = validateOpConfig(schema, op, context);
+            const { config } = validateOpConfig(schema, op, context);
             expect(config).toEqual({
                 _op: 'some-op',
                 _encoding: 'json',
@@ -361,7 +361,7 @@ describe('when using native clustering', () => {
                 formatted_value: 'hi',
             };
 
-            const config = validateOpConfig(schema, op, context);
+            const { config } = validateOpConfig(schema, op, context);
             expect(config).toEqual({
                 _op: 'some-op',
                 _encoding: 'json',
@@ -407,7 +407,7 @@ describe('when using native clustering', () => {
                 formatted_value: 'hi',
             };
 
-            const config = validateOpConfig(schema, op, context);
+            const { config } = validateOpConfig(schema, op, context);
             expect(config).toEqual({
                 _op: 'some-op',
                 _encoding: 'json',
@@ -480,7 +480,7 @@ describe('when using native clustering', () => {
                 formatted_value: 'hi'
             };
 
-            const config = validateAPIConfig(schema, api, context);
+            const { config } = validateAPIConfig(schema, api, context);
             expect(config).toEqual({
                 _name: 'some-api',
                 example: 'example',

--- a/packages/job-components/test/config-validators-spec.ts
+++ b/packages/job-components/test/config-validators-spec.ts
@@ -37,7 +37,7 @@ describe('when using native clustering', () => {
                 slicers: 1,
             };
 
-            const jobConfig = validateJobConfig(schema, job, context);
+            const { config: jobConfig } = validateJobConfig(schema, job, context);
             delete (jobConfig as any).workers;
             expect(jobConfig).toMatchObject(validJob);
         });
@@ -536,7 +536,7 @@ describe('when using native clustering', () => {
                     slicers: 1,
                 };
 
-                const jobConfig = validateJobConfig(schema, job, context);
+                const { config: jobConfig } = validateJobConfig(schema, job, context);
                 delete (jobConfig as any).workers;
                 expect(jobConfig).toMatchObject(validJob);
             });
@@ -623,7 +623,7 @@ describe('when using native clustering', () => {
                     slicers: 1,
                 };
 
-                const jobConfig = validateJobConfig(schema, job, context);
+                const { config: jobConfig } = validateJobConfig(schema, job, context);
                 delete (jobConfig as any).workers;
                 expect(jobConfig).toMatchObject(validJob);
             });
@@ -723,7 +723,7 @@ describe('when validating k8s v2 clustering', () => {
                 ],
             };
 
-            const jobConfig = validateJobConfig(schema, job, context);
+            const { config: jobConfig } = validateJobConfig(schema, job, context);
             expect(jobConfig.cpu).toEqual(job.cpu);
             expect(jobConfig.memory).toEqual(job.memory);
         });
@@ -747,7 +747,7 @@ describe('when validating k8s v2 clustering', () => {
                 ],
             };
 
-            const jobConfig = validateJobConfig(schema, job, context);
+            const { config: jobConfig } = validateJobConfig(schema, job, context);
             expect(jobConfig.resources_requests_cpu).toEqual(job.resources_requests_cpu);
             expect(jobConfig.resources_requests_memory).toEqual(job.resources_requests_memory);
             expect(jobConfig.resources_limits_cpu).toEqual(job.resources_limits_cpu);
@@ -820,7 +820,7 @@ describe('when validating k8s v2 clustering', () => {
                 volumes: [],
             };
 
-            const jobConfig = validateJobConfig(schema, job, context);
+            const { config: jobConfig } = validateJobConfig(schema, job, context);
             delete (jobConfig as any).workers;
             expect(jobConfig).toMatchObject(validJob);
         });
@@ -865,7 +865,7 @@ describe('when validating k8s v2 clustering', () => {
                 slicers: 1,
             };
 
-            const jobConfig = validateJobConfig(schema, job, context);
+            const { config: jobConfig } = validateJobConfig(schema, job, context);
             delete (jobConfig as any).workers;
             expect(jobConfig).toMatchObject(validJob);
         });

--- a/packages/job-components/test/config-validators-spec.ts
+++ b/packages/job-components/test/config-validators-spec.ts
@@ -462,14 +462,12 @@ describe('when using native clustering', () => {
             expect(warnings[0]).toMatchObject({
                 type: 'JobValidation',
                 reason: {
-                    type: 'assetOperationProperty',
+                    type: 'assetOperation',
+                    kind: 'deprecation',
                     reason: {
-                        name: 'some-op',
-                        type: 'deprecation',
-                        reason: {
-                            name: 'old_value',
-                            description: 'use example instead',
-                        },
+                        _op: 'some-op',
+                        field: 'old_value',
+                        description: 'use example instead',
                     },
                 },
             });
@@ -566,13 +564,11 @@ describe('when using native clustering', () => {
                 type: 'JobValidation',
                 reason: {
                     type: 'assetAPIProperty',
+                    kind: 'deprecation',
                     reason: {
-                        name: 'some-api',
-                        type: 'deprecation',
-                        reason: {
-                            name: 'old_value',
-                            description: 'use example instead',
-                        },
+                        api_name: 'some-api',
+                        field: 'old_value',
+                        description: 'use example instead',
                     },
                 },
             });
@@ -838,13 +834,10 @@ describe('when validating k8s v2 clustering', () => {
                 type: 'JobValidation',
                 reason: {
                     type: 'jobProperty',
+                    kind: 'deprecation',
                     reason: {
-                        name: 'test-job',
-                        type: 'deprecation',
-                        reason: {
-                            name: 'cpu',
-                            description: '"cpu" on a job is deprecated and should use "resources_requests_cpu" instead',
-                        },
+                        field: 'cpu',
+                        description: '"cpu" on a job is deprecated and should use "resources_requests_cpu" instead',
                     },
                 },
             });
@@ -852,13 +845,10 @@ describe('when validating k8s v2 clustering', () => {
                 type: 'JobValidation',
                 reason: {
                     type: 'jobProperty',
+                    kind: 'deprecation',
                     reason: {
-                        name: 'test-job',
-                        type: 'deprecation',
-                        reason: {
-                            name: 'memory',
-                            description: '"memory" on a job is deprecated and should use "resources_requests_memory" instead',
-                        },
+                        field: 'memory',
+                        description: '"memory" on a job is deprecated and should use "resources_requests_memory" instead',
                     },
                 },
             });

--- a/packages/job-components/test/fixtures/asset/example-api/schema.ts
+++ b/packages/job-components/test/fixtures/asset/example-api/schema.ts
@@ -7,7 +7,13 @@ export default class Schema extends BaseSchema<any, any> {
                 default: 'examples are quick and easy',
                 doc: 'A random example schema property',
                 format: 'String',
-            }
+            },
+            old_example: {
+                default: 'old_default',
+                doc: 'Deprecated example field',
+                format: 'String',
+                deprecated: 'use example instead',
+            },
         };
     }
 }

--- a/packages/job-components/test/fixtures/asset/example-op/schema.ts
+++ b/packages/job-components/test/fixtures/asset/example-op/schema.ts
@@ -13,6 +13,12 @@ export default class Schema extends BaseSchema<any, any> {
                 doc: 'Test flushing',
                 format: 'Boolean',
             },
+            old_example: {
+                default: 'old_default',
+                doc: 'Deprecated example field',
+                format: 'String',
+                deprecated: 'use example instead',
+            },
         };
     }
 }

--- a/packages/job-components/test/fixtures/asset/example-reader/schema.ts
+++ b/packages/job-components/test/fixtures/asset/example-reader/schema.ts
@@ -15,6 +15,12 @@ export default class Schema extends BaseSchema<any, any> {
                 doc: 'A random example schema property',
                 format: 'String',
             },
+            old_example: {
+                default: 'old_default',
+                doc: 'Deprecated example field',
+                format: 'String',
+                deprecated: 'use example instead',
+            },
         };
     }
 }

--- a/packages/job-components/test/job-validator-spec.ts
+++ b/packages/job-components/test/job-validator-spec.ts
@@ -61,7 +61,7 @@ describe('JobValidator', () => {
             const { warnings } = await api.validateConfig(jobSpec);
             expect(warnings).toBeArrayOfSize(2);
             expect(warnings.every((w) => w.type === 'JobValidation')).toBeTrue();
-            expect(warnings.every((w) => w.reason.reason.type === 'deprecation')).toBeTrue();
+            expect(warnings.every((w) => w.reason.kind === 'deprecation')).toBeTrue();
         });
 
         it('collects deprecation warnings from an api', async () => {
@@ -90,13 +90,11 @@ describe('JobValidator', () => {
                 type: 'JobValidation',
                 reason: {
                     type: 'assetAPIProperty',
+                    kind: 'deprecation',
                     reason: {
-                        name: 'example-api',
-                        type: 'deprecation',
-                        reason: {
-                            name: 'old_example',
-                            description: 'use example instead',
-                        },
+                        api_name: 'example-api',
+                        field: 'old_example',
+                        description: 'use example instead',
                     },
                 },
             });

--- a/packages/job-components/test/job-validator-spec.ts
+++ b/packages/job-components/test/job-validator-spec.ts
@@ -60,7 +60,7 @@ describe('JobValidator', () => {
 
             const { warnings } = await api.validateConfig(jobSpec);
             expect(warnings).toBeArrayOfSize(2);
-            expect(warnings.every((w) => w.type === 'deprecation')).toBeTrue();
+            expect(warnings.every((w) => w.category === 'deprecation')).toBeTrue();
         });
 
         it('will throw based off op validation errors', async () => {

--- a/packages/job-components/test/job-validator-spec.ts
+++ b/packages/job-components/test/job-validator-spec.ts
@@ -38,7 +38,7 @@ describe('JobValidator', () => {
                 ],
             });
 
-            const validJob = await api.validateConfig(jobSpec);
+            const { jobConfig: validJob } = await api.validateConfig(jobSpec);
             expect(validJob).toMatchObject(jobSpec);
         });
 
@@ -172,7 +172,7 @@ describe('JobValidator', () => {
                 ],
             });
 
-            const validJob = await testApi.validateConfig(jobSpec);
+            const { jobConfig: validJob } = await testApi.validateConfig(jobSpec);
             expect(validJob).toMatchObject(jobSpec);
         });
 
@@ -204,7 +204,7 @@ describe('JobValidator', () => {
                 ],
             });
 
-            const validJob = await testApi.validateConfig(jobSpec);
+            const { jobConfig: validJob } = await testApi.validateConfig(jobSpec);
 
             expect(validJob).toMatchObject(jobSpec);
         });
@@ -276,7 +276,7 @@ describe('JobValidator', () => {
                 ],
             });
 
-            const validJob = await testApi.validateConfig(jobSpec);
+            const { jobConfig: validJob } = await testApi.validateConfig(jobSpec);
 
             await expect(
                 () => api.validateConfig(oldJobSpec)

--- a/packages/job-components/test/job-validator-spec.ts
+++ b/packages/job-components/test/job-validator-spec.ts
@@ -42,6 +42,27 @@ describe('JobValidator', () => {
             expect(validJob).toMatchObject(jobSpec);
         });
 
+        it('collects deprecation warnings from multiple ops', async () => {
+            const jobSpec: JobConfigParams = {
+                name: 'test',
+                assets: ['fixtures'],
+                operations: [
+                    {
+                        _op: 'example-reader',
+                        old_example: 'triggered',
+                    },
+                    {
+                        _op: 'example-op',
+                        old_example: 'triggered',
+                    },
+                ],
+            };
+
+            const { warnings } = await api.validateConfig(jobSpec);
+            expect(warnings).toBeArrayOfSize(2);
+            expect(warnings.every((w) => w.type === 'deprecation')).toBeTrue();
+        });
+
         it('will throw based off op validation errors', async () => {
         // if subslice_by_key, then it needs type specified or it will error
             const jobSpec: JobConfigParams = {

--- a/packages/job-components/test/job-validator-spec.ts
+++ b/packages/job-components/test/job-validator-spec.ts
@@ -64,6 +64,44 @@ describe('JobValidator', () => {
             expect(warnings.every((w) => w.reason.reason.type === 'deprecation')).toBeTrue();
         });
 
+        it('collects deprecation warnings from an api', async () => {
+            const jobSpec: JobConfigParams = {
+                name: 'test',
+                assets: ['fixtures'],
+                apis: [
+                    {
+                        _name: 'example-api',
+                        old_example: 'triggered',
+                    },
+                ],
+                operations: [
+                    {
+                        _op: 'test-reader',
+                    },
+                    {
+                        _op: 'noop',
+                    },
+                ],
+            };
+
+            const { warnings } = await api.validateConfig(jobSpec);
+            expect(warnings).toBeArrayOfSize(1);
+            expect(warnings[0]).toMatchObject({
+                type: 'JobValidation',
+                reason: {
+                    type: 'assetAPIProperty',
+                    reason: {
+                        name: 'example-api',
+                        type: 'deprecation',
+                        reason: {
+                            name: 'old_example',
+                            description: 'use example instead',
+                        },
+                    },
+                },
+            });
+        });
+
         it('will throw based off op validation errors', async () => {
         // if subslice_by_key, then it needs type specified or it will error
             const jobSpec: JobConfigParams = {

--- a/packages/job-components/test/job-validator-spec.ts
+++ b/packages/job-components/test/job-validator-spec.ts
@@ -60,7 +60,8 @@ describe('JobValidator', () => {
 
             const { warnings } = await api.validateConfig(jobSpec);
             expect(warnings).toBeArrayOfSize(2);
-            expect(warnings.every((w) => w.category === 'deprecation')).toBeTrue();
+            expect(warnings.every((w) => w.type === 'JobValidation')).toBeTrue();
+            expect(warnings.every((w) => w.reason.reason.type === 'deprecation')).toBeTrue();
         });
 
         it('will throw based off op validation errors', async () => {

--- a/packages/job-components/test/operations/base-schema-spec.ts
+++ b/packages/job-components/test/operations/base-schema-spec.ts
@@ -81,11 +81,18 @@ describe('Base Schema', () => {
             const { warnings } = depSchema.validate({ _op: 'hello', old_field: 'some_value' });
             expect(warnings).toBeArrayOfSize(1);
             expect(warnings[0]).toMatchObject({
-                category: 'deprecation',
-                subcategory: 'assetOperationProperty',
-                name: 'hello',
-                field: 'old_field',
-                description: 'use new_field instead',
+                type: 'JobValidation',
+                reason: {
+                    type: 'assetOperationProperty',
+                    reason: {
+                        name: 'hello',
+                        type: 'deprecation',
+                        reason: {
+                            name: 'old_field',
+                            description: 'use new_field instead',
+                        },
+                    },
+                },
             });
         });
 

--- a/packages/job-components/test/operations/base-schema-spec.ts
+++ b/packages/job-components/test/operations/base-schema-spec.ts
@@ -20,6 +20,23 @@ describe('Base Schema', () => {
         }
     }
 
+    interface DeprecatedOpConfig extends OpConfig {
+        old_field: string;
+    }
+
+    class DeprecatedSchema extends BaseSchema<DeprecatedOpConfig> {
+        build() {
+            return {
+                old_field: {
+                    default: 'default_value',
+                    doc: 'A deprecated field',
+                    format: 'String',
+                    deprecated: 'use new_field instead',
+                }
+            };
+        }
+    }
+
     const schema = new ExampleSchema(context);
 
     describe('->build', () => {
@@ -52,6 +69,27 @@ describe('Base Schema', () => {
             expect(() => {
                 schema.validate({});
             }).toThrow();
+        });
+
+        it('should return no warnings when no deprecated fields are used', () => {
+            const { warnings } = schema.validate({ _op: 'hello', example: 'hi' });
+            expect(warnings).toBeArrayOfSize(0);
+        });
+
+        it('should return a warning when a deprecated field is provided', () => {
+            const depSchema = new DeprecatedSchema(context);
+            const { warnings } = depSchema.validate({ _op: 'hello', old_field: 'some_value' });
+            expect(warnings).toBeArrayOfSize(1);
+            expect(warnings[0]).toMatchObject({
+                type: 'deprecation',
+                description: 'use new_field instead',
+            });
+        });
+
+        it('should not warn about deprecated fields set to their default value', () => {
+            const depSchema = new DeprecatedSchema(context);
+            const { warnings } = depSchema.validate({ _op: 'hello' });
+            expect(warnings).toBeArrayOfSize(0);
         });
     });
 

--- a/packages/job-components/test/operations/base-schema-spec.ts
+++ b/packages/job-components/test/operations/base-schema-spec.ts
@@ -81,7 +81,10 @@ describe('Base Schema', () => {
             const { warnings } = depSchema.validate({ _op: 'hello', old_field: 'some_value' });
             expect(warnings).toBeArrayOfSize(1);
             expect(warnings[0]).toMatchObject({
-                type: 'deprecation',
+                category: 'deprecation',
+                subcategory: 'assetOperationProperty',
+                name: 'hello',
+                field: 'old_field',
                 description: 'use new_field instead',
             });
         });

--- a/packages/job-components/test/operations/base-schema-spec.ts
+++ b/packages/job-components/test/operations/base-schema-spec.ts
@@ -36,10 +36,11 @@ describe('Base Schema', () => {
 
     describe('->validate', () => {
         it('should succeed when given valid data', () => {
-            expect(schema.validate({
+            const { config } = schema.validate({
                 _op: 'hello',
                 example: 'hi'
-            })).toEqual({
+            });
+            expect(config).toEqual({
                 _op: 'hello',
                 _encoding: 'json',
                 _dead_letter_action: 'throw',

--- a/packages/job-components/test/operations/base-schema-spec.ts
+++ b/packages/job-components/test/operations/base-schema-spec.ts
@@ -83,14 +83,12 @@ describe('Base Schema', () => {
             expect(warnings[0]).toMatchObject({
                 type: 'JobValidation',
                 reason: {
-                    type: 'assetOperationProperty',
+                    type: 'assetOperation',
+                    kind: 'deprecation',
                     reason: {
-                        name: 'hello',
-                        type: 'deprecation',
-                        reason: {
-                            name: 'old_field',
-                            description: 'use new_field instead',
-                        },
+                        _op: 'hello',
+                        field: 'old_field',
+                        description: 'use new_field instead',
                     },
                 },
             });

--- a/packages/opensearch-client/package.json
+++ b/packages/opensearch-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/opensearch-client",
     "displayName": "Opensearch Client",
-    "version": "2.13.0",
+    "version": "2.14.0",
     "description": "A Node.js facade client for opensearch & elasticsearch.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/opensearch-client#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.20.1",
+    "version": "2.21.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/misc.ts
+++ b/packages/scripts/src/helpers/misc.ts
@@ -65,7 +65,7 @@ function _getRootInfo(pkgJSONPath: string): RootPackageInfo | undefined {
             engines: {
                 node: '>=16.0.0',
                 // TODO: re-enable once all repos are fully migrated to pnpm
-                // pnpm: '>=10.25.0'
+                // pnpm: '>=11.3.0'
             },
             terascope: {
                 root: true,
@@ -90,7 +90,7 @@ function _getRootInfo(pkgJSONPath: string): RootPackageInfo | undefined {
             engines: {
                 node: '>=16.0.0',
                 // TODO: re-enable once all repos are fully migrated to pnpm
-                // pnpm: '>=10.25.0'
+                // pnpm: '>=11.3.0'
             },
             terascope: {
                 root: true,

--- a/packages/scripts/src/helpers/misc.ts
+++ b/packages/scripts/src/helpers/misc.ts
@@ -64,8 +64,7 @@ function _getRootInfo(pkgJSONPath: string): RootPackageInfo | undefined {
             displayName: getName(pkg.name),
             engines: {
                 node: '>=16.0.0',
-                // TODO: re-enable once all repos are fully migrated to pnpm
-                // pnpm: '>=11.3.0'
+                pnpm: '>=11.3.0'
             },
             terascope: {
                 root: true,
@@ -89,8 +88,7 @@ function _getRootInfo(pkgJSONPath: string): RootPackageInfo | undefined {
             },
             engines: {
                 node: '>=16.0.0',
-                // TODO: re-enable once all repos are fully migrated to pnpm
-                // pnpm: '>=11.3.0'
+                pnpm: '>=11.3.0'
             },
             terascope: {
                 root: true,

--- a/packages/scripts/src/helpers/package-manager.ts
+++ b/packages/scripts/src/helpers/package-manager.ts
@@ -12,7 +12,7 @@ const logger = debugLogger('ts-scripts:cmd');
 
 /**
  * Returns the package manager by reading the `packageManager` field from the
- * root package.json (e.g. "pnpm@10.25.0" → "pnpm"). Defaults to 'pnpm' if not set.
+ * root package.json (e.g. "pnpm@11.3.0" → "pnpm"). Defaults to 'pnpm' if not set.
  */
 export function getPackageManager(): string {
     const rootInfo = getRootInfo();

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "2.15.0",
+    "version": "2.16.0",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/teraslice-cli/package.json
+++ b/packages/teraslice-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-cli",
     "displayName": "Teraslice CLI",
-    "version": "3.0.6",
+    "version": "3.1.0",
     "description": "Command line manager for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "teraslice"

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -89,6 +89,16 @@ export default class Jobs {
         }
     }
 
+    // TODO: v3 v4 uses submitWithWarnings instead of submit() to surface warnings without
+    // a breaking change to the client. Remove this when submit() is updated in a future major version.
+    async submitJobConfigWithWarnings(jobConfig: Teraslice.JobConfigParams) {
+        try {
+            return this.teraslice.client.jobs.submitWithWarnings(jobConfig, true);
+        } catch (e) {
+            reply.fatal(e);
+        }
+    }
+
     async verifyK8sImageContinuity(cliConfig: Config) {
         /// Grab all job files and verify each
         const clusterStats = await this.teraslice.client.cluster.info();

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -163,7 +163,7 @@ export default class Jobs {
                 const response = await job.api.recover();
 
                 for (const warning of response.warnings ?? []) {
-                    reply.warning(`Warning: (${warning.type}) ${warning.description}`);
+                    reply.warning(`Warning: (${warning.category}) ${warning.description}`);
                 }
 
                 this.logUpdate({
@@ -309,7 +309,7 @@ export default class Jobs {
                 if (action === 'start') {
                     const startResult = result as Teraslice.ApiJobCreateResponse;
                     for (const warning of startResult.warnings ?? []) {
-                        reply.warning(`Warning: (${warning.type}) ${warning.description}`);
+                        reply.warning(`Warning: (${warning.category}) ${warning.description}`);
                     }
                 }
             } catch (e) {

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -81,14 +81,6 @@ export default class Jobs {
         return this.jobs;
     }
 
-    async submitJobConfig(jobConfig: Teraslice.JobConfigParams) {
-        try {
-            return this.teraslice.client.jobs.submit(jobConfig, true);
-        } catch (e) {
-            reply.fatal(e);
-        }
-    }
-
     // TODO: Teraslice v4 uses submitWithWarnings instead of submit() to surface warnings without
     // a breaking change to the client. Remove this when submit() is updated in Teraslice v4.
     async submitJobConfigWithWarnings(jobConfig: Teraslice.JobConfigParams) {
@@ -169,6 +161,10 @@ export default class Jobs {
 
             try {
                 const response = await job.api.recover();
+
+                for (const warning of response.warnings ?? []) {
+                    reply.warning(`Warning: (${warning.type}) ${warning.description}`);
+                }
 
                 this.logUpdate({
                     job,
@@ -309,7 +305,13 @@ export default class Jobs {
             this.logUpdate({ action: display.setAction(action, 'present'), job });
 
             try {
-                await job.api[action]();
+                const result = await job.api[action]();
+                if (action === 'start') {
+                    const startResult = result as Teraslice.ApiJobCreateResponse;
+                    for (const warning of startResult.warnings ?? []) {
+                        reply.warning(`Warning: (${warning.type}) ${warning.description}`);
+                    }
+                }
             } catch (e) {
                 this.commandFailed(e.message, job);
             }

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -83,6 +83,7 @@ export default class Jobs {
 
     // TODO: Teraslice v4 uses submitWithWarnings instead of submit() to surface warnings without
     // a breaking change to the client. Remove this when submit() is updated in Teraslice v4.
+    // See https://github.com/terascope/teraslice/issues/4501
     async submitJobConfigWithWarnings(jobConfig: Teraslice.JobConfigParams) {
         try {
             return this.teraslice.client.jobs.submitWithWarnings(jobConfig, true);

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -163,7 +163,9 @@ export default class Jobs {
                 const response = await job.api.recover();
 
                 for (const warning of response.warnings ?? []) {
-                    reply.warning(`Warning: (${warning.category}) ${warning.description}`);
+                    const assetDeprecation = warning.reason.reason;
+                    const fieldDeprecation = assetDeprecation.reason;
+                    reply.warning(`Warning: (${assetDeprecation.type}) ${fieldDeprecation.description}`);
                 }
 
                 this.logUpdate({
@@ -309,7 +311,9 @@ export default class Jobs {
                 if (action === 'start') {
                     const startResult = result as Teraslice.ApiJobCreateResponse;
                     for (const warning of startResult.warnings ?? []) {
-                        reply.warning(`Warning: (${warning.category}) ${warning.description}`);
+                        const assetDeprecation = warning.reason.reason;
+                        const fieldDeprecation = assetDeprecation.reason;
+                        reply.warning(`Warning: (${assetDeprecation.type}) ${fieldDeprecation.description}`);
                     }
                 }
             } catch (e) {

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -163,9 +163,8 @@ export default class Jobs {
                 const response = await job.api.recover();
 
                 for (const warning of response.warnings ?? []) {
-                    const assetDeprecation = warning.reason.reason;
-                    const fieldDeprecation = assetDeprecation.reason;
-                    reply.warning(`Warning: (${assetDeprecation.type}) ${fieldDeprecation.description}`);
+                    const { kind, reason } = warning.reason;
+                    reply.warning(`Warning: (${kind}) ${reason.description}`);
                 }
 
                 this.logUpdate({
@@ -311,9 +310,8 @@ export default class Jobs {
                 if (action === 'start') {
                     const startResult = result as Teraslice.ApiJobCreateResponse;
                     for (const warning of startResult.warnings ?? []) {
-                        const assetDeprecation = warning.reason.reason;
-                        const fieldDeprecation = assetDeprecation.reason;
-                        reply.warning(`Warning: (${assetDeprecation.type}) ${fieldDeprecation.description}`);
+                        const { kind, reason } = warning.reason;
+                        reply.warning(`Warning: (${kind}) ${reason.description}`);
                     }
                 }
             } catch (e) {

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -90,7 +90,8 @@ export default class Jobs {
     }
 
     // TODO: v3 v4 uses submitWithWarnings instead of submit() to surface warnings without
-    // a breaking change to the client. Remove this when submit() is updated in a future major version.
+    // a breaking change to the client. Remove this when submit() is updated in a future
+    // major version.
     async submitJobConfigWithWarnings(jobConfig: Teraslice.JobConfigParams) {
         try {
             return this.teraslice.client.jobs.submitWithWarnings(jobConfig, true);

--- a/packages/teraslice-cli/src/helpers/jobs.ts
+++ b/packages/teraslice-cli/src/helpers/jobs.ts
@@ -89,9 +89,8 @@ export default class Jobs {
         }
     }
 
-    // TODO: v3 v4 uses submitWithWarnings instead of submit() to surface warnings without
-    // a breaking change to the client. Remove this when submit() is updated in a future
-    // major version.
+    // TODO: Teraslice v4 uses submitWithWarnings instead of submit() to surface warnings without
+    // a breaking change to the client. Remove this when submit() is updated in Teraslice v4.
     async submitJobConfigWithWarnings(jobConfig: Teraslice.JobConfigParams) {
         try {
             return this.teraslice.client.jobs.submitWithWarnings(jobConfig, true);

--- a/packages/teraslice-cli/src/helpers/tjm-util.ts
+++ b/packages/teraslice-cli/src/helpers/tjm-util.ts
@@ -8,7 +8,7 @@ import {
     cloneDeep,
     isKey
 } from '@terascope/core-utils';
-import { Teraslice, Terafoundation } from '@terascope/types';
+import { Teraslice } from '@terascope/types';
 import Config from './config.js';
 import Jobs from './jobs.js';
 import { getPackage } from './utils.js';
@@ -92,7 +92,7 @@ export async function updateJobConfig(cliConfig: Config) {
                 reply.fatal(`Could not be updated job ${jobId} on ${tsCluster}`);
             }
 
-            const warnings: Terafoundation.JobWarning[] = get(update, 'warnings', []);
+            const warnings: Teraslice.JobWarning[] = get(update, 'warnings', []);
             for (const warning of warnings) {
                 const { kind, reason } = warning.reason;
                 reply.warning(`Warning: (${kind}) ${reason.description}`);

--- a/packages/teraslice-cli/src/helpers/tjm-util.ts
+++ b/packages/teraslice-cli/src/helpers/tjm-util.ts
@@ -8,7 +8,7 @@ import {
     cloneDeep,
     isKey
 } from '@terascope/core-utils';
-import { Teraslice } from '@terascope/types';
+import { Teraslice, Terafoundation } from '@terascope/types';
 import Config from './config.js';
 import Jobs from './jobs.js';
 import { getPackage } from './utils.js';
@@ -92,7 +92,7 @@ export async function updateJobConfig(cliConfig: Config) {
                 reply.fatal(`Could not be updated job ${jobId} on ${tsCluster}`);
             }
 
-            const warnings: { type: string; description: string }[] = get(update, 'warnings', []);
+            const warnings: Terafoundation.JobWarning[] = get(update, 'warnings', []);
             for (const warning of warnings) {
                 reply.warning(`Warning: (${warning.type}) ${warning.description}`);
             }

--- a/packages/teraslice-cli/src/helpers/tjm-util.ts
+++ b/packages/teraslice-cli/src/helpers/tjm-util.ts
@@ -94,7 +94,7 @@ export async function updateJobConfig(cliConfig: Config) {
 
             const warnings: Terafoundation.JobWarning[] = get(update, 'warnings', []);
             for (const warning of warnings) {
-                reply.warning(`Warning: (${warning.type}) ${warning.description}`);
+                reply.warning(`Warning: (${warning.category}) ${warning.description}`);
             }
 
             addMetaData(jobConfig, jobId, tsCluster);
@@ -132,7 +132,7 @@ export async function registerJobToCluster(cliConfig: Config) {
                 const jobId = resp.job.id();
 
                 for (const warning of resp.warnings) {
-                    reply.warning(`Warning: (${warning.type}) ${warning.description}`);
+                    reply.warning(`Warning: (${warning.category}) ${warning.description}`);
                 }
 
                 reply.green(`Successfully registered ${jobConfig.name} on ${cliConfig.clusterUrl} with job id ${jobId}`);

--- a/packages/teraslice-cli/src/helpers/tjm-util.ts
+++ b/packages/teraslice-cli/src/helpers/tjm-util.ts
@@ -94,9 +94,8 @@ export async function updateJobConfig(cliConfig: Config) {
 
             const warnings: Terafoundation.JobWarning[] = get(update, 'warnings', []);
             for (const warning of warnings) {
-                const assetDeprecation = warning.reason.reason;
-                const fieldDeprecation = assetDeprecation.reason;
-                reply.warning(`Warning: (${assetDeprecation.type}) ${fieldDeprecation.description}`);
+                const { kind, reason } = warning.reason;
+                reply.warning(`Warning: (${kind}) ${reason.description}`);
             }
 
             addMetaData(jobConfig, jobId, tsCluster);
@@ -134,9 +133,8 @@ export async function registerJobToCluster(cliConfig: Config) {
                 const jobId = resp.job.id();
 
                 for (const warning of resp.warnings) {
-                    const assetDeprecation = warning.reason.reason;
-                    const fieldDeprecation = assetDeprecation.reason;
-                    reply.warning(`Warning: (${assetDeprecation.type}) ${fieldDeprecation.description}`);
+                    const { kind, reason } = warning.reason;
+                    reply.warning(`Warning: (${kind}) ${reason.description}`);
                 }
 
                 reply.green(`Successfully registered ${jobConfig.name} on ${cliConfig.clusterUrl} with job id ${jobId}`);

--- a/packages/teraslice-cli/src/helpers/tjm-util.ts
+++ b/packages/teraslice-cli/src/helpers/tjm-util.ts
@@ -94,7 +94,9 @@ export async function updateJobConfig(cliConfig: Config) {
 
             const warnings: Terafoundation.JobWarning[] = get(update, 'warnings', []);
             for (const warning of warnings) {
-                reply.warning(`Warning: (${warning.category}) ${warning.description}`);
+                const assetDeprecation = warning.reason.reason;
+                const fieldDeprecation = assetDeprecation.reason;
+                reply.warning(`Warning: (${assetDeprecation.type}) ${fieldDeprecation.description}`);
             }
 
             addMetaData(jobConfig, jobId, tsCluster);
@@ -132,7 +134,9 @@ export async function registerJobToCluster(cliConfig: Config) {
                 const jobId = resp.job.id();
 
                 for (const warning of resp.warnings) {
-                    reply.warning(`Warning: (${warning.category}) ${warning.description}`);
+                    const assetDeprecation = warning.reason.reason;
+                    const fieldDeprecation = assetDeprecation.reason;
+                    reply.warning(`Warning: (${assetDeprecation.type}) ${fieldDeprecation.description}`);
                 }
 
                 reply.green(`Successfully registered ${jobConfig.name} on ${cliConfig.clusterUrl} with job id ${jobId}`);

--- a/packages/teraslice-cli/src/helpers/tjm-util.ts
+++ b/packages/teraslice-cli/src/helpers/tjm-util.ts
@@ -92,6 +92,11 @@ export async function updateJobConfig(cliConfig: Config) {
                 reply.fatal(`Could not be updated job ${jobId} on ${tsCluster}`);
             }
 
+            const warnings: { type: string; description: string }[] = get(update, 'warnings', []);
+            for (const warning of warnings) {
+                reply.warning(`Warning: (${warning.type}) ${warning.description}`);
+            }
+
             addMetaData(jobConfig, jobId, tsCluster);
             saveConfig(cliConfig.args.srcDir, jobFile, jobConfig);
 
@@ -121,10 +126,14 @@ export async function registerJobToCluster(cliConfig: Config) {
         }
 
         try {
-            const resp = await job.submitJobConfig(jobConfig);
+            const resp = await job.submitJobConfigWithWarnings(jobConfig);
 
             if (resp) {
-                const jobId = resp.id();
+                const jobId = resp.job.id();
+
+                for (const warning of resp.warnings) {
+                    reply.warning(`Warning: (${warning.type}) ${warning.description}`);
+                }
 
                 reply.green(`Successfully registered ${jobConfig.name} on ${cliConfig.clusterUrl} with job id ${jobId}`);
 

--- a/packages/teraslice-cli/test/fixtures/testAssetWithBuild/package.json
+++ b/packages/teraslice-cli/test/fixtures/testAssetWithBuild/package.json
@@ -7,5 +7,5 @@
     "workspaces": [
         "asset"
     ],
-    "packageManager": "pnpm@10.25.0"
+    "packageManager": "pnpm@11.3.0"
 }

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "2.13.0",
+    "version": "2.14.0",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",

--- a/packages/teraslice-client-js/src/job.ts
+++ b/packages/teraslice-client-js/src/job.ts
@@ -87,13 +87,13 @@ export default class Job extends Client {
         return this.post(`/jobs/${this._jobId}/_recover`, null, options);
     }
 
-    async update(jobSpec: Teraslice.JobConfig): Promise<Teraslice.JobConfig> {
+    async update(jobSpec: Teraslice.JobConfig): Promise<Teraslice.ApiJobUpdateResponse> {
         return this.put(`/jobs/${this._jobId}`, jobSpec);
     }
 
     async updatePartial(
         jobSpec: Partial<Teraslice.JobConfig>
-    ): Promise<Teraslice.JobConfig> {
+    ): Promise<Teraslice.ApiJobUpdateResponse> {
         const current = await this.config();
         const body: Teraslice.JobConfig = Object.assign({}, current, jobSpec);
         return this.update(body);

--- a/packages/teraslice-client-js/src/jobs.ts
+++ b/packages/teraslice-client-js/src/jobs.ts
@@ -1,5 +1,5 @@
 import { TSError } from '@terascope/core-utils';
-import { Teraslice } from '@terascope/types';
+import { Teraslice, Terafoundation } from '@terascope/types';
 import autoBind from 'auto-bind';
 import Client from './client.js';
 import Job from './job.js';
@@ -23,6 +23,29 @@ export default class Jobs extends Client {
         });
 
         return this.wrap(job.job_id);
+    }
+
+    // TODO: v3 v4 this exists to avoid a breaking change to submit() which returns just the Job.
+    // This is only used by teraslice-cli. In a future major version, submit() should
+    // be updated to return warnings and this method removed.
+    async submitWithWarnings(
+        jobSpec: Teraslice.JobConfigParams,
+        shouldNotStart?: boolean
+    ): Promise<{ job: Job; warnings: Terafoundation.JobWarning[] }> {
+        if (!jobSpec) {
+            throw new TSError('Submit requires a jobSpec', {
+                statusCode: 400
+            });
+        }
+
+        const response: Teraslice.ApiJobCreateResponse = await this.post('/jobs', jobSpec, {
+            searchParams: { start: !shouldNotStart }
+        });
+
+        return {
+            job: this.wrap(response.job_id),
+            warnings: response.warnings ?? []
+        };
     }
 
     async list(

--- a/packages/teraslice-client-js/src/jobs.ts
+++ b/packages/teraslice-client-js/src/jobs.ts
@@ -28,6 +28,7 @@ export default class Jobs extends Client {
     // TODO: Teraslice v4 this exists to avoid a breaking change to submit() which returns just
     // the Job. This is only used by teraslice-cli. In Teraslice v4, submit() should
     // be updated to return warnings and this method removed.
+    // See https://github.com/terascope/teraslice/issues/4501
     async submitWithWarnings(
         jobSpec: Teraslice.JobConfigParams,
         shouldNotStart?: boolean

--- a/packages/teraslice-client-js/src/jobs.ts
+++ b/packages/teraslice-client-js/src/jobs.ts
@@ -25,8 +25,8 @@ export default class Jobs extends Client {
         return this.wrap(job.job_id);
     }
 
-    // TODO: v3 v4 this exists to avoid a breaking change to submit() which returns just the Job.
-    // This is only used by teraslice-cli. In a future major version, submit() should
+    // TODO: Teraslice v4 this exists to avoid a breaking change to submit() which returns just
+    // the Job. This is only used by teraslice-cli. In Teraslice v4, submit() should
     // be updated to return warnings and this method removed.
     async submitWithWarnings(
         jobSpec: Teraslice.JobConfigParams,

--- a/packages/teraslice-client-js/src/jobs.ts
+++ b/packages/teraslice-client-js/src/jobs.ts
@@ -1,5 +1,5 @@
 import { TSError } from '@terascope/core-utils';
-import { Teraslice, Terafoundation } from '@terascope/types';
+import { Teraslice } from '@terascope/types';
 import autoBind from 'auto-bind';
 import Client from './client.js';
 import Job from './job.js';
@@ -31,7 +31,7 @@ export default class Jobs extends Client {
     async submitWithWarnings(
         jobSpec: Teraslice.JobConfigParams,
         shouldNotStart?: boolean
-    ): Promise<{ job: Job; warnings: Terafoundation.JobWarning[] }> {
+    ): Promise<{ job: Job; warnings: Teraslice.JobWarning[] }> {
         if (!jobSpec) {
             throw new TSError('Submit requires a jobSpec', {
                 statusCode: 400

--- a/packages/teraslice-client-js/test/job-spec.ts
+++ b/packages/teraslice-client-js/test/job-spec.ts
@@ -1,5 +1,5 @@
 import nock from 'nock';
-import { Teraslice, Terafoundation } from '@terascope/types';
+import { Teraslice } from '@terascope/types';
 import Job from '../src/job.js';
 
 describe('Teraslice Job', () => {
@@ -225,7 +225,7 @@ describe('Teraslice Job', () => {
 
     describe('->start', () => {
         describe('when the server returns deprecation warnings', () => {
-            const deprecationWarning: Terafoundation.JobWarning = {
+            const deprecationWarning: Teraslice.JobWarning = {
                 type: 'JobValidation',
                 reason: {
                     type: 'assetOperation',
@@ -312,7 +312,7 @@ describe('Teraslice Job', () => {
 
     describe('->recover with warnings', () => {
         describe('when the server returns deprecation warnings', () => {
-            const deprecationWarning: Terafoundation.JobWarning = {
+            const deprecationWarning: Teraslice.JobWarning = {
                 type: 'JobValidation',
                 reason: {
                     type: 'assetAPIProperty',

--- a/packages/teraslice-client-js/test/job-spec.ts
+++ b/packages/teraslice-client-js/test/job-spec.ts
@@ -1,5 +1,5 @@
 import nock from 'nock';
-import { Teraslice } from '@terascope/types';
+import { Teraslice, Terafoundation } from '@terascope/types';
 import Job from '../src/job.js';
 
 describe('Teraslice Job', () => {
@@ -223,6 +223,43 @@ describe('Teraslice Job', () => {
         });
     });
 
+    describe('->start', () => {
+        describe('when the server returns deprecation warnings', () => {
+            const deprecationWarning: Terafoundation.JobWarning = {
+                type: 'JobValidation',
+                reason: {
+                    type: 'assetOperationProperty',
+                    reason: {
+                        name: 'some-op',
+                        type: 'deprecation',
+                        reason: {
+                            name: 'old_field',
+                            description: 'old_field is deprecated, use new_field instead',
+                        },
+                    },
+                },
+            };
+
+            const response: Teraslice.ApiJobCreateResponse = {
+                job_id: 'some-job-id',
+                warnings: [deprecationWarning],
+            };
+
+            beforeEach(() => {
+                scope.post('/jobs/some-job-id/_start')
+                    .reply(200, response);
+            });
+
+            it('should return the response with warnings', async () => {
+                const job = new Job({ baseUrl }, 'some-job-id');
+                const result = await job.start();
+                expect(result.job_id).toEqual('some-job-id');
+                expect(result.warnings).toBeArrayOfSize(1);
+                expect(result.warnings![0]).toMatchObject(deprecationWarning);
+            });
+        });
+    });
+
     describe('->recover', () => {
         describe('when called with nothing', () => {
             beforeEach(() => {
@@ -271,6 +308,43 @@ describe('Teraslice Job', () => {
                 expect(results).toEqual({
                     key: 'some-other-key'
                 });
+            });
+        });
+    });
+
+    describe('->recover with warnings', () => {
+        describe('when the server returns deprecation warnings', () => {
+            const deprecationWarning: Terafoundation.JobWarning = {
+                type: 'JobValidation',
+                reason: {
+                    type: 'assetAPIProperty',
+                    reason: {
+                        name: 'some-api',
+                        type: 'deprecation',
+                        reason: {
+                            name: 'old_api_field',
+                            description: 'old_api_field is deprecated, use new_api_field instead',
+                        },
+                    },
+                },
+            };
+
+            const response: Teraslice.ApiJobCreateResponse = {
+                job_id: 'some-other-job-id',
+                warnings: [deprecationWarning],
+            };
+
+            beforeEach(() => {
+                scope.post('/jobs/some-other-job-id/_recover')
+                    .reply(200, response);
+            });
+
+            it('should return the response with warnings', async () => {
+                const job = new Job({ baseUrl }, 'some-other-job-id');
+                const result = await job.recover();
+                expect(result.job_id).toEqual('some-other-job-id');
+                expect(result.warnings).toBeArrayOfSize(1);
+                expect(result.warnings![0]).toMatchObject(deprecationWarning);
             });
         });
     });

--- a/packages/teraslice-client-js/test/job-spec.ts
+++ b/packages/teraslice-client-js/test/job-spec.ts
@@ -228,14 +228,12 @@ describe('Teraslice Job', () => {
             const deprecationWarning: Terafoundation.JobWarning = {
                 type: 'JobValidation',
                 reason: {
-                    type: 'assetOperationProperty',
+                    type: 'assetOperation',
+                    kind: 'deprecation',
                     reason: {
-                        name: 'some-op',
-                        type: 'deprecation',
-                        reason: {
-                            name: 'old_field',
-                            description: 'old_field is deprecated, use new_field instead',
-                        },
+                        _op: 'some-op',
+                        field: 'old_field',
+                        description: 'old_field is deprecated, use new_field instead',
                     },
                 },
             };
@@ -318,13 +316,11 @@ describe('Teraslice Job', () => {
                 type: 'JobValidation',
                 reason: {
                     type: 'assetAPIProperty',
+                    kind: 'deprecation',
                     reason: {
-                        name: 'some-api',
-                        type: 'deprecation',
-                        reason: {
-                            name: 'old_api_field',
-                            description: 'old_api_field is deprecated, use new_api_field instead',
-                        },
+                        api_name: 'some-api',
+                        field: 'old_api_field',
+                        description: 'old_api_field is deprecated, use new_api_field instead',
                     },
                 },
             };

--- a/packages/teraslice-client-js/test/jobs-spec.ts
+++ b/packages/teraslice-client-js/test/jobs-spec.ts
@@ -184,14 +184,12 @@ describe('Teraslice Jobs', () => {
                 warnings: [{
                     type: 'JobValidation',
                     reason: {
-                        type: 'assetOperationProperty',
+                        type: 'assetOperation',
+                        kind: 'deprecation',
                         reason: {
-                            name: 'operation',
-                            type: 'deprecation',
-                            reason: {
-                                name: 'old_field',
-                                description: 'old_field is deprecated',
-                            },
+                            _op: 'operation',
+                            field: 'old_field',
+                            description: 'old_field is deprecated',
                         },
                     },
                 }]
@@ -211,14 +209,12 @@ describe('Teraslice Jobs', () => {
                 expect(result.warnings[0]).toMatchObject({
                     type: 'JobValidation',
                     reason: {
-                        type: 'assetOperationProperty',
+                        type: 'assetOperation',
+                        kind: 'deprecation',
                         reason: {
-                            name: 'operation',
-                            type: 'deprecation',
-                            reason: {
-                                name: 'old_field',
-                                description: 'old_field is deprecated',
-                            },
+                            _op: 'operation',
+                            field: 'old_field',
+                            description: 'old_field is deprecated',
                         },
                     },
                 });

--- a/packages/teraslice-client-js/test/jobs-spec.ts
+++ b/packages/teraslice-client-js/test/jobs-spec.ts
@@ -181,7 +181,20 @@ describe('Teraslice Jobs', () => {
             const jobSpec = { operations: [{ _op: 'operation' }] };
             const response = {
                 job_id: 'some-job-id',
-                warnings: [{ category: 'deprecation', subcategory: 'assetOperationProperty', name: 'operation', field: 'old_field', description: 'old_field is deprecated' }]
+                warnings: [{
+                    type: 'JobValidation',
+                    reason: {
+                        type: 'assetOperationProperty',
+                        reason: {
+                            name: 'operation',
+                            type: 'deprecation',
+                            reason: {
+                                name: 'old_field',
+                                description: 'old_field is deprecated',
+                            },
+                        },
+                    },
+                }]
             };
 
             beforeEach(() => {
@@ -196,11 +209,18 @@ describe('Teraslice Jobs', () => {
                 expect(result.job.id()).toEqual(response.job_id);
                 expect(result.warnings).toBeArrayOfSize(1);
                 expect(result.warnings[0]).toMatchObject({
-                    category: 'deprecation',
-                    subcategory: 'assetOperationProperty',
-                    name: 'operation',
-                    field: 'old_field',
-                    description: 'old_field is deprecated'
+                    type: 'JobValidation',
+                    reason: {
+                        type: 'assetOperationProperty',
+                        reason: {
+                            name: 'operation',
+                            type: 'deprecation',
+                            reason: {
+                                name: 'old_field',
+                                description: 'old_field is deprecated',
+                            },
+                        },
+                    },
                 });
             });
         });

--- a/packages/teraslice-client-js/test/jobs-spec.ts
+++ b/packages/teraslice-client-js/test/jobs-spec.ts
@@ -164,6 +164,65 @@ describe('Teraslice Jobs', () => {
         });
     });
 
+    describe('->submitWithWarnings', () => {
+        describe('when submitting without a jobSpec', () => {
+            it('should fail', async () => {
+                expect.hasAssertions();
+                try {
+                    // @ts-expect-error
+                    await jobs.submitWithWarnings();
+                } catch (err) {
+                    expect(err.message).toEqual('Submit requires a jobSpec');
+                }
+            });
+        });
+
+        describe('when the server returns warnings', () => {
+            const jobSpec = { operations: [{ _op: 'operation' }] };
+            const response = {
+                job_id: 'some-job-id',
+                warnings: [{ category: 'deprecation', subcategory: 'assetOperationProperty', name: 'operation', field: 'old_field', description: 'old_field is deprecated' }]
+            };
+
+            beforeEach(() => {
+                scope.post('/jobs', jobSpec)
+                    .query({ start: false })
+                    .reply(202, response);
+            });
+
+            it('should return the job and warnings', async () => {
+                const result = await jobs.submitWithWarnings(jobSpec, true);
+                expect(result.job).toBeInstanceOf(Job);
+                expect(result.job.id()).toEqual(response.job_id);
+                expect(result.warnings).toBeArrayOfSize(1);
+                expect(result.warnings[0]).toMatchObject({
+                    category: 'deprecation',
+                    subcategory: 'assetOperationProperty',
+                    name: 'operation',
+                    field: 'old_field',
+                    description: 'old_field is deprecated'
+                });
+            });
+        });
+
+        describe('when the response includes no warnings field', () => {
+            const jobSpec = { operations: [{ _op: 'operation' }] };
+            const response = { job_id: 'some-job-id' };
+
+            beforeEach(() => {
+                scope.post('/jobs', jobSpec)
+                    .query({ start: false })
+                    .reply(202, response);
+            });
+
+            it('should return the job with an empty warnings array', async () => {
+                const result = await jobs.submitWithWarnings(jobSpec, true);
+                expect(result.job).toBeInstanceOf(Job);
+                expect(result.warnings).toBeArrayOfSize(0);
+            });
+        });
+    });
+
     describe('->list', () => {
         describe('when called with nothing', () => {
             beforeEach(() => {

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "2.13.0",
+    "version": "2.14.0",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "2.13.0",
+    "version": "2.14.0",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "2.16.0",
+    "version": "2.17.0",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/src/base-test-harness.ts
+++ b/packages/teraslice-test-harness/src/base-test-harness.ts
@@ -67,7 +67,7 @@ export default class BaseTestHarness<U extends ExecutionContext> {
         job.assets = assetIds;
 
         const jobValidator = new JobValidator(this.context);
-        const executionConfig = await jobValidator.validateConfig(job) as ExecutionConfig;
+        const { jobConfig: executionConfig } = await jobValidator.validateConfig(job) as unknown as { jobConfig: ExecutionConfig };
 
         return {
             context: this.context,

--- a/packages/teraslice-test-harness/src/base-test-harness.ts
+++ b/packages/teraslice-test-harness/src/base-test-harness.ts
@@ -67,7 +67,8 @@ export default class BaseTestHarness<U extends ExecutionContext> {
         job.assets = assetIds;
 
         const jobValidator = new JobValidator(this.context);
-        const { jobConfig: executionConfig } = await jobValidator.validateConfig(job) as unknown as { jobConfig: ExecutionConfig };
+        const { jobConfig } = await jobValidator.validateConfig(job);
+        const executionConfig = jobConfig as ExecutionConfig;
 
         return {
             context: this.context,

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "3.14.0",
+    "version": "3.15.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -7,7 +7,7 @@ import {
     JobConfigParams, JobValidator, RecoveryCleanupType,
     ValidatedJobConfig, parseName
 } from '@terascope/job-components';
-import { JobConfig, ExecutionConfig } from '@terascope/types';
+import { Terafoundation, JobConfig, ExecutionConfig } from '@terascope/types';
 import { ClusterMasterContext } from '../../../interfaces.js';
 import { makeLogger } from '../../workers/helpers/terafoundation.js';
 import { spawnAssetLoader } from '../../workers/assets/spawn.js';
@@ -61,10 +61,9 @@ export class JobsService {
     */
     private async _validateJobSpec(
         jobSpec: Partial<JobConfig | JobConfigParams>
-    ): Promise<ValidatedJobConfig | JobConfig> {
+    ): Promise<{ jobConfig: ValidatedJobConfig | JobConfig, warnings: Terafoundation.JobWarning[] }> {
         const parsedAssetJob = await this._ensureAssets(cloneDeep(jobSpec));
-        const validJob = await this.jobValidator.validateConfig(parsedAssetJob);
-        return validJob;
+        return this.jobValidator.validateConfig(parsedAssetJob);
     }
 
     async submitJob(jobSpec: Partial<JobConfig | JobConfigParams>, shouldRun?: boolean) {
@@ -77,21 +76,29 @@ export class JobsService {
 
         this.addExternalPortsToJobSpec(jobSpec);
 
-        const validJob = await this._validateJobSpec(jobSpec);
+        const { jobConfig: validJob, warnings } = await this._validateJobSpec(jobSpec);
 
         // We don't create with the fully parsed validJob as it changes the asset names
         // to their asset id which we don't want stored as at the job level
         const job = await this.jobsStorage.create(jobSpec as ValidatedJobConfig);
 
         if (!shouldRun) {
-            return { job_id: job.job_id };
+            const response = { job_id: job.job_id };
+            if (warnings.length) {
+                Object.assign(response, { warnings });
+            }
+            return response;
         }
 
         const jobRecord = Object.assign({}, jobSpec, validJob, {
             job_id: job.job_id
         }) as JobConfig;
 
-        return this.executionService.createExecutionContext(jobRecord);
+        const result = await this.executionService.createExecutionContext(jobRecord);
+        if (warnings.length) {
+            Object.assign(result, { warnings });
+        }
+        return result;
     }
 
     /**
@@ -124,7 +131,14 @@ export class JobsService {
             this.logger.info(`Skipping job validation to set jobId ${jobId} as _inactive`);
         } else {
             this.addExternalPortsToJobSpec(jobSpec);
-            await this._validateJobSpec(jobSpec);
+            const { warnings } = await this._validateJobSpec(jobSpec);
+            const updated = await this.jobsStorage.update(jobId, Object.assign({}, jobSpec, {
+                _created: originalJob._created
+            }));
+            if (warnings.length) {
+                Object.assign(updated, { warnings });
+            }
+            return updated;
         }
 
         return this.jobsStorage.update(jobId, Object.assign({}, jobSpec, {
@@ -172,13 +186,21 @@ export class JobsService {
             });
         }
 
-        const validJob = await this._validateJobSpec(jobSpec) as JobConfig;
+        const { jobConfig: validJob, warnings } = await this._validateJobSpec(jobSpec);
 
-        if (validJob.autorecover) {
-            return this._recoverValidJob(validJob);
+        if ((validJob as JobConfig).autorecover) {
+            const result = await this._recoverValidJob(validJob as JobConfig);
+            if (warnings.length) {
+                Object.assign(result, { warnings });
+            }
+            return result;
         }
 
-        return this.executionService.createExecutionContext(validJob);
+        const result = await this.executionService.createExecutionContext(validJob as JobConfig);
+        if (warnings.length) {
+            Object.assign(result, { warnings });
+        }
+        return result;
     }
 
     /**
@@ -233,9 +255,10 @@ export class JobsService {
             });
         }
 
-        const validJob = await this._validateJobSpec(jobSpec) as JobConfig;
+        // warnings are not surfaced here
+        const { jobConfig: validJob } = await this._validateJobSpec(jobSpec);
 
-        return this._recoverValidJob(validJob, cleanupType);
+        return this._recoverValidJob(validJob as JobConfig, cleanupType);
     }
 
     async pauseJob(jobId: string) {

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -7,7 +7,7 @@ import {
     JobConfigParams, JobValidator, RecoveryCleanupType,
     ValidatedJobConfig, parseName
 } from '@terascope/job-components';
-import { Terafoundation, JobConfig, ExecutionConfig } from '@terascope/types';
+import { Teraslice, JobConfig, ExecutionConfig } from '@terascope/types';
 import { ClusterMasterContext } from '../../../interfaces.js';
 import { makeLogger } from '../../workers/helpers/terafoundation.js';
 import { spawnAssetLoader } from '../../workers/assets/spawn.js';
@@ -63,7 +63,7 @@ export class JobsService {
         jobSpec: Partial<JobConfig | JobConfigParams>
     ): Promise<{
         jobConfig: ValidatedJobConfig | JobConfig;
-        warnings: Terafoundation.JobWarning[];
+        warnings: Teraslice.JobWarning[];
     }> {
         const parsedAssetJob = await this._ensureAssets(cloneDeep(jobSpec));
         return this.jobValidator.validateConfig(parsedAssetJob);

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -61,7 +61,10 @@ export class JobsService {
     */
     private async _validateJobSpec(
         jobSpec: Partial<JobConfig | JobConfigParams>
-    ): Promise<{ jobConfig: ValidatedJobConfig | JobConfig, warnings: Terafoundation.JobWarning[] }> {
+    ): Promise<{
+        jobConfig: ValidatedJobConfig | JobConfig;
+        warnings: Terafoundation.JobWarning[];
+    }> {
         const parsedAssetJob = await this._ensureAssets(cloneDeep(jobSpec));
         return this.jobValidator.validateConfig(parsedAssetJob);
     }

--- a/packages/teraslice/src/lib/cluster/services/jobs.ts
+++ b/packages/teraslice/src/lib/cluster/services/jobs.ts
@@ -132,21 +132,20 @@ export class JobsService {
         // This allows for old jobs that are missing required resources to be marked inactive
         if (originalJob.active !== false && jobSpec.active === false) {
             this.logger.info(`Skipping job validation to set jobId ${jobId} as _inactive`);
-        } else {
-            this.addExternalPortsToJobSpec(jobSpec);
-            const { warnings } = await this._validateJobSpec(jobSpec);
-            const updated = await this.jobsStorage.update(jobId, Object.assign({}, jobSpec, {
+            return this.jobsStorage.update(jobId, Object.assign({}, jobSpec, {
                 _created: originalJob._created
             }));
-            if (warnings.length) {
-                Object.assign(updated, { warnings });
-            }
-            return updated;
         }
 
-        return this.jobsStorage.update(jobId, Object.assign({}, jobSpec, {
+        this.addExternalPortsToJobSpec(jobSpec);
+        const { warnings } = await this._validateJobSpec(jobSpec);
+        const updated = await this.jobsStorage.update(jobId, Object.assign({}, jobSpec, {
             _created: originalJob._created
         }));
+        if (warnings.length) {
+            Object.assign(updated, { warnings });
+        }
+        return updated;
     }
 
     /**
@@ -258,10 +257,13 @@ export class JobsService {
             });
         }
 
-        // warnings are not surfaced here
-        const { jobConfig: validJob } = await this._validateJobSpec(jobSpec);
+        const { jobConfig: validJob, warnings } = await this._validateJobSpec(jobSpec);
 
-        return this._recoverValidJob(validJob as JobConfig, cleanupType);
+        const result = await this._recoverValidJob(validJob as JobConfig, cleanupType);
+        if (warnings.length) {
+            Object.assign(result, { warnings });
+        }
+        return result;
     }
 
     async pauseJob(jobId: string) {

--- a/packages/teraslice/src/lib/workers/helpers/job.ts
+++ b/packages/teraslice/src/lib/workers/helpers/job.ts
@@ -11,7 +11,8 @@ export async function validateJob(context: Context, jobSpec: JobConfigParams) {
     const jobValidator = new JobValidator(context);
 
     try {
-        return await jobValidator.validateConfig(jobSpec);
+        const { jobConfig } = await jobValidator.validateConfig(jobSpec);
+        return jobConfig;
     } catch (error) {
         throw new Error(`validating job: ${error}`);
     }

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "2.14.0",
+    "version": "2.15.0",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/types",
     "displayName": "Types",
-    "version": "2.12.0",
+    "version": "2.13.0",
     "description": "A collection of typescript interfaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/types#readme",
     "bugs": {

--- a/packages/types/src/terafoundation.ts
+++ b/packages/types/src/terafoundation.ts
@@ -26,23 +26,53 @@ export interface SchemaObj<T = any> {
     [key: string]: any;
 }
 
-export interface DeprecationFieldReason {
+/** A deprecated field on an asset API */
+export interface AssetAPIDeprecationReason {
+    /** the api name the deprecated field came from */
+    api_name: string;
     /** the specific field that is deprecated */
-    name: string;
+    field: string;
     description: string;
 }
 
-export interface AssetDeprecationReason {
-    /** the op or api name the deprecated field came from */
-    name: string;
-    type: 'deprecation';
-    reason: DeprecationFieldReason;
+/** A deprecated field on an asset operation */
+export interface AssetOperationDeprecationReason {
+    /** the op name the deprecated field came from */
+    _op: string;
+    /** the specific field that is deprecated */
+    field: string;
+    description: string;
 }
 
-export interface JobValidationReason {
-    type: 'assetAPIProperty' | 'assetOperationProperty' | 'jobProperty';
-    reason: AssetDeprecationReason;
+/** A deprecated field on a job property */
+export interface JobPropertyDeprecationReason {
+    /** the specific field that is deprecated */
+    field: string;
+    description: string;
 }
+
+export interface AssetAPIValidationReason {
+    type: 'assetAPIProperty';
+    kind: 'deprecation';
+    reason: AssetAPIDeprecationReason;
+}
+
+export interface AssetOperationValidationReason {
+    type: 'assetOperation';
+    kind: 'deprecation';
+    reason: AssetOperationDeprecationReason;
+}
+
+export interface JobPropertyValidationReason {
+    type: 'jobProperty';
+    kind: 'deprecation';
+    reason: JobPropertyDeprecationReason;
+}
+
+export type JobValidationReason
+    = | AssetAPIValidationReason
+        | AssetOperationValidationReason
+        | JobPropertyValidationReason;
 
 export interface JobWarning {
     type: 'JobValidation';

--- a/packages/types/src/terafoundation.ts
+++ b/packages/types/src/terafoundation.ts
@@ -26,18 +26,28 @@ export interface SchemaObj<T = any> {
     [key: string]: any;
 }
 
-export interface DeprecationWarning {
-    category: 'deprecation';
-    subcategory: 'assetAPIProperty' | 'assetOperationProperty' | 'jobProperty';
-    /** the op or api name the deprecated field came from */
-    name: string;
+export interface DeprecationFieldReason {
     /** the specific field that is deprecated */
-    field: string;
-    // TODO: add assetId once the op loader exposes the resolved asset id
+    name: string;
     description: string;
 }
 
-export type JobWarning = DeprecationWarning;
+export interface AssetDeprecationReason {
+    /** the op or api name the deprecated field came from */
+    name: string;
+    type: 'deprecation';
+    reason: DeprecationFieldReason;
+}
+
+export interface JobValidationReason {
+    type: 'assetAPIProperty' | 'assetOperationProperty' | 'jobProperty';
+    reason: AssetDeprecationReason;
+}
+
+export interface JobWarning {
+    type: 'JobValidation';
+    reason: JobValidationReason;
+}
 
 export type Schema<T> = {
     [P in keyof T]: Schema<T[P]> | SchemaObj<T[P]>;

--- a/packages/types/src/terafoundation.ts
+++ b/packages/types/src/terafoundation.ts
@@ -26,10 +26,18 @@ export interface SchemaObj<T = any> {
     [key: string]: any;
 }
 
-export interface JobWarning {
-    type: string;
+export interface DeprecationWarning {
+    category: 'deprecation';
+    subcategory: 'assetAPIProperty' | 'assetOperationProperty' | 'jobProperty';
+    /** the op or api name the deprecated field came from */
+    name: string;
+    /** the specific field that is deprecated */
+    field: string;
+    // TODO: add assetId once the op loader exposes the resolved asset id
     description: string;
 }
+
+export type JobWarning = DeprecationWarning;
 
 export type Schema<T> = {
     [P in keyof T]: Schema<T[P]> | SchemaObj<T[P]>;

--- a/packages/types/src/terafoundation.ts
+++ b/packages/types/src/terafoundation.ts
@@ -26,59 +26,6 @@ export interface SchemaObj<T = any> {
     [key: string]: any;
 }
 
-/** A deprecated field on an asset API */
-export interface AssetAPIDeprecationReason {
-    /** the api name the deprecated field came from */
-    api_name: string;
-    /** the specific field that is deprecated */
-    field: string;
-    description: string;
-}
-
-/** A deprecated field on an asset operation */
-export interface AssetOperationDeprecationReason {
-    /** the op name the deprecated field came from */
-    _op: string;
-    /** the specific field that is deprecated */
-    field: string;
-    description: string;
-}
-
-/** A deprecated field on a job property */
-export interface JobPropertyDeprecationReason {
-    /** the specific field that is deprecated */
-    field: string;
-    description: string;
-}
-
-export interface AssetAPIValidationReason {
-    type: 'assetAPIProperty';
-    kind: 'deprecation';
-    reason: AssetAPIDeprecationReason;
-}
-
-export interface AssetOperationValidationReason {
-    type: 'assetOperation';
-    kind: 'deprecation';
-    reason: AssetOperationDeprecationReason;
-}
-
-export interface JobPropertyValidationReason {
-    type: 'jobProperty';
-    kind: 'deprecation';
-    reason: JobPropertyDeprecationReason;
-}
-
-export type JobValidationReason
-    = | AssetAPIValidationReason
-        | AssetOperationValidationReason
-        | JobPropertyValidationReason;
-
-export interface JobWarning {
-    type: 'JobValidation';
-    reason: JobValidationReason;
-}
-
 export type Schema<T> = {
     [P in keyof T]: Schema<T[P]> | SchemaObj<T[P]>;
 };

--- a/packages/types/src/terafoundation.ts
+++ b/packages/types/src/terafoundation.ts
@@ -22,7 +22,13 @@ export interface SchemaObj<T = any> {
     format?: ConvictFormat;
     env?: string | undefined;
     arg?: string | undefined;
+    deprecated?: string | undefined;
     [key: string]: any;
+}
+
+export interface JobWarning {
+    type: string;
+    description: string;
 }
 
 export type Schema<T> = {

--- a/packages/types/src/teraslice.ts
+++ b/packages/types/src/teraslice.ts
@@ -1,4 +1,4 @@
-import { SysConfig as BaseSysconfig } from './terafoundation.js';
+import { SysConfig as BaseSysconfig, JobWarning } from './terafoundation.js';
 
 export type ClusterManagerType = 'native' | 'kubernetesV2';
 
@@ -386,6 +386,7 @@ export interface ApiRootResponse {
 export interface ApiJobCreateResponse {
     job_id: string;
     ex_id?: string;
+    warnings?: JobWarning[];
 }
 
 export interface ApiPausedResponse {

--- a/packages/types/src/teraslice.ts
+++ b/packages/types/src/teraslice.ts
@@ -1,6 +1,59 @@
-import { SysConfig as BaseSysconfig, JobWarning } from './terafoundation.js';
+import { SysConfig as BaseSysconfig } from './terafoundation.js';
 
 export type ClusterManagerType = 'native' | 'kubernetesV2';
+
+/** A deprecated field on an asset API */
+export interface AssetAPIDeprecationReason {
+    /** the api name the deprecated field came from */
+    api_name: string;
+    /** the specific field that is deprecated */
+    field: string;
+    description: string;
+}
+
+/** A deprecated field on an asset operation */
+export interface AssetOperationDeprecationReason {
+    /** the op name the deprecated field came from */
+    _op: string;
+    /** the specific field that is deprecated */
+    field: string;
+    description: string;
+}
+
+/** A deprecated field on a job property */
+export interface JobPropertyDeprecationReason {
+    /** the specific field that is deprecated */
+    field: string;
+    description: string;
+}
+
+export interface AssetAPIValidationReason {
+    type: 'assetAPIProperty';
+    kind: 'deprecation';
+    reason: AssetAPIDeprecationReason;
+}
+
+export interface AssetOperationValidationReason {
+    type: 'assetOperation';
+    kind: 'deprecation';
+    reason: AssetOperationDeprecationReason;
+}
+
+export interface JobPropertyValidationReason {
+    type: 'jobProperty';
+    kind: 'deprecation';
+    reason: JobPropertyDeprecationReason;
+}
+
+export type JobValidationReason
+    = | AssetAPIValidationReason
+        | AssetOperationValidationReason
+        | JobPropertyValidationReason;
+
+export interface JobWarning {
+    type: 'JobValidation';
+    reason: JobValidationReason;
+}
 
 export interface AssetRecord {
     blob: SharedArrayBuffer | string | Buffer;

--- a/packages/types/src/teraslice.ts
+++ b/packages/types/src/teraslice.ts
@@ -389,6 +389,10 @@ export interface ApiJobCreateResponse {
     warnings?: JobWarning[];
 }
 
+export interface ApiJobUpdateResponse extends JobConfig {
+    warnings?: JobWarning[];
+}
+
 export interface ApiPausedResponse {
     status: ExecutionStatusEnum.paused;
 }

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/valkey",
     "displayName": "Valkey Connector",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "description": "A Terafoundation connector and facade client for Valkey.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/valkey#readme",
     "bugs": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "2.14.0",
+    "version": "2.15.0",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "2.13.0",
+    "version": "2.14.0",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "2.13.0",
+    "version": "2.14.0",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:

- Adds a `deprecated` key to the convict-style schema definition for op and API config fields
  - This allows asset authors to mark individual config properties as deprecated directly in the schema. This gets handled by teraslice internally and returns these deprecations in the api response.
- Returns structured deprecation warnings on job `submit`, `start`, `update`, and `recover` responses
  - Users will now see exactly what deprecated config properties their job is using without having to dig through logs
- Structures warnings as a nested reason chain
  - Makes it easy for users like the CLI or future tooling to better see what is deprecated, where it came from, and what to use instead.
- Adds backward compatibility for v3 asset schemas that return a plain config from `validate()` instead of `{ config, warnings }`
  - Existing assets that haven't been updated to the new shape continue to work without warnings being silently dropped or causing errors
- Updates teraslice-cli to display deprecation warnings in the terminal when running `submit`, `register`, `start`, `update`, and `recover` commands

Ref to issue https://github.com/terascope/kafka-assets/issues/1158