### PR TITLE
WIP:  fix tuple to support objects

### DIFF
--- a/packages/data-types/src/types/index.ts
+++ b/packages/data-types/src/types/index.ts
@@ -100,8 +100,19 @@ function getTupleType({
         });
     }
 
+    const tupleNestedObjs: string[] = [];
     fields.forEach(({ field, config }) => {
-        const index = toIntegerOrThrow(getLast(field.split('.')));
+        if (config?.type === 'Object') tupleNestedObjs.push(field);
+
+        let index: number | undefined;
+        try {
+            index = toIntegerOrThrow(getLast(field.split('.')));
+        } catch (error) {
+            index = tupleNestedObjs.findIndex((el) => field.startsWith(el));
+            if (index === -1) throw error;
+            index = nestedTypes.length;
+        }
+
         nestedTypes[index] = getType({
             field,
             config: config || { type: FieldType.Any },

--- a/packages/data-types/test/data-type-spec.ts
+++ b/packages/data-types/test/data-type-spec.ts
@@ -113,13 +113,23 @@ describe('DataType', () => {
                 foo: { type: FieldType.Tuple },
                 'foo.0': { type: FieldType.Keyword },
                 'foo.1': { type: FieldType.Integer },
+                'foo.2': { type: FieldType.Object },
+                'foo.2.nested': { type: FieldType.Keyword },
             },
         };
 
         const dataType = new DataType(typeConfig, 'Test', 'hello there');
+
+        // FIXME add tests for these - toGQL throws i think
+        // console.log(dataType.toXlucene());
+        // - throws JSON not supported
+        // console.log(dataType.toGraphQL());
+        // console.log('===data', dataType.fields);
+        // console.log('===data', dataType.groupedFields);
+
         expect(dataType).toHaveProperty('groupedFields', {
             hello: ['hello'],
-            foo: ['foo', 'foo.0', 'foo.1']
+            foo: ['foo', 'foo.0', 'foo.1', 'foo.2', 'foo.2.nested']
         });
         // @ts-expect-error
         const types = dataType._types;


### PR DESCRIPTION
fix tuples to support objects - making a DataType will throw if it's a tuple with a nested object at getTypes

NOTE: was said in meeting we don't want to support nested objects right now