### PR TITLE
[teraslice] add error log when race condition in slice_id identified

### DIFF
--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.32.0
-appVersion: v3.15.0
+version: 3.33.0
+appVersion: v3.15.1
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "3.15.0",
+    "version": "3.15.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "3.15.0",
+    "version": "3.15.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/workers/worker/slice.ts
+++ b/packages/teraslice/src/lib/workers/worker/slice.ts
@@ -145,11 +145,11 @@ export class SliceExecution {
         const { slice } = this;
 
         await this.stateStorage.updateState(slice, SliceState.completed, undefined, retryCount);
+
+        this.logger.trace(`completed slice for execution: ${this.executionContext.exId}`, slice);
         if (this.logger.fields.slice_id !== slice.slice_id) {
             // This log is used to identify this issue: https://github.com/terascope/teraslice/issues/4495
-            this.logger.error('The slice_id of the slice does not match the slice_id of this logger. slice: ', slice);
-        } else {
-            this.logger.trace(`completed slice for execution: ${this.executionContext.exId}`, slice);
+            this.logger.error(`The slice_id of the slice: ${slice.slice_id} does not match the slice_id of this logger: ${this.logger.fields.slice_id}`);
         }
         this.events.emit('slice:success', slice);
     }

--- a/packages/teraslice/src/lib/workers/worker/slice.ts
+++ b/packages/teraslice/src/lib/workers/worker/slice.ts
@@ -145,8 +145,13 @@ export class SliceExecution {
         const { slice } = this;
 
         await this.stateStorage.updateState(slice, SliceState.completed, undefined, retryCount);
-
-        this.logger.trace(`completed slice for execution: ${this.executionContext.exId}`, slice);
+        this.logger.warn('this.logger.fields.slice_id: ', this.logger.fields.slice_id);
+        if (this.logger.fields.slice_id !== slice.slice_id) {
+            // This log is used to identify this issue: https://github.com/terascope/teraslice/issues/4495
+            this.logger.error('The slice_id of the slice does not match the slice_id of this logger. slice: ', slice);
+        } else {
+            this.logger.trace(`completed slice for execution: ${this.executionContext.exId}`, slice);
+        }
         this.events.emit('slice:success', slice);
     }
 

--- a/packages/teraslice/src/lib/workers/worker/slice.ts
+++ b/packages/teraslice/src/lib/workers/worker/slice.ts
@@ -145,7 +145,6 @@ export class SliceExecution {
         const { slice } = this;
 
         await this.stateStorage.updateState(slice, SliceState.completed, undefined, retryCount);
-        this.logger.warn('this.logger.fields.slice_id: ', this.logger.fields.slice_id);
         if (this.logger.fields.slice_id !== slice.slice_id) {
             // This log is used to identify this issue: https://github.com/terascope/teraslice/issues/4495
             this.logger.error('The slice_id of the slice does not match the slice_id of this logger. slice: ', slice);


### PR DESCRIPTION
This PR adds an error log when slice_ids do not match during worker shutdown flush().

Ref: #4495