### PR TITLE
[CI] Fix teraslice image dev tag

### DIFF
--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -10,6 +10,9 @@ on:
 
 permissions: {}
 
+env:
+  NODE_VERSION: 24
+
 jobs:
   build-release:
     if: github.event.pull_request.merged == true
@@ -38,7 +41,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version:  24
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
@@ -73,10 +76,10 @@ jobs:
       - name: Get build info
         id: build-info
         run: |
-          FULL_NODE=$(docker run --rm node:24-alpine node -v | tr -d 'v')
+          FULL_NODE=$(docker run --rm node:${{ env.NODE_VERSION }}-alpine node -v | tr -d 'v')
           TS_VERSION=$(jq -r .version package.json)
           echo "ts_version=$TS_VERSION" >> $GITHUB_OUTPUT
-          echo "image_tag=ghcr.io/terascope/teraslice:dev-local-nodev${FULL_NODE}" >> $GITHUB_OUTPUT
+          echo "image_tag=ghcr.io/terascope/teraslice:dev-local-nodev${{ env.NODE_VERSION }}" >> $GITHUB_OUTPUT
           echo "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_OUTPUT
 
       - name: Build and push by digest (linux/amd64)
@@ -86,7 +89,7 @@ jobs:
           context: .
           platforms: linux/amd64
           build-args: |
-            NODE_VERSION=24
+            NODE_VERSION=${{ env.NODE_VERSION }}
             TERASLICE_VERSION=${{ steps.build-info.outputs.ts_version }}
             BUILD_TIMESTAMP=${{ steps.build-info.outputs.timestamp }}
             GITHUB_SHA=${{ github.sha }}
@@ -130,7 +133,7 @@ jobs:
       - name: Get build info
         id: build-info
         run: |
-          FULL_NODE=$(docker run --rm node:24-alpine node -v | tr -d 'v')
+          FULL_NODE=$(docker run --rm node:${{ env.NODE_VERSION }}-alpine node -v | tr -d 'v')
           TS_VERSION=$(jq -r .version package.json)
           echo "ts_version=$TS_VERSION" >> $GITHUB_OUTPUT
           echo "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" >> $GITHUB_OUTPUT
@@ -142,7 +145,7 @@ jobs:
           context: .
           platforms: linux/arm64
           build-args: |
-            NODE_VERSION=24
+            NODE_VERSION=${{ env.NODE_VERSION }}
             TERASLICE_VERSION=${{ steps.build-info.outputs.ts_version }}
             BUILD_TIMESTAMP=${{ steps.build-info.outputs.timestamp }}
             GITHUB_SHA=${{ github.sha }}
@@ -373,7 +376,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version:  24
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 


### PR DESCRIPTION
This PR makes the following changes:

- Fixes the teraslice dev tag to only have the major node version in the tag
- Moves node version in `publish-master.yml` to env var for easier node version updates in the future  

Ref to mistake PR #4483 