### PR TITLE
[teraslice] Secure worker and execution controller pods

### DIFF
--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.29.0
-appVersion: v3.12.1
+version: 3.30.0
+appVersion: v3.13.0
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/helm/teraslice/values.yaml
+++ b/helm/teraslice/values.yaml
@@ -81,7 +81,16 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podSecurityContext: {} # fsGroup: 2000
+podSecurityContext:
+  # fsGroup is required so the non-root runtime user (uid 10001) can write to the
+  # mounted assets PVC. Without it the volume mounts root-owned and, combined with
+  # securityContext.readOnlyRootFilesystem, asset writes fail at runtime.
+  fsGroup: 10001
+  # fsGroupChangePolicy avoids a slow recursive chown on large volumes by only
+  # fixing ownership when the volume's top-level dir doesn't already match the fsGroup.
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   allowPrivilegeEscalation: false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "3.12.1",
+    "version": "3.13.0",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "3.12.1",
+    "version": "3.13.0",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/deployments/worker.hbs
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/deployments/worker.hbs
@@ -60,7 +60,15 @@
                                 "fieldPath": "status.podIP"
                             }
                         }
-                    }]
+                    }],
+                    "securityContext": {
+                        "allowPrivilegeEscalation": false,
+                        "capabilities": {
+                            "drop": ["ALL"]
+                        },
+                        "runAsNonRoot": true,
+                        "runAsUser": 10001
+                    }
                 }],
                 "volumes": [{
                     "name": "config",
@@ -72,7 +80,17 @@
                         }]
                     }
                 }],
-                "terminationGracePeriodSeconds": {{shutdownTimeout}}
+                "terminationGracePeriodSeconds": {{shutdownTimeout}},
+                "securityContext": {
+                    "runAsNonRoot": true,
+                    "runAsUser": 10001,
+                    "runAsGroup": 10001,
+                    "fsGroup": 10001,
+                    "fsGroupChangePolicy": "OnRootMismatch",
+                    "seccompProfile": {
+                        "type": "RuntimeDefault"
+                    }
+                }
             }
         },
         "selector": {

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/deployments/worker.hbs
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/deployments/worker.hbs
@@ -66,6 +66,7 @@
                         "capabilities": {
                             "drop": ["ALL"]
                         },
+                        "readOnlyRootFilesystem": true,
                         "runAsNonRoot": true,
                         "runAsUser": 10001
                     }

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/jobs/execution_controller.hbs
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/jobs/execution_controller.hbs
@@ -66,6 +66,7 @@
                         "capabilities": {
                             "drop": ["ALL"]
                         },
+                        "readOnlyRootFilesystem": true,
                         "runAsNonRoot": true,
                         "runAsUser": 10001
                     }

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/jobs/execution_controller.hbs
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/jobs/execution_controller.hbs
@@ -60,7 +60,15 @@
                                 "fieldPath": "status.podIP"
                             }
                         }
-                    }]
+                    }],
+                    "securityContext": {
+                        "allowPrivilegeEscalation": false,
+                        "capabilities": {
+                            "drop": ["ALL"]
+                        },
+                        "runAsNonRoot": true,
+                        "runAsUser": 10001
+                    }
                 }],
                 "volumes": [{
                     "name": "config",
@@ -73,7 +81,17 @@
                     }
                 }],
                 "terminationGracePeriodSeconds": {{shutdownTimeout}},
-                "restartPolicy": "Never"
+                "restartPolicy": "Never",
+                "securityContext": {
+                    "runAsNonRoot": true,
+                    "runAsUser": 10001,
+                    "runAsGroup": 10001,
+                    "fsGroup": 10001,
+                    "fsGroupChangePolicy": "OnRootMismatch",
+                    "seccompProfile": {
+                        "type": "RuntimeDefault"
+                    }
+                }
             }
         }
     }

--- a/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sResource.ts
+++ b/packages/teraslice/src/lib/cluster/services/cluster/backends/kubernetesV2/k8sResource.ts
@@ -223,18 +223,32 @@ export abstract class K8sResource<T extends TSService | TSDeployment | TSJob> {
     }
 
     _setAssetsVolume(resource: TSJob | TSDeployment) {
-        if (this.terasliceConfig.assets_volume
-            && this.terasliceConfig.assets_directory
+        if (this.terasliceConfig.assets_directory
             && typeof this.terasliceConfig.assets_directory === 'string'
         ) {
-            resource.spec.template.spec.volumes.push({
-                name: this.terasliceConfig.assets_volume,
-                persistentVolumeClaim: { claimName: this.terasliceConfig.assets_volume }
-            });
-            resource.spec.template.spec.containers[0].volumeMounts.push({
-                name: this.terasliceConfig.assets_volume,
-                mountPath: this.terasliceConfig.assets_directory
-            });
+            if (this.terasliceConfig.assets_volume) {
+                // A shared asset volume (PVC) was configured: mount it at assets_directory.
+                resource.spec.template.spec.volumes.push({
+                    name: this.terasliceConfig.assets_volume,
+                    persistentVolumeClaim: { claimName: this.terasliceConfig.assets_volume }
+                });
+                resource.spec.template.spec.containers[0].volumeMounts.push({
+                    name: this.terasliceConfig.assets_volume,
+                    mountPath: this.terasliceConfig.assets_directory
+                });
+            } else {
+                // No shared volume: mount an emptyDir so downloaded assets can still be
+                // written while the pod runs with a read-only root filesystem. This is
+                // ephemeral per-pod, matching the previous (image root filesystem) behavior.
+                resource.spec.template.spec.volumes.push({
+                    name: 'assets',
+                    emptyDir: {}
+                });
+                resource.spec.template.spec.containers[0].volumeMounts.push({
+                    name: 'assets',
+                    mountPath: this.terasliceConfig.assets_directory
+                });
+            }
         }
     }
 

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8sResource-v2-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8sResource-v2-spec.ts
@@ -947,6 +947,40 @@ describe('k8sResource', () => {
         });
     });
 
+    describe('securityContext', () => {
+        const podSecurityContext = {
+            runAsNonRoot: true,
+            runAsUser: 10001,
+            runAsGroup: 10001,
+            fsGroup: 10001,
+            fsGroupChangePolicy: 'OnRootMismatch',
+            seccompProfile: {
+                type: 'RuntimeDefault'
+            }
+        };
+        const securityContext = {
+            allowPrivilegeEscalation: false,
+            capabilities: {
+                drop: ['ALL']
+            },
+            runAsNonRoot: true,
+            runAsUser: 10001
+        };
+
+        it('applies configured pod and container securityContext to worker and execution controller pods', () => {
+            const krWorker = new K8sDeploymentResource(terasliceConfig, execution, logger, 'example-job-abcd', 'UID1');
+            expect(krWorker.resource.spec.template.spec.securityContext)
+                .toEqual(podSecurityContext);
+            expect(krWorker.resource.spec.template.spec.containers[0].securityContext)
+                .toEqual(securityContext);
+
+            const krExc = new K8sJobResource(terasliceConfig, execution, logger);
+            expect(krExc.resource.spec.template.spec.securityContext).toEqual(podSecurityContext);
+            expect(krExc.resource.spec.template.spec.containers[0].securityContext)
+                .toEqual(securityContext);
+        });
+    });
+
     describe('execution_controller service', () => {
         it('has valid resource object.', () => {
             const kr = new K8sServiceResource(terasliceConfig, execution, logger, 'example-job-abcd', 'UID1');

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8sResource-v2-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8sResource-v2-spec.ts
@@ -140,6 +140,21 @@ describe('k8sResource', () => {
                     mountPath: /assets`));
         });
 
+        it('mounts an emptyDir at assets_directory when no assets_volume is set.', () => {
+            terasliceConfig.assets_directory = '/app/assets';
+            terasliceConfig.assets_volume = '';
+
+            const kr = new K8sDeploymentResource(terasliceConfig, execution, logger, 'example-job-abcd', 'UID1');
+
+            expect(kr.resource.spec.template.spec.volumes[1]).toEqual(yaml.load(`
+                    name: assets
+                    emptyDir: {}`));
+            expect(kr.resource.spec.template.spec.containers[0].volumeMounts[1])
+                .toEqual(yaml.load(`
+                    name: assets
+                    mountPath: /app/assets`));
+        });
+
         it('has valid resource object with volumes when execution has a single job volume', () => {
             execution.volumes = [
                 { name: 'teraslice-data1', path: '/data' }
@@ -963,6 +978,7 @@ describe('k8sResource', () => {
             capabilities: {
                 drop: ['ALL']
             },
+            readOnlyRootFilesystem: true,
             runAsNonRoot: true,
             runAsUser: 10001
         };

--- a/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8sResource-v2-spec.ts
+++ b/packages/teraslice/test/lib/cluster/services/cluster/backends/kubernetes/v2/k8sResource-v2-spec.ts
@@ -146,11 +146,11 @@ describe('k8sResource', () => {
 
             const kr = new K8sDeploymentResource(terasliceConfig, execution, logger, 'example-job-abcd', 'UID1');
 
-            expect(kr.resource.spec.template.spec.volumes[1]).toEqual(yaml.load(`
+            expect(kr.resource.spec.template.spec.volumes[1]).toEqual(load(`
                     name: assets
                     emptyDir: {}`));
             expect(kr.resource.spec.template.spec.containers[0].volumeMounts[1])
-                .toEqual(yaml.load(`
+                .toEqual(load(`
                     name: assets
                     mountPath: /app/assets`));
         });


### PR DESCRIPTION
This PR makes the following changes:
- add `podSecurityContext` settings to teraslice helm chart so volumes have needed permissions
- add `securityContext` and `podSecurityContext` settings to worker and execution controller templates
- if not using a `PVC` for `asset_directory` set up an `emptyDir` instead. This will be owned by the group, allowing assets to be written to the container while `readOnlyRootFilesystem` is true.

Ref: #4456