### PR TITLE
[CI] Add multi-arch teraslice image support

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Publish to npm
         run: pnpm ts-scripts publish -t prerelease npm
 
-  build-docker:
+  build-docker-amd64:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
@@ -69,30 +69,152 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: ${{ matrix.node-version }}
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
-
-      - name: Install and build packages
-        run: pnpm install --frozen-lockfile && pnpm run setup
-
-      # we login to docker to publish new teraslice image
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish to docker
-        run: pnpm ts-scripts publish -t prerelease -n ${{ matrix.node-version }} docker
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Get build info
+        id: build-info
+        run: |
+          FULL_NODE=$(docker run --rm node:${{ matrix.node-version }}-alpine node -v | tr -d 'v')
+          TS_VERSION=$(jq -r .version package.json)
+          echo "ts_version=$TS_VERSION" >> $GITHUB_OUTPUT
+          echo "image_tag=ghcr.io/terascope/teraslice:v${TS_VERSION}-nodev${FULL_NODE}" >> $GITHUB_OUTPUT
+          echo "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_OUTPUT
+
+      - name: Build and push by digest (linux/amd64)
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            NODE_VERSION=${{ matrix.node-version }}
+            TERASLICE_VERSION=${{ steps.build-info.outputs.ts_version }}
+            BUILD_TIMESTAMP=${{ steps.build-info.outputs.timestamp }}
+            GITHUB_SHA=${{ github.sha }}
+          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+
+      - name: Export digest and tag
+        run: |
+          mkdir -p /tmp/docker-meta
+          echo "${{ steps.build.outputs.digest }}" > /tmp/docker-meta/digest.txt
+          echo "${{ steps.build-info.outputs.image_tag }}" > /tmp/docker-meta/tag.txt
+
+      - name: Upload docker meta artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docker-meta-amd64-node${{ matrix.node-version }}
+          path: /tmp/docker-meta/
+
+  build-docker-arm64:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        node-version: [22, 24]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Get build info
+        id: build-info
+        run: |
+          FULL_NODE=$(docker run --rm node:${{ matrix.node-version }}-alpine node -v | tr -d 'v')
+          TS_VERSION=$(jq -r .version package.json)
+          echo "ts_version=$TS_VERSION" >> $GITHUB_OUTPUT
+          echo "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_OUTPUT
+
+      - name: Build and push by digest (linux/arm64)
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          platforms: linux/arm64
+          build-args: |
+            NODE_VERSION=${{ matrix.node-version }}
+            TERASLICE_VERSION=${{ steps.build-info.outputs.ts_version }}
+            BUILD_TIMESTAMP=${{ steps.build-info.outputs.timestamp }}
+            GITHUB_SHA=${{ github.sha }}
+          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/docker-meta
+          echo "${{ steps.build.outputs.digest }}" > /tmp/docker-meta/digest.txt
+
+      - name: Upload docker meta artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docker-meta-arm64-node${{ matrix.node-version }}
+          path: /tmp/docker-meta/
+
+  create-docker-manifests:
+    if: github.event.pull_request.merged == true
+    needs: [build-docker-amd64, build-docker-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        node-version: [22, 24]
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Download amd64 meta
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docker-meta-amd64-node${{ matrix.node-version }}
+          path: /tmp/amd64-meta
+
+      - name: Download arm64 meta
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docker-meta-arm64-node${{ matrix.node-version }}
+          path: /tmp/arm64-meta
+
+      - name: Create and push multi-arch manifest
+        run: |
+          TAG=$(cat /tmp/amd64-meta/tag.txt)
+          AMD64_DIGEST=$(cat /tmp/amd64-meta/digest.txt)
+          ARM64_DIGEST=$(cat /tmp/arm64-meta/digest.txt)
+          echo "Creating manifest for ${TAG}"
+          docker buildx imagetools create \
+            -t "${TAG}" \
+            "ghcr.io/terascope/teraslice@${AMD64_DIGEST}" \
+            "ghcr.io/terascope/teraslice@${ARM64_DIGEST}"
 
   create-release-on-teraslice-bump:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -10,7 +10,34 @@ on:
 
 permissions: {}
 
+env:
+  NODE_VERSIONS: "[22, 24]"
+
 jobs:
+  compute-vars:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      NODE_VERSIONS: ${{ steps.node-versions.outputs.NODE_VERSIONS }}
+      is_dev_release: ${{ steps.version-check.outputs.is_dev_release }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - id: node-versions
+        run: echo "NODE_VERSIONS=${{ env.NODE_VERSIONS }}" >> $GITHUB_OUTPUT
+
+      - id: version-check
+        run: |
+          TERASLICE_VERSION=$(jq -r .version package.json)
+          PRERELEASE_TAG=$(./scripts/semver-tool.sh get prerelease "$TERASLICE_VERSION")
+          IS_DEV_RELEASE=$([ -n "$PRERELEASE_TAG" ] && echo true || echo false)
+          echo "is_dev_release=$IS_DEV_RELEASE" >> $GITHUB_OUTPUT
+
   build-npm:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
@@ -55,14 +82,15 @@ jobs:
         run: pnpm ts-scripts publish -t prerelease npm
 
   build-docker-amd64:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && needs.compute-vars.outputs.is_dev_release == 'true'
+    needs: compute-vars
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: ${{ fromJSON(needs.compute-vars.outputs.NODE_VERSIONS) }}
     steps:
       - name: Check out code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -99,7 +127,7 @@ jobs:
             TERASLICE_VERSION=${{ steps.build-info.outputs.ts_version }}
             BUILD_TIMESTAMP=${{ steps.build-info.outputs.timestamp }}
             GITHUB_SHA=${{ github.sha }}
-          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,push=true
           provenance: false
 
       - name: Export digest and tag
@@ -115,14 +143,15 @@ jobs:
           path: /tmp/docker-meta/
 
   build-docker-arm64:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && needs.compute-vars.outputs.is_dev_release == 'true'
+    needs: compute-vars
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: ${{ fromJSON(needs.compute-vars.outputs.NODE_VERSIONS) }}
     steps:
       - name: Check out code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -158,7 +187,7 @@ jobs:
             TERASLICE_VERSION=${{ steps.build-info.outputs.ts_version }}
             BUILD_TIMESTAMP=${{ steps.build-info.outputs.timestamp }}
             GITHUB_SHA=${{ github.sha }}
-          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,push=true
           provenance: false
 
       - name: Export digest
@@ -173,15 +202,15 @@ jobs:
           path: /tmp/docker-meta/
 
   create-docker-manifests:
-    if: github.event.pull_request.merged == true
-    needs: [build-docker-amd64, build-docker-arm64]
+    if: github.event.pull_request.merged == true && needs.compute-vars.outputs.is_dev_release == 'true'
+    needs: [compute-vars, build-docker-amd64, build-docker-arm64]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: ${{ fromJSON(needs.compute-vars.outputs.NODE_VERSIONS) }}
     steps:
       - name: Login to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -90,7 +90,7 @@ jobs:
             TERASLICE_VERSION=${{ steps.build-info.outputs.ts_version }}
             BUILD_TIMESTAMP=${{ steps.build-info.outputs.timestamp }}
             GITHUB_SHA=${{ github.sha }}
-          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,push=true
           provenance: false
 
       - name: Export digest and tag
@@ -146,7 +146,7 @@ jobs:
             TERASLICE_VERSION=${{ steps.build-info.outputs.ts_version }}
             BUILD_TIMESTAMP=${{ steps.build-info.outputs.timestamp }}
             GITHUB_SHA=${{ github.sha }}
-          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,push=true
           provenance: false
 
       - name: Export digest

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -19,8 +19,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      # we login to docker to publish new teraslice image
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
@@ -49,8 +48,158 @@ jobs:
       - name: Publish to npm
         run: pnpm ts-scripts publish -t latest npm
 
-      - name: Publish to docker
-        run: pnpm ts-scripts publish -t dev docker
+  build-docker-amd64:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Get build info
+        id: build-info
+        run: |
+          FULL_NODE=$(docker run --rm node:24-alpine node -v | tr -d 'v')
+          TS_VERSION=$(jq -r .version package.json)
+          echo "ts_version=$TS_VERSION" >> $GITHUB_OUTPUT
+          echo "image_tag=ghcr.io/terascope/teraslice:dev-local-nodev${FULL_NODE}" >> $GITHUB_OUTPUT
+          echo "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_OUTPUT
+
+      - name: Build and push by digest (linux/amd64)
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            NODE_VERSION=24
+            TERASLICE_VERSION=${{ steps.build-info.outputs.ts_version }}
+            BUILD_TIMESTAMP=${{ steps.build-info.outputs.timestamp }}
+            GITHUB_SHA=${{ github.sha }}
+          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+
+      - name: Export digest and tag
+        run: |
+          mkdir -p /tmp/docker-meta
+          echo "${{ steps.build.outputs.digest }}" > /tmp/docker-meta/digest.txt
+          echo "${{ steps.build-info.outputs.image_tag }}" > /tmp/docker-meta/tag.txt
+
+      - name: Upload docker meta artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docker-meta-dev-amd64
+          path: /tmp/docker-meta/
+
+  build-docker-arm64:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Get build info
+        id: build-info
+        run: |
+          FULL_NODE=$(docker run --rm node:24-alpine node -v | tr -d 'v')
+          TS_VERSION=$(jq -r .version package.json)
+          echo "ts_version=$TS_VERSION" >> $GITHUB_OUTPUT
+          echo "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_OUTPUT
+
+      - name: Build and push by digest (linux/arm64)
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          platforms: linux/arm64
+          build-args: |
+            NODE_VERSION=24
+            TERASLICE_VERSION=${{ steps.build-info.outputs.ts_version }}
+            BUILD_TIMESTAMP=${{ steps.build-info.outputs.timestamp }}
+            GITHUB_SHA=${{ github.sha }}
+          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/docker-meta
+          echo "${{ steps.build.outputs.digest }}" > /tmp/docker-meta/digest.txt
+
+      - name: Upload docker meta artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docker-meta-dev-arm64
+          path: /tmp/docker-meta/
+
+  create-docker-manifests:
+    if: github.event.pull_request.merged == true
+    needs: [build-docker-amd64, build-docker-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Download amd64 meta
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docker-meta-dev-amd64
+          path: /tmp/amd64-meta
+
+      - name: Download arm64 meta
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docker-meta-dev-arm64
+          path: /tmp/arm64-meta
+
+      - name: Create and push multi-arch manifest
+        run: |
+          TAG=$(cat /tmp/amd64-meta/tag.txt)
+          AMD64_DIGEST=$(cat /tmp/amd64-meta/digest.txt)
+          ARM64_DIGEST=$(cat /tmp/arm64-meta/digest.txt)
+          echo "Creating manifest for ${TAG}"
+          docker buildx imagetools create \
+            -t "${TAG}" \
+            "ghcr.io/terascope/teraslice@${AMD64_DIGEST}" \
+            "ghcr.io/terascope/teraslice@${ARM64_DIGEST}"
 
   create-release-on-teraslice-bump:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version:  24
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
@@ -63,7 +63,7 @@ jobs:
       - name: Publish to npm
         run: pnpm ts-scripts publish -t tag npm
 
-  docker-build-publish:
+  docker-build-publish-amd64:
     needs: ensure-non-pre-release
     if: needs.ensure-non-pre-release.outputs.is_dev_release == 'false'
     runs-on: ubuntu-latest
@@ -74,8 +74,7 @@ jobs:
       matrix:
         node-version: [22, 24]
     steps:
-      # we login to docker to publish new teraslice image
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
@@ -87,44 +86,159 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-
-      - name: Install and build packages
-        run: pnpm install --frozen-lockfile && pnpm run setup
-
-      - name: Publish to docker
-        id: docker-publish
+      - name: Get build info
+        id: build-info
         run: |
-          pnpm ts-scripts publish -t tag -n ${{ matrix.node-version }} docker 2>/dev/null | tee /tmp/docker-output.txt
-          grep "^- " /tmp/docker-output.txt | sed 's/^- //' > /tmp/docker-tags.txt
-          echo "images=$(grep "^- " /tmp/docker-output.txt | sed 's/^- //' | paste -sd ',' -)" >> $GITHUB_OUTPUT
+          FULL_NODE=$(docker run --rm node:${{ matrix.node-version }}-alpine node -v | tr -d 'v')
+          TS_VERSION=$(jq -r .version package.json)
+          echo "ts_version=$TS_VERSION" >> $GITHUB_OUTPUT
+          echo "image_tag=ghcr.io/terascope/teraslice:v${TS_VERSION}-nodev${FULL_NODE}" >> $GITHUB_OUTPUT
+          echo "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_OUTPUT
 
-      - name: Upload docker tags artifact
-        if: steps.docker-publish.outputs.images != ''
+      - name: Build and push by digest (linux/amd64)
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            NODE_VERSION=${{ matrix.node-version }}
+            TERASLICE_VERSION=${{ steps.build-info.outputs.ts_version }}
+            BUILD_TIMESTAMP=${{ steps.build-info.outputs.timestamp }}
+            GITHUB_SHA=${{ github.sha }}
+          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+
+      - name: Export digest and tag
+        run: |
+          mkdir -p /tmp/docker-meta
+          echo "${{ steps.build.outputs.digest }}" > /tmp/docker-meta/digest.txt
+          echo "${{ steps.build-info.outputs.image_tag }}" > /tmp/docker-meta/tag.txt
+
+      - name: Upload docker meta artifact
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: docker-tags-node${{ matrix.node-version }}
-          path: /tmp/docker-tags.txt
+          name: docker-meta-amd64-node${{ matrix.node-version }}
+          path: /tmp/docker-meta/
+
+  docker-build-publish-arm64:
+    needs: ensure-non-pre-release
+    if: needs.ensure-non-pre-release.outputs.is_dev_release == 'false'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        node-version: [22, 24]
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Get build info
+        id: build-info
+        run: |
+          FULL_NODE=$(docker run --rm node:${{ matrix.node-version }}-alpine node -v | tr -d 'v')
+          TS_VERSION=$(jq -r .version package.json)
+          echo "ts_version=$TS_VERSION" >> $GITHUB_OUTPUT
+          echo "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_OUTPUT
+
+      - name: Build and push by digest (linux/arm64)
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          platforms: linux/arm64
+          build-args: |
+            NODE_VERSION=${{ matrix.node-version }}
+            TERASLICE_VERSION=${{ steps.build-info.outputs.ts_version }}
+            BUILD_TIMESTAMP=${{ steps.build-info.outputs.timestamp }}
+            GITHUB_SHA=${{ github.sha }}
+          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/docker-meta
+          echo "${{ steps.build.outputs.digest }}" > /tmp/docker-meta/digest.txt
+
+      - name: Upload docker meta artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docker-meta-arm64-node${{ matrix.node-version }}
+          path: /tmp/docker-meta/
+
+  create-docker-manifests:
+    needs: [ensure-non-pre-release, docker-build-publish-amd64, docker-build-publish-arm64]
+    if: needs.ensure-non-pre-release.outputs.is_dev_release == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        node-version: [22, 24]
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Download amd64 meta
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docker-meta-amd64-node${{ matrix.node-version }}
+          path: /tmp/amd64-meta
+
+      - name: Download arm64 meta
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docker-meta-arm64-node${{ matrix.node-version }}
+          path: /tmp/arm64-meta
+
+      - name: Create and push multi-arch manifest
+        run: |
+          TAG=$(cat /tmp/amd64-meta/tag.txt)
+          AMD64_DIGEST=$(cat /tmp/amd64-meta/digest.txt)
+          ARM64_DIGEST=$(cat /tmp/arm64-meta/digest.txt)
+          echo "Creating manifest for ${TAG}"
+          docker buildx imagetools create \
+            -t "${TAG}" \
+            "ghcr.io/terascope/teraslice@${AMD64_DIGEST}" \
+            "ghcr.io/terascope/teraslice@${ARM64_DIGEST}"
 
   append-docker-tags-to-release:
-    needs: [ensure-non-pre-release, docker-build-publish]
+    needs: [ensure-non-pre-release, create-docker-manifests]
     if: needs.ensure-non-pre-release.outputs.is_dev_release == 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Download docker tags artifacts
+      - name: Download amd64 meta artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: docker-tags-node*
+          pattern: docker-meta-amd64-node*
           merge-multiple: false
           path: artifacts
 
@@ -132,12 +246,11 @@ jobs:
         id: build-body
         run: |
           BODY=$'### Docker Images\n\n'
-          for dir in artifacts/docker-tags-node*/; do
+          for dir in artifacts/docker-meta-amd64-node*/; do
             [ -d "$dir" ] || continue
-            while IFS= read -r img; do
-              [ -z "$img" ] && continue
-              BODY+="  - \`${img}\`"$'\n'
-            done < "$dir/docker-tags.txt"
+            TAG=$(cat "$dir/tag.txt")
+            [ -z "$TAG" ] && continue
+            BODY+="  - \`${TAG}\`"$'\n'
           done
           {
             echo "body<<EOF"
@@ -153,7 +266,7 @@ jobs:
           body: ${{ steps.build-body.outputs.body }}
 
   slack-announcement:
-    needs: [ensure-non-pre-release, build-release, docker-build-publish, append-docker-tags-to-release]
+    needs: [ensure-non-pre-release, build-release, docker-build-publish-amd64, docker-build-publish-arm64, create-docker-manifests, append-docker-tags-to-release]
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -10,6 +10,9 @@ on:
 
 permissions: {}
 
+env:
+  NODE_VERSIONS: "[22, 24]"
+
 jobs:
   ensure-non-pre-release:
     runs-on: ubuntu-latest
@@ -18,6 +21,7 @@ jobs:
     outputs:
       teraslice_version: ${{ steps.teraslice-version.outputs.teraslice_version }}
       is_dev_release: ${{ steps.teraslice-version.outputs.is_dev_release }}
+      NODE_VERSIONS: ${{ steps.node-versions.outputs.NODE_VERSIONS }}
     steps:
       - name: Check out code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -32,6 +36,9 @@ jobs:
           PRERELEASE_TAG=$(./scripts/semver-tool.sh get prerelease $TERASLICE_VERSION)
           IS_DEV_RELEASE=$([ -n "$PRERELEASE_TAG" ] && echo true || echo false)
           echo "is_dev_release=$IS_DEV_RELEASE" | tee -a $GITHUB_OUTPUT
+
+      - id: node-versions
+        run: echo "NODE_VERSIONS=${{ env.NODE_VERSIONS }}" >> $GITHUB_OUTPUT
 
   build-release:
     needs: ensure-non-pre-release
@@ -72,7 +79,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: ${{ fromJSON(needs.ensure-non-pre-release.outputs.NODE_VERSIONS) }}
     steps:
       - name: Login to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -109,7 +116,7 @@ jobs:
             TERASLICE_VERSION=${{ steps.build-info.outputs.ts_version }}
             BUILD_TIMESTAMP=${{ steps.build-info.outputs.timestamp }}
             GITHUB_SHA=${{ github.sha }}
-          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,push=true
           provenance: false
 
       - name: Export digest and tag
@@ -134,7 +141,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: ${{ fromJSON(needs.ensure-non-pre-release.outputs.NODE_VERSIONS) }}
     steps:
       - name: Login to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -170,7 +177,7 @@ jobs:
             TERASLICE_VERSION=${{ steps.build-info.outputs.ts_version }}
             BUILD_TIMESTAMP=${{ steps.build-info.outputs.timestamp }}
             GITHUB_SHA=${{ github.sha }}
-          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=ghcr.io/terascope/teraslice,push-by-digest=true,push=true
           provenance: false
 
       - name: Export digest
@@ -193,7 +200,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: ${{ fromJSON(needs.ensure-non-pre-release.outputs.NODE_VERSIONS) }}
     steps:
       - name: Login to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0


### PR DESCRIPTION
This PR makes the following changes:

- Splits the single `build-docker` job into separate `build-docker-amd64` and `build-docker-arm64` jobs across all three publish workflows [3ec9280] [9fc2b56] [fd4a311]
  - `amd64` builds run on `ubuntu-latest`
  - `arm64` builds run on `ubuntu-24.04-arm`
  - Each job builds and pushes by digest only (no tag), then uploads the digest and image tag as a workflow artifact
- Adds a `create-docker-manifests` job that runs after both arch builds complete
  - downloads the digests from both arch jobs and creates a multi-arch manifest using `docker buildx imagetools create`
  - Tags the manifest with the versioned image tag (e.g. `ghcr.io/terascope/teraslice:v1.2.3-nodev22.14.0`)
- Replaces `pnpm ts-scripts publish docker` with `docker/build-push-action` [3ec9280] [9fc2b56] [fd4a311]
  - Uses `docker/setup-buildx-action` for multi-platform build support
  - Passes `NODE_VERSION`, `TERASLICE_VERSION`, `BUILD_TIMESTAMP`, and `GITHUB_SHA` as build args
- Adds a `compute-vars` job to `publish-dev.yml` to stop docker builds on prerelease versions [6cc20c7]
  - Checks if the current version has a prerelease tag using `semver-tool.sh`
  - All docker jobs conditionally run only when `is_dev_release == 'true'`, preserving the behavior of the old `pnpm ts-scripts publish -t prerelease docker` command
- Extracts `NODE_VERSIONS` as a top-level `env` variable in `publish-dev.yml` and `publish-tag.yml` [6cc20c7]
  - Node versions are passed through job outputs via `fromJSON()` for matrix expansion
- Updates `append-docker-tags-to-release` in `publish-tag.yml` to read image tags from the amd64 artifact instead of the old `docker-tags.txt` format [fd4a311]

Ref to issue #3522