### PR TITLE
[teraslice, job-components] Await lifecycle hooks

### DIFF
--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.36.0
-appVersion: v3.17.1
+version: 3.37.0
+appVersion: v3.17.2
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "3.17.1",
+    "version": "3.17.2",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "2.18.3",
+    "version": "2.18.4",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/job-components/src/execution-context/worker.ts
+++ b/packages/job-components/src/execution-context/worker.ts
@@ -196,8 +196,7 @@ export class WorkerExecutionContext
         };
 
         if (currentSliceId === slice.slice_id) return;
-        // TODO: this should be awaited. Do this after we validate changes in v3.16.0
-        this.onSliceInitialized();
+        return this.onSliceInitialized();
     }
 
     /**

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "2.19.3",
+    "version": "2.19.4",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "3.17.1",
+    "version": "3.17.2",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/lib/workers/worker/index.ts
+++ b/packages/teraslice/src/lib/workers/worker/index.ts
@@ -272,13 +272,12 @@ export class Worker {
         const extra = event ? ` due to event: ${event}` : '';
         this.logger.warn(`worker shutdown was called for execution ${exId}${extra}`);
 
-        // set the slice to to failed to avoid
-        // flushing the slice at the end
-        // we need to check if this.executionContext.sliceState
-        // in case a slice isn't currently active
+        // Set the slice to failed to avoid
+        // flushing the slice at the end.
+        // We need to check if this.executionContext.sliceState exists
+        // in case a slice isn't currently active.
         if (shutdownError && this.executionContext.sliceState) {
-            // TODO: this should be awaited. Do this after we validate changes in v3.16.0
-            this.executionContext.onSliceFailed();
+            await this.executionContext.onSliceFailed();
         }
 
         const start = Date.now();


### PR DESCRIPTION
This PR makes the following changes:
- There were two async [worker lifecycle event hooks](https://terascope.github.io/teraslice/docs/jobs/slices/#worker-lifecycle-events) that were not being properly awaited: `onSliceInitialized` and `onSliceFailed`. A search of both public and internal assets did not reveal any uses of these hooks, which is probably why this hadn't been noticed before.

Ref: #4506