### PR TITLE
[teraslice, scripts] Dockerfile security improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,10 +65,23 @@ RUN apk --no-cache add tini ca-certificates bash curl
 WORKDIR /app/source
 RUN corepack enable
 
-# Bring over the built app + production deps
+# Create an unprivileged user (uid/gid pinned to 10001 to match `USER 10001`).
+# /app is root-owned, group 'apps', mode 1775: group members can create entries
+# but the sticky bit + root ownership stop them deleting/overwriting root-owned
+# code like /app/source. Volume dirs are chowned to the user for runtime writes.
+RUN addgroup -S -g 10001 apps && adduser -S -u 10001 -G apps teraslice && \
+    mkdir -p /app/config /app/logs /app/assets && \
+    chown -R 10001:apps /app/config /app/logs /app/assets && \
+    chown root:apps /app && chmod 1775 /app
+
+# Bring over the built app + production deps. Left root-owned (the default) so
+# the running teraslice user has read/execute but cannot modify the code.
 COPY --from=builder /app/source /app/source
 
 COPY service.js /app/source/
+
+# Drop privileges for everything that follows
+USER 10001
 
 # Check if it still works
 RUN node -e "import('teraslice')"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,7 +9,7 @@ WORKDIR /app/source
 RUN apk --no-cache add tini ca-certificates bash curl
 
 # Install nodemon globally so we can use it with the CMD
-ENV PNPM_HOME=/usr/local/bin
+ENV PNPM_HOME=/usr/local
 RUN corepack enable && pnpm add -g nodemon@3.1.4
 
 EXPOSE 5678

--- a/e2e/test/global.setup.ts
+++ b/e2e/test/global.setup.ts
@@ -38,6 +38,10 @@ export default async () => {
         fse.ensureDir(CONFIG_PATH),
     ]);
 
+    // The teraslice container runs as non-root (uid 10001) and must create asset
+    // directories in this bind-mounted dir. Make it writable regardless of host owner.
+    await fse.chmod(ASSETS_PATH, 0o777);
+
     // Try to load in the cache before trying to download
     loadAssetCache();
 

--- a/e2e/test/global.setup.ts
+++ b/e2e/test/global.setup.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { pDelay } from '@terascope/core-utils';
 import fse from 'fs-extra';
 import { helmfileCommand, setAlias } from '@terascope/scripts';
@@ -11,7 +12,7 @@ import { teardown } from './teardown.js';
 
 const {
     CONFIG_PATH, ASSETS_PATH, TEST_PLATFORM,
-    TERASLICE_PORT, STERN_LOGS
+    TERASLICE_PORT, STERN_LOGS, FILE_LOGGING, LOG_PATH
 } = config;
 
 export default async () => {
@@ -38,9 +39,18 @@ export default async () => {
         fse.ensureDir(CONFIG_PATH),
     ]);
 
-    // The teraslice container runs as non-root (uid 10001) and must create asset
-    // directories in this bind-mounted dir. Make it writable regardless of host owner.
+    // The teraslice container runs as non-root (uid 10001) and writes into these
+    // bind-mounted dirs (assets, and the host-owned log file when file logging is on).
+    // Make them writable regardless of host owner, else it hits EACCES at startup.
     await fse.chmod(ASSETS_PATH, 0o777);
+    if (FILE_LOGGING) {
+        const logDir = path.dirname(LOG_PATH);
+        await fse.ensureDir(logDir);
+        await fse.chmod(logDir, 0o777);
+        if (fse.existsSync(LOG_PATH)) {
+            await fse.chmod(LOG_PATH, 0o666);
+        }
+    }
 
     // Try to load in the cache before trying to download
     loadAssetCache();

--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,7 +4,7 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.26.0
+version: 3.27.0
 appVersion: v3.11.1
 sources:
   - https://github.com/terascope/teraslice

--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,7 +4,7 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.27.0
+version: 3.26.0
 appVersion: v3.11.1
 sources:
   - https://github.com/terascope/teraslice

--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.27.0
-appVersion: v3.11.1
+version: 3.28.0
+appVersion: v3.12.0
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/helm/teraslice/values.yaml
+++ b/helm/teraslice/values.yaml
@@ -87,7 +87,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-    - ALL
+      - ALL
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 10001
@@ -136,34 +136,34 @@ httpRoute:
   enabled: false
   annotations: {}
   parentRefs:
-  - name: gateway
-    sectionName: http
-    # namespace: default
+    - name: gateway
+      sectionName: http
+      # namespace: default
   hostnames:
-  - teraslice.local
+    - teraslice.local
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /
-  # Example of an advanced match (commented out)
-  # - matches:
-  #     - path:
-  #         type: PathPrefix
-  #         value: /
-  #       headers:
-  #         - name: version
-  #           value: v2
-  #   timeouts:
-  #     request: 600s
-  #   filters:
-  #     - type: RequestHeaderModifier
-  #       requestHeaderModifier:
-  #         set:
-  #           - name: My-Overwrite-Header
-  #             value: this-is-the-only-value
-  #         remove:
-  #           - User-Agent
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+    # Example of an advanced match (commented out)
+    # - matches:
+    #     - path:
+    #         type: PathPrefix
+    #         value: /
+    #       headers:
+    #         - name: version
+    #           value: v2
+    #   timeouts:
+    #     request: 600s
+    #   filters:
+    #     - type: RequestHeaderModifier
+    #       requestHeaderModifier:
+    #         set:
+    #           - name: My-Overwrite-Header
+    #             value: this-is-the-only-value
+    #         remove:
+    #           - User-Agent
 
 
 resources: {}

--- a/helm/teraslice/values.yaml
+++ b/helm/teraslice/values.yaml
@@ -83,13 +83,14 @@ serviceAccount:
 
 podSecurityContext: {} # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 10001
 
 strategyType: Recreate
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "3.11.1",
+    "version": "3.12.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/scripts/docker/asset-e2e/Dockerfile
+++ b/packages/scripts/docker/asset-e2e/Dockerfile
@@ -3,12 +3,22 @@
 ARG TERASLICE_IMAGE=ghcr.io/terascope/teraslice:dev-local-nodev24
 FROM ${TERASLICE_IMAGE}
 
+# The production base image keeps /app/source root-owned (read-only to the
+# unprivileged user). This image rewrites package.json and runs
+# `pnpm run setup` in that tree, so re-grant write access to the app user here.
+USER root
+RUN chown -R 10001:apps /app/source
+
+# The base image runs as the unprivileged '10001' user, so copy files with
+# explicit ownership and set the executable bit at copy time.
 # swap-packages.js rewrites package.json dep entries to file: references
 # for any dev packages mounted via TERASLICE_DEV_PACKAGES before pnpm resolves them.
 # Kept in packages/scripts/scripts/ so it is easy to edit and debug locally.
-COPY scripts/swap-packages.js /app/source/swap-packages.js
-COPY docker/asset-e2e/entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+COPY --chown=10001:apps scripts/swap-packages.js /app/source/swap-packages.js
+COPY --chown=10001:apps --chmod=0755 docker/asset-e2e/entrypoint.sh /app/entrypoint.sh
+
+# Drop back to the unprivileged user for runtime
+USER 10001
 
 # tini is already the entrypoint in the base image; just override the command
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/packages/scripts/helm/templates/teraslice.yaml.gotmpl
+++ b/packages/scripts/helm/templates/teraslice.yaml.gotmpl
@@ -281,9 +281,12 @@ worker:
             state:
                 number_of_replicas: 0
 
+securityContext:
+    {{- .Values.teraslice.securityContext | toYaml | nindent 4 }}
+
 extraVolumes: |
     {{- $customVolumes := .Values.teraslice.extraVolumes | default list }}
-    {{- $autoloadVolume := list (dict 
+    {{- $autoloadVolume := list (dict
           "name" "autoload" 
           "hostPath" (dict 
             "path" "/autoload" 

--- a/packages/scripts/helm/values.yaml
+++ b/packages/scripts/helm/values.yaml
@@ -199,6 +199,7 @@ teraslice:
   env: {}
   extraVolumes: []
   extraVolumeMounts: []
+  securityContext: {}
 
 prometheus_stack:
   # If enabled, the prom dashboard will be available on http://localhost:9090

--- a/packages/scripts/k8s/kindConfigDefaultPorts.yaml
+++ b/packages/scripts/k8s/kindConfigDefaultPorts.yaml
@@ -6,7 +6,7 @@ nodes:
   extraPortMappings: []
   # Leaving this commented out as a reference instead if removing.
   # `image`, `hostPort` and `containerPort` are dynamically set here:
-  # https://https://github.com/terascope/teraslice/blob/master/packages/scripts/src/helpers/kind.ts
+  # https://github.com/terascope/teraslice/blob/master/packages/scripts/src/helpers/kind.ts
   #
   # image: kindest/node:<K8S_VERSION>@sha256:<some_hash>
   #

--- a/packages/scripts/k8s/kindConfigDefaultPortsDev.yaml
+++ b/packages/scripts/k8s/kindConfigDefaultPortsDev.yaml
@@ -10,7 +10,7 @@ nodes:
   extraPortMappings: []
   # Leaving this commented out as a reference instead if removing.
   # `image`, `hostPort` and `containerPort` are dynamically set here:
-  # https://https://github.com/terascope/teraslice/blob/master/packages/scripts/src/helpers/kind.ts
+  # https://github.com/terascope/teraslice/blob/master/packages/scripts/src/helpers/kind.ts
   #
   # image: kindest/node:<K8S_VERSION>@sha256:<some_hash>
   #

--- a/packages/scripts/k8s/kindConfigTestPorts.yaml
+++ b/packages/scripts/k8s/kindConfigTestPorts.yaml
@@ -6,7 +6,7 @@ nodes:
   extraPortMappings: []
   # Leaving this commented out as a reference instead if removing.
   # `image`, `hostPort` and `containerPort` are dynamically set here:
-  # https://https://github.com/terascope/teraslice/blob/master/packages/scripts/src/helpers/kind.ts
+  # https://github.com/terascope/teraslice/blob/master/packages/scripts/src/helpers/kind.ts
   #
   # image: kindest/node:<K8S_VERSION>@sha256:<some_hash>
   #

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.18.0",
+    "version": "2.19.0",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/k8s-env/index.ts
+++ b/packages/scripts/src/helpers/k8s-env/index.ts
@@ -214,7 +214,7 @@ async function ensureTeraslice(): Promise<void> {
         } else {
             throw new Error(`Teraslice endpoint returned an object that didn't have 'teraslice_version' as a key: ${data}`);
         }
-    }, { retries: 7, delay: 1000, backoff: 1.5, maxDelay: 12000 });
+    }, { retries: 10, delay: 1000, backoff: 1.5, maxDelay: 12000 });
 }
 
 export async function rebuildTeraslice(options: K8sEnvOptions) {

--- a/packages/scripts/src/helpers/k8s-env/index.ts
+++ b/packages/scripts/src/helpers/k8s-env/index.ts
@@ -216,7 +216,7 @@ function buildNextStepsMessage(kind: Kind, options: K8sEnvOptions): string {
 
 /**
  * Hits the Teraslice API endpoint until it responds with a valid response
- * containing `teraslice_version`. Retries up to 7 times with exponential backoff.
+ * containing `teraslice_version`. Retries up to 10 times with exponential backoff.
  * Throws if the endpoint never becomes healthy.
  */
 async function ensureTeraslice(): Promise<void> {

--- a/packages/scripts/src/helpers/k8s-env/index.ts
+++ b/packages/scripts/src/helpers/k8s-env/index.ts
@@ -28,7 +28,28 @@ export async function launchK8sEnv(options: K8sEnvOptions) {
 
     if (options.configFile) {
         signale.pending('Starting k8s environment with a config file..');
-        // set the repo and tag to whats in th custom config to use later
+
+        // Encryption is not yet supported when launching with a custom config file
+        const encryptionValuePaths = [
+            'opensearch2.ssl.enabled',
+            'opensearch3.ssl.enabled',
+            'kafka.ssl.enabled',
+            'minio.tls.enabled',
+            'valkey.tls.enabled'
+        ];
+        const encryptedServices: string[] = [];
+        for (const valuePath of encryptionValuePaths) {
+            const enabled = await getConfigValueFromCustomYaml(options.configFile, valuePath);
+            if (enabled) {
+                encryptedServices.push(valuePath.split('.')[0]);
+            }
+        }
+        if (encryptedServices.length > 0) {
+            signale.error(`Encryption is not supported when launching with a config file. Disable encryption for the following service(s): ${encryptedServices.join(', ')}`);
+            process.exit(1);
+        }
+
+        // set the repo and tag to what's in the custom config to use later
         repo = await getConfigValueFromCustomYaml(options.configFile, 'teraslice.image.repository');
         tag = await getConfigValueFromCustomYaml(options.configFile, 'teraslice.image.tag');
         imageName = `${repo}:${tag}`;

--- a/packages/scripts/src/helpers/scripts.ts
+++ b/packages/scripts/src/helpers/scripts.ts
@@ -1190,6 +1190,16 @@ function generateHelmValuesFromServices(
     values.setIn(['teraslice', 'e2e'], e2e);
 
     if (devMode) {
+        // Dev image runs as root and writes/compiles into the bind-mounted source at
+        // runtime, so the chart's hardened securityContext won't work. Override the
+        // blocking fields back to permissive (explicit values, since Helm deep-merges
+        // and an empty {} would leave the hardened defaults in place).
+        values.setIn(['teraslice', 'securityContext'], {
+            runAsUser: 0,
+            runAsNonRoot: false,
+            readOnlyRootFilesystem: false
+        });
+
         const dockerfileMounts = getVolumesFromDockerfile(false, logger);
 
         // Shared node_modules volume: lives on the Kind node

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "3.11.1",
+    "version": "3.12.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {


### PR DESCRIPTION
This PR makes the following changes:
- create an unprivileged user in teraslice Dockerfile and run teraslice as that user.
- add more secure defaults to teraslice helmfile `securityContext`.
- add check to `k8s-env` command to fails fast if using a config-file and encrypted services (combination not supported).

Ref: #4456