### PR TITLE
[scripts] Replace pMaps in ts-scripts publishToNPM with for loop

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.19.1",
+    "version": "2.19.2",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -41,8 +41,7 @@ async function publishToNPM(options: PublishOptions) {
     for (const pkgInfo of listPackages()) {
         try {
             result.push(await npmPublish(pkgInfo, options));
-        }
-        catch (err) {
+        } catch (err) {
             signale.error(`Failed to publish ${pkgInfo.name}`, err);
             errors.push(err);
         }

--- a/packages/scripts/src/helpers/publish/index.ts
+++ b/packages/scripts/src/helpers/publish/index.ts
@@ -29,10 +29,28 @@ async function publishToNPM(options: PublishOptions) {
     if (![PublishType.Latest, PublishType.Tag, PublishType.Prerelease].includes(options.type)) {
         throw new Error(`NPM publish does NOT support publish type "${options.type}"`);
     }
-    const result = await pMap(listPackages(), (pkgInfo) => npmPublish(pkgInfo, options), {
-        concurrency: 3,
-        stopOnError: false,
-    });
+    // Publish serially rather than via pMap. Concurrent `yarn npm publish`
+    // calls against a slow registry trigger yarn 4.x's got/p-cancelable
+    // "onCancel handler was attached after the promise settled" crash on the
+    // timeout-retry path, which can leave partial/duplicate publishes (409
+    // Conflict). A plain serial loop keeps one publish in flight at a time and
+    // gives clear per-package logging. We mirror pMap's stopOnError:false by
+    // collecting failures and throwing them together at the end.
+    const result = [];
+    const errors = [];
+    for (const pkgInfo of listPackages()) {
+        try {
+            result.push(await npmPublish(pkgInfo, options));
+        }
+        catch (err) {
+            signale.error(`Failed to publish ${pkgInfo.name}`, err);
+            errors.push(err);
+        }
+    }
+    if (errors.length) {
+        throw new AggregateError(errors, `Failed to publish ${errors.length} package(s)`);
+    }
+    signale.info('publishToNPM-result', result);
 
     const bumped = result.filter(isString);
 


### PR DESCRIPTION
This PR makes the following changes:

- Replaces the `pMap` function with a for loop when running `publishToNPM`

Ref to issue #4490