### PR TITLE
[teraslice] properly type the API service

### DIFF
--- a/helm/teraslice/Chart.yaml
+++ b/helm/teraslice/Chart.yaml
@@ -4,8 +4,8 @@ description: Teraslice -  Distributed computing platform for processing JSON dat
 home: https://github.com/terascope/teraslice
 icon: https://terascope.github.io/teraslice/img/logo.png
 type: application
-version: 3.38.0
-appVersion: v3.18.0
+version: 3.39.0
+appVersion: v3.18.1
 sources:
   - https://github.com/terascope/teraslice
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-workspace",
     "displayName": "Teraslice",
-    "version": "3.18.0",
+    "version": "3.18.1",
     "private": true,
     "homepage": "https://github.com/terascope/teraslice",
     "bugs": {

--- a/packages/teraslice/package.json
+++ b/packages/teraslice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice",
     "displayName": "Teraslice",
-    "version": "3.18.0",
+    "version": "3.18.1",
     "description": "Distributed computing platform for processing JSON data",
     "homepage": "https://github.com/terascope/teraslice#readme",
     "bugs": {

--- a/packages/teraslice/src/interfaces.ts
+++ b/packages/teraslice/src/interfaces.ts
@@ -23,10 +23,12 @@ declare global {
 }
 
 /**
- * Aliases kept for readability at call sites; `any` params let route handlers
- * with typed params (e.g. `Request<{ jobId: string }>`) pass without casting.
+ * Aliases kept for readability at call sites. The `P` generic forwards to
+ * express `Request`'s route-params type, so handlers can express typed params
+ * (e.g. `TerasliceRequest<{ jobId: string }>`) while defaulting to `any` lets
+ * untyped handlers pass without casting.
  */
-export type TerasliceRequest = Request<any>;
+export type TerasliceRequest<P = any> = Request<P>;
 
 export type TerasliceResponse = Response;
 

--- a/packages/teraslice/src/interfaces.ts
+++ b/packages/teraslice/src/interfaces.ts
@@ -8,11 +8,27 @@ import type {
     ClusterServiceType
 } from './lib/cluster/services/index.js';
 
-export interface TerasliceRequest extends Request {
-    logger: Logger;
+/**
+ * Every request passes through middleware that attaches `logger` (see ApiService
+ * and AssetsService). Declaration merging makes that known to the type system so
+ * express `Request` no longer has to be cast to a Teraslice-specific type.
+ */
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace Express {
+        interface Request {
+            logger: Logger;
+        }
+    }
 }
 
-export interface TerasliceResponse extends Response {}
+/**
+ * Aliases kept for readability at call sites; `any` params let route handlers
+ * with typed params (e.g. `Request<{ jobId: string }>`) pass without casting.
+ */
+export type TerasliceRequest = Request<any>;
+
+export type TerasliceResponse = Response;
 
 export interface ClusterMasterContext extends Context {
     stores: {

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -238,12 +238,11 @@ export class ApiService {
                 node_version: process.version,
                 platform: this.context.platform,
                 teraslice_version: `v${terasliceVersion}`
-            } as any));
+            }));
         });
 
         v1routes.get('/cluster/state', (req, res) => {
             const requestHandler = handleTerasliceRequest(req, res);
-            // @ts-expect-error
             requestHandler(() => this.clusterService.getClusterState());
         });
 
@@ -492,10 +491,8 @@ export class ApiService {
             requestHandler(async () => {
                 const stats = executionService.getClusterAnalytics();
 
-                // for backwards compatibility
-                // @ts-expect-error
-                stats.slicer = stats.controllers;
-                return stats;
+                // `slicer` is the legacy alias for `controllers`, kept for backwards compatibility
+                return { ...stats, slicer: stats.controllers };
             });
         });
         v1routes.get(['/cluster/slicers', '/cluster/controllers'], (req, res) => {

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -1,4 +1,4 @@
-import { Router, Express } from 'express';
+import { Router, Express, ErrorRequestHandler } from 'express';
 import bodyParser from 'body-parser';
 import { pipeline as streamPipeline } from 'node:stream/promises';
 import got, { OptionsInit } from 'got';
@@ -209,14 +209,14 @@ export class ApiService {
                 return (req.headers['content-type'] === 'application/json' || req.headers['content-type'] === 'application/x-www-form-urlencoded');
             }
         }));
-        // @ts-expect-error
-        this.app.use((err, req, res, next) => {
+        const handleJsonParseError: ErrorRequestHandler = (err, _req, res, next) => {
             if (err instanceof SyntaxError) {
                 sendError(res, 400, 'the json submitted is malformed');
             } else {
                 next();
             }
-        });
+        };
+        this.app.use(handleJsonParseError);
 
         this.app.use((req, res, next) => {
             if (!this.available) {

--- a/packages/teraslice/src/lib/cluster/services/api.ts
+++ b/packages/teraslice/src/lib/cluster/services/api.ts
@@ -223,7 +223,6 @@ export class ApiService {
                 res.json({ error: 'api is not available' });
                 return;
             }
-            // @ts-expect-error
             req.logger = this.logger;
             next();
         });
@@ -231,7 +230,7 @@ export class ApiService {
         this.app.set('json spaces', 4);
 
         v1routes.get('/', (req, res) => {
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res);
+            const requestHandler = handleTerasliceRequest(req, res);
             requestHandler(() => ({
                 arch: this.context.arch,
                 clustering_type: this.context.sysconfig.teraslice.cluster_manager_type,
@@ -243,23 +242,22 @@ export class ApiService {
         });
 
         v1routes.get('/cluster/state', (req, res) => {
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res);
+            const requestHandler = handleTerasliceRequest(req, res);
             // @ts-expect-error
             requestHandler(() => this.clusterService.getClusterState());
         });
 
         v1routes.route('/assets{*splat}')
             .delete((req, res) => {
-                assetRedirect(req as TerasliceRequest, res);
+                assetRedirect(req, res);
             })
             .post((req, res) => {
                 if (req.headers['content-type'] === 'application/json' || req.headers['content-type'] === 'application/x-www-form-urlencoded') {
                     sendError(res, 400, '/asset endpoints do not accept json');
                     return;
                 }
-                assetRedirect(req as TerasliceRequest, res);
+                assetRedirect(req, res);
             })
-            // @ts-expect-error
             .get(assetRedirect);
 
         v1routes.post('/jobs', (req, res) => {
@@ -273,15 +271,15 @@ export class ApiService {
             const jobSpec = req.body;
             const shouldRun = `${start}` !== 'false';
 
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Job submission failed');
+            const requestHandler = handleTerasliceRequest(req, res, 'Job submission failed');
             requestHandler(() => jobsService.submitJob(jobSpec, shouldRun));
         });
 
         v1routes.get('/jobs', (req, res) => {
             const { active = '', deleted = 'false', ex } = req.query;
-            const { size, from, sort, filter } = getSearchOptions(req as TerasliceRequest);
+            const { size, from, sort, filter } = getSearchOptions(req);
 
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not retrieve list of jobs');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not retrieve list of jobs');
             requestHandler(() => {
                 validateGetDeletedOption(deleted as string);
 
@@ -298,8 +296,7 @@ export class ApiService {
         v1routes.get('/jobs/:jobId', (req, res) => {
             const { ex } = req.query;
             const { jobId } = req.params;
-            // @ts-expect-error
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not retrieve job');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not retrieve job');
             typeof ex === 'string'
                 ? requestHandler(async () => this.jobsService.getJobWithExInfo(jobId, ex.split(',')))
                 : requestHandler(async () => this.jobsStorage.get(jobId));
@@ -313,37 +310,32 @@ export class ApiService {
                 sendError(res, 400, `no data was provided to update job ${jobId}`);
                 return;
             }
-            // @ts-expect-error
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not update job');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not update job');
             requestHandler(async () => jobsService.updateJob(jobId, jobSpec));
         });
 
         v1routes.get('/jobs/:jobId/ex', (req, res) => {
             const { jobId } = req.params;
-            // @ts-expect-error
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not retrieve list of execution contexts');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not retrieve list of execution contexts');
             requestHandler(async () => jobsService.getLatestExecution(jobId));
         });
 
         v1routes.post('/jobs/:jobId/_active', (req, res) => {
             const { jobId } = req.params;
-            // @ts-expect-error
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, `Could not change active to 'true' for job: ${jobId}`);
+            const requestHandler = handleTerasliceRequest(req, res, `Could not change active to 'true' for job: ${jobId}`);
             requestHandler(async () => jobsService.setActiveState(jobId, true));
         });
 
         v1routes.post('/jobs/:jobId/_inactive', (req, res) => {
             const { jobId } = req.params;
-            // @ts-expect-error
 
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, `Could not change active to 'false' for job: ${jobId}`);
+            const requestHandler = handleTerasliceRequest(req, res, `Could not change active to 'false' for job: ${jobId}`);
             requestHandler(async () => jobsService.setActiveState(jobId, false));
         });
 
         v1routes.post('/jobs/:jobId/_start', (req, res) => {
             const { jobId } = req.params;
-            // @ts-expect-error
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, `Could not start job: ${jobId}`);
+            const requestHandler = handleTerasliceRequest(req, res, `Could not start job: ${jobId}`);
             requestHandler(async () => jobsService.startJob(jobId));
         });
 
@@ -354,9 +346,9 @@ export class ApiService {
                 force = false
             } = req.query as unknown as { timeout: number; blocking: boolean; force: boolean };
 
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not stop execution');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not stop execution');
             requestHandler(async () => {
-                const exId = await this._getExIdFromRequest(req as TerasliceRequest);
+                const exId = await this._getExIdFromRequest(req);
 
                 await executionService.stopExecution(exId, { timeout, force });
 
@@ -374,33 +366,31 @@ export class ApiService {
         });
 
         v1routes.post(['/jobs/:jobId/_pause', '/ex/:exId/_pause'], (req, res) => {
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not pause execution');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not pause execution');
             requestHandler(async () => {
-                const exId = await this._getExIdFromRequest(req as TerasliceRequest);
+                const exId = await this._getExIdFromRequest(req);
                 return executionService.pauseExecution(exId);
             });
         });
 
         v1routes.post(['/jobs/:jobId/_resume', '/ex/:exId/_resume'], (req, res) => {
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not resume execution');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not resume execution');
             requestHandler(async () => {
-                const exId = await this._getExIdFromRequest(req as TerasliceRequest);
+                const exId = await this._getExIdFromRequest(req);
                 return executionService.resumeExecution(exId);
             });
         });
 
         v1routes.delete('/jobs/:jobId', (req, res) => {
             const { jobId } = req.params;
-            // @ts-expect-error
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not delete job');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not delete job');
             requestHandler(async () => jobsService.softDeleteJob(jobId));
         });
 
         v1routes.post('/jobs/:jobId/_recover', (req, res) => {
             const cleanupType = req.query.cleanup_type || req.query.cleanup;
             const { jobId } = req.params;
-            // @ts-expect-error
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not recover job');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not recover job');
             requestHandler(async () => {
                 validateCleanupType(cleanupType as RecoveryCleanupType);
                 return jobsService.recoverJob(jobId, cleanupType as RecoveryCleanupType);
@@ -410,8 +400,7 @@ export class ApiService {
         v1routes.post('/ex/:exId/_recover', (req, res) => {
             const cleanupType = req.query.cleanup_type || req.query.cleanup;
             const { exId } = req.params;
-            // @ts-expect-error
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not recover execution');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not recover execution');
             requestHandler(async () => {
                 validateCleanupType(cleanupType as RecoveryCleanupType);
                 return executionService.recoverExecution(exId, cleanupType as RecoveryCleanupType);
@@ -419,11 +408,9 @@ export class ApiService {
         });
 
         v1routes.post('/jobs/:jobId/_settings', (req, res) => {
-            // @ts-expect-error
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not update dynamic job settings');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not update dynamic job settings');
             requestHandler(async () => {
-                // @ts-expect-error
-                const exId = await this._getExIdFromRequest(req as TerasliceRequest);
+                const exId = await this._getExIdFromRequest(req);
                 const { log_level } = req.query;
                 return executionService.setLogLevel(exId, log_level as string);
             });
@@ -432,9 +419,9 @@ export class ApiService {
         v1routes.post(['/jobs/:jobId/_workers', '/ex/:exId/_workers'], (req, res) => {
             const { query } = req;
 
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not change workers count');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not change workers count');
             requestHandler(async () => {
-                const exId = await this._getExIdFromRequest(req as TerasliceRequest);
+                const exId = await this._getExIdFromRequest(req);
                 const result = await this._changeWorkers(exId, query);
                 return { message: `${result.workerNum} workers have been ${result.action} for execution: ${result.ex_id}` };
             });
@@ -446,9 +433,9 @@ export class ApiService {
             '/ex/:exId/slicer',
             '/ex/:exId/controller'
         ], (req, res) => {
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not get slicer statistics');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not get slicer statistics');
             requestHandler(async () => {
-                const exId = await this._getExIdFromRequest(req as TerasliceRequest);
+                const exId = await this._getExIdFromRequest(req);
                 return this._controllerStats(exId);
             });
         });
@@ -458,11 +445,11 @@ export class ApiService {
             '/ex/:exId/errors',
             '/ex/errors',
         ], (req, res) => {
-            const { size, from, sort, filter } = getSearchOptions(req as TerasliceRequest);
+            const { size, from, sort, filter } = getSearchOptions(req);
 
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not get errors for job');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not get errors for job');
             requestHandler(async () => {
-                const exId = await this._getExIdFromRequest(req as TerasliceRequest, true);
+                const exId = await this._getExIdFromRequest(req, true);
                 const query = addFilterToQuery(
                     `state:error AND ex_id:"${exId}"`,
                     filter as string
@@ -473,9 +460,9 @@ export class ApiService {
 
         v1routes.get('/ex', (req, res) => {
             const { status = '', deleted = 'false' } = req.query;
-            const { size, from, sort, filter } = getSearchOptions(req as TerasliceRequest);
+            const { size, from, sort, filter } = getSearchOptions(req);
 
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not retrieve list of execution contexts');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not retrieve list of execution contexts');
             requestHandler(async () => {
                 validateGetDeletedOption(deleted as string);
                 const statuses = parseList(status);
@@ -496,13 +483,12 @@ export class ApiService {
 
         v1routes.get('/ex/:exId', (req, res) => {
             const { exId } = req.params;
-            // @ts-expect-error
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, `Could not retrieve execution context ${exId}`);
+            const requestHandler = handleTerasliceRequest(req, res, `Could not retrieve execution context ${exId}`);
             requestHandler(async () => executionService.getExecutionContext(exId));
         });
 
         v1routes.get('/cluster/stats', (req, res) => {
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not get cluster statistics');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not get cluster statistics');
             requestHandler(async () => {
                 const stats = executionService.getClusterAnalytics();
 
@@ -513,7 +499,7 @@ export class ApiService {
             });
         });
         v1routes.get(['/cluster/slicers', '/cluster/controllers'], (req, res) => {
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not get execution statistics');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not get execution statistics');
             requestHandler(() => this._controllerStats());
         });
 
@@ -522,11 +508,10 @@ export class ApiService {
         this.app.use('/v1', v1routes);
 
         this.app.route('/txt/assets{*splat}')
-        // @ts-expect-error
             .get(assetRedirect);
 
         this.app.get('/txt/workers', (req, res) => {
-            const { size, from } = getSearchOptions(req as TerasliceRequest);
+            const { size, from } = getSearchOptions(req);
             let defaults: string[];
             if (this.clusterType === 'native') {
                 defaults = ['assignment', 'job_id', 'ex_id', 'node_id', 'pid'];
@@ -536,18 +521,18 @@ export class ApiService {
                 defaults = ['assignment', 'job_id', 'ex_id', 'node_id', 'pod_name', 'image'];
             }
 
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not get all workers');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not get all workers');
             requestHandler(async () => {
                 const workers = await executionService.findAllWorkers() as Record<string, any>[];
-                return makeTable(req as TerasliceRequest, defaults, workers.slice(from, size));
+                return makeTable(req, defaults, workers.slice(from, size));
             });
         });
 
         this.app.get('/txt/nodes', (req, res) => {
-            const { size, from } = getSearchOptions(req as TerasliceRequest);
+            const { size, from } = getSearchOptions(req);
             const defaults = ['node_id', 'state', 'hostname', 'total', 'active', 'pid', 'teraslice_version', 'node_version'];
 
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not get all nodes');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not get all nodes');
             requestHandler(async () => {
                 const nodes = await clusterService.getClusterState();
 
@@ -559,17 +544,17 @@ export class ApiService {
                         { active: node.active.length }
                     ));
 
-                return makeTable(req as TerasliceRequest, defaults, transform);
+                return makeTable(req, defaults, transform);
             });
         });
 
         this.app.get('/txt/jobs', (req, res) => {
             const { active = '', deleted = 'false' } = req.query;
-            const { size, from, sort, filter } = getSearchOptions(req as TerasliceRequest);
+            const { size, from, sort, filter } = getSearchOptions(req);
 
             const defaults = ['job_id', 'name', 'active', 'lifecycle', 'slicers', 'workers', '_created', '_updated'];
 
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not get all jobs');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not get all jobs');
             requestHandler(async () => {
                 validateGetDeletedOption(deleted as string);
 
@@ -585,17 +570,17 @@ export class ApiService {
                     query, from, size, sort as string
                 ) as Record<string, any>[];
 
-                return makeTable(req as TerasliceRequest, defaults, jobs);
+                return makeTable(req, defaults, jobs);
             });
         });
 
         this.app.get('/txt/ex', (req, res) => {
             const { deleted = 'false' } = req.query;
-            const { size, from, sort, filter } = getSearchOptions(req as TerasliceRequest);
+            const { size, from, sort, filter } = getSearchOptions(req);
 
             const defaults = ['name', 'lifecycle', 'slicers', 'workers', '_status', 'ex_id', 'job_id', '_created', '_updated'];
 
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not get all executions');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not get all executions');
 
             requestHandler(async () => {
                 validateGetDeletedOption(deleted as string);
@@ -612,12 +597,12 @@ export class ApiService {
                     query, from, size, sort as string
                 ) as Record<string, any>[];
 
-                return makeTable(req as TerasliceRequest, defaults, exs);
+                return makeTable(req, defaults, exs);
             });
         });
 
         this.app.get(['/txt/slicers', '/txt/controllers'], (req, res) => {
-            const { size, from } = getSearchOptions(req as TerasliceRequest);
+            const { size, from } = getSearchOptions(req);
 
             const defaults = [
                 'name',
@@ -629,10 +614,10 @@ export class ApiService {
                 'processed'
             ];
 
-            const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, 'Could not get all execution statistics');
+            const requestHandler = handleTerasliceRequest(req, res, 'Could not get all execution statistics');
             requestHandler(async () => {
                 const stats = await this._controllerStats();
-                return makeTable(req as TerasliceRequest, defaults, stats.slice(from, size));
+                return makeTable(req, defaults, stats.slice(from, size));
             });
         });
 

--- a/packages/teraslice/src/lib/cluster/services/assets.ts
+++ b/packages/teraslice/src/lib/cluster/services/assets.ts
@@ -32,7 +32,6 @@ export class AssetsService {
         this.app.set('json spaces', 4);
 
         this.app.use((req, _res, next) => {
-            // @ts-expect-error
             req.logger = this.logger;
             next();
         });
@@ -44,7 +43,7 @@ export class AssetsService {
             await this.assetsStorage.initialize();
 
             this.app.get('/status', (req, res) => {
-                const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res);
+                const requestHandler = handleTerasliceRequest(req, res);
                 requestHandler(async () => ({ available: this.running }));
             });
 
@@ -86,8 +85,7 @@ export class AssetsService {
 
             this.app.delete('/assets/:assetId', (req, res) => {
                 const { assetId } = req.params;
-                // @ts-expect-error
-                const requestHandler = handleTerasliceRequest(req as TerasliceRequest, res, `Could not delete asset ${assetId}`);
+                const requestHandler = handleTerasliceRequest(req, res, `Could not delete asset ${assetId}`);
 
                 if (assetId.length !== 40) {
                     res.status(400).json({
@@ -107,32 +105,32 @@ export class AssetsService {
 
             this.app.get('/txt/assets', (req, res) => {
                 const query = 'id:*';
-                this.createAssetTable(query, req as TerasliceRequest, res);
+                this.createAssetTable(query, req, res);
             });
 
             this.app.get('/txt/assets/:name', (req, res) => {
                 const query = `id:* AND name:"${req.params.name}"`;
-                this.createAssetTable(query, req as unknown as TerasliceRequest, res);
+                this.createAssetTable(query, req, res);
             });
 
             this.app.get('/txt/assets/:name/:version', (req, res) => {
                 const query = `id:* AND name:"${req.params.name}" AND version:"${req.params.version}"`;
-                this.createAssetTable(query, req as unknown as TerasliceRequest, res);
+                this.createAssetTable(query, req, res);
             });
 
             this.app.get('/assets', (req, res) => {
                 const query = 'id:*';
-                this.assetsSearch(query, req as TerasliceRequest, res);
+                this.assetsSearch(query, req, res);
             });
 
             this.app.get('/assets/:name', (req, res) => {
                 const query = `id:* AND name:"${req.params.name}"`;
-                this.assetsSearch(query, req as unknown as TerasliceRequest, res);
+                this.assetsSearch(query, req, res);
             });
 
             this.app.get('/assets/:name/:version', (req, res) => {
                 const query = `id:* AND name:"${req.params.name}" AND version:"${req.params.version}"`;
-                this.assetsSearch(query, req as unknown as TerasliceRequest, res);
+                this.assetsSearch(query, req, res);
             });
 
             await new Promise((resolve, reject) => {

--- a/packages/teraslice/src/lib/utils/api_utils.ts
+++ b/packages/teraslice/src/lib/utils/api_utils.ts
@@ -55,7 +55,11 @@ export function handleTerasliceRequest(
     { errorCode = 500, successCode = 200 } = {}
 ) {
     logTerasliceRequest(req);
-    return async (fn: () => Promise<string | Record<string, any>>) => {
+    // `fn` returns whatever should be serialized as the response body: a string is
+    // sent as-is, anything else is sent as JSON. The value is intentionally `unknown`
+    // because callers return a wide range of endpoint payloads (objects, arrays,
+    // cluster state, etc.); the response shape is narrowed below.
+    return async (fn: () => unknown) => {
         try {
             const result = await fn();
 


### PR DESCRIPTION
This PR makes the following changes:

- Types the `logger` that middleware attaches to every request via a `declare global` Express `Request` augmentation in `interfaces.ts`, and converts `TerasliceRequest`/`TerasliceResponse` to aliases
  - Removes `as TerasliceRequest` casts across `api.ts` and `assets.ts`
- Types the JSON-parse error middleware as an `ErrorRequestHandler` instead of suppressing it
- Widens `handleTerasliceRequest`'s callback to `() => unknown` (narrowed at the point of use), and expresses the legacy `slicer` alias as a spread instead of an `@ts-expect-error` mutation
- Removes all `@ts-expect-error` directives from `api.ts`

Type-only change, should be no runtime or http behavior change.

Ref to issue #3892