### PR TITLE
Add support for Gateway API HTTPRoute

### DIFF
--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,7 +4,7 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.26.0
+version: 3.27.0
 appVersion: v3.11.1
 sources:
   - https://github.com/terascope/teraslice

--- a/helm/teraslice/README.md
+++ b/helm/teraslice/README.md
@@ -67,12 +67,22 @@ View the `values.yaml` for charts configuration settings.
 | `ingress.hosts[0].paths[0].path`  | Ingress path                                     | `/`                       |
 | `ingress.hosts[0].paths[0].pathType` | Path type                                      | `ImplementationSpecific`  |
 | `ingress.tls`                     | TLS configuration for ingress                    | `[]`                      |
-| `resources`                       | Resource limits and requests                     | `{}`                      |
-| `nodeSelector`                    | Node selector configuration                      | `{}`                      |
-| `tolerations`                     | Tolerations for scheduling                       | `[]`                      |
-| `affinity`                        | Affinity rules for scheduling                    | `{}`                      |
-| `persistence.enabled`             | Enable persistent storage                        | `false`                   |
-| `persistence.size`                | Storage size                                     | `20Gi`                    |
+| `httpRoute.enabled`               | Enable HTTPRoute resource creation              | `false`                   |
+| `httpRoute.annotations`           | Annotations to add to the HTTPRoute             | `{}`                      |
+| `httpRoute.parentRefs[0].name`    | Name of the target Gateway                      | `gateway`                 |
+| `httpRoute.parentRefs[0].sectionName` | Gateway listener section name               | `http`                    |
+| `httpRoute.parentRefs[0].namespace` | Namespace of the target Gateway               | `nil`                     |
+| `httpRoute.hostnames[0]`          | Hostname matched by the route                   | `teraslice.local`         |
+| `httpRoute.rules[0].matches[0].path.type` | Path match type                         | `PathPrefix`              |
+| `httpRoute.rules[0].matches[0].path.value` | Path matched by the route              | `/`                       |
+| `httpRoute.rules[0].filters`      | HTTPRoute filters                               | `nil`                     |
+| `httpRoute.rules[0].timeouts`     | HTTPRoute timeouts                              | `nil`                     |
+| `resources`                       | Resource limits and requests                    | `{}`                      |
+| `nodeSelector`                    | Node selector configuration                     | `{}`                      |
+| `tolerations`                     | Tolerations for scheduling                      | `[]`                      |
+| `affinity`                        | Affinity rules for scheduling                   | `{}`                      |
+| `persistence.enabled`             | Enable persistent storage                       | `false`                   |
+| `persistence.size`                | Storage size                                    | `20Gi`                    |
 | `persistence.accessModes`         | Storage access modes                            | `["ReadWriteMany"]`       |
 | `extraVolumes`                    | Additional volumes                              | `[]`                      |
 | `extraVolumeMounts`               | Additional volume mounts                        | `[]`                      |

--- a/helm/teraslice/templates/httproute.yaml
+++ b/helm/teraslice/templates/httproute.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "teraslice.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "teraslice.master.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .timeouts }}
+      timeouts:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/helm/teraslice/values.yaml
+++ b/helm/teraslice/values.yaml
@@ -131,6 +131,40 @@ ingress:
   #    hosts:
   #      - teraslice.local
 
+httpRoute:
+  enabled: false
+  annotations: {}
+  parentRefs:
+  - name: gateway
+    sectionName: http
+    # namespace: default
+  hostnames:
+  - teraslice.local
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+  # Example of an advanced match (commented out)
+  # - matches:
+  #     - path:
+  #         type: PathPrefix
+  #         value: /
+  #       headers:
+  #         - name: version
+  #           value: v2
+  #   timeouts:
+  #     request: 600s
+  #   filters:
+  #     - type: RequestHeaderModifier
+  #       requestHeaderModifier:
+  #         set:
+  #           - name: My-Overwrite-Header
+  #             value: this-is-the-only-value
+  #         remove:
+  #           - User-Agent
+
+
 resources: {}
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
### [Helm] Summary

Add Gateway API HTTPRoute support to the Helm chart.

Gateway API Docs: https://gateway-api.sigs.k8s.io/reference/api-types/httproute/

### Changes

* Added `HTTPRoute` support for terasclice

  * `annotations`
  * `parentRefs`
  * `hostnames`
  * `rules`
  * `filters`
  * `timeouts`


### Motivation

This change provides an alternative to Ingress resources by supporting the Kubernetes Gateway API. Users can now expose Teraslice through an HTTPRoute while retaining flexibility for advanced routing features such as header matching, request filters, and timeout configuration.

