### PR TITLE
[CI] Workflow fixes

### DIFF
--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -190,7 +190,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add ./helm/helm-repo-site/index.yaml
           git commit -m "Update Helm chart index.yaml for version $CHART_VERSION"
-          git -c "http.extraheader=Authorization: Bearer $REPO_TOKEN" push origin HEAD:master
+          AUTH=$(printf 'x-access-token:%s' "$REPO_TOKEN" | base64 | tr -d '\n')
+          git -c http.extraheader="AUTHORIZATION: basic $AUTH" push origin HEAD:master
 
       - name: Publish Helm Chart to GHCR
         if: steps.check-version.outputs.version_exists == 'false'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,6 +222,7 @@ jobs:
         env:
           REPORT_COVERAGE: true
           MAX_PROJECTS_PER_BATCH: 6
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm run test --suite unit --
 
       - name: Upload Node ${{ matrix.node-version }} unit test coverage
@@ -313,6 +314,8 @@ jobs:
         run: pnpm install && pnpm run setup
 
       - name: Create Docker Image List
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm run docker:listImages
           cat ./images/image-list.txt
@@ -452,6 +455,8 @@ jobs:
         run: pnpm install && pnpm run setup
 
       - name: Create Docker Image List
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm run docker:listImages
           cat ./images/image-list.txt
@@ -606,6 +611,8 @@ jobs:
         run: pnpm install && pnpm run setup
 
       - name: Create Docker Image List
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm run docker:listImages
           cat ./images/image-list.txt
@@ -713,6 +720,8 @@ jobs:
         run: pnpm install && pnpm run setup
 
       - name: Create Docker Image List
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm run docker:listImages
           cat ./images/image-list.txt
@@ -830,6 +839,8 @@ jobs:
         run: pnpm install && pnpm run setup
 
       - name: Create Docker Image List
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm run docker:listImages
           cat ./images/image-list.txt
@@ -915,6 +926,8 @@ jobs:
         run: pnpm install && pnpm run setup
 
       - name: Create Docker Image List
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm run docker:listImages
           cat ./images/image-list.txt
@@ -999,6 +1012,8 @@ jobs:
         run: pnpm install && pnpm run setup
 
       - name: Create Docker Image List
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm run docker:listImages
           cat ./images/image-list.txt
@@ -1083,6 +1098,8 @@ jobs:
         run: pnpm install && pnpm run setup
 
       - name: Create Docker Image List
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm run docker:listImages
           cat ./images/image-list.txt
@@ -1198,6 +1215,8 @@ jobs:
         run: pnpm install && pnpm run setup
 
       - name: Create Docker Image List
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm run docker:listImages
           cat ./images/image-list.txt
@@ -1282,6 +1301,8 @@ jobs:
         run: pnpm install && pnpm run setup
 
       - name: Create Docker Image List
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm run docker:listImages
           cat ./images/image-list.txt


### PR DESCRIPTION
In #4469 there were several changes to improve workflow security. This PR fixes the following mistakes:
- add `GITHUB_TOKEN` as env variable to some steps that call the github API. When not authenticated we hit rate limits. 
- In publish-master, when committing the new index.yaml for the helm chart update, we perform a `git push`. This command needs `basic` authentication, not `Bearer`.