### PR TITLE
[xLucene] Allow separate geo sort field than geo query

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/core-utils",
     "displayName": "Core Utils",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "description": "A collection of Teraslice Core Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/core-utils#readme",
     "bugs": {

--- a/packages/data-mate/package.json
+++ b/packages/data-mate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-mate",
     "displayName": "Data-Mate",
-    "version": "2.18.1",
+    "version": "2.18.2",
     "description": "Library of data validations/transformations",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-mate#readme",
     "repository": {

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/data-types",
     "displayName": "Data Types",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "description": "A library for defining the data structures and mapping",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/data-types#readme",
     "bugs": {

--- a/packages/elasticsearch-api/package.json
+++ b/packages/elasticsearch-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-api",
     "displayName": "Elasticsearch API",
-    "version": "5.17.1",
+    "version": "5.17.2",
     "description": "Elasticsearch client api used across multiple services, handles retries and exponential backoff",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-api#readme",
     "bugs": {

--- a/packages/elasticsearch-store/package.json
+++ b/packages/elasticsearch-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-store",
     "displayName": "Elasticsearch Store",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "description": "An API for managing an elasticsearch index, with versioning and migration support.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/elasticsearch-store#readme",
     "bugs": {

--- a/packages/geo-utils/package.json
+++ b/packages/geo-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/geo-utils",
     "displayName": "Geo Utils",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "description": "A collection of Teraslice Geo Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/geo-utils#readme",
     "bugs": {

--- a/packages/ip-utils/package.json
+++ b/packages/ip-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/ip-utils",
     "displayName": "IP Utils",
-    "version": "2.18.1",
+    "version": "2.18.2",
     "description": "A collection of Teraslice IP Utilities",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ip-utils#readme",
     "bugs": {

--- a/packages/job-components/package.json
+++ b/packages/job-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/job-components",
     "displayName": "Job Components",
-    "version": "2.19.1",
+    "version": "2.19.2",
     "description": "A teraslice library for validating jobs schemas, registering apis, and defining and running new Job APIs",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/job-components#readme",
     "bugs": {

--- a/packages/opensearch-client/package.json
+++ b/packages/opensearch-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/opensearch-client",
     "displayName": "Opensearch Client",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "description": "A Node.js facade client for opensearch & elasticsearch.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/opensearch-client#readme",
     "bugs": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/scripts",
     "displayName": "Scripts",
-    "version": "2.25.0",
+    "version": "2.25.1",
     "description": "A collection of terascope monorepo scripts",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/scripts#readme",
     "bugs": {

--- a/packages/terafoundation/package.json
+++ b/packages/terafoundation/package.json
@@ -1,7 +1,7 @@
 {
     "name": "terafoundation",
     "displayName": "Terafoundation",
-    "version": "2.19.1",
+    "version": "2.19.2",
     "description": "A Clustering and Foundation tool for Terascope Tools",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/terafoundation#readme",
     "bugs": {

--- a/packages/teraslice-client-js/package.json
+++ b/packages/teraslice-client-js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-client-js",
     "displayName": "Teraslice Client (JavaScript)",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "description": "A Node.js client for teraslice jobs, assets, and cluster references.",
     "keywords": [
         "elasticsearch",

--- a/packages/teraslice-messaging/package.json
+++ b/packages/teraslice-messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-messaging",
     "displayName": "Teraslice Messaging",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "description": "An internal teraslice messaging library using socket.io",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-messaging#readme",
     "bugs": {

--- a/packages/teraslice-state-storage/package.json
+++ b/packages/teraslice-state-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/teraslice-state-storage",
     "displayName": "Teraslice State Storage",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "description": "State storage operation api for teraslice",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-state-storage#readme",
     "bugs": {

--- a/packages/teraslice-test-harness/package.json
+++ b/packages/teraslice-test-harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "teraslice-test-harness",
     "displayName": "Teraslice Test Harness",
-    "version": "2.20.1",
+    "version": "2.20.2",
     "description": "A helpful library for testing teraslice jobs, operations, and other components.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/teraslice-test-harness#readme",
     "bugs": {

--- a/packages/ts-transforms/package.json
+++ b/packages/ts-transforms/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-transforms",
     "displayName": "TS Transforms",
-    "version": "2.18.1",
+    "version": "2.18.2",
     "description": "An ETL framework built upon xlucene-evaluator",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/ts-transforms#readme",
     "bugs": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/types",
     "displayName": "Types",
-    "version": "2.16.0",
+    "version": "2.16.1",
     "description": "A collection of typescript interfaces",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/types#readme",
     "bugs": {

--- a/packages/types/src/elasticsearch-interfaces.ts
+++ b/packages/types/src/elasticsearch-interfaces.ts
@@ -159,18 +159,21 @@ export type MatchNoneQuery = {
     match_none: Record<PropertyKey, never>; // empty object {}
 };
 
-export type GeoDistanceSort = {
-    [field: string]: SortOrder | geo.GeoDistanceUnit | {
-        lat: number;
-        lon: number;
+export type FieldSort = string | {
+    [field: string]: {
+        order: SortOrder;
     };
 };
 
-export type GeoQuerySort = {
-    _geo_distance: GeoDistanceSort;
+export type GeoDistanceSort = {
+    _geo_distance: {
+        unit: geo.GeoDistanceUnit;
+        order: SortOrder;
+        [field: string]: geo.GeoPoint | geo.GeoPointArr | geo.GeoPointStr;
+    };
 };
 
-export type AnyQuerySort = GeoQuerySort;
+export type AnyQuerySort = FieldSort | GeoDistanceSort;
 
 export type ElasticsearchDSLResult = {
     query: ConstantScoreQuery | MatchAllQuery | MatchNoneQuery | KNNQuery;

--- a/packages/types/src/elasticsearch-interfaces.ts
+++ b/packages/types/src/elasticsearch-interfaces.ts
@@ -166,11 +166,11 @@ export type GeoDistanceSort = {
     };
 };
 
-export type GeoSortQuery = {
+export type GeoQuerySort = {
     _geo_distance: GeoDistanceSort;
 };
 
-export type AnyQuerySort = GeoSortQuery;
+export type AnyQuerySort = GeoQuerySort;
 
 export type ElasticsearchDSLResult = {
     query: ConstantScoreQuery | MatchAllQuery | MatchNoneQuery | KNNQuery;

--- a/packages/types/src/geo-interfaces.ts
+++ b/packages/types/src/geo-interfaces.ts
@@ -48,8 +48,8 @@ export type JoinGeoShape = GeoShape | ESGeoShape;
 
 export type CoordinateTuple = [lon: number, lat: number];
 
-type GeoPointArr = [lon: number, lat: number];
-type GeoPointStr = string;
+export type GeoPointArr = [lon: number, lat: number];
+export type GeoPointStr = string;
 type GeoObjShort = { lat: string | number; lon: string | number };
 type GeoObjLong = { latitude: string | number; longitude: string | number };
 

--- a/packages/types/src/xlucene-interfaces.ts
+++ b/packages/types/src/xlucene-interfaces.ts
@@ -1,3 +1,7 @@
+import type { ClientMetadata, SortOrder } from './elasticsearch-interfaces.js';
+import type { GeoDistanceUnit, GeoPoint } from './geo-interfaces.js';
+import type { Logger } from './logger.js';
+
 export enum xLuceneFieldType {
     Geo = 'geo',
     Date = 'date',
@@ -29,3 +33,25 @@ export interface xLuceneTypeConfig {
 export interface xLuceneVariables {
     readonly [key: string]: any;
 }
+
+export interface XluceneBaseOptions {
+    type_config: xLuceneTypeConfig;
+    variables?: xLuceneVariables;
+}
+
+export type XluceneTranslateQueryOptions = XluceneBaseOptions & Partial<ClientMetadata> & {
+    logger?: Logger;
+    geo_sort_config?: XluceneGeoSortConfig;
+};
+
+export type XluceneGeoSortConfig = {
+    // field & point required
+    field?: string;
+    point?: GeoPoint;
+    // order & unit can use defaults if not provided
+    order?: SortOrder;
+    unit?: GeoDistanceUnit;
+    // defaults if no order/unit provided
+    default_order: SortOrder;
+    default_unit: GeoDistanceUnit;
+};

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/valkey",
     "displayName": "Valkey Connector",
-    "version": "0.12.1",
+    "version": "0.12.2",
     "description": "A Terafoundation connector and facade client for Valkey.",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/valkey#readme",
     "bugs": {

--- a/packages/xlucene-parser/package.json
+++ b/packages/xlucene-parser/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-parser",
     "displayName": "xLucene Parser",
-    "version": "2.18.1",
+    "version": "2.18.2",
     "description": "Flexible Lucene-like evaluator and language parser",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-parser#readme",
     "repository": {

--- a/packages/xlucene-parser/src/functions/geo/box.ts
+++ b/packages/xlucene-parser/src/functions/geo/box.ts
@@ -1,4 +1,4 @@
-import { AnyQuery, xLuceneVariables } from '@terascope/types';
+import { GeoQuery, xLuceneVariables } from '@terascope/types';
 import { inGeoBoundingBoxFP, validateBoundingBox } from '@terascope/geo-utils';
 import * as i from '../../interfaces.js';
 import { getFieldValue, logger } from '../../utils.js';
@@ -37,11 +37,13 @@ const geoBox: i.FunctionDefinition = {
         const { top_left, bottom_right } = validate(node.params as i.Term[], variables);
 
         function toElasticsearchQuery(field: string) {
-            const query: AnyQuery = {};
-            query.geo_bounding_box = {};
-            query.geo_bounding_box[field] = {
-                top_left,
-                bottom_right,
+            const query: GeoQuery = {
+                geo_bounding_box: {
+                    [field]: {
+                        top_left,
+                        bottom_right
+                    }
+                }
             };
 
             if (logger.level() === 10) logger.trace('built geo bounding box query', { query });

--- a/packages/xlucene-parser/src/functions/geo/contains-point.ts
+++ b/packages/xlucene-parser/src/functions/geo/contains-point.ts
@@ -1,5 +1,5 @@
 import {
-    AnyQuery, GeoShapeRelation, ESGeoShapeType,
+    GeoQuery, GeoShapeRelation, ESGeoShapeType,
     xLuceneVariables
 } from '@terascope/types';
 import { parseGeoPoint, geoContainsFP } from '@terascope/geo-utils';
@@ -28,7 +28,7 @@ const geoContainsPoint: i.FunctionDefinition = {
         const { lat, lon } = validate(node.params as i.Term[], variables);
 
         function toElasticsearchQuery(field: string) {
-            const query: AnyQuery = {
+            const query: GeoQuery = {
                 geo_shape: {
                     [field]: {
                         shape: {

--- a/packages/xlucene-parser/src/functions/geo/distance.ts
+++ b/packages/xlucene-parser/src/functions/geo/distance.ts
@@ -1,5 +1,5 @@
 import {
-    GEO_DISTANCE_UNITS, GeoDistanceUnit, GeoQuery, GeoQuerySort,
+    GEO_DISTANCE_UNITS, GeoDistanceUnit, GeoQuery, GeoDistanceSort,
     xLuceneVariables
 } from '@terascope/types';
 import { parseGeoPoint, parseGeoDistance, geoPointWithinRangeFP } from '@terascope/geo-utils';
@@ -30,7 +30,7 @@ function validate(params: i.Term[], variables: xLuceneVariables) {
 }
 
 /** returns the value if valid, otherwise the default value */
-function getValidUnit(defaultValue: GeoDistanceUnit, value: any) {
+function getValidUnit(defaultValue: GeoDistanceUnit, value: GeoDistanceUnit): GeoDistanceUnit {
     if (!value || typeof value !== 'string') return defaultValue;
     if (Object.values(GEO_DISTANCE_UNITS).includes(value as GeoDistanceUnit)) return value;
     return defaultValue;
@@ -67,7 +67,7 @@ const geoDistance: i.FunctionDefinition = {
                 }
             };
 
-            const sort: GeoQuerySort = {
+            const sort: GeoDistanceSort = {
                 _geo_distance: {
                     order,
                     unit: sortUnit,

--- a/packages/xlucene-parser/src/functions/geo/distance.ts
+++ b/packages/xlucene-parser/src/functions/geo/distance.ts
@@ -30,7 +30,7 @@ function validate(params: i.Term[], variables: xLuceneVariables) {
 }
 
 /** returns the value if valid, otherwise the default value */
-function getValidUnit(defaultValue: GeoDistanceUnit, value: GeoDistanceUnit): GeoDistanceUnit {
+function getValidUnit(defaultValue: GeoDistanceUnit, value?: GeoDistanceUnit): GeoDistanceUnit {
     if (!value || typeof value !== 'string') return defaultValue;
     if (Object.values(GEO_DISTANCE_UNITS).includes(value as GeoDistanceUnit)) return value;
     return defaultValue;
@@ -51,11 +51,11 @@ const geoDistance: i.FunctionDefinition = {
         } = validate(node.params as i.Term[], variables);
 
         function toElasticsearchQuery(field: string, options: i.FunctionElasticsearchOptions) {
-            const sortUnit = getValidUnit(paramUnit, options.geo_sort.unit);
-            const sortPoint = parseGeoPoint(options.geo_sort.point, false);
+            const sortUnit = getValidUnit(paramUnit, options.geo_sort_config?.unit);
+            const sortPoint = parseGeoPoint(options.geo_sort_config?.point, false);
 
             const unit = paramUnit || sortUnit;
-            const order = options.geo_sort.order || options.geo_sort.default_order;
+            const order = options.geo_sort_config?.order || options.geo_sort_config?.default_order || 'asc';
 
             const query: GeoQuery = {
                 geo_distance: {

--- a/packages/xlucene-parser/src/functions/geo/distance.ts
+++ b/packages/xlucene-parser/src/functions/geo/distance.ts
@@ -1,4 +1,7 @@
-import { AnyQuery, xLuceneVariables } from '@terascope/types';
+import {
+    GEO_DISTANCE_UNITS, GeoDistanceUnit, GeoQuery, GeoQuerySort,
+    xLuceneVariables
+} from '@terascope/types';
 import { parseGeoPoint, parseGeoDistance, geoPointWithinRangeFP } from '@terascope/geo-utils';
 import * as i from '../../interfaces.js';
 import { getFieldValue, logger } from '../../utils.js';
@@ -26,6 +29,13 @@ function validate(params: i.Term[], variables: xLuceneVariables) {
     };
 }
 
+/** returns the value if valid, otherwise the default value */
+function getValidUnit(defaultValue: GeoDistanceUnit, value: any) {
+    if (!value || typeof value !== 'string') return defaultValue;
+    if (Object.values(GEO_DISTANCE_UNITS).includes(value as GeoDistanceUnit)) return value;
+    return defaultValue;
+}
+
 const geoDistance: i.FunctionDefinition = {
     name: 'geoDistance',
     version: '1',
@@ -35,30 +45,35 @@ const geoDistance: i.FunctionDefinition = {
         if (!node.field || node.field === '*') {
             throw new Error('Field for geoDistance cannot be empty or "*"');
         }
+
         const {
             lat, lon, distance, unit: paramUnit
         } = validate(node.params as i.Term[], variables);
 
         function toElasticsearchQuery(field: string, options: i.FunctionElasticsearchOptions) {
-            const unit = paramUnit || options.geo_sort_unit;
-            const order = options.geo_sort_order;
+            const sortUnit = getValidUnit(paramUnit, options.geo_sort.unit);
+            const sortPoint = parseGeoPoint(options.geo_sort.point, false);
 
-            const query: AnyQuery = {};
-            query.geo_distance = {
-                distance: `${distance}${unit}`,
-            };
-            query.geo_distance[field] = {
-                lat,
-                lon,
-            };
+            const unit = paramUnit || sortUnit;
+            const order = options.geo_sort.order || options.geo_sort.default_order;
 
-            const sort = {
-                _geo_distance: {
-                    order,
-                    unit,
+            const query: GeoQuery = {
+                geo_distance: {
+                    distance: `${distance}${unit}`,
                     [field]: {
                         lat,
                         lon
+                    }
+                }
+            };
+
+            const sort: GeoQuerySort = {
+                _geo_distance: {
+                    order,
+                    unit: sortUnit,
+                    [field]: {
+                        lat: sortPoint?.lat || lat,
+                        lon: sortPoint?.lon || lon
                     }
                 }
             };

--- a/packages/xlucene-parser/src/interfaces.ts
+++ b/packages/xlucene-parser/src/interfaces.ts
@@ -1,4 +1,3 @@
-import { Logger } from '@terascope/core-utils';
 import * as t from '@terascope/types';
 
 /**
@@ -12,11 +11,9 @@ import * as t from '@terascope/types';
  *  because the real value of the variable is not known at the current stage of execution
 
  */
-export interface ParserOptions {
-    type_config?: t.xLuceneTypeConfig;
+export interface ParserOptions extends Partial<t.XluceneBaseOptions> {
     filterNilVariables?: boolean;
     instantiateVariableValues?: boolean;
-    variables?: t.xLuceneVariables;
 }
 
 /**
@@ -351,14 +348,13 @@ export interface FunctionDefinition {
     create: (config: FunctionConfig) => FunctionMethods;
 }
 
+/** Similar to t.ElasticsearchDSLResult */
 export interface FunctionMethodsResults {
     query: t.AnyQuery;
     sort?: t.AnyQuerySort;
 }
 
-export type FunctionElasticsearchOptions
-    = { logger: Logger; type_config: t.xLuceneTypeConfig }
-        & Record<string, any>;
+export type FunctionElasticsearchOptions = t.XluceneTranslateQueryOptions;
 
 export interface FunctionMethods {
     match(arg: any): boolean;

--- a/packages/xlucene-parser/test/xlucene-functions/geo-box-spec.ts
+++ b/packages/xlucene-parser/test/xlucene-functions/geo-box-spec.ts
@@ -8,8 +8,10 @@ describe('geoBox', () => {
     const typeConfig: xLuceneTypeConfig = { location: xLuceneFieldType.GeoPoint };
     const options: FunctionElasticsearchOptions = {
         logger: debugLogger('test'),
-        geo_sort_order: 'asc',
-        geo_sort_unit: 'meters',
+        geo_sort_config: {
+            default_order: 'asc',
+            default_unit: 'meters'
+        },
         type_config: {}
     };
 

--- a/packages/xlucene-parser/test/xlucene-functions/geo-contains-point-spec.ts
+++ b/packages/xlucene-parser/test/xlucene-functions/geo-contains-point-spec.ts
@@ -12,8 +12,10 @@ describe('geoContainsPoint', () => {
     const typeConfig: xLuceneTypeConfig = { location: xLuceneFieldType.GeoJSON };
     const options: FunctionElasticsearchOptions = {
         logger: debugLogger('test'),
-        geo_sort_order: 'asc',
-        geo_sort_unit: 'meters',
+        geo_sort_config: {
+            default_order: 'asc',
+            default_unit: 'meters'
+        },
         type_config: {}
     };
 

--- a/packages/xlucene-parser/test/xlucene-functions/geo-distance-spec.ts
+++ b/packages/xlucene-parser/test/xlucene-functions/geo-distance-spec.ts
@@ -12,8 +12,10 @@ describe('geoDistance', () => {
     const typeConfig: xLuceneTypeConfig = { location: xLuceneFieldType.GeoPoint };
     const options: FunctionElasticsearchOptions = {
         logger: debugLogger('test'),
-        geo_sort_order: 'asc',
-        geo_sort_unit: 'meters',
+        geo_sort_config: {
+            default_order: 'asc',
+            default_unit: 'meters'
+        },
         type_config: {}
     };
 

--- a/packages/xlucene-parser/test/xlucene-functions/geo-polygon-spec.ts
+++ b/packages/xlucene-parser/test/xlucene-functions/geo-polygon-spec.ts
@@ -20,8 +20,10 @@ describe('geoPolygon', () => {
         const typeConfig: xLuceneTypeConfig = { location: xLuceneFieldType.GeoPoint };
         const options: FunctionElasticsearchOptions = {
             logger: debugLogger('test'),
-            geo_sort_order: 'asc',
-            geo_sort_unit: 'meters',
+            geo_sort_config: {
+                default_order: 'asc',
+                default_unit: 'meters'
+            },
             type_config: {}
         };
 
@@ -608,9 +610,12 @@ describe('geoPolygon', () => {
         const typeConfig: xLuceneTypeConfig = { location: xLuceneFieldType.GeoJSON };
         const options: FunctionElasticsearchOptions = {
             logger: debugLogger('test'),
-            geo_sort_order: 'asc',
-            geo_sort_unit: 'meters',
-            type_config: {}
+            geo_sort_config: {
+                default_order: 'asc',
+                default_unit: 'meters'
+            },
+            type_config: {},
+            variables: {}
         };
 
         it('can parse really long polygons', () => {

--- a/packages/xlucene-translator/package.json
+++ b/packages/xlucene-translator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xlucene-translator",
     "displayName": "xLucene Translator",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "description": "Translate xlucene query to database queries",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xlucene-translator#readme",
     "repository": {

--- a/packages/xlucene-translator/src/query-access/query-access.ts
+++ b/packages/xlucene-translator/src/query-access/query-access.ts
@@ -11,9 +11,9 @@ import {
     NodeType
 } from 'xlucene-parser';
 import {
-    SortOrder, GeoDistanceUnit, xLuceneVariables,
-    xLuceneTypeConfig, xLuceneFieldType, ClientParams,
-    ElasticsearchDistribution,
+    ClientParams, ElasticsearchDSLResult,
+    SortOrder, GeoDistanceUnit,
+    xLuceneFieldType, xLuceneTypeConfig, xLuceneVariables
 } from '@terascope/types';
 import { CachedTranslator } from '../translator/index.js';
 import { RestrictSearchQueryOptions, QueryAccessConfig } from './interfaces.js';
@@ -220,27 +220,15 @@ export class QueryAccess<T extends Record<string, any> = Record<string, any>> {
     ): Promise<ClientParams.SearchParams> {
         const {
             params: _params = {},
-            majorVersion = 2,
-            minorVersion = 15,
-            distribution = ElasticsearchDistribution.opensearch,
-            version = '2.15.0',
             ...options
         } = opts ?? {};
 
-        const translateOptions = {
-            ...options,
-            distribution,
-            majorVersion,
-            minorVersion,
-            version
-        };
-
-        const variables = Object.assign({}, this.variables, opts?.variables ?? {});
-
+        const params = { ..._params };
         if (_params._source) {
             throw new Error('Cannot include _source in params, use _source_includes or _source_excludes');
         }
-        const params = { ..._params };
+
+        const variables = Object.assign({}, this.variables, opts?.variables ?? {});
 
         const parser = this._restrict(query, variables, _overrideParsedQuery);
 
@@ -255,40 +243,10 @@ export class QueryAccess<T extends Record<string, any> = Record<string, any>> {
             filterNilVariables: this.filterNilVariables
         });
 
-        const translated = translator.toElasticsearchDSL(translateOptions);
+        const translated = translator.toElasticsearchDSL({ ...options });
 
         if (translated.sort && params.sort) {
-            const sorts: any[] = castArray(translated.sort);
-
-            /**
-             * Convert URL-style sort string (e.g. "foo:desc,bar:asc")
-             * into request-body sort array [{ foo: { order: desc }, etc.] and
-             * add as tie-breaker to translated geo sorts for less ambiguity
-             * with a single sort array
-             */
-            params.sort
-                .split(',')
-                .map((s) => s.trim())
-                .filter(Boolean)
-                .forEach((sort) => {
-                    const delimiter = sort.lastIndexOf(':');
-
-                    if (delimiter !== -1) {
-                        const field = sort.substring(0, delimiter);
-                        const order = sort.substring(delimiter + 1);
-
-                        if (order === 'asc' || order === 'desc') {
-                            sorts.push({ [field]: { order } });
-                        }
-
-                        // no order provided
-                        sorts.push(field);
-                    }
-
-                    sorts.push(sort);
-                });
-
-            delete params.sort;
+            this.mergeSorts(translated, params);
         }
 
         const {
@@ -314,6 +272,45 @@ export class QueryAccess<T extends Record<string, any> = Record<string, any>> {
         }
 
         return searchParams;
+    }
+
+    /**
+     * Merges different sorts for less ambiguity - there can be
+     * URL-style sort string (e.g. "foo:desc,bar:asc") and also
+     * request-body sort array [{ foo: { order: desc }, etc.] -
+     * the request body geo sort takes precedence
+     */
+    private mergeSorts(
+        translated: ElasticsearchDSLResult,
+        params: Partial<ClientParams.SearchParams>
+    ) {
+        if (translated.sort && params.sort) {
+            const sorts: any[] = castArray(translated.sort);
+
+            params.sort
+                .split(',')
+                .map((s) => s.trim())
+                .filter(Boolean)
+                .forEach((sort) => {
+                    const delimiter = sort.lastIndexOf(':');
+
+                    if (delimiter !== -1) {
+                        const field = sort.substring(0, delimiter);
+                        const order = sort.substring(delimiter + 1);
+
+                        if (order === 'asc' || order === 'desc') {
+                            sorts.push({ [field]: { order } });
+                        }
+
+                        // no order provided
+                        sorts.push(field);
+                    }
+
+                    sorts.push(sort);
+                });
+
+            delete params.sort;
+        }
     }
 
     /**

--- a/packages/xlucene-translator/src/query-access/query-access.ts
+++ b/packages/xlucene-translator/src/query-access/query-access.ts
@@ -12,7 +12,7 @@ import {
 } from 'xlucene-parser';
 import {
     ClientParams, ElasticsearchDSLResult,
-    SortOrder, GeoDistanceUnit,
+    FieldSort, SortOrder, GeoDistanceUnit,
     xLuceneFieldType, xLuceneTypeConfig, xLuceneVariables
 } from '@terascope/types';
 import { CachedTranslator } from '../translator/index.js';
@@ -287,28 +287,30 @@ export class QueryAccess<T extends Record<string, any> = Record<string, any>> {
         if (translated.sort && params.sort) {
             const sorts: any[] = castArray(translated.sort);
 
+            const parseSort = (sort: string): FieldSort => {
+                const delimiter = sort.lastIndexOf(':');
+
+                // no order, let search engine use default
+                if (delimiter == -1) return sort;
+
+                const field = sort.substring(0, delimiter);
+                const order = sort.substring(delimiter + 1);
+                if (order === 'asc' || order === 'desc') {
+                    return { [field]: { order } };
+                }
+                // field has colon or order is bad
+                return field;
+            };
+
             params.sort
                 .split(',')
                 .map((s) => s.trim())
                 .filter(Boolean)
                 .forEach((sort) => {
-                    const delimiter = sort.lastIndexOf(':');
-
-                    if (delimiter !== -1) {
-                        const field = sort.substring(0, delimiter);
-                        const order = sort.substring(delimiter + 1);
-
-                        if (order === 'asc' || order === 'desc') {
-                            sorts.push({ [field]: { order } });
-                        }
-
-                        // no order provided
-                        sorts.push(field);
-                    }
-
-                    sorts.push(sort);
+                    sorts.push(parseSort(sort));
                 });
 
+            translated.sort = sorts;
             delete params.sort;
         }
     }

--- a/packages/xlucene-translator/src/query-access/query-access.ts
+++ b/packages/xlucene-translator/src/query-access/query-access.ts
@@ -257,6 +257,40 @@ export class QueryAccess<T extends Record<string, any> = Record<string, any>> {
 
         const translated = translator.toElasticsearchDSL(translateOptions);
 
+        if (translated.sort && params.sort) {
+            const sorts: any[] = castArray(translated.sort);
+
+            /**
+             * Convert URL-style sort string (e.g. "foo:desc,bar:asc")
+             * into request-body sort array [{ foo: { order: desc }, etc.] and
+             * add as tie-breaker to translated geo sorts for less ambiguity
+             * with a single sort array
+             */
+            params.sort
+                .split(',')
+                .map((s) => s.trim())
+                .filter(Boolean)
+                .forEach((sort) => {
+                    const delimiter = sort.lastIndexOf(':');
+
+                    if (delimiter !== -1) {
+                        const field = sort.substring(0, delimiter);
+                        const order = sort.substring(delimiter + 1);
+
+                        if (order === 'asc' || order === 'desc') {
+                            sorts.push({ [field]: { order } });
+                        }
+
+                        // no order provided
+                        sorts.push(field);
+                    }
+
+                    sorts.push(sort);
+                });
+
+            delete params.sort;
+        }
+
         const {
             _source_includes: sourceIncludes,
             _source_excludes: sourceExcludes,

--- a/packages/xlucene-translator/src/translator/interfaces.ts
+++ b/packages/xlucene-translator/src/translator/interfaces.ts
@@ -1,34 +1,9 @@
-import type { Logger } from '@terascope/core-utils';
-import {
-    SortOrder, xLuceneTypeConfig, xLuceneVariables,
-    GeoDistanceUnit, GeoPoint, ClientMetadata
-} from '@terascope/types';
-import { ParserOptions } from 'xlucene-parser';
+import type { GeoDistanceUnit, Logger, SortOrder } from '@terascope/types';
+import type { ParserOptions } from 'xlucene-parser';
 
 export interface TranslatorOptions extends ParserOptions {
     logger?: Logger;
     default_geo_field?: string;
     default_geo_sort_order?: SortOrder;
     default_geo_sort_unit?: GeoDistanceUnit | string;
-}
-
-export type TranslatorGeoConfig = {
-    // field & point required
-    field?: string;
-    point?: GeoPoint;
-    // order & unit can use defaults if not provided
-    order?: SortOrder;
-    unit?: GeoDistanceUnit;
-    default_order: SortOrder;
-    default_unit: GeoDistanceUnit;
-};
-
-/**
- * @internal
-*/
-export interface UtilsTranslateQueryOptions extends Partial<ClientMetadata> {
-    logger: Logger;
-    type_config: xLuceneTypeConfig;
-    variables: xLuceneVariables;
-    geo_sort: TranslatorGeoConfig;
 }

--- a/packages/xlucene-translator/src/translator/interfaces.ts
+++ b/packages/xlucene-translator/src/translator/interfaces.ts
@@ -12,6 +12,17 @@ export interface TranslatorOptions extends ParserOptions {
     default_geo_sort_unit?: GeoDistanceUnit | string;
 }
 
+export type TranslatorGeoConfig = {
+    // field & point required
+    field?: string;
+    point?: GeoPoint;
+    // order & unit can use defaults if not provided
+    order?: SortOrder;
+    unit?: GeoDistanceUnit;
+    default_order: SortOrder;
+    default_unit: GeoDistanceUnit;
+};
+
 /**
  * @internal
 */
@@ -19,8 +30,5 @@ export interface UtilsTranslateQueryOptions extends Partial<ClientMetadata> {
     logger: Logger;
     type_config: xLuceneTypeConfig;
     variables: xLuceneVariables;
-    default_geo_field?: string;
-    geo_sort_point?: GeoPoint;
-    geo_sort_order: SortOrder;
-    geo_sort_unit: GeoDistanceUnit;
+    geo_sort: TranslatorGeoConfig;
 }

--- a/packages/xlucene-translator/src/translator/translator.ts
+++ b/packages/xlucene-translator/src/translator/translator.ts
@@ -3,10 +3,10 @@ import { parseGeoDistanceUnit } from '@terascope/geo-utils';
 import {
     xLuceneVariables, xLuceneTypeConfig,
     ElasticsearchDSLOptions, ElasticsearchDSLResult,
-    ElasticsearchDistribution
+    ElasticsearchDistribution, XluceneGeoSortConfig
 } from '@terascope/types';
 import { Parser } from 'xlucene-parser';
-import type { TranslatorGeoConfig, TranslatorOptions } from './interfaces.js';
+import type { TranslatorOptions } from './interfaces.js';
 import { translateQuery } from './utils.js';
 
 const logger = debugLogger('xlucene-translator');
@@ -16,7 +16,7 @@ export class Translator {
     readonly typeConfig: xLuceneTypeConfig;
     readonly variables: xLuceneVariables | undefined;
     private readonly _parser: Parser;
-    private _defaultGeoSortConfig: TranslatorGeoConfig;
+    private _defaultGeoSortConfig: XluceneGeoSortConfig;
 
     constructor(input: string | Parser, options: TranslatorOptions = {}) {
         this.variables = options.variables;
@@ -52,7 +52,7 @@ export class Translator {
             distribution: opts.distribution ?? ElasticsearchDistribution.opensearch,
             type_config: this.typeConfig,
             variables: this.variables ?? {},
-            geo_sort: {
+            geo_sort_config: {
                 ...this._defaultGeoSortConfig,
                 point: opts.geo_sort_point,
                 order: opts.geo_sort_order,

--- a/packages/xlucene-translator/src/translator/translator.ts
+++ b/packages/xlucene-translator/src/translator/translator.ts
@@ -1,12 +1,12 @@
 import { debugLogger, isString } from '@terascope/core-utils';
 import { parseGeoDistanceUnit } from '@terascope/geo-utils';
 import {
-    xLuceneVariables, xLuceneTypeConfig, GeoDistanceUnit,
+    xLuceneVariables, xLuceneTypeConfig,
     ElasticsearchDSLOptions, ElasticsearchDSLResult,
     ElasticsearchDistribution
 } from '@terascope/types';
 import { Parser } from 'xlucene-parser';
-import { TranslatorOptions } from './interfaces.js';
+import type { TranslatorGeoConfig, TranslatorOptions } from './interfaces.js';
 import { translateQuery } from './utils.js';
 
 const logger = debugLogger('xlucene-translator');
@@ -16,9 +16,7 @@ export class Translator {
     readonly typeConfig: xLuceneTypeConfig;
     readonly variables: xLuceneVariables | undefined;
     private readonly _parser: Parser;
-    private _defaultGeoField?: string;
-    private _defaultGeoSortOrder: 'asc' | 'desc' = 'asc';
-    private _defaultGeoSortUnit: GeoDistanceUnit = 'meters';
+    private _defaultGeoSortConfig: TranslatorGeoConfig;
 
     constructor(input: string | Parser, options: TranslatorOptions = {}) {
         this.variables = options.variables;
@@ -34,15 +32,13 @@ export class Translator {
             this._parser = input;
         }
 
-        if (options.default_geo_field) {
-            this._defaultGeoField = options.default_geo_field;
-        }
-        if (options.default_geo_sort_order) {
-            this._defaultGeoSortOrder = options.default_geo_sort_order;
-        }
-        if (options.default_geo_sort_unit) {
-            this._defaultGeoSortUnit = parseGeoDistanceUnit(options.default_geo_sort_unit);
-        }
+        this._defaultGeoSortConfig = {
+            field: options.default_geo_field,
+            default_order: options.default_geo_sort_order || 'asc',
+            default_unit: options.default_geo_sort_unit
+                ? parseGeoDistanceUnit(options.default_geo_sort_unit)
+                : 'meters'
+        };
 
         this.query = this._parser.query;
     }
@@ -55,11 +51,13 @@ export class Translator {
             version: opts.version ?? '2.15.0',
             distribution: opts.distribution ?? ElasticsearchDistribution.opensearch,
             type_config: this.typeConfig,
-            default_geo_field: this._defaultGeoField,
             variables: this.variables ?? {},
-            geo_sort_point: opts.geo_sort_point,
-            geo_sort_order: opts.geo_sort_order || this._defaultGeoSortOrder,
-            geo_sort_unit: opts.geo_sort_unit || this._defaultGeoSortUnit,
+            geo_sort: {
+                ...this._defaultGeoSortConfig,
+                point: opts.geo_sort_point,
+                order: opts.geo_sort_order,
+                unit: opts.geo_sort_unit
+            },
         });
 
         if (logger.level() === 10) {

--- a/packages/xlucene-translator/src/translator/utils.ts
+++ b/packages/xlucene-translator/src/translator/utils.ts
@@ -19,7 +19,7 @@ import type {
     RangeQuery, AnyQuerySort, ElasticsearchDSLResult,
     MatchAllQuery, ConstantScoreQuery, MatchNoneQuery,
     AnyQuery, BoolQuery, ExistsQuery, RegExprQuery,
-    BoolQueryTypes, KNNQuery, GeoQuerySort
+    BoolQueryTypes, KNNQuery, GeoDistanceSort
 } from '@terascope/types';
 import { UtilsTranslateQueryOptions } from './interfaces.js';
 
@@ -125,8 +125,8 @@ export function translateQuery(
         const order = geo_sort.order || geo_sort.default_order;
         const unit = geo_sort.unit || geo_sort.default_unit;
 
-        // add if no sort, OR override existing geo distance sort
-        if (!sort || (sort as GeoQuerySort)?._geo_distance) {
+        // add if no sort - OR - override existing geo distance sort
+        if (!sort || (sort as GeoDistanceSort)?._geo_distance) {
             sort = {
                 _geo_distance: {
                     order,

--- a/packages/xlucene-translator/src/translator/utils.ts
+++ b/packages/xlucene-translator/src/translator/utils.ts
@@ -1,6 +1,6 @@
 import {
-    TSError, isString, isArray, isEmpty,
-    matchWildcard
+    castArray, isArray, isEmpty, isString,
+    matchWildcard, TSError
 } from '@terascope/core-utils';
 import {
     isEmptyNode, isWildcardField, isTerm,
@@ -19,7 +19,7 @@ import type {
     RangeQuery, AnyQuerySort, ElasticsearchDSLResult,
     MatchAllQuery, ConstantScoreQuery, MatchNoneQuery,
     AnyQuery, BoolQuery, ExistsQuery, RegExprQuery,
-    BoolQueryTypes, KNNQuery
+    BoolQueryTypes, KNNQuery, GeoQuerySort
 } from '@terascope/types';
 import { UtilsTranslateQueryOptions } from './interfaces.js';
 
@@ -119,14 +119,32 @@ export function translateQuery(
 
     let { sort } = context;
 
-    if (!sort && options.default_geo_field && options.geo_sort_point) {
-        sort = {
-            _geo_distance: {
-                order: options.geo_sort_order,
-                unit: options.geo_sort_unit,
-                [options.default_geo_field]: options.geo_sort_point,
-            }
-        };
+    const { geo_sort } = options;
+
+    if (geo_sort.field && geo_sort.point) {
+        const order = geo_sort.order || geo_sort.default_order;
+        const unit = geo_sort.unit || geo_sort.default_unit;
+
+        // add if no sort, OR override existing geo distance sort
+        if (!sort || (sort as GeoQuerySort)?._geo_distance) {
+            sort = {
+                _geo_distance: {
+                    order,
+                    unit,
+                    [geo_sort.field]: geo_sort.point
+                }
+            };
+        } else {
+            // tack on to existing sort
+            sort = castArray(sort);
+            sort.push({
+                _geo_distance: {
+                    order,
+                    unit,
+                    [geo_sort.field]: geo_sort.point
+                }
+            });
+        }
     }
 
     return {

--- a/packages/xlucene-translator/src/translator/utils.ts
+++ b/packages/xlucene-translator/src/translator/utils.ts
@@ -19,9 +19,9 @@ import type {
     RangeQuery, AnyQuerySort, ElasticsearchDSLResult,
     MatchAllQuery, ConstantScoreQuery, MatchNoneQuery,
     AnyQuery, BoolQuery, ExistsQuery, RegExprQuery,
-    BoolQueryTypes, KNNQuery, GeoDistanceSort
+    BoolQueryTypes, KNNQuery, GeoDistanceSort,
+    XluceneTranslateQueryOptions
 } from '@terascope/types';
-import { UtilsTranslateQueryOptions } from './interfaces.js';
 
 type WildCardQueryResults
     = WildcardQuery
@@ -41,15 +41,17 @@ type RangeQueryResults
 
 type SortArgs = AnyQuerySort | AnyQuerySort[] | undefined;
 
-interface QueryContext extends UtilsTranslateQueryOptions {
+type PartialRequired<T, K extends keyof T> = Partial<T> & Pick<Required<T>, K>;
+interface QueryContext extends PartialRequired<XluceneTranslateQueryOptions, 'variables' | 'type_config'> {
     sort?: SortArgs;
 }
 
 export function translateQuery(
     parser: Parser,
-    options: UtilsTranslateQueryOptions
+    options: XluceneTranslateQueryOptions
 ): ElasticsearchDSLResult {
     const context: QueryContext = {
+        variables: {},
         ...options
     };
     // TODO: this should probably reference the search type from opensearch, maybe not
@@ -92,7 +94,7 @@ export function translateQuery(
                 },
             });
 
-            options.logger.error(error);
+            options.logger?.error(error);
         }
 
         const filter = compactFinalQuery(anyQuery);
@@ -119,11 +121,11 @@ export function translateQuery(
 
     let { sort } = context;
 
-    const { geo_sort } = options;
+    const { geo_sort_config } = options;
 
-    if (geo_sort.field && geo_sort.point) {
-        const order = geo_sort.order || geo_sort.default_order;
-        const unit = geo_sort.unit || geo_sort.default_unit;
+    if (geo_sort_config?.field && geo_sort_config?.point) {
+        const order = geo_sort_config.order || geo_sort_config.default_order;
+        const unit = geo_sort_config.unit || geo_sort_config.default_unit;
 
         // add if no sort - OR - override existing geo distance sort
         if (!sort || (sort as GeoDistanceSort)?._geo_distance) {
@@ -131,7 +133,7 @@ export function translateQuery(
                 _geo_distance: {
                     order,
                     unit,
-                    [geo_sort.field]: geo_sort.point
+                    [geo_sort_config.field]: geo_sort_config.point
                 }
             };
         } else {
@@ -141,7 +143,7 @@ export function translateQuery(
                 _geo_distance: {
                     order,
                     unit,
-                    [geo_sort.field]: geo_sort.point
+                    [geo_sort_config.field]: geo_sort_config.point
                 }
             });
         }
@@ -193,7 +195,7 @@ function buildTermLevelQuery(
     }
 
     if (isFunctionNode(node)) {
-        const { variables, type_config } = context;
+        const { variables, type_config = {} } = context;
         const instance = initFunction({ node, variables, type_config });
         const { query, sort: sortQuery } = instance.toElasticsearchQuery(
             getTermField(node),
@@ -426,7 +428,7 @@ function buildKNNQuery(
 
     parser.walkAST((node: Node) => {
         if (isFunctionNode(node) && node.name === 'knn') {
-            const { variables, type_config } = context;
+            const { variables, type_config = {} } = context;
             const instance = initFunction({ node, variables, type_config });
             const { query } = instance.toElasticsearchQuery(
                 getTermField(node),

--- a/packages/xlucene-translator/test/structure/cases/translator/geo.ts
+++ b/packages/xlucene-translator/test/structure/cases/translator/geo.ts
@@ -95,10 +95,10 @@ export default [
             sort: {
                 _geo_distance: {
                     order: 'asc',
-                    unit: 'inch',
-                    loc: {
-                        lat: 33.435518,
-                        lon: -111.873616,
+                    unit: 'nauticalmiles',
+                    some_other_loc: {
+                        lat: 35.435518,
+                        lon: 35.435518,
                     }
                 }
             }
@@ -110,7 +110,7 @@ export default [
         {
             geo_sort_point: {
                 lat: 35.435518,
-                lon: -120.873616,
+                lon: 35.435518,
             },
             geo_sort_unit: 'nauticalmiles'
         }

--- a/packages/xlucene-translator/test/structure/query-access-spec.ts
+++ b/packages/xlucene-translator/test/structure/query-access-spec.ts
@@ -693,6 +693,34 @@ describe('QueryAccess', () => {
             });
         });
 
+        it('should be able to return a restricted geo query and disambiguate sorts', async () => {
+            const q = 'foo:geoDistance(point:"33.435518,-111.873616" distance:5000yd)';
+            const result = await queryAccess.restrictSearchQuery(q, {
+                geo_sort_order: 'asc',
+                params: { sort: 'bar:desc' },
+            });
+
+            expect(result).toMatchObject({
+                body: {
+                    sort: [
+                        {
+                            _geo_distance: {
+                                order: 'asc',
+                                unit: 'yards',
+                                foo: {
+                                    lat: 33.435518,
+                                    lon: -111.873616,
+                                }
+                            }
+                        },
+                        {
+                            bar: { order: 'desc' }
+                        }
+                    ]
+                }
+            });
+        });
+
         it('can process quoted values correctly', async () => {
             const q = 'foo:"something-xy40\\" value 8008"';
             const result = await queryAccess.restrictSearchQuery(q);

--- a/packages/xlucene-translator/test/structure/translator-spec.ts
+++ b/packages/xlucene-translator/test/structure/translator-spec.ts
@@ -24,10 +24,12 @@ describe('Translator', () => {
             logger,
             type_config: {},
             variables: {},
-            geo_sort_order: 'asc',
-            geo_sort_unit: 'meters',
+            geo_sort: {
+                default_order: 'asc',
+                default_unit: 'meters'
+            },
             majorVersion: 2,
-            distribution: ElasticsearchDistribution.opensearch
+            distribution: ElasticsearchDistribution.opensearch,
         })).toEqual({
             query: {
                 match_none: {}
@@ -53,8 +55,8 @@ describe('Translator', () => {
 
         const translator = new Translator(query);
 
-        expect(translator).toHaveProperty('_defaultGeoSortOrder', 'asc');
-        expect(translator).toHaveProperty('_defaultGeoSortUnit', 'meters');
+        expect(translator).toHaveProperty('_defaultGeoSortConfig.default_order', 'asc');
+        expect(translator).toHaveProperty('_defaultGeoSortConfig.default_unit', 'meters');
     });
 
     it('should have the geo sort properties', () => {
@@ -66,9 +68,9 @@ describe('Translator', () => {
             default_geo_sort_unit: 'km'
         });
 
-        expect(translator).toHaveProperty('_defaultGeoField', 'test_loc');
-        expect(translator).toHaveProperty('_defaultGeoSortOrder', 'desc');
-        expect(translator).toHaveProperty('_defaultGeoSortUnit', 'kilometers');
+        expect(translator).toHaveProperty('_defaultGeoSortConfig.field', 'test_loc');
+        expect(translator).toHaveProperty('_defaultGeoSortConfig.default_order', 'desc');
+        expect(translator).toHaveProperty('_defaultGeoSortConfig.default_unit', 'kilometers');
     });
 
     for (const [key, testCases] of Object.entries(allTestCases)) {

--- a/packages/xlucene-translator/test/structure/translator-spec.ts
+++ b/packages/xlucene-translator/test/structure/translator-spec.ts
@@ -24,7 +24,7 @@ describe('Translator', () => {
             logger,
             type_config: {},
             variables: {},
-            geo_sort: {
+            geo_sort_config: {
                 default_order: 'asc',
                 default_unit: 'meters'
             },

--- a/packages/xpressions/package.json
+++ b/packages/xpressions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xpressions",
     "displayName": "Xpressions",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "description": "Variable expressions with date-math support",
     "homepage": "https://github.com/terascope/teraslice/tree/master/packages/xpressions#readme",
     "bugs": {


### PR DESCRIPTION
Main changes - translator and geo-dist fn were preventing geo_sort params to override the default sort for a geo_distance query 

- [x] Fix opensearch sort types
- [x] Fix so geo sort args can override the sort that the geo distance query adds
- [x] Disambiguate sorts - Opensearch accepts url & req body params - request body sort seems to take precedence over string url sort, but it's not documented so is confusing - figured just having one sort is clearer and less confusing so merged them
- [x] Remove unnecessary client metadata defaults  in query access - it sets defaults in translator so not needed twice
